### PR TITLE
Shinigami: Fix chapter URL selector

### DIFF
--- a/multisrc/overrides/madara/shinigami/src/Shinigami.kt
+++ b/multisrc/overrides/madara/shinigami/src/Shinigami.kt
@@ -51,6 +51,8 @@ class Shinigami : Madara("Shinigami", "https://shinigamitoon.com", "id") {
     // Tags are useless as they are just SEO keywords.
     override val mangaDetailsSelectorTag = ""
 
+    override val chapterUrlSelector = "a:not([href*=troll-page])"
+
     override fun chapterFromElement(element: Element): SChapter = SChapter.create().apply {
         val urlElement = element.selectFirst(chapterUrlSelector)!!
 

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -442,7 +442,7 @@ class MadaraGenerator : ThemeSourceGenerator {
         SingleLang("Shayami", "https://shayami.com", "es"),
         SingleLang("Shiba Manga", "https://shibamanga.com", "en"),
         SingleLang("Shield Manga", "https://shieldmanga.io", "en", overrideVersionCode = 3),
-        SingleLang("Shinigami", "https://shinigamitoon.com", "id", overrideVersionCode = 12),
+        SingleLang("Shinigami", "https://shinigamitoon.com", "id", overrideVersionCode = 13),
         SingleLang("Shooting Star Scans", "https://shootingstarscans.com", "en"),
         SingleLang("ShoujoHearts", "https://shoujohearts.com", "en", overrideVersionCode = 2),
         SingleLang("Sinensis Scan", "https://sinensisscan.net", "pt-BR", pkgName = "sinensis", overrideVersionCode = 6),


### PR DESCRIPTION
Closes #415 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
