### PR TITLE
999Hentai: update api url

### DIFF
--- a/src/all/ninenineninehentai/build.gradle
+++ b/src/all/ninenineninehentai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = '999Hentai'
     extClass = '.NineNineNineHentaiFactory'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = true
 }
 

--- a/src/all/ninenineninehentai/src/eu/kanade/tachiyomi/extension/all/ninenineninehentai/NineNineNineHentai.kt
+++ b/src/all/ninenineninehentai/src/eu/kanade/tachiyomi/extension/all/ninenineninehentai/NineNineNineHentai.kt
@@ -44,7 +44,7 @@ open class NineNineNineHentai(
 
     override val baseUrl = "https://999hentai.net"
 
-    private val apiUrl = "https://api.999hentai.net/api"
+    private val apiUrl = "https://hapi.999hentai.net/api"
 
     override val supportsLatest = true
 


### PR DESCRIPTION
closes #834

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
