### PR TITLE
Pin all external GitHub actions to their SHA

### DIFF
--- a/.github/workflows/batch_close_issues.yml
+++ b/.github/workflows/batch_close_issues.yml
@@ -8,18 +8,19 @@ on:
   workflow_dispatch:
     inputs:
 
+
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v9
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        # Close everything older than a year
-        days-before-issue-stale: 365
-        days-before-issue-close: 0
-        exempt-issue-labels: "do-not-autoclose,Meta request"
-        close-issue-message: "In an effort to have a more manageable issue backlog, we're closing older requests that weren't addressed since there's a low chance of it being addressed if it hasn't already. If your request is still relevant, please [open a new request](https://github.com/keiyoushi/extensions-source/issues/new/choose)."
-        close-issue-reason: not_planned
-        ascending: true
-        operations-per-run: 250
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # Close everything older than a year
+          days-before-issue-stale: 365
+          days-before-issue-close: 0
+          exempt-issue-labels: "do-not-autoclose,Meta request"
+          close-issue-message: "In an effort to have a more manageable issue backlog, we're closing older requests that weren't addressed since there's a low chance of it being addressed if it hasn't already. If your request is still relevant, please [open a new request](https://github.com/keiyoushi/extensions-source/issues/new/choose)."
+          close-issue-reason: not_planned
+          ascending: true
+          operations-per-run: 250

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -26,20 +26,20 @@ jobs:
       CI_MODULE_GEN: true
     steps:
       - name: Clone repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4 # v1
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4
         with:
           java-version: 17
           distribution: temurin
 
       - id: get-changed-files
         name: Get changed files
-        uses: Ana06/get-changed-files@v2.2.0
+        uses: Ana06/get-changed-files@e0c398b7065a8d84700c471b6afc4116d1ba4e96 # v2.2.0
 
       - id: parse-changed-files
         name: Parse changed files
@@ -66,7 +66,7 @@ jobs:
 
       - name: Generate multisrc sources
         if: ${{ steps.parse-changed-files.outputs.isMultisrcChanged == '1' }}
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@982da8e78c05368c70dac0351bb82647a9e9a5d2 # v2
         with:
           arguments: :multisrc:generateExtensions
 
@@ -80,7 +80,7 @@ jobs:
 
       - id: generate-matrices
         name: Create output matrices
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           script: |
             const numIndividualModules = process.env.NUM_INDIVIDUAL_MODULES;
@@ -105,16 +105,16 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare.outputs.multisrcMatrix) }}
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4
         with:
           java-version: 17
           distribution: temurin
 
       - name: Generate sources from the multi-source library
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@982da8e78c05368c70dac0351bb82647a9e9a5d2 # v2
         env:
           CI_MODULE_GEN: "true"
         with:
@@ -122,7 +122,7 @@ jobs:
           cache-read-only: true
 
       - name: Build extensions (chunk ${{ matrix.chunk }})
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@982da8e78c05368c70dac0351bb82647a9e9a5d2 # v2
         env:
           CI_MULTISRC: "true"
           CI_CHUNK_NUM: ${{ matrix.chunk }}
@@ -139,16 +139,16 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare.outputs.individualMatrix) }}
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4
         with:
           java-version: 17
           distribution: temurin
 
       - name: Build extensions (chunk ${{ matrix.chunk }})
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@982da8e78c05368c70dac0351bb82647a9e9a5d2 # v2
         env:
           CI_MULTISRC: "false"
           CI_CHUNK_NUM: ${{ matrix.chunk }}

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -26,19 +26,19 @@ jobs:
       CI_MODULE_GEN: true
     steps:
       - name: Clone repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4 # v1
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4
         with:
           java-version: 17
           distribution: temurin
 
       - name: Generate multisrc sources
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@982da8e78c05368c70dac0351bb82647a9e9a5d2 # v2
         with:
           arguments: :multisrc:generateExtensions
 
@@ -52,7 +52,7 @@ jobs:
 
       - id: generate-matrices
         name: Create output matrices
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           script: |
             const numIndividualModules = process.env.NUM_INDIVIDUAL_MODULES;
@@ -76,10 +76,10 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare.outputs.multisrcMatrix) }}
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4
         with:
           java-version: 17
           distribution: temurin
