### PR TITLE
Updated parsing of manga title from URL.

### DIFF
--- a/src/en/madokami/build.gradle
+++ b/src/en/madokami/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Madokami'
     pkgNameSuffix = 'en.madokami'
     extClass = '.Madokami'
-    extVersionCode = 7
+    extVersionCode = 8
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
+++ b/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
@@ -69,6 +69,7 @@ class Madokami : ConfigurableSource, ParsedHttpSource() {
         manga.url = element.attr("href")
         val pathSegments = element.attr("href").split("/")
         var i = pathSegments.size
+        manga.description = URLDecoder.decode(pathSegments[i - 1], "UTF-8")
         do { i--; manga.title = URLDecoder.decode(pathSegments[i], "UTF-8") } while (URLDecoder.decode(pathSegments[i], "UTF-8").startsWith("!"))
         return manga
     }
@@ -111,8 +112,7 @@ class Madokami : ConfigurableSource, ParsedHttpSource() {
     override fun mangaDetailsParse(document: Document): SManga {
         val manga = SManga.create()
         manga.author = document.select("a[itemprop=\"author\"]").joinToString(", ") { it.text() }
-        manga.description = "Tags: " + document.select("div.genres[itemprop=\"keywords\"] a.tag.tag-category").joinToString(", ") { it.text() }
-        manga.genre = document.select("div.genres a.tag[itemprop=\"genre\"]").joinToString(", ") { it.text() }
+        manga.genre = document.select("div.genres a.tag").joinToString(", ") { it.text() }
         manga.status = if (document.select("span.scanstatus").text() == "Yes") SManga.COMPLETED else SManga.UNKNOWN
         manga.thumbnail_url = document.select("div.manga-info img[itemprop=\"image\"]").attr("src")
         return manga

--- a/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
+++ b/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
@@ -67,7 +67,9 @@ class Madokami : ConfigurableSource, ParsedHttpSource() {
     override fun popularMangaFromElement(element: Element): SManga {
         val manga = SManga.create()
         manga.url = element.attr("href")
-        manga.title = URLDecoder.decode(element.attr("href").split("/").last(), "UTF-8").trimStart('!')
+        val pathSegments = element.attr("href").split("/")
+        var i = pathSegments.size
+        do { i--; manga.title = URLDecoder.decode(pathSegments[i], "UTF-8") } while (URLDecoder.decode(pathSegments[i], "UTF-8").startsWith("!"))
         return manga
     }
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio

Closes #58 

Tested by building apk and installing on my Samsung S23.

![Screenshot_20240109_202829_Tachiyomi](https://github.com/keiyoushi/extensions-source/assets/10172265/a3b5ed6a-d23f-492e-9038-6b46b3f4b094)

