### PR TITLE
Switch to in-organization extensions inspector

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -188,7 +188,7 @@ jobs:
         run: |
           cd main
           python ./.github/scripts/move-apks.py
-          INSPECTOR_LINK="$(curl -s "https://api.github.com/repos/tachiyomiorg/tachiyomi-extensions-inspector/releases/latest" | jq -r '.assets[0].browser_download_url')"
+          INSPECTOR_LINK="$(curl -s "https://api.github.com/repos/keiyoushi/extensions-inspector/releases/latest" | jq -r '.assets[0].browser_download_url')"
           curl -L "$INSPECTOR_LINK" -o ./Inspector.jar
           java -jar ./Inspector.jar "repo/apk" "output.json" "tmp"
           python ./.github/scripts/create-repo.py


### PR DESCRIPTION
Currently, it has a fix for APK files with assets, which addresses the build failure in https://github.com/keiyoushi/extensions-source/commit/537a544c19cfa7e47c38540ec895d64bee7d05ab. Will probably have more stuff in the future.
