### PR TITLE
komikcast: fix referer

### DIFF
--- a/multisrc/overrides/mangathemesia/komikcast/src/KomikCast.kt
+++ b/multisrc/overrides/mangathemesia/komikcast/src/KomikCast.kt
@@ -36,7 +36,7 @@ class KomikCast : MangaThemesia("Komik Cast", "https://komikcast.lol", "id", "/d
     override fun imageRequest(page: Page): Request {
         val newHeaders = headersBuilder()
             .set("Accept", "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8")
-            .set("Referer", baseUrl)
+            .set("Referer", "$baseUrl/")
             .build()
 
         return GET(page.imageUrl!!, newHeaders)

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaGenerator.kt
@@ -59,7 +59,7 @@ class MangaThemesiaGenerator : ThemeSourceGenerator {
         SingleLang("King of Shojo", "https://kingofshojo.com", "ar", overrideVersionCode = 1),
         SingleLang("Kiryuu", "https://kiryuu.id", "id", overrideVersionCode = 6),
         SingleLang("Komik AV", "https://komikav.com", "id", overrideVersionCode = 1),
-        SingleLang("Komik Cast", "https://komikcast.lol", "id", overrideVersionCode = 25),
+        SingleLang("Komik Cast", "https://komikcast.lol", "id", overrideVersionCode = 26),
         SingleLang("Komik Lab", "https://komiklab.com", "en", overrideVersionCode = 3),
         SingleLang("Komik Seru", "https://komikseru.me", "id", isNsfw = true),
         SingleLang("Komik Station", "https://komikstation.co", "id", overrideVersionCode = 4),


### PR DESCRIPTION
Closes #582

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
