### PR TITLE
MangaTale: fix null error

### DIFF
--- a/multisrc/overrides/mangathemesia/mangatale/src/MangaTale.kt
+++ b/multisrc/overrides/mangathemesia/mangatale/src/MangaTale.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.extension.id.mangatale
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import okhttp3.OkHttpClient
+import org.jsoup.nodes.Document
 
 class MangaTale : MangaThemesia("MangaTale", "https://mangatale.co", "id") {
 
@@ -11,4 +12,8 @@ class MangaTale : MangaThemesia("MangaTale", "https://mangatale.co", "id") {
         .build()
 
     override val seriesTitleSelector = ".ts-breadcrumb li:last-child span"
+
+    override fun mangaDetailsParse(document: Document) = super.mangaDetailsParse(document).apply {
+        thumbnail_url = document.selectFirst(seriesThumbnailSelector)?.imgAttr()
+    }
 }

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaGenerator.kt
@@ -88,7 +88,7 @@ class MangaThemesiaGenerator : ThemeSourceGenerator {
         SingleLang("MangaShiro", "https://mangashiro.me", "id"),
         SingleLang("Mangasusu", "https://mangasusuku.xyz", "id", isNsfw = true, overrideVersionCode = 3),
         SingleLang("MangaSwat", "https://goldragon.me", "ar", overrideVersionCode = 15),
-        SingleLang("MangaTale", "https://mangatale.co", "id", overrideVersionCode = 1),
+        SingleLang("MangaTale", "https://mangatale.co", "id", overrideVersionCode = 2),
         SingleLang("MangaWT", "https://mangawt.com", "tr", overrideVersionCode = 5),
         SingleLang("Mangayaro", "https://www.mangayaro.id", "id", overrideVersionCode = 1),
         SingleLang("Mangás Chan", "https://mangaschan.net", "pt-BR", className = "MangasChan", overrideVersionCode = 2),


### PR DESCRIPTION
closes #596
cant reproduce the images issue. probably site issue

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
