### PR TITLE
PicaComic: Fix bad base64

### DIFF
--- a/src/zh/picacomic/build.gradle
+++ b/src/zh/picacomic/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Picacomic'
     extClass = '.Picacomic'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/zh/picacomic/src/eu/kanade/tachiyomi/extension/zh/picacomic/PicaApiSchemas.kt
+++ b/src/zh/picacomic/src/eu/kanade/tachiyomi/extension/zh/picacomic/PicaApiSchemas.kt
@@ -22,6 +22,12 @@ data class PicaResponse(
 )
 
 @Serializable
+data class PicaJWTPayload(
+    val exp: Long? = null,
+    val iat: Long? = null,
+)
+
+@Serializable
 data class PicaData(
     // /comics/advanced-search: PicaSearchComics
     // /comics/random: List<PicaSearchComic>

--- a/src/zh/picacomic/src/eu/kanade/tachiyomi/extension/zh/picacomic/Picacomic.kt
+++ b/src/zh/picacomic/src/eu/kanade/tachiyomi/extension/zh/picacomic/Picacomic.kt
@@ -26,7 +26,6 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
-import org.json.JSONObject
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.net.URLEncoder
@@ -100,12 +99,19 @@ class Picacomic : HttpSource(), ConfigurableSource {
             )
         }
 
-        val payload = parts[1]?.let { JSONObject(Base64.decode(it, Base64.DEFAULT).toString(Charsets.UTF_8)) }
+        val payload = parts[1]?.let {
+            json.decodeFromString<PicaJWTPayload>(
+                Base64.decode(
+                    it,
+                    Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING,
+                ).toString(Charsets.UTF_8),
+            )
+        }
 
-        val exp = payload?.getLong("exp")?.let {
+        val exp = payload?.exp?.let {
             Date(it * 1000)
         }
-        val iat = payload?.getLong("iat")?.let {
+        val iat = payload?.iat?.let {
             Date(it * 1000)
         }
 


### PR DESCRIPTION
Closes #274
Can't replicate but basically copy the decoding from [JWT Library](https://github.com/auth0/JWTDecode.Android/blob/ec4b54496e684c5fb9e65f5ebb36e6241ef46161/lib/src/main/java/com/auth0/android/jwt/JWT.java#L234) and remove the org.json dependency

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
