### PR TITLE
Improve Dynasty Scans

### DIFF
--- a/src/en/dynasty/build.gradle
+++ b/src/en/dynasty/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Dynasty'
     pkgNameSuffix = 'en.dynasty'
     extClass = '.DynastyFactory'
-    extVersionCode = 21
+    extVersionCode = 22
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyAnthologies.kt
+++ b/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyAnthologies.kt
@@ -4,6 +4,7 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.SManga
 import okhttp3.Request
+import okhttp3.Response
 import org.jsoup.nodes.Document
 
 class DynastyAnthologies : DynastyScans() {
@@ -12,7 +13,9 @@ class DynastyAnthologies : DynastyScans() {
 
     override val searchPrefix = "anthologies"
 
-    override fun popularMangaInitialUrl() = "$baseUrl/anthologies?view=cover"
+    override fun popularMangaInitialUrl() = ""
+
+    private fun popularMangaInitialUrl(page: Int) = "$baseUrl/search?q=&classes%5B%5D=Anthology&page=$page=$&sort="
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         return GET("$baseUrl/search?q=$query&classes%5B%5D=Anthology&sort=&page=$page", headers)
@@ -26,4 +29,14 @@ class DynastyAnthologies : DynastyScans() {
         parseDescription(document, manga)
         return manga
     }
+
+    override fun popularMangaRequest(page: Int): Request {
+        return GET(popularMangaInitialUrl(page), headers)
+    }
+
+    override fun popularMangaNextPageSelector() = searchMangaNextPageSelector()
+
+    override fun popularMangaSelector() = searchMangaSelector()
+
+    override fun popularMangaParse(response: Response) = searchMangaParse(response)
 }

--- a/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyAnthologies.kt
+++ b/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyAnthologies.kt
@@ -4,7 +4,6 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.SManga
 import okhttp3.Request
-import okhttp3.Response
 import org.jsoup.nodes.Document
 
 class DynastyAnthologies : DynastyScans() {
@@ -13,9 +12,9 @@ class DynastyAnthologies : DynastyScans() {
 
     override val searchPrefix = "anthologies"
 
-    override fun popularMangaInitialUrl() = ""
+    override val categoryPrefix = "Anthology"
 
-    private fun popularMangaInitialUrl(page: Int) = "$baseUrl/search?q=&classes%5B%5D=Anthology&page=$page=$&sort="
+    override fun popularMangaInitialUrl() = ""
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         return GET("$baseUrl/search?q=$query&classes%5B%5D=Anthology&sort=&page=$page", headers)
@@ -29,14 +28,4 @@ class DynastyAnthologies : DynastyScans() {
         parseDescription(document, manga)
         return manga
     }
-
-    override fun popularMangaRequest(page: Int): Request {
-        return GET(popularMangaInitialUrl(page), headers)
-    }
-
-    override fun popularMangaNextPageSelector() = searchMangaNextPageSelector()
-
-    override fun popularMangaSelector() = searchMangaSelector()
-
-    override fun popularMangaParse(response: Response) = searchMangaParse(response)
 }

--- a/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyChapters.kt
+++ b/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyChapters.kt
@@ -13,9 +13,9 @@ import org.jsoup.nodes.Element
 class DynastyChapters : DynastyScans() {
     override val name = "Dynasty-Chapters"
     override val searchPrefix = "chapters"
+    override val categoryPrefix = "Chapter"
     override fun popularMangaInitialUrl() = ""
 
-    private fun popularMangaInitialUrl(page: Int) = "$baseUrl/search?q=&classes%5B%5D=Chapter&page=$page=$&sort="
     private fun latestUpdatesInitialUrl(page: Int) = "$baseUrl/search?q=&classes%5B%5D=Chapter&page=$page=$&sort=created_at"
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
@@ -76,23 +76,15 @@ class DynastyChapters : DynastyScans() {
         return chapter
     }
 
-    override fun popularMangaRequest(page: Int): Request {
-        return GET(popularMangaInitialUrl(page), headers)
-    }
-
     override fun latestUpdatesRequest(page: Int): Request {
         return GET(latestUpdatesInitialUrl(page), headers)
     }
 
-    override fun popularMangaNextPageSelector() = searchMangaNextPageSelector()
     override fun latestUpdatesNextPageSelector() = searchMangaNextPageSelector()
 
-    override fun popularMangaSelector() = searchMangaSelector()
     override fun latestUpdatesSelector() = searchMangaSelector()
 
-    override fun popularMangaFromElement(element: Element) = searchMangaFromElement(element)
     override fun latestUpdatesFromElement(element: Element) = searchMangaFromElement(element)
 
-    override fun popularMangaParse(response: Response) = searchMangaParse(response)
     override fun latestUpdatesParse(response: Response) = searchMangaParse(response)
 }

--- a/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyDoujins.kt
+++ b/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyDoujins.kt
@@ -53,7 +53,7 @@ class DynastyDoujins : DynastyScans() {
     override fun chapterListParse(response: Response): List<SChapter> {
         val document = response.asJsoup()
 
-        val chapters = document.select(chapterListSelector()).map { chapterFromElement(it) }.toMutableList()
+        val chapters = try { document.select(chapterListSelector()).map { chapterFromElement(it) }.toMutableList() } catch (e: IndexOutOfBoundsException) { mutableListOf() }
 
         document.select("a.thumbnail img").let { images ->
             if (images.isNotEmpty()) {

--- a/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyDoujins.kt
+++ b/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyDoujins.kt
@@ -17,7 +17,9 @@ class DynastyDoujins : DynastyScans() {
 
     override val searchPrefix = "doujins"
 
-    override fun popularMangaInitialUrl() = "$baseUrl/doujins?view=cover"
+    override fun popularMangaInitialUrl() = ""
+
+    private fun popularMangaInitialUrl(page: Int) = "$baseUrl/search?q=&classes%5B%5D=Doujin&page=$page=$&sort="
 
     override fun popularMangaFromElement(element: Element): SManga {
         return super.popularMangaFromElement(element).apply {
@@ -80,4 +82,14 @@ class DynastyDoujins : DynastyScans() {
     override fun imageUrlParse(document: Document): String {
         return document.select("div.image img").attr("abs:src")
     }
+
+    override fun popularMangaRequest(page: Int): Request {
+        return GET(popularMangaInitialUrl(page), headers)
+    }
+
+    override fun popularMangaNextPageSelector() = searchMangaNextPageSelector()
+
+    override fun popularMangaSelector() = searchMangaSelector()
+
+    override fun popularMangaParse(response: Response) = searchMangaParse(response)
 }

--- a/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyDoujins.kt
+++ b/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyDoujins.kt
@@ -17,9 +17,8 @@ class DynastyDoujins : DynastyScans() {
 
     override val searchPrefix = "doujins"
 
+    override val categoryPrefix = "Doujin"
     override fun popularMangaInitialUrl() = ""
-
-    private fun popularMangaInitialUrl(page: Int) = "$baseUrl/search?q=&classes%5B%5D=Doujin&page=$page=$&sort="
 
     override fun popularMangaFromElement(element: Element): SManga {
         return super.popularMangaFromElement(element).apply {
@@ -82,14 +81,4 @@ class DynastyDoujins : DynastyScans() {
     override fun imageUrlParse(document: Document): String {
         return document.select("div.image img").attr("abs:src")
     }
-
-    override fun popularMangaRequest(page: Int): Request {
-        return GET(popularMangaInitialUrl(page), headers)
-    }
-
-    override fun popularMangaNextPageSelector() = searchMangaNextPageSelector()
-
-    override fun popularMangaSelector() = searchMangaSelector()
-
-    override fun popularMangaParse(response: Response) = searchMangaParse(response)
 }

--- a/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyIssues.kt
+++ b/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyIssues.kt
@@ -4,6 +4,7 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.SManga
 import okhttp3.Request
+import okhttp3.Response
 import org.jsoup.nodes.Document
 
 class DynastyIssues : DynastyScans() {
@@ -12,7 +13,9 @@ class DynastyIssues : DynastyScans() {
 
     override val searchPrefix = "issues"
 
-    override fun popularMangaInitialUrl() = "$baseUrl/issues?view=cover"
+    override fun popularMangaInitialUrl() = ""
+
+    private fun popularMangaInitialUrl(page: Int) = "$baseUrl/search?q=&classes%5B%5D=Issue&page=$page=$&sort="
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         return GET("$baseUrl/search?q=$query&classes%5B%5D=Issue&sort=&page=$page", headers)
@@ -26,4 +29,14 @@ class DynastyIssues : DynastyScans() {
         parseDescription(document, manga)
         return manga
     }
+
+    override fun popularMangaRequest(page: Int): Request {
+        return GET(popularMangaInitialUrl(page), headers)
+    }
+
+    override fun popularMangaNextPageSelector() = searchMangaNextPageSelector()
+
+    override fun popularMangaSelector() = searchMangaSelector()
+
+    override fun popularMangaParse(response: Response) = searchMangaParse(response)
 }

--- a/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyIssues.kt
+++ b/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyIssues.kt
@@ -4,7 +4,6 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.SManga
 import okhttp3.Request
-import okhttp3.Response
 import org.jsoup.nodes.Document
 
 class DynastyIssues : DynastyScans() {
@@ -13,9 +12,9 @@ class DynastyIssues : DynastyScans() {
 
     override val searchPrefix = "issues"
 
-    override fun popularMangaInitialUrl() = ""
+    override val categoryPrefix = "Issue"
 
-    private fun popularMangaInitialUrl(page: Int) = "$baseUrl/search?q=&classes%5B%5D=Issue&page=$page=$&sort="
+    override fun popularMangaInitialUrl() = ""
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         return GET("$baseUrl/search?q=$query&classes%5B%5D=Issue&sort=&page=$page", headers)
@@ -29,14 +28,4 @@ class DynastyIssues : DynastyScans() {
         parseDescription(document, manga)
         return manga
     }
-
-    override fun popularMangaRequest(page: Int): Request {
-        return GET(popularMangaInitialUrl(page), headers)
-    }
-
-    override fun popularMangaNextPageSelector() = searchMangaNextPageSelector()
-
-    override fun popularMangaSelector() = searchMangaSelector()
-
-    override fun popularMangaParse(response: Response) = searchMangaParse(response)
 }

--- a/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyScans.kt
+++ b/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyScans.kt
@@ -39,6 +39,8 @@ abstract class DynastyScans : ParsedHttpSource() {
 
     open val searchPrefix = ""
 
+    open val categoryPrefix = ""
+
     private var parent: List<Node> = ArrayList()
 
     private var list = InternalList(ArrayList(), "")
@@ -49,11 +51,13 @@ abstract class DynastyScans : ParsedHttpSource() {
 
     private val json: Json by injectLazy()
 
+    protected fun popularMangaInitialUrl(page: Int) = "$baseUrl/search?q=&classes%5B%5D=$categoryPrefix&page=$page=$&sort="
+
     override fun popularMangaRequest(page: Int): Request {
-        return GET(popularMangaInitialUrl(), headers)
+        return GET(popularMangaInitialUrl(page), headers)
     }
 
-    override fun popularMangaSelector() = "ul.thumbnails > li.span2"
+    override fun popularMangaSelector() = searchMangaSelector()
 
     override fun popularMangaFromElement(element: Element): SManga {
         val manga = SManga.create()
@@ -62,12 +66,7 @@ abstract class DynastyScans : ParsedHttpSource() {
         return manga
     }
 
-    override fun popularMangaParse(response: Response): MangasPage {
-        val mangas = response.asJsoup().select(popularMangaSelector()).map { element ->
-            popularMangaFromElement(element)
-        }
-        return MangasPage(mangas, false)
-    }
+    override fun popularMangaParse(response: Response) = searchMangaParse(response)
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
         if (query.startsWith("manga:")) {
@@ -249,7 +248,7 @@ abstract class DynastyScans : ParsedHttpSource() {
 
     data class Validate(val _isManga: Boolean, val _pos: Int)
 
-    override fun popularMangaNextPageSelector() = ""
+    override fun popularMangaNextPageSelector() = searchMangaNextPageSelector()
     override fun latestUpdatesSelector() = ""
     override fun latestUpdatesNextPageSelector() = ""
     override fun imageUrlParse(document: Document): String = ""

--- a/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastySeries.kt
+++ b/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastySeries.kt
@@ -5,6 +5,7 @@ import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.SManga
 import okhttp3.Request
+import okhttp3.Response
 import org.jsoup.nodes.Document
 import rx.Observable
 
@@ -14,7 +15,9 @@ class DynastySeries : DynastyScans() {
 
     override val searchPrefix = "series"
 
-    override fun popularMangaInitialUrl() = "$baseUrl/series?view=cover"
+    override fun popularMangaInitialUrl() = ""
+
+    private fun popularMangaInitialUrl(page: Int) = "$baseUrl/search?q=&classes%5B%5D=Series&page=$page=$&sort="
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         return GET("$baseUrl/search?q=$query&classes%5B%5D=Series&sort=&page=$page", headers)
@@ -38,4 +41,14 @@ class DynastySeries : DynastyScans() {
         parseDescription(document, manga)
         return manga
     }
+
+    override fun popularMangaRequest(page: Int): Request {
+        return GET(popularMangaInitialUrl(page), headers)
+    }
+
+    override fun popularMangaNextPageSelector() = searchMangaNextPageSelector()
+
+    override fun popularMangaSelector() = searchMangaSelector()
+
+    override fun popularMangaParse(response: Response) = searchMangaParse(response)
 }

--- a/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastySeries.kt
+++ b/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastySeries.kt
@@ -5,7 +5,6 @@ import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.SManga
 import okhttp3.Request
-import okhttp3.Response
 import org.jsoup.nodes.Document
 import rx.Observable
 
@@ -15,9 +14,9 @@ class DynastySeries : DynastyScans() {
 
     override val searchPrefix = "series"
 
-    override fun popularMangaInitialUrl() = ""
+    override val categoryPrefix = "Series"
 
-    private fun popularMangaInitialUrl(page: Int) = "$baseUrl/search?q=&classes%5B%5D=Series&page=$page=$&sort="
+    override fun popularMangaInitialUrl() = ""
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         return GET("$baseUrl/search?q=$query&classes%5B%5D=Series&sort=&page=$page", headers)
@@ -41,14 +40,4 @@ class DynastySeries : DynastyScans() {
         parseDescription(document, manga)
         return manga
     }
-
-    override fun popularMangaRequest(page: Int): Request {
-        return GET(popularMangaInitialUrl(page), headers)
-    }
-
-    override fun popularMangaNextPageSelector() = searchMangaNextPageSelector()
-
-    override fun popularMangaSelector() = searchMangaSelector()
-
-    override fun popularMangaParse(response: Response) = searchMangaParse(response)
 }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio

These fixes address two outstanding issues:

1. In all subextensions except `DynastyChapters`, browsing the category would never advance to the next page, only showing the content from the first page.
2. In `DynastyDoujins`, trying to access an entry that contains no chapters but does contain images [(example)](https://dynasty-scans.com/doujins/the_amazing_digital_circus) would result in an unhandled IndexOutOfBoundsException, preventing users from viewing the images as intended.