### PR TITLE
Mangatown - longstrip parsing

### DIFF
--- a/src/en/mangatown/build.gradle
+++ b/src/en/mangatown/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Mangatown'
     extClass = '.Mangatown'
-    extVersionCode = 6
+    extVersionCode = 7
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/mangatown/src/eu/kanade/tachiyomi/extension/en/mangatown/Mangatown.kt
+++ b/src/en/mangatown/src/eu/kanade/tachiyomi/extension/en/mangatown/Mangatown.kt
@@ -122,9 +122,18 @@ class Mangatown : ParsedHttpSource() {
         }
     }
 
+    // check for paged first, then try longstrip
     override fun pageListParse(document: Document): List<Page> {
-        return document.select("select#top_chapter_list ~ div.page_select option:not(:contains(featured))").mapIndexed { i, element ->
-            Page(i, element.attr("value").substringAfter("com"))
+        return document.select("select#top_chapter_list ~ div.page_select option:not(:contains(featured))").let { elements ->
+            if (elements.isNotEmpty()) {
+                elements.mapIndexed { i, e ->
+                    Page(i, e.attr("value").substringAfter("com"))
+                }
+            } else {
+                document.select("#viewer .image").mapIndexed { i, e ->
+                    Page(i, "", e.attr("abs:src"))
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Closes #708 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
