### PR TITLE
ci: Use keiyoushi-bot for deploying extensions

### DIFF
--- a/.github/scripts/commit-repo.sh
+++ b/.github/scripts/commit-repo.sh
@@ -2,8 +2,8 @@
 set -e
 
 rsync -a --delete --exclude .git --exclude .gitignore --exclude README.md ../main/repo/ .
-git config --global user.email "107297513+FourTOne5@users.noreply.github.com"
-git config --global user.name "FourTOne5"
+git config --global user.email "156378334+keiyoushi-bot@users.noreply.github.com"
+git config --global user.name "keiyoushi-bot"
 git status
 if [ -n "$(git status --porcelain)" ]; then
     git add .


### PR DESCRIPTION
`secrets.BOT_PAT` has also been changed to use @keiyoushi-bot's token instead.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
