### PR TITLE
Asura Scans: Fix Brotli interceptor for J2K

### DIFF
--- a/multisrc/overrides/mangathemesia/asurascans/src/AsuraScans.kt
+++ b/multisrc/overrides/mangathemesia/asurascans/src/AsuraScans.kt
@@ -45,6 +45,13 @@ class AsuraScans : MangaThemesia(
         .addInterceptor(::urlChangeInterceptor)
         .addInterceptor(::domainChangeIntercept)
         .rateLimit(1, 3, TimeUnit.SECONDS)
+        .apply {
+            val interceptors = interceptors()
+            val index = interceptors.indexOfFirst { "Brotli" in it.javaClass.simpleName }
+            if (index >= 0) {
+                interceptors.add(interceptors.removeAt(index))
+            }
+        }
         .build()
 
     override val seriesDescriptionSelector = "div.desc p, div.entry-content p, div[itemprop=description]:not(:has(p))"

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaGenerator.kt
@@ -21,7 +21,7 @@ class MangaThemesiaGenerator : ThemeSourceGenerator {
         SingleLang("Animated Glitched Scans", "https://anigliscans.xyz", "en", overrideVersionCode = 1),
         SingleLang("Arven Scans", "https://arvenscans.com", "en"),
         SingleLang("AscalonScans", "https://ascalonscans.com", "en", overrideVersionCode = 1),
-        SingleLang("Asura Scans", "https://asuratoon.com", "en"),
+        SingleLang("Asura Scans", "https://asuratoon.com", "en", overrideVersionCode = 1),
         SingleLang("Azure Scans", "https://azuremanga.com", "en", overrideVersionCode = 1),
         SingleLang("Banana-Scan", "https://banana-scan.com", "fr", className = "BananaScan", isNsfw = true),
         SingleLang("Beast Scans", "https://beastscans.net", "ar", overrideVersionCode = 1),


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
