### PR TITLE
NetTruyen: Update domain

### DIFF
--- a/multisrc/overrides/wpcomics/nettruyen/src/NetTruyen.kt
+++ b/multisrc/overrides/wpcomics/nettruyen/src/NetTruyen.kt
@@ -9,7 +9,7 @@ import okhttp3.Request
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class NetTruyen : WPComics("NetTruyen", "https://www.nettruyenbing.com", "vi", SimpleDateFormat("dd/MM/yy", Locale.getDefault()), null) {
+class NetTruyen : WPComics("NetTruyen", "https://www.nettruyenclub.com", "vi", SimpleDateFormat("dd/MM/yy", Locale.getDefault()), null) {
     override fun headersBuilder(): Headers.Builder = Headers.Builder()
     override fun imageRequest(page: Page): Request = GET(page.imageUrl!!, headersBuilder().add("Referer", baseUrl).build())
     override fun getFilterList(): FilterList {

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpcomics/WPComicsGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpcomics/WPComicsGenerator.kt
@@ -12,7 +12,7 @@ class WPComicsGenerator : ThemeSourceGenerator {
     override val baseVersionCode: Int = 2
 
     override val sources = listOf(
-        SingleLang("NetTruyen", "https://www.nettruyenbing.com", "vi", overrideVersionCode = 20),
+        SingleLang("NetTruyen", "https://www.nettruyenclub.com", "vi", overrideVersionCode = 21),
         SingleLang("NhatTruyen", "https://nhattruyenmax.com", "vi", overrideVersionCode = 13),
         SingleLang("TruyenChon", "http://truyenchon.com", "vi", overrideVersionCode = 3),
         SingleLang("XOXO Comics", "https://xoxocomic.com", "en", className = "XoxoComics", overrideVersionCode = 3),


### PR DESCRIPTION
If I had a thousand VND every time NetTruyen changes its domain...

Closes #116

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
