### PR TITLE
Anchira - Add tag grouping, allow to get the source URL without the keys

### DIFF
--- a/src/en/anchira/build.gradle
+++ b/src/en/anchira/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anchira'
     extClass = '.Anchira'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/en/anchira/src/eu/kanade/tachiyomi/extension/en/anchira/AnchiraDto.kt
+++ b/src/en/anchira/src/eu/kanade/tachiyomi/extension/en/anchira/AnchiraDto.kt
@@ -48,14 +48,8 @@ data class ImageData(
 @Serializable
 data class EntryKey(
     val id: Int,
-    val key: String,
-    val hash: String,
-    val url: String?,
+    val key: String? = null,
+    val hash: String? = null,
+    val url: String? = null,
     val names: List<String> = emptyList(),
-)
-
-@Serializable
-data class AnchiraData(
-    val key: String,
-    val galleries: List<EntryKey>,
 )

--- a/src/en/anchira/src/eu/kanade/tachiyomi/extension/en/anchira/AnchiraHelper.kt
+++ b/src/en/anchira/src/eu/kanade/tachiyomi/extension/en/anchira/AnchiraHelper.kt
@@ -1,34 +1,28 @@
 package eu.kanade.tachiyomi.extension.en.anchira
 
-import android.util.Base64
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.json.Json
-import okhttp3.ResponseBody
-import okio.ByteString.Companion.decodeBase64
-
 object AnchiraHelper {
-    const val KEY = "ZnVja19uaWdnZXJzX2FuZF9mYWdnb3RzLF9hbmRfZGVhdGhfdG9fYWxsX2pld3M="
-
-    val json = Json { ignoreUnknownKeys = true }
-
     fun getPathFromUrl(url: String) = "${url.split("/").reversed()[1]}/${url.split("/").last()}"
 
-    inline fun <reified T> decodeBytes(body: ResponseBody, key: String = KEY): T {
-        val encryptedText = body.string().decodeBase64()!!
-        return json.decodeFromString(
-            XXTEA.decryptToString(
-                encryptedText.toByteArray(),
-                key = Base64.decode(key, Base64.DEFAULT).decodeToString(),
-            )!!,
-        )
-    }
-
-    fun prepareTags(tags: List<Tag>) = tags.map {
+    fun prepareTags(tags: List<Tag>, group: Boolean) = tags.map {
         if (it.namespace == null) {
             it.namespace = 6
         }
         it
-    }.sortedBy { it.namespace }.map {
-        return@map it.name.lowercase()
-    }.joinToString(", ") { it }
+    }
+        .sortedBy { it.namespace }
+        .map {
+            val tag = it.name.lowercase()
+            return@map if (group) {
+                when (it.namespace) {
+                    1 -> "artist:$tag"
+                    2 -> "circle:$tag"
+                    3 -> "parody:$tag"
+                    4 -> "magazine:$tag"
+                    else -> "tag:$tag"
+                }
+            } else {
+                tag
+            }
+        }
+        .joinToString(", ") { it }
 }


### PR DESCRIPTION
- Added a tag grouping feature that can be enabled in preferences.
- Allowed users to open the original source for the gallery without the data file having the keys or hash.
- Changed to wording of the original source preference.
- Removed unused code.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
