### PR TITLE
[meta] Create a Codeberg mirror

### DIFF
--- a/.github/workflows/codeberg_mirror.yml
+++ b/.github/workflows/codeberg_mirror.yml
@@ -12,7 +12,7 @@ jobs:
   codeberg:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: pixta-dev/repository-mirroring-action@v1

--- a/.github/workflows/codeberg_mirror.yml
+++ b/.github/workflows/codeberg_mirror.yml
@@ -1,0 +1,21 @@
+# Sync repo to the Codeberg mirror
+name: Mirror Sync
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch: # Manual dispatch
+  schedule:
+    - cron: "0 */8 * * *"
+
+jobs:
+  codeberg:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: pixta-dev/repository-mirroring-action@v1
+        with:
+          target_repo_url: "git@codeberg.org:keiyoushi/extensions-source.git"
+          ssh_private_key: ${{ secrets.CODEBERG_SSH }}


### PR DESCRIPTION
Codeberg mirror for a contingency plan if we ever got screwed over.

Mirror is already set up at https://codeberg.org/keiyoushi/extensions-source.

This PR adds an action for syncing the repo between GitHub and Codeberg. `secrets.CODEBERG_SSH` has already been set up.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
