### PR TITLE
Pururin - fix pages

### DIFF
--- a/src/all/pururin/build.gradle
+++ b/src/all/pururin/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Pururin'
     extClass = '.PururinFactory'
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = true
 }
 

--- a/src/all/pururin/src/eu/kanade/tachiyomi/extension/all/pururin/Pururin.kt
+++ b/src/all/pururin/src/eu/kanade/tachiyomi/extension/all/pururin/Pururin.kt
@@ -150,7 +150,7 @@ abstract class Pururin(
     override fun pageListParse(document: Document): List<Page> {
         return document.select(".gallery-preview a img")
             .mapIndexed { i, img ->
-                Page(i, "", img.attr("abs:src").replace("t.", "."))
+                Page(i, "", (if (img.hasAttr("abs:src")) img.attr("abs:src") else img.attr("abs:data-src")).replace("t.", "."))
             }
     }
 


### PR DESCRIPTION
Fix to use data-src for pages after 16. Closes #469 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