@@ -89,14 +89,14 @@ jobs:
           echo ${{ secrets.SIGNING_KEY }} | base64 -d > signingkey.jks
 
       - name: Generate sources from the multi-source library
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@982da8e78c05368c70dac0351bb82647a9e9a5d2 # v2
         env:
           CI_MODULE_GEN: "true"
         with:
           arguments: :multisrc:generateExtensions
 
       - name: Build extensions (chunk ${{ matrix.chunk }})
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@982da8e78c05368c70dac0351bb82647a9e9a5d2 # v2
         env:
           CI_MULTISRC: "true"
           CI_CHUNK_NUM: ${{ matrix.chunk }}
@@ -107,7 +107,7 @@ jobs:
           arguments: assembleRelease
 
       - name: Upload APKs (chunk ${{ matrix.chunk }})
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6 # v4
         if: "github.repository == 'keiyoushi/extensions-source'"
         with:
           name: "multisrc-apks-${{ matrix.chunk }}"
@@ -125,10 +125,10 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare.outputs.individualMatrix) }}
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4
         with:
           java-version: 17
           distribution: temurin
@@ -138,7 +138,7 @@ jobs:
           echo ${{ secrets.SIGNING_KEY }} | base64 -d > signingkey.jks
 
       - name: Build extensions (chunk ${{ matrix.chunk }})
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@982da8e78c05368c70dac0351bb82647a9e9a5d2 # v2
         env:
           CI_MULTISRC: "false"
           CI_CHUNK_NUM: ${{ matrix.chunk }}
@@ -149,7 +149,7 @@ jobs:
           arguments: assembleRelease
 
       - name: Upload APKs (chunk ${{ matrix.chunk }})
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6 # v4
         if: "github.repository == 'keiyoushi/extensions-source'"
         with:
           name: "individual-apks-${{ matrix.chunk }}"
@@ -168,18 +168,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download APK artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4
         with:
           path: ~/apk-artifacts
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4
         with:
           java-version: 17
           distribution: temurin
 
       - name: Checkout main branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           ref: main
           path: main
@@ -194,7 +194,7 @@ jobs:
           python ./.github/scripts/create-repo.py
 
       - name: Checkout repo branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           repository: keiyoushi/extensions
           token: ${{ secrets.BOT_PAT }}

--- a/.github/workflows/codeberg_mirror.yml
+++ b/.github/workflows/codeberg_mirror.yml
@@ -3,7 +3,7 @@ name: Mirror Sync
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
   workflow_dispatch: # Manual dispatch
   schedule:
     - cron: "0 */8 * * *"
@@ -12,10 +12,10 @@ jobs:
   codeberg:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           fetch-depth: 0
-      - uses: pixta-dev/repository-mirroring-action@v1
+      - uses: pixta-dev/repository-mirroring-action@674e65a7d483ca28dafaacba0d07351bdcc8bd75 # v1
         with:
           target_repo_url: "git@codeberg.org:keiyoushi/extensions-source.git"
           ssh_private_key: ${{ secrets.CODEBERG_SSH }}

--- a/.github/workflows/issue_moderator.yml
+++ b/.github/workflows/issue_moderator.yml
@@ -2,16 +2,16 @@ name: Issue moderator
 
 on:
   issues:
-    types: [opened, edited, reopened]
+    types: [ opened, edited, reopened ]
   issue_comment:
-    types: [created]
+    types: [ created ]
 
 jobs:
   autoclose:
     runs-on: ubuntu-latest
     steps:
       - name: Moderate issues
-        uses: tachiyomiorg/issue-moderator-action@v2
+        uses: tachiyomiorg/issue-moderator-action@39b363606e00c4ae39a15b3705a63535cd428c15 # v2
         with:
           repo-token: ${{ secrets.ISSUE_MODERATOR_PAT }}
           duplicate-label: Duplicate

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -8,11 +8,12 @@ on:
   workflow_dispatch:
     inputs:
 
+
 jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v5
+      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: '2'


### PR DESCRIPTION
Rationale: https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash (TL;DR: Git tags are mutable and a malicious actor could change what the tag points to.)

Getting the SHA of actions can be automated by [pin-github-action](https://github.com/mheap/pin-github-action), and if there is a need to update actions in the future Renovate can [handle it](https://docs.renovatebot.com/modules/manager/github-actions/).