### PR TITLE
Mangaku: use `by lazy` for loading assets

### DIFF
--- a/src/id/mangaku/src/eu/kanade/tachiyomi/extension/id/mangaku/Mangaku.kt
+++ b/src/id/mangaku/src/eu/kanade/tachiyomi/extension/id/mangaku/Mangaku.kt
@@ -204,7 +204,6 @@ class Mangaku : ParsedHttpSource() {
         latch.await(5, TimeUnit.SECONDS)
         handler.post { webView?.destroy() }
 
-
         if (latch.count == 1L) {
             throw Exception("Kehabisan waktu saat men-decrypt tautan gambar") //Timeout while decrypting image links
         }
@@ -238,10 +237,15 @@ class Mangaku : ParsedHttpSource() {
         }
     }
 
-    private val jQueryScript = javaClass
-        .getResource("/assets/zepto.min.js")!!
-        .readText() // Zepto v1.2.0 (jQuery compatible)
-    private val cryptoJSScript = javaClass
-        .getResource("/assets/crypto-js.min.js")!!
-        .readText() // CryptoJS v4.0.0 (on site: cpr2.js)
+    private val jQueryScript by lazy {
+        javaClass
+            .getResource("/assets/zepto.min.js")!!
+            .readText() // Zepto v1.2.0 (jQuery compatible)
+    }
+
+    private val cryptoJSScript by lazy {
+        javaClass
+            .getResource("/assets/crypto-js.min.js")!!
+            .readText() // CryptoJS v4.0.0 (on site: cpr2.js)
+    }
 }


### PR DESCRIPTION
No idea if this fixes the issue in CI. The extension still works when testing locally. Did not bump the version since the last build failed.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
