### PR TITLE
Update WestManga.kt URL to westmanga.fun

### DIFF
--- a/multisrc/overrides/mangathemesia/westmanga/src/WestManga.kt
+++ b/multisrc/overrides/mangathemesia/westmanga/src/WestManga.kt
@@ -4,7 +4,7 @@ import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import okhttp3.OkHttpClient
 
-class WestManga : MangaThemesia("West Manga", "https://westmanga.org", "id") {
+class WestManga : MangaThemesia("West Manga", "https://westmanga.fun", "id") {
     // Formerly "West Manga (WP Manga Stream)"
     override val id = 8883916630998758688
 

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaGenerator.kt
@@ -161,7 +161,7 @@ class MangaThemesiaGenerator : ThemeSourceGenerator {
         SingleLang("Uzay Manga", "https://uzaymanga.com", "tr", overrideVersionCode = 6),
         SingleLang("VF Scan", "https://www.vfscan.cc", "fr"),
         SingleLang("Walpurgi Scan", "https://www.walpurgiscan.it", "it", overrideVersionCode = 7, className = "WalpurgisScan", pkgName = "walpurgisscan"),
-        SingleLang("West Manga", "https://westmanga.org", "id", overrideVersionCode = 2),
+        SingleLang("West Manga", "https://westmanga.org", "id", overrideVersionCode = 3),
         SingleLang("World Romance Translation", "https://wrt.my.id", "id", overrideVersionCode = 11),
         SingleLang("xCaliBR Scans", "https://xcalibrscans.com", "en", overrideVersionCode = 5),
         SingleLang("YumeKomik", "https://yumekomik.com", "id", isNsfw = true, className = "YumeKomik", pkgName = "inazumanga", overrideVersionCode = 6),

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaGenerator.kt
@@ -161,7 +161,7 @@ class MangaThemesiaGenerator : ThemeSourceGenerator {
         SingleLang("Uzay Manga", "https://uzaymanga.com", "tr", overrideVersionCode = 6),
         SingleLang("VF Scan", "https://www.vfscan.cc", "fr"),
         SingleLang("Walpurgi Scan", "https://www.walpurgiscan.it", "it", overrideVersionCode = 7, className = "WalpurgisScan", pkgName = "walpurgisscan"),
-        SingleLang("West Manga", "https://westmanga.org", "id", overrideVersionCode = 3),
+        SingleLang("West Manga", "https://westmanga.fun", "id", overrideVersionCode = 3),
         SingleLang("World Romance Translation", "https://wrt.my.id", "id", overrideVersionCode = 11),
         SingleLang("xCaliBR Scans", "https://xcalibrscans.com", "en", overrideVersionCode = 5),
         SingleLang("YumeKomik", "https://yumekomik.com", "id", isNsfw = true, className = "YumeKomik", pkgName = "inazumanga", overrideVersionCode = 6),


### PR DESCRIPTION
 Closes #76

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [X] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [X] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
