### PR TITLE
HN: Show only entire images

### DIFF
--- a/src/en/hentainexus/build.gradle
+++ b/src/en/hentainexus/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = "HentaiNexus"
     extClass = ".HentaiNexus"
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = true
 }
 

--- a/src/en/hentainexus/src/eu/kanade/tachiyomi/extension/en/hentainexus/HentaiNexus.kt
+++ b/src/en/hentainexus/src/eu/kanade/tachiyomi/extension/en/hentainexus/HentaiNexus.kt
@@ -146,9 +146,9 @@ class HentaiNexus : ParsedHttpSource() {
         val encoded = script.substringAfter("initReader(\"").substringBefore("\",")
         val data = HentaiNexusUtils.decryptData(encoded)
 
-        return json.parseToJsonElement(data).jsonArray.mapIndexed { i, it ->
-            Page(i, imageUrl = it.jsonObject["image"]!!.jsonPrimitive.content)
-        }
+        return json.parseToJsonElement(data).jsonArray
+            .filter { it.jsonObject["type"]!!.jsonPrimitive.content == "image" }
+            .mapIndexed { i, it -> Page(i, imageUrl = it.jsonObject["image"]!!.jsonPrimitive.content) }
     }
 
     override fun imageUrlParse(document: Document) = throw UnsupportedOperationException()


### PR DESCRIPTION
The site has spread'images that contain two separate images. This just filters to only show the 'image' type.

Example gallery "Key Next Number Girls".

```json
[
  {
    "image": "{URL_1}",
    "label": "1",
    "url_label": "001",
    "type": "image"
  },
  {
    "image": "{URL_2}",
    "label": "2",
    "url_label": "002",
    "type": "image"
  },
  {
    "left": "{URL_1}",
    "right": "{URL_2}",
    "label": "1-2",
    "url_label": "001-002",
    "type": "spread"
  }
]
```

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
