### PR TITLE
Ler Manga: Filter out empty page URLs

### DIFF
--- a/src/pt/lermanga/build.gradle
+++ b/src/pt/lermanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Ler Mangá'
     extClass = '.LerManga'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = true
 }
 

--- a/src/pt/lermanga/src/eu/kanade/tachiyomi/extension/pt/lermanga/LerManga.kt
+++ b/src/pt/lermanga/src/eu/kanade/tachiyomi/extension/pt/lermanga/LerManga.kt
@@ -162,12 +162,13 @@ class LerManga : ParsedHttpSource() {
             .replace(PAGES_VARIABLE_REGEX, "")
             .substringBeforeLast(";")
             .let { json.decodeFromString<List<String>>(it) }
+            .filter { it.isNotBlank() }
             .mapIndexed { index, imageUrl ->
-                Page(index, document.location(), imageUrl)
+                Page(index, imageUrl = imageUrl)
             }
     }
 
-    override fun imageUrlParse(document: Document) = ""
+    override fun imageUrlParse(document: Document) = throw UnsupportedOperationException()
 
     override fun imageRequest(page: Page): Request {
         val newHeaders = headersBuilder()


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
