### PR TITLE
Manga-Scan: Fix manga name with useless words

### DIFF
--- a/multisrc/overrides/mmrcms/mangascan/src/MangaScan.kt
+++ b/multisrc/overrides/mmrcms/mangascan/src/MangaScan.kt
@@ -6,6 +6,13 @@ import eu.kanade.tachiyomi.source.model.Page
 import okhttp3.Request
 
 class MangaScan : MMRCMS("Manga-Scan", "https://mangascan-fr.com", "fr") {
+
+    override fun mangaDetailsParse(response: Response): SManga {
+        return super.mangaDetailsParse(response).apply {
+            title = title.substringBefore("Chapitres en ligne").substringAfter("Scan").trim()
+        }
+    }
+
     override fun imageRequest(page: Page): Request {
         val newHeaders = headersBuilder()
             .set("Referer", baseUrl)

--- a/multisrc/overrides/mmrcms/mangascan/src/MangaScan.kt
+++ b/multisrc/overrides/mmrcms/mangascan/src/MangaScan.kt
@@ -3,7 +3,9 @@ package eu.kanade.tachiyomi.extension.fr.mangascan
 import eu.kanade.tachiyomi.multisrc.mmrcms.MMRCMS
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SManga
 import okhttp3.Request
+import okhttp3.Response
 
 class MangaScan : MMRCMS("Manga-Scan", "https://mangascan-fr.com", "fr") {
 

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mmrcms/MMRCMSGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mmrcms/MMRCMSGenerator.kt
@@ -27,7 +27,7 @@ class MMRCMSGenerator : ThemeSourceGenerator {
         SingleLang("MangaID", "https://mangaid.click", "id", overrideVersionCode = 1),
         SingleLang("Jpmangas", "https://jpmangas.xyz", "fr", overrideVersionCode = 2),
         SingleLang("Manga-FR", "https://manga-fr.cc", "fr", className = "MangaFR", overrideVersionCode = 2),
-        SingleLang("Manga-Scan", "https://mangascan-fr.com", "fr", className = "MangaScan", overrideVersionCode = 3),
+        SingleLang("Manga-Scan", "https://mangascan-fr.com", "fr", className = "MangaScan", overrideVersionCode = 4),
         SingleLang("Ama Scans", "https://amascan.com", "pt-BR", isNsfw = true, overrideVersionCode = 2),
         SingleLang("Bentoscan", "https://bentoscan.com", "fr"),
         // NOTE: THIS SOURCE CONTAINS A CUSTOM LANGUAGE SYSTEM (which will be ignored)!


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
