### PR TITLE
Madara, WPMangaThemesia: add CloudFlare lazy-load images parsing

### DIFF
--- a/multisrc/overrides/madara/lectormangalat/src/LectorMangaLat.kt
+++ b/multisrc/overrides/madara/lectormangalat/src/LectorMangaLat.kt
@@ -6,7 +6,6 @@ import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import okhttp3.FormBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.concurrent.TimeUnit
@@ -62,5 +61,4 @@ class LectorMangaLat : Madara(
     }
 
     override val pageListParseSelector = "div.reading-content div.page-break > img"
-
 }

--- a/multisrc/overrides/madara/lectormangalat/src/LectorMangaLat.kt
+++ b/multisrc/overrides/madara/lectormangalat/src/LectorMangaLat.kt
@@ -63,13 +63,4 @@ class LectorMangaLat : Madara(
 
     override val pageListParseSelector = "div.reading-content div.page-break > img"
 
-    override fun imageFromElement(element: Element): String? {
-        return when {
-            element.hasAttr("data-cfsrc") -> element.attr("abs:data-cfsrc")
-            element.hasAttr("data-src") -> element.attr("abs:data-src")
-            element.hasAttr("data-lazy-src") -> element.attr("abs:data-lazy-src")
-            element.hasAttr("srcset") -> element.attr("abs:srcset").substringBefore(" ")
-            else -> element.attr("abs:src")
-        }
-    }
 }

--- a/multisrc/overrides/madara/mangareadorg/src/MangaReadOrg.kt
+++ b/multisrc/overrides/madara/mangareadorg/src/MangaReadOrg.kt
@@ -10,14 +10,4 @@ class MangaReadOrg : Madara(
     "https://www.mangaread.org",
     "en",
     SimpleDateFormat("dd.MM.yyy", Locale.US),
-) {
-    override fun imageFromElement(element: Element): String? {
-        return when {
-            element.hasAttr("data-cfsrc") -> element.attr("abs:data-cfsrc")
-            element.hasAttr("data-src") -> element.attr("abs:data-src")
-            element.hasAttr("data-lazy-src") -> element.attr("abs:data-lazy-src")
-            element.hasAttr("srcset") -> element.attr("abs:srcset").substringBefore(" ")
-            else -> element.attr("abs:src")
-        }
-    }
-}
+)

--- a/multisrc/overrides/madara/mangareadorg/src/MangaReadOrg.kt
+++ b/multisrc/overrides/madara/mangareadorg/src/MangaReadOrg.kt
@@ -1,7 +1,6 @@
 package eu.kanade.tachiyomi.extension.en.mangareadorg
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
-import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
 

--- a/multisrc/overrides/mangathemesia/asurascans/src/AsuraScans.kt
+++ b/multisrc/overrides/mangathemesia/asurascans/src/AsuraScans.kt
@@ -115,13 +115,6 @@ class AsuraScans : MangaThemesia(
             .mapIndexed { i, img -> Page(i, document.location(), img.attr("abs:src")) }
     }
 
-    override fun Element.imgAttr(): String = when {
-        hasAttr("data-lazy-src") -> attr("abs:data-lazy-src")
-        hasAttr("data-src") -> attr("abs:data-src")
-        hasAttr("data-cfsrc") -> attr("abs:data-cfsrc")
-        else -> attr("abs:src")
-    }
-
     private fun Observable<MangasPage>.tempUrlToPermIfNeeded(): Observable<MangasPage> {
         return this.map { mangasPage ->
             MangasPage(

--- a/multisrc/overrides/mangathemesia/asurascans/src/AsuraScans.kt
+++ b/multisrc/overrides/mangathemesia/asurascans/src/AsuraScans.kt
@@ -18,7 +18,6 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
-import org.jsoup.nodes.Element
 import rx.Observable
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get

--- a/multisrc/overrides/mangathemesia/carteldemanhwas/src/CarteldeManhwas.kt
+++ b/multisrc/overrides/mangathemesia/carteldemanhwas/src/CarteldeManhwas.kt
@@ -1,7 +1,6 @@
 package eu.kanade.tachiyomi.extension.es.carteldemanhwas
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
-import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
 

--- a/multisrc/overrides/mangathemesia/carteldemanhwas/src/CarteldeManhwas.kt
+++ b/multisrc/overrides/mangathemesia/carteldemanhwas/src/CarteldeManhwas.kt
@@ -15,13 +15,6 @@ class CarteldeManhwas : MangaThemesia(
     override val hasProjectPage = true
     override val projectPageString = "/proyectos"
 
-    override fun Element.imgAttr(): String = when {
-        hasAttr("data-lazy-src") -> attr("abs:data-lazy-src")
-        hasAttr("data-cfsrc") -> attr("abs:data-cfsrc")
-        hasAttr("data-src") -> attr("abs:data-src")
-        else -> attr("abs:src")
-    }
-
     override fun searchMangaSelector() = ".utao .uta .imgu:not(:has(span.novelabel)), " +
         ".listupd .bs .bsx:not(:has(span.novelabel)), " +
         ".listo .bs .bsx:not(:has(span.novelabel))"

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
@@ -619,6 +619,7 @@ abstract class Madara(
             element.hasAttr("data-src") -> element.attr("abs:data-src")
             element.hasAttr("data-lazy-src") -> element.attr("abs:data-lazy-src")
             element.hasAttr("srcset") -> element.attr("abs:srcset").substringBefore(" ")
+            element.hasAttr("data-cfsrc") -> element.attr("abs:data-cfsrc")
             else -> element.attr("abs:src")
         }
     }

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -10,7 +10,7 @@ class MadaraGenerator : ThemeSourceGenerator {
 
     override val themeClass = "Madara"
 
-    override val baseVersionCode: Int = 32
+    override val baseVersionCode: Int = 33
 
     override val sources = listOf(
         MultiLang("MangaForFree.net", "https://mangaforfree.net", listOf("en", "ko", "all"), isNsfw = true, className = "MangaForFreeFactory", pkgName = "mangaforfree", overrideVersionCode = 1),

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesia.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesia.kt
@@ -497,6 +497,7 @@ abstract class MangaThemesia(
     protected open fun Element.imgAttr(): String = when {
         hasAttr("data-lazy-src") -> attr("abs:data-lazy-src")
         hasAttr("data-src") -> attr("abs:data-src")
+        hasAttr("data-cfsrc") -> attr("abs:data-cfsrc")
         else -> attr("abs:src")
     }
 

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaGenerator.kt
@@ -11,7 +11,7 @@ class MangaThemesiaGenerator : ThemeSourceGenerator {
 
     override val themeClass = "MangaThemesia"
 
-    override val baseVersionCode: Int = 27
+    override val baseVersionCode: Int = 28
 
     override val sources = listOf(
         MultiLang("Miau Scan", "https://miaucomics.org", listOf("es", "pt-BR"), overrideVersionCode = 2),


### PR DESCRIPTION
> The data-cfsrc is used by CloudFlare's Mirage feature to lazy-load images to improve website performance.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
