### PR TITLE
Update domain for TonizuToon

### DIFF
--- a/multisrc/overrides/madara/tonizutoon/src/TonizuToon.kt
+++ b/multisrc/overrides/madara/tonizutoon/src/TonizuToon.kt
@@ -6,7 +6,17 @@ import java.util.Locale
 
 class TonizuToon : Madara(
     "TonizuToon",
-    "https://tonizutoon.com",
+    "https://tonizu.com",
     "tr",
-    SimpleDateFormat("MMMMM d, yyyy", Locale("tr")),
-)
+    dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.ROOT),
+) {
+    override val useNewChapterEndpoint = true
+
+    override val mangaDetailsSelectorTitle = "#manga-title"
+
+    override val mangaDetailsSelectorAuthor = ".summary-heading:contains(Yazar) ~ .summary-content"
+
+    override val mangaDetailsSelectorStatus = ".summary-heading:contains(Durumu) ~ .summary-content"
+
+    override fun searchPage(page: Int): String = if (page == 1) "" else "page/$page/"
+}

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
@@ -467,24 +467,27 @@ abstract class Madara(
         "مكتملة",
         "مكتمل",
         "已完结",
+        "Tamamlandı",
     )
 
     protected val ongoingStatusList: Array<String> = arrayOf(
         "OnGoing", "Продолжается", "Updating", "Em Lançamento", "Em lançamento", "Em andamento",
         "Em Andamento", "En cours", "En Cours", "En cours de publication", "Ativo", "Lançando", "Đang Tiến Hành", "Devam Ediyor",
         "Devam ediyor", "In Corso", "In Arrivo", "مستمرة", "مستمر", "En Curso", "En curso", "Emision",
-        "Curso", "En marcha", "Publicandose", "En emision", "连载中", "Em Lançamento",
+        "Curso", "En marcha", "Publicandose", "En emision", "连载中", "Em Lançamento", "Devam Ediyo",
     )
 
     protected val hiatusStatusList: Array<String> = arrayOf(
         "On Hold",
         "Pausado",
         "En espera",
+        "Durduruldu",
     )
 
     protected val canceledStatusList: Array<String> = arrayOf(
         "Canceled",
         "Cancelado",
+        "İptal Edildi",
     )
 
     override fun mangaDetailsParse(document: Document): SManga {

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -455,7 +455,7 @@ class MadaraGenerator : ThemeSourceGenerator {
         SingleLang("The Guild", "https://theguildscans.com", "en"),
         SingleLang("Time Naight", "https://timenaight.com", "tr"),
         SingleLang("Todaymic", "https://todaymic.com", "en", overrideVersionCode = 1),
-        SingleLang("TonizuToon", "https://tonizutoon.com", "tr", isNsfw = true),
+        SingleLang("TonizuToon", "https://tonizu.com", "tr", isNsfw = true, overrideVersionCode = 1),
         SingleLang("ToonChill", "https://toonchill.com", "en", overrideVersionCode = 1),
         SingleLang("ToonGod", "https://www.toongod.org", "en", isNsfw = true, overrideVersionCode = 5),
         SingleLang("Toonily", "https://toonily.com", "en", isNsfw = true, overrideVersionCode = 11),


### PR DESCRIPTION
Closes #88

While changes have been made to the base Madara class, I don't believe the changes warrant bumping the base version. Let me know if you want it bumped regardless.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
