### PR TITLE
Fix popular selector for Mundo Hentai

### DIFF
--- a/src/pt/mundohentai/build.gradle
+++ b/src/pt/mundohentai/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Mundo Hentai'
     pkgNameSuffix = 'pt.mundohentai'
     extClass = '.MundoHentai'
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = true
 }
 

--- a/src/pt/mundohentai/src/eu/kanade/tachiyomi/extension/pt/mundohentai/MundoHentai.kt
+++ b/src/pt/mundohentai/src/eu/kanade/tachiyomi/extension/pt/mundohentai/MundoHentai.kt
@@ -56,7 +56,7 @@ class MundoHentai : ParsedHttpSource() {
         return GET("$baseUrl/category/doujinshi/$pageStr", newHeaders)
     }
 
-    override fun popularMangaSelector(): String = "div.lista > ul > li div.thumb-conteudo:has(a[href^=$baseUrl]:has(span.thumb-imagem)):not(:contains(Tufos))"
+    override fun popularMangaSelector(): String = "div.lista > ul > li div.thumb-conteudo:has(a[href^=$baseUrl]):not(:contains(Tufos))"
 
     override fun popularMangaFromElement(element: Element): SManga = genericMangaFromElement(element)
 


### PR DESCRIPTION
Closes #103

Issue might be caused by a regression in Jsoup. Did not investigate further as the additional condition was not necessary.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
