### PR TITLE
COLAMANGA: fix unencrypted image error

### DIFF
--- a/src/zh/onemanhua/build.gradle
+++ b/src/zh/onemanhua/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'COLAMANGA'
     pkgNameSuffix = 'zh.onemanhua'
     extClass = '.Onemanhua'
-    extVersionCode = 13
+    extVersionCode = 14
 }
 
 dependencies {

--- a/src/zh/onemanhua/src/eu/kanade/tachiyomi/extension/zh/onemanhua/Onemanhua.kt
+++ b/src/zh/onemanhua/src/eu/kanade/tachiyomi/extension/zh/onemanhua/Onemanhua.kt
@@ -437,7 +437,11 @@ class Onemanhua : ConfigurableSource, ParsedHttpSource() {
             if (imageUrl.startsWith("//")) {
                 imageUrl = "https:$imageUrl"
             }
-            Page(i, imageUrl = imageUrl + "#key=$key")
+            // Empty key means image is not encrypted
+            if (key != "") {
+                imageUrl = "$imageUrl#key=$key"
+            }
+            Page(i, imageUrl = imageUrl)
         }
     }
 


### PR DESCRIPTION
Some images are not encrypted.

For example:
https://www.colamanga.com/manga-df707095/1/441.html
https://img.colamanga.com/comic/12221/SnpGUENQWFRYajhRemRvYm1KK3FZR2xYZkFMZXhNa25oTkRMMHREek9QQT0=/0001.jpg

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
