### PR TITLE
Adult Webtoon: Fix manga path

### DIFF
--- a/multisrc/overrides/madara/adultwebtoon/src/AdultWebtoon.kt
+++ b/multisrc/overrides/madara/adultwebtoon/src/AdultWebtoon.kt
@@ -6,20 +6,5 @@ import okhttp3.CacheControl
 import okhttp3.Request
 
 class AdultWebtoon : Madara("Adult Webtoon", "https://adultwebtoon.com", "en") {
-    override fun popularMangaRequest(page: Int): Request {
-        val pageSuffix = if (page != 1) "page/$page/" else ""
-        return GET(
-            "$baseUrl/manga/$pageSuffix?m_orderby=trending",
-            headers,
-            CacheControl.FORCE_NETWORK,
-        )
-    }
-    override fun latestUpdatesRequest(page: Int): Request {
-        val pageSuffix = if (page != 1) "page/$page/" else ""
-        return GET(
-            "$baseUrl/manga/$pageSuffix?m_orderby=latest",
-            headers,
-            CacheControl.FORCE_NETWORK,
-        )
-    }
+    override val mangaSubString = "adult-webtoon"
 }

--- a/multisrc/overrides/madara/adultwebtoon/src/AdultWebtoon.kt
+++ b/multisrc/overrides/madara/adultwebtoon/src/AdultWebtoon.kt
@@ -1,9 +1,6 @@
 package eu.kanade.tachiyomi.extension.en.adultwebtoon
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
-import eu.kanade.tachiyomi.network.GET
-import okhttp3.CacheControl
-import okhttp3.Request
 
 class AdultWebtoon : Madara("Adult Webtoon", "https://adultwebtoon.com", "en") {
     override val mangaSubString = "adult-webtoon"

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -24,7 +24,7 @@ class MadaraGenerator : ThemeSourceGenerator {
         SingleLang("247Manga", "https://247manga.com", "en", className = "Manga247", overrideVersionCode = 1),
         SingleLang("365Manga", "https://365manga.com", "en", className = "ThreeSixtyFiveManga", overrideVersionCode = 1),
         SingleLang("Adonis Fansub", "https://manga.adonisfansub.com", "tr", overrideVersionCode = 1),
-        SingleLang("Adult Webtoon", "https://adultwebtoon.com", "en", isNsfw = true, overrideVersionCode = 1),
+        SingleLang("Adult Webtoon", "https://adultwebtoon.com", "en", isNsfw = true, overrideVersionCode = 2),
         SingleLang("Akimangá", "https://akimanga.com", "pt-BR", isNsfw = true, className = "Akimanga"),
         SingleLang("AkuManga", "https://akumanga.com", "en", isNsfw = true, overrideVersionCode = 2),
         SingleLang("Akuzenai Arts", "https://akuzenaiarts.org", "en"),


### PR DESCRIPTION
Closes #483

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
