### PR TITLE
Setsu Scans: fix pages loading

### DIFF
--- a/multisrc/overrides/madara/setsuscans/src/SetsuScans.kt
+++ b/multisrc/overrides/madara/setsuscans/src/SetsuScans.kt
@@ -17,6 +17,7 @@ class SetsuScans : Madara(
             if (url.host == "i0.wp.com") {
                 val newUrl = url.newBuilder()
                     .removeAllQueryParameters("fit")
+                    .removeAllQueryParameters("ssl")
                     .build()
 
                 return@addNetworkInterceptor chain.proceed(

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -435,7 +435,7 @@ class MadaraGenerator : ThemeSourceGenerator {
         SingleLang("Scan Hentai Menu", "https://scan.hentai.menu", "fr", isNsfw = true, overrideVersionCode = 1),
         SingleLang("Scantrad-VF", "https://scantrad-vf.co", "fr", className = "ScantradVF"),
         SingleLang("Sdl scans", "https://sdlscans.com", "es", className = "SdlScans"),
-        SingleLang("Setsu Scans", "https://setsuscans.com", "en"),
+        SingleLang("Setsu Scans", "https://setsuscans.com", "en", overrideVersionCode = 1),
         SingleLang("Shadowtrad", "https://shadowtrad.net", "fr"),
         SingleLang("ShavelProiection", "https://www.shavelproiection.com", "it", true),
         SingleLang("Shayami", "https://shayami.com", "es"),


### PR DESCRIPTION
Fix some pages not loading in the Setsu Scans extensions

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
