### PR TITLE
Kemono: update URL

### DIFF
--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/kemono/Kemono.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/kemono/Kemono.kt
@@ -32,12 +32,10 @@ import kotlin.math.min
 
 open class Kemono(
     override val name: String,
-    private val defaultUrl: String,
+    override val baseUrl: String,
     override val lang: String = "all",
 ) : HttpSource(), ConfigurableSource {
     override val supportsLatest = true
-
-    private val mirrorUrls get() = arrayOf(defaultUrl, defaultUrl.removeSuffix(".party") + ".su")
 
     override val client = network.client.newBuilder().rateLimit(2).build()
 
@@ -49,14 +47,9 @@ open class Kemono(
     private val preferences =
         Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
 
-    override val baseUrl = preferences.getString(BASE_URL_PREF, defaultUrl)!!
-
     private val apiPath = "api/v1"
 
-    private val imgCdnUrl = when (name) {
-        "Kemono" -> baseUrl
-        else -> defaultUrl
-    }.replace("//", "//img.")
+    private val imgCdnUrl = baseUrl.replace("//", "//img.")
 
     private fun String.formatAvatarUrl(): String = removePrefix("https://").replaceBefore('/', imgCdnUrl)
 
@@ -218,15 +211,6 @@ open class Kemono(
             setDefaultValue(POST_PAGES_DEFAULT)
         }.let { screen.addPreference(it) }
 
-        ListPreference(screen.context).apply {
-            key = BASE_URL_PREF
-            title = "Mirror URL"
-            summary = "%s\nRequires app restart to take effect"
-            entries = mirrorUrls
-            entryValues = mirrorUrls
-            setDefaultValue(defaultUrl)
-        }.let(screen::addPreference)
-
         SwitchPreferenceCompat(screen.context).apply {
             key = USE_LOW_RES_IMG
             title = "Use low resolution images"
@@ -246,7 +230,7 @@ open class Kemono(
 
         private fun List<SManga>.filterUnsupported() = filterNot { it.author == "Discord" }
 
-        private const val BASE_URL_PREF = "BASE_URL"
+        // private const val BASE_URL_PREF = "BASE_URL"
         private const val USE_LOW_RES_IMG = "USE_LOW_RES_IMG"
     }
 }

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/kemono/KemonoGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/kemono/KemonoGenerator.kt
@@ -9,11 +9,11 @@ class KemonoGenerator : ThemeSourceGenerator {
 
     override val themePkg = "kemono"
 
-    override val baseVersionCode = 8
+    override val baseVersionCode = 9
 
     override val sources = listOf(
-        SingleLang("Kemono", "https://kemono.party", "all", isNsfw = true),
-        SingleLang("Coomer", "https://coomer.party", "all", isNsfw = true),
+        SingleLang("Kemono", "https://kemono.su", "all", isNsfw = true),
+        SingleLang("Coomer", "https://coomer.su", "all", isNsfw = true),
     )
 
     companion object {


### PR DESCRIPTION
Closes #925

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
