### PR TITLE
ci: Properly configure the rest of issue moderator

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_report_issue.yml
+++ b/.github/ISSUE_TEMPLATE/01_report_issue.yml
@@ -95,7 +95,7 @@ body:
           required: true
         - label: I have written a short but informative title.
           required: true
-        - label: I have updated the app to version **[0.15.1](https://github.com/tachiyomiorg/tachiyomi/releases/latest)**.
+        - label: I have updated the app to version **[0.15.2](https://github.com/tachiyomiorg/tachiyomi/releases/latest)**.
           required: true
         - label: I have updated all installed extensions.
           required: true

--- a/.github/workflows/issue_moderator.yml
+++ b/.github/workflows/issue_moderator.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Moderate issues
         uses: tachiyomiorg/issue-moderator-action@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.ISSUE_MODERATOR_PAT }}
           duplicate-label: Duplicate
 
           blurbs: |

--- a/.github/workflows/issue_moderator.yml
+++ b/.github/workflows/issue_moderator.yml
@@ -16,6 +16,14 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           duplicate-label: Duplicate
 
+          blurbs: |
+            [
+              {
+                "keywords": ["cf", "cloudflare"],
+                "message": "Refer to the **Solving Cloudflare issues** section at https://tachiyomi.org/docs/guides/troubleshooting/#cloudflare. If it doesn't work, migrate to other sources or wait until they lower their protection."
+              }
+            ]
+
           duplicate-check-enabled: true
           duplicate-check-labels: |
             ["Source request", "Domain changed"]
@@ -23,6 +31,7 @@ jobs:
           existing-check-enabled: true
           existing-check-labels: |
             ["Source request", "Domain changed"]
+          existing-check-repo-url: https://raw.githubusercontent.com/keiyoushi/extensions/repo/index.min.json
 
           auto-close-rules: |
             [


### PR DESCRIPTION
- Add a blurb for Cloudflare `/blurb cf`
- Point issue moderator to the correct repo URL so the existing extension check works
- Move to a separate token for issue moderation. The token only has access to keiyoushi/extensions-source and these permissions:
  - Read access to members 
  - Read access to metadata  
  - Read and Write access to issues 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
