### PR TITLE
Nexo Scans: Fix chapter parsing

### DIFF
--- a/multisrc/overrides/madara/nexoscans/src/NexoScans.kt
+++ b/multisrc/overrides/madara/nexoscans/src/NexoScans.kt
@@ -3,15 +3,22 @@ package eu.kanade.tachiyomi.extension.pt.nexoscans
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import okhttp3.OkHttpClient
+import java.text.SimpleDateFormat
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 class NexoScans : Madara(
     "Nexo Scans",
     "https://nexoscans.com",
     "pt-BR",
+    SimpleDateFormat("dd/MM/yyyy", Locale.US),
 ) {
 
     override val client: OkHttpClient = super.client.newBuilder()
         .rateLimit(1, 2, TimeUnit.SECONDS)
         .build()
+
+    override val useNewChapterEndpoint = true
+
+    override val chapterUrlSelector = "a:not(div.chapter-thumbnail a)"
 }

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -371,7 +371,7 @@ class MadaraGenerator : ThemeSourceGenerator {
         SingleLang("NekoPost.co (unoriginal)", "https://www.nekopost.co", "th", isNsfw = false, className = "NekoPostCo"),
         SingleLang("NekoScan", "https://nekoscan.com", "en", overrideVersionCode = 2),
         SingleLang("NewManhua", "https://newmanhua.com", "en", isNsfw = true),
-        SingleLang("Nexo Scans", "https://nexoscans.com", "pt-BR"),
+        SingleLang("Nexo Scans", "https://nexoscans.com", "pt-BR", overrideVersionCode = 1),
         SingleLang("Night Comic", "https://www.nightcomic.com", "en", overrideVersionCode = 1),
         SingleLang("Niji Translations", "https://niji-translations.com", "ar", overrideVersionCode = 1),
         SingleLang("Nitro Manga", "https://nitromanga.com", "en", className = "NitroScans", overrideVersionCode = 1),


### PR DESCRIPTION
Closes #260

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
