### PR TITLE
Topmanhua: fix browse

### DIFF
--- a/multisrc/overrides/madara/topmanhua/src/TopManhua.kt
+++ b/multisrc/overrides/madara/topmanhua/src/TopManhua.kt
@@ -1,10 +1,19 @@
 package eu.kanade.tachiyomi.extension.en.topmanhua
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import java.text.SimpleDateFormat
 import java.util.Locale
 
 class TopManhua : Madara("Top Manhua", "https://topmanhua.com", "en", SimpleDateFormat("MM/dd/yy", Locale.US)) {
+    override val client = super.client.newBuilder()
+        .rateLimit(2)
+        .build()
+
     // The website does not flag the content.
     override val filterNonMangaItems = false
+
+    override val mangaSubString = "manhua"
+
+    override fun searchPage(page: Int): String = if (page == 1) "" else "page/$page/"
 }

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -472,7 +472,7 @@ class MadaraGenerator : ThemeSourceGenerator {
         SingleLang("Toonily", "https://toonily.com", "en", isNsfw = true, overrideVersionCode = 11),
         SingleLang("Toonizy", "https://toonizy.com", "en", isNsfw = true),
         SingleLang("ToonMany", "https://toonmany.com", "en", isNsfw = true),
-        SingleLang("Top Manhua", "https://topmanhua.com", "en", overrideVersionCode = 2),
+        SingleLang("Top Manhua", "https://topmanhua.com", "en", overrideVersionCode = 3),
         SingleLang("TopReadManhwa", "https://topreadmanhwa.com", "en", isNsfw = true),
         SingleLang("Tortuga Ceviri", "https://tortuga-ceviri.com", "tr"),
         SingleLang("Traducciones Moonlight", "https://traduccionesmoonlight.com", "es"),


### PR DESCRIPTION
Closes #522

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
