### PR TITLE
Setsu Scans: Fix some more pages not loading

### DIFF
--- a/multisrc/overrides/madara/setsuscans/src/SetsuScans.kt
+++ b/multisrc/overrides/madara/setsuscans/src/SetsuScans.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.extension.en.setsuscans
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.source.model.MangasPage
+import okhttp3.Interceptor
 import okhttp3.Response
 
 class SetsuScans : Madara(
@@ -17,7 +18,6 @@ class SetsuScans : Madara(
             if (url.host == "i0.wp.com") {
                 val newUrl = url.newBuilder()
                     .removeAllQueryParameters("fit")
-                    .removeAllQueryParameters("ssl")
                     .build()
 
                 return@addNetworkInterceptor chain.proceed(
@@ -29,8 +29,35 @@ class SetsuScans : Madara(
 
             return@addNetworkInterceptor chain.proceed(request)
         }
+        .addInterceptor(::handleFailedImages)
         .rateLimit(2)
         .build()
+
+    private fun handleFailedImages(chain: Interceptor.Chain): Response {
+        val response: Response = chain.proceed(chain.request())
+        val url = response.request.url
+        if (url.host == "i0.wp.com" && response.code == 404) {
+            val ssl = response.request.url.queryParameter("ssl")
+            var newUrl = url.newBuilder()
+                .removeAllQueryParameters("ssl")
+
+            if (ssl.isNullOrBlank()) {
+                newUrl = newUrl.addQueryParameter("ssl", "0")
+            } else if (ssl.toInt() >= 5) {
+                return response
+            } else if (ssl.toInt() == 0) {
+                newUrl = newUrl.addQueryParameter("ssl", "2")
+            } else if (ssl.toInt() >= 2) {
+                newUrl = newUrl.addQueryParameter("ssl", (ssl.toInt() + 1).toString())
+            }
+
+            val newRequest = chain.request().newBuilder()
+                .url(newUrl.build())
+                .build()
+            return client.newCall(newRequest).execute()
+        }
+        return response
+    }
 
     override val useNewChapterEndpoint = true
 

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -436,7 +436,7 @@ class MadaraGenerator : ThemeSourceGenerator {
         SingleLang("Scan Hentai Menu", "https://scan.hentai.menu", "fr", isNsfw = true, overrideVersionCode = 1),
         SingleLang("Scantrad-VF", "https://scantrad-vf.co", "fr", className = "ScantradVF"),
         SingleLang("Sdl scans", "https://sdlscans.com", "es", className = "SdlScans"),
-        SingleLang("Setsu Scans", "https://setsuscans.com", "en", overrideVersionCode = 1),
+        SingleLang("Setsu Scans", "https://setsuscans.com", "en", overrideVersionCode = 2),
         SingleLang("Shadowtrad", "https://shadowtrad.net", "fr"),
         SingleLang("ShavelProiection", "https://www.shavelproiection.com", "it", true),
         SingleLang("Shayami", "https://shayami.com", "es"),


### PR DESCRIPTION
Some pages weren't fix by #575 also fix loading them.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
