### PR TITLE
en/AscalonScans: Fix http 403

### DIFF
--- a/multisrc/overrides/mangathemesia/ascalonscans/src/AscalonScans.kt
+++ b/multisrc/overrides/mangathemesia/ascalonscans/src/AscalonScans.kt
@@ -1,0 +1,52 @@
+package eu.kanade.tachiyomi.extension.en.ascalonscans
+
+import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
+import okhttp3.FormBody
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+import java.security.MessageDigest
+
+class AscalonScans : MangaThemesia("AscalonScans", "https://ascalonscans.com", "en") {
+    override val client = super.client.newBuilder()
+        .rateLimitHost(baseUrl.toHttpUrl(), 2)
+        .addInterceptor(::jsChallengeInterceptor)
+        .build()
+
+    private fun jsChallengeInterceptor(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val origRes = chain.proceed(request)
+        if (origRes.code != 403) return origRes
+        origRes.close()
+
+        val token = fetchToken(chain).sha256()
+
+        val body = FormBody.Builder().add("challenge", token).build()
+        val challengeReq = POST("$baseUrl/hcdn-cgi/jschallenge-validate", headers, body = body)
+        chain.proceed(challengeReq).use {
+            if (it.code != 200) throw IOException("Failed to bypass js challenge!")
+        }
+
+        return chain.proceed(request)
+    }
+
+    private fun fetchToken(chain: Interceptor.Chain, attempt: Int = 0): String {
+        if (attempt > 5) throw IOException("Failed to fetch challenge token!")
+        val request = GET("$baseUrl/hcdn-cgi/jschallenge", headers)
+        val res = chain.proceed(request).body.string()
+
+        return res.substringAfter("cjs = '").substringBefore("'")
+            .takeUnless { it == "nil" } ?: fetchToken(chain, attempt + 1)
+    }
+
+    private fun String.sha256(): String {
+        return MessageDigest
+            .getInstance("SHA-256")
+            .digest(toByteArray())
+            .fold("", { str, it -> str + "%02x".format(it) })
+    }
+}

--- a/multisrc/overrides/mangathemesia/ascalonscans/src/AscalonScans.kt
+++ b/multisrc/overrides/mangathemesia/ascalonscans/src/AscalonScans.kt
@@ -23,6 +23,8 @@ class AscalonScans : MangaThemesia("AscalonScans", "https://ascalonscans.com", "
         if (origRes.code != 403) return origRes
         origRes.close()
 
+        // Same delay as the source
+        Thread.sleep(3000L)
         val token = fetchToken(chain).sha256()
 
         val body = FormBody.Builder().add("challenge", token).build()

--- a/multisrc/overrides/mangathemesia/ascalonscans/src/AscalonScans.kt
+++ b/multisrc/overrides/mangathemesia/ascalonscans/src/AscalonScans.kt
@@ -35,7 +35,7 @@ class AscalonScans : MangaThemesia("AscalonScans", "https://ascalonscans.com", "
         return chain.proceed(request)
     }
 
-    private fun fetchToken(chain: Interceptor.Chain, attempt: Int = 0): String {
+    private tailrec fun fetchToken(chain: Interceptor.Chain, attempt: Int = 0): String {
         if (attempt > 5) throw IOException("Failed to fetch challenge token!")
         val request = GET("$baseUrl/hcdn-cgi/jschallenge", headers)
         val res = chain.proceed(request).body.string()

--- a/multisrc/overrides/mangathemesia/ascalonscans/src/AscalonScans.kt
+++ b/multisrc/overrides/mangathemesia/ascalonscans/src/AscalonScans.kt
@@ -31,8 +31,8 @@ class AscalonScans : MangaThemesia("AscalonScans", "https://ascalonscans.com", "
         val challengeReq = POST("$baseUrl/hcdn-cgi/jschallenge-validate", headers, body = body)
 
         val challengeResponse = chain.proceed(challengeReq)
-        if (challengeResponse.code != 200) throw IOException("Failed to bypass js challenge!")
         challengeResponse.close()
+        if (challengeResponse.code != 200) throw IOException("Failed to bypass js challenge!")
 
         return chain.proceed(request)
     }

--- a/multisrc/overrides/mangathemesia/ascalonscans/src/AscalonScans.kt
+++ b/multisrc/overrides/mangathemesia/ascalonscans/src/AscalonScans.kt
@@ -27,9 +27,10 @@ class AscalonScans : MangaThemesia("AscalonScans", "https://ascalonscans.com", "
 
         val body = FormBody.Builder().add("challenge", token).build()
         val challengeReq = POST("$baseUrl/hcdn-cgi/jschallenge-validate", headers, body = body)
-        chain.proceed(challengeReq).use {
-            if (it.code != 200) throw IOException("Failed to bypass js challenge!")
-        }
+
+        val challengeResponse = chain.proceed(challengeReq)
+        if (challengeResponse.code != 200) throw IOException("Failed to bypass js challenge!")
+        challengeResponse.close()
 
         return chain.proceed(request)
     }

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaGenerator.kt
@@ -20,7 +20,7 @@ class MangaThemesiaGenerator : ThemeSourceGenerator {
         SingleLang("Animated Glitched Comics", "https://agscomics.com", "en"),
         SingleLang("Animated Glitched Scans", "https://anigliscans.xyz", "en", overrideVersionCode = 1),
         SingleLang("Arven Scans", "https://arvenscans.com", "en"),
-        SingleLang("AscalonScans", "https://ascalonscans.com", "en"),
+        SingleLang("AscalonScans", "https://ascalonscans.com", "en", overrideVersionCode = 1),
         SingleLang("Asura Scans", "https://asuratoon.com", "en"),
         SingleLang("Azure Scans", "https://azuremanga.com", "en", overrideVersionCode = 1),
         SingleLang("Banana-Scan", "https://banana-scan.com", "fr", className = "BananaScan", isNsfw = true),


### PR DESCRIPTION
Closes #347

The interessing part is that the js challenge itself sometimes fails miserably in the browser, but seems to be working just fine in the interceptor (tested in two different devices).
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
