### PR TITLE
PeachScan: Add workaround for TachiyomiJ2K

### DIFF
--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/peachscan/PeachScan.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/peachscan/PeachScan.kt
@@ -28,11 +28,9 @@ import okhttp3.ResponseBody.Companion.toResponseBody
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
-import tachiyomi.decoder.ImageDecoder
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
-import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.text.SimpleDateFormat

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/peachscan/PeachScan.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/peachscan/PeachScan.kt
@@ -202,21 +202,7 @@ abstract class PeachScan(
                     Base64.decode(b64, Base64.DEFAULT)
                 }
 
-                val decoder = ImageDecoder.newInstance(ByteArrayInputStream(imageData))
-
-                if (decoder == null || decoder.width <= 0 || decoder.height <= 0) {
-                    throw IOException("Falha ao inicializar o decodificador de imagem")
-                }
-
-                val bitmap = decoder.decode(rgb565 = isLowRamDevice)
-
-                decoder.recycle()
-
-                if (bitmap == null) {
-                    throw IOException("Não foi possível decodificar a imagem $filename#$entryName")
-                }
-
-                entryIndex to bitmap
+                entryIndex to PeachScanUtils.decodeImage(imageData, isLowRamDevice, filename, entryName)
             }
             .sortedBy { it.first }
             .toList()

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/peachscan/PeachScanGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/peachscan/PeachScanGenerator.kt
@@ -9,7 +9,7 @@ class PeachScanGenerator : ThemeSourceGenerator {
 
     override val themeClass = "PeachScan"
 
-    override val baseVersionCode = 1
+    override val baseVersionCode = 2
 
     override val sources = listOf(
         SingleLang("Aurora Scan", "https://aurorascan.net", "pt-BR"),

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/peachscan/PeachScanUtils.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/peachscan/PeachScanUtils.kt
@@ -7,6 +7,15 @@ import java.io.ByteArrayInputStream
 import java.io.IOException
 import java.lang.reflect.Method
 
+/**
+ * TachiyomiJ2K is on a 2-year-old version of ImageDecoder at the time of writing,
+ * with a different signature than the one being used as a compile-only dependency.
+ *
+ * Because of this, if [ImageDecoder.decode] is called as-is on TachiyomiJ2K, we
+ * end up with a [NoSuchMethodException].
+ *
+ * This is a hack for determining which signature to call when decoding images.
+ */
 object PeachScanUtils {
     private var decodeMethod: Method
 

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/peachscan/PeachScanUtils.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/peachscan/PeachScanUtils.kt
@@ -1,0 +1,56 @@
+package eu.kanade.tachiyomi.multisrc.peachscan
+
+import android.graphics.Bitmap
+import android.graphics.Rect
+import tachiyomi.decoder.ImageDecoder
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.lang.reflect.Method
+
+object PeachScanUtils {
+    private var decodeMethod: Method
+
+    private var isNewDecodeMethod = false
+
+    init {
+        val rectClass = Rect::class.java
+        val booleanClass = Boolean::class.java
+        val intClass = Int::class.java
+        val byteArrayClass = ByteArray::class.java
+
+        decodeMethod = try {
+            isNewDecodeMethod = true
+
+            // decode(region, rgb565, sampleSize, applyColorManagement, displayProfile)
+            ImageDecoder::class.java.getMethod("decode", rectClass, booleanClass, intClass, booleanClass, byteArrayClass)
+        } catch (e: NoSuchMethodException) {
+            isNewDecodeMethod = false
+
+            // decode(region, rgb565, sampleSize)
+            ImageDecoder::class.java.getMethod("decode", rectClass, booleanClass, intClass)
+        }
+    }
+
+    fun decodeImage(data: ByteArray, rgb565: Boolean, filename: String, entryName: String): Bitmap {
+        val decoder = ImageDecoder.newInstance(ByteArrayInputStream(data))
+
+        if (decoder == null || decoder.width <= 0 || decoder.height <= 0) {
+            throw IOException("Falha ao inicializar o decodificador de imagem")
+        }
+
+        val rect = Rect(0, 0, decoder.width, decoder.height)
+        val bitmap = if (isNewDecodeMethod) {
+            decodeMethod.invoke(decoder, rect, rgb565, 1, false, null)
+        } else {
+            decodeMethod.invoke(decoder, rect, rgb565, 1)
+        } as Bitmap?
+
+        decoder.recycle()
+
+        if (bitmap == null) {
+            throw IOException("Não foi possível decodificar a imagem $filename#$entryName")
+        }
+
+        return bitmap
+    }
+}


### PR DESCRIPTION
Closes #950

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
