### PR TITLE
Kemono: retry when fetching posts

### DIFF
--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/kemono/Kemono.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/kemono/Kemono.kt
@@ -37,7 +37,7 @@ open class Kemono(
 ) : HttpSource(), ConfigurableSource {
     override val supportsLatest = true
 
-    override val client = network.client.newBuilder().rateLimit(2).build()
+    override val client = network.client.newBuilder().rateLimit(1).build()
 
     override fun headersBuilder() = super.headersBuilder()
         .add("Referer", "$baseUrl/")

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/kemono/KemonoGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/kemono/KemonoGenerator.kt
@@ -9,7 +9,7 @@ class KemonoGenerator : ThemeSourceGenerator {
 
     override val themePkg = "kemono"
 
-    override val baseVersionCode = 9
+    override val baseVersionCode = 10
 
     override val sources = listOf(
         SingleLang("Kemono", "https://kemono.su", "all", isNsfw = true),


### PR DESCRIPTION
Hopefully fixes #925

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
