### PR TITLE
YMO: fix selectors

### DIFF
--- a/src/all/yaoimangaonline/build.gradle
+++ b/src/all/yaoimangaonline/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Yaoi Manga Online'
     pkgNameSuffix = 'all.yaoimangaonline'
     extClass = '.YaoiMangaOnline'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/all/yaoimangaonline/src/eu/kanade/tachiyomi/extension/all/yaoimangaonline/YaoiMangaOnline.kt
+++ b/src/all/yaoimangaonline/src/eu/kanade/tachiyomi/extension/all/yaoimangaonline/YaoiMangaOnline.kt
@@ -67,26 +67,25 @@ class YaoiMangaOnline : ParsedHttpSource() {
         SManga.create().apply {
             title = element.attr("title")
             setUrlWithoutDomain(element.attr("href"))
-            thumbnail_url = element.selectFirst("img")!!.attr("src")
+            thumbnail_url = element.selectFirst("img")?.attr("src")
         }
 
     override fun mangaDetailsParse(document: Document) =
         SManga.create().apply {
-            title = document.selectFirst(".entry-title")!!.text()
-            thumbnail_url = document.head()
-                .selectFirst("meta[property=og:image]")!!.attr("content")
-            description = document.selectFirst(".entry-content > p")!!
-                .html().replace("<br> ", "\n")
+            title = document.select("h1.entry-title").text()
+            thumbnail_url = document
+                .selectFirst(".herald-post-thumbnail img")?.attr("src")
+            description = document.select(".entry-content > p").text()
             genre = document.select(".meta-tags > a").joinToString { it.text() }
         }
 
-    override fun chapterListSelector() = "#acp_paging_menu > li"
+    override fun chapterListSelector() = ".mpp-toc a"
 
     override fun chapterFromElement(element: Element) =
         SChapter.create().apply {
-            name = element.selectFirst(".acp_title")!!.text()
+            name = element.ownText()
             setUrlWithoutDomain(
-                element.selectFirst("a")?.attr("href") ?: element.baseUri(),
+                element.attr("href") ?: element.baseUri(),
             )
         }
 
@@ -96,10 +95,10 @@ class YaoiMangaOnline : ParsedHttpSource() {
                 name = "Chapter"
                 url = response.request.url.encodedPath
             }.let(::listOf)
-        }
+        }.reversed()
 
     override fun pageListParse(document: Document) =
-        document.select(".size-full").mapIndexed { idx, img ->
+        document.select(".entry-content img").mapIndexed { idx, img ->
             Page(idx, "", img.attr("src"))
         }
 


### PR DESCRIPTION
closes #130

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
