### PR TITLE
Ler Manga: Escape HTML entities in titles

### DIFF
--- a/src/pt/lermanga/build.gradle
+++ b/src/pt/lermanga/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Ler Mangá'
     pkgNameSuffix = 'pt.lermanga'
     extClass = '.LerManga'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/pt/lermanga/src/eu/kanade/tachiyomi/extension/pt/lermanga/LerMangaDto.kt
+++ b/src/pt/lermanga/src/eu/kanade/tachiyomi/extension/pt/lermanga/LerMangaDto.kt
@@ -4,6 +4,7 @@ import eu.kanade.tachiyomi.source.model.SManga
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.jsoup.Jsoup
+import org.jsoup.nodes.Entities
 
 @Serializable
 data class LmMangaDto(
@@ -14,7 +15,7 @@ data class LmMangaDto(
 ) {
 
     fun toSManga(): SManga = SManga.create().apply {
-        title = this@LmMangaDto.title.rendered
+        title = Entities.unescape(this@LmMangaDto.title.rendered)
         thumbnail_url = "${LerManga.IMG_CDN_URL}/${slug.first().uppercase()}/$slug/capa.jpg"
         description = content?.rendered?.let { Jsoup.parseBodyFragment(it) }?.text()?.trim()
         genre = embedded?.wpTerm.orEmpty().flatten()


### PR DESCRIPTION
Closes #182 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
