### PR TITLE
Add custom UA to Happymh and Jinman Tiantang

### DIFF
--- a/lib/randomua/src/main/java/eu/kanade/tachiyomi/lib/randomua/RandomUserAgentPreference.kt
+++ b/lib/randomua/src/main/java/eu/kanade/tachiyomi/lib/randomua/RandomUserAgentPreference.kt
@@ -34,7 +34,9 @@ fun SharedPreferences.getPrefCustomUA(): String? {
 fun addRandomUAPreferenceToScreen(
     screen: PreferenceScreen,
 ) {
-    ListPreference(screen.context).apply {
+    val context = screen.context
+
+    ListPreference(context).apply {
         key = PREF_KEY_RANDOM_UA
         title = TITLE_RANDOM_UA
         entries = RANDOM_UA_ENTRIES
@@ -43,28 +45,28 @@ fun addRandomUAPreferenceToScreen(
         setDefaultValue("off")
     }.also(screen::addPreference)
 
-    EditTextPreference(screen.context).apply {
+    EditTextPreference(context).apply {
         key = PREF_KEY_CUSTOM_UA
         title = TITLE_CUSTOM_UA
         summary = CUSTOM_UA_SUMMARY
         setOnPreferenceChangeListener { _, newValue ->
             try {
-                Headers.Builder().add("User-Agent", newValue as String).build()
+                Headers.headersOf("User-Agent", newValue as String)
                 true
             } catch (e: IllegalArgumentException) {
-                Toast.makeText(screen.context, "User Agent invalid：${e.message}", Toast.LENGTH_LONG).show()
+                Toast.makeText(context, "Invalid user agent string: ${e.message}", Toast.LENGTH_LONG).show()
                 false
             }
         }
     }.also(screen::addPreference)
 }
 
-const val TITLE_RANDOM_UA = "Random User-Agent (Requires Restart)"
+const val TITLE_RANDOM_UA = "Random user agent string (requires restart)"
 const val PREF_KEY_RANDOM_UA = "pref_key_random_ua_"
 val RANDOM_UA_ENTRIES = arrayOf("OFF", "Desktop", "Mobile")
 val RANDOM_UA_VALUES = arrayOf("off", "desktop", "mobile")
 
-const val TITLE_CUSTOM_UA = "Custom User-Agent (Requires Restart)"
+const val TITLE_CUSTOM_UA = "Custom user agent string (requires restart)"
 const val PREF_KEY_CUSTOM_UA = "pref_key_custom_ua_"
-const val CUSTOM_UA_SUMMARY = "Leave blank to use application default user-agent (IGNORED if Random User-Agent is enabled)"
+const val CUSTOM_UA_SUMMARY = "Leave blank to use the default user agent string (ignored if random user agent string is enabled)"
 

--- a/src/zh/happymh/build.gradle
+++ b/src/zh/happymh/build.gradle
@@ -1,7 +1,11 @@
 ext {
     extName = 'Happymh'
     extClass = '.Happymh'
-    extVersionCode = 6
+    extVersionCode = 7
 }
 
 apply from: "$rootDir/common.gradle"
+
+dependencies {
+    implementation(project(":lib:randomua"))
+}

--- a/src/zh/jinmantiantang/build.gradle
+++ b/src/zh/jinmantiantang/build.gradle
@@ -1,8 +1,12 @@
 ext {
     extName = 'Jinman Tiantang'
     extClass = '.Jinmantiantang'
-    extVersionCode = 40
+    extVersionCode = 41
     isNsfw = true
 }
 
 apply from: "$rootDir/common.gradle"
+
+dependencies {
+    implementation(project(":lib:randomua"))
+}

--- a/src/zh/jinmantiantang/src/eu/kanade/tachiyomi/extension/zh/jinmantiantang/Jinmantiantang.kt
+++ b/src/zh/jinmantiantang/src/eu/kanade/tachiyomi/extension/zh/jinmantiantang/Jinmantiantang.kt
@@ -2,6 +2,10 @@ package eu.kanade.tachiyomi.extension.zh.jinmantiantang
 
 import android.content.SharedPreferences
 import androidx.preference.PreferenceScreen
+import eu.kanade.tachiyomi.lib.randomua.addRandomUAPreferenceToScreen
+import eu.kanade.tachiyomi.lib.randomua.getPrefCustomUA
+import eu.kanade.tachiyomi.lib.randomua.getPrefUAType
+import eu.kanade.tachiyomi.lib.randomua.setRandomUserAgent
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.asObservableSuccess
 import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
@@ -47,6 +51,7 @@ class Jinmantiantang : ParsedHttpSource(), ConfigurableSource {
             preferences.getString(MAINSITE_RATELIMIT_PREF, MAINSITE_RATELIMIT_PREF_DEFAULT)!!.toInt(),
             preferences.getString(MAINSITE_RATELIMIT_PERIOD, MAINSITE_RATELIMIT_PERIOD_DEFAULT)!!.toLong(),
         )
+        .setRandomUserAgent(preferences.getPrefUAType(), preferences.getPrefCustomUA())
         .apply { interceptors().add(0, updateUrlInterceptor) }
         .addInterceptor(ScrambledImageInterceptor).build()
 
@@ -383,6 +388,7 @@ class Jinmantiantang : ParsedHttpSource(), ConfigurableSource {
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         getPreferenceList(screen.context, preferences, updateUrlInterceptor.isUpdated).forEach(screen::addPreference)
+        addRandomUAPreferenceToScreen(screen)
     }
     companion object {
         private const val PREFIX_ID_SEARCH_NO_COLON = "JM"

--- a/src/zh/jinmantiantang/src/eu/kanade/tachiyomi/extension/zh/jinmantiantang/JinmantiantangPreferences.kt
+++ b/src/zh/jinmantiantang/src/eu/kanade/tachiyomi/extension/zh/jinmantiantang/JinmantiantangPreferences.kt
@@ -84,7 +84,6 @@ private val SITE_ENTRIES_ARRAY_DESCRIPTION get() = arrayOf(
     "东南亚线路2",
 )
 
-// List is based on https://jmcomic1.bet/
 // Please also update AndroidManifest
 private val SITE_ENTRIES_ARRAY get() = arrayOf(
     "18comic.vip",
@@ -93,7 +92,7 @@ private val SITE_ENTRIES_ARRAY get() = arrayOf(
     "jmcomic1.me",
 )
 
-private const val DEFAULT_LIST = "jm-comic3.art,jm-comic1.art,jm-comic2.ark"
+private const val DEFAULT_LIST = "18comic-cn.vip,18comic-c.xyz,18comic-c.art"
 private const val DEFAULT_LIST_PREF = "defaultBaseUrlList"
 private const val URL_LIST_PREF = "baseUrlList"
 


### PR DESCRIPTION
Both are Cloudflare-protected sites. Also changed the wording in random UA lib a bit.

Closes #704

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
