### PR TITLE
Mangahub update

### DIFF
--- a/multisrc/overrides/mangahub/mangafoxfun/src/MangaFoxFun.kt
+++ b/multisrc/overrides/mangahub/mangafoxfun/src/MangaFoxFun.kt
@@ -1,0 +1,5 @@
+package eu.kanade.tachiyomi.extension.en.mangafoxfun
+
+import eu.kanade.tachiyomi.multisrc.mangahub.MangaHub
+
+class MangaFoxFun : MangaHub("MangaFox.fun", "https://mangafox.fun", "en", "mf01")

--- a/multisrc/overrides/mangahub/mangahereonl/src/MangaHereOnl.kt
+++ b/multisrc/overrides/mangahub/mangahereonl/src/MangaHereOnl.kt
@@ -1,0 +1,5 @@
+package eu.kanade.tachiyomi.extension.en.mangahereonl
+
+import eu.kanade.tachiyomi.multisrc.mangahub.MangaHub
+
+class MangaHereOnl : MangaHub("MangaHere.onl", "https://mangahere.onl", "en", "mh01")

--- a/multisrc/overrides/mangahub/mangahubio/src/MangaHubIo.kt
+++ b/multisrc/overrides/mangahub/mangahubio/src/MangaHubIo.kt
@@ -1,0 +1,5 @@
+package eu.kanade.tachiyomi.extension.en.mangahubio
+
+import eu.kanade.tachiyomi.multisrc.mangahub.MangaHub
+
+class MangaHubIo : MangaHub("MangaHub", "https://mangahub.io", "en", "m01")

--- a/multisrc/overrides/mangahub/mangakakalotfun/src/MangakakalotFun.kt
+++ b/multisrc/overrides/mangahub/mangakakalotfun/src/MangakakalotFun.kt
@@ -1,0 +1,5 @@
+package eu.kanade.tachiyomi.extension.en.mangakakalotfun
+
+import eu.kanade.tachiyomi.multisrc.mangahub.MangaHub
+
+class MangakakalotFun : MangaHub("Mangakakalot.fun", "https://mangakakalot.fun", "en", "mn01")

--- a/multisrc/overrides/mangahub/manganel/src/MangaNel.kt
+++ b/multisrc/overrides/mangahub/manganel/src/MangaNel.kt
@@ -1,0 +1,5 @@
+package eu.kanade.tachiyomi.extension.en.manganel
+
+import eu.kanade.tachiyomi.multisrc.mangahub.MangaHub
+
+class MangaNel : MangaHub("MangaNel", "https://manganel.me", "en", "mn05")

--- a/multisrc/overrides/mangahub/mangaonlinefun/src/MangaOnlineFun.kt
+++ b/multisrc/overrides/mangahub/mangaonlinefun/src/MangaOnlineFun.kt
@@ -1,0 +1,5 @@
+package eu.kanade.tachiyomi.extension.en.mangaonlinefun
+
+import eu.kanade.tachiyomi.multisrc.mangahub.MangaHub
+
+class MangaOnlineFun : MangaHub("MangaOnline.fun", "https://mangaonline.fun", "en", "m02")

--- a/multisrc/overrides/mangahub/mangapandaonl/src/MangaPandaOnl.kt
+++ b/multisrc/overrides/mangahub/mangapandaonl/src/MangaPandaOnl.kt
@@ -1,0 +1,5 @@
+package eu.kanade.tachiyomi.extension.en.mangapandaonl
+
+import eu.kanade.tachiyomi.multisrc.mangahub.MangaHub
+
+class MangaPandaOnl : MangaHub("MangaPanda.onl", "https://mangapanda.onl", "en", "mr02")

--- a/multisrc/overrides/mangahub/mangareadersite/src/MangaReaderSite.kt
+++ b/multisrc/overrides/mangahub/mangareadersite/src/MangaReaderSite.kt
@@ -1,0 +1,5 @@
+package eu.kanade.tachiyomi.extension.en.mangareadersite
+
+import eu.kanade.tachiyomi.multisrc.mangahub.MangaHub
+
+class MangaReaderSite : MangaHub("MangaReader.site", "https://mangareader.site", "en", "mr01")

--- a/multisrc/overrides/mangahub/mangatoday/src/MangaToday.kt
+++ b/multisrc/overrides/mangahub/mangatoday/src/MangaToday.kt
@@ -1,0 +1,5 @@
+package eu.kanade.tachiyomi.extension.en.mangatoday
+
+import eu.kanade.tachiyomi.multisrc.mangahub.MangaHub
+
+class MangaToday : MangaHub("MangaToday", "https://mangatoday.fun", "en", "m03")

--- a/multisrc/overrides/mangahub/onemangaco/src/OneMangaCo.kt
+++ b/multisrc/overrides/mangahub/onemangaco/src/OneMangaCo.kt
@@ -1,0 +1,5 @@
+package eu.kanade.tachiyomi.extension.en.onemangaco
+
+import eu.kanade.tachiyomi.multisrc.mangahub.MangaHub
+
+class OneMangaCo : MangaHub("1Manga.co", "https://1manga.co", "en", "mn03")

--- a/multisrc/overrides/mangahub/onemangainfo/src/OneMangaInfo.kt
+++ b/multisrc/overrides/mangahub/onemangainfo/src/OneMangaInfo.kt
@@ -1,0 +1,5 @@
+package eu.kanade.tachiyomi.extension.en.onemangainfo
+
+import eu.kanade.tachiyomi.multisrc.mangahub.MangaHub
+
+class OneMangaInfo : MangaHub("OneManga.info", "https://onemanga.info", "en", "mh01")

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangahub/MangaHub.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangahub/MangaHub.kt
@@ -131,19 +131,57 @@ abstract class MangaHub(
         client.newCall(request).execute()
     }
 
+    data class SMangaDTO(
+        val url: String,
+        val title: String,
+        val thumbnailUrl: String,
+        val signature: String
+    )
+
+    private fun Element.toSignature(): String {
+        val author = this.select("small").text()
+        val chNum = this.select(".col-sm-6 a:contains(#)").text()
+        val genres = this.select(".genre-label").joinToString { it.text() }
+
+        return author + chNum + genres
+    }
+
     // popular
     override fun popularMangaRequest(page: Int): Request {
         return GET("$baseUrl/popular/page/$page", headers)
     }
 
+    // often enough there will be nearly identical entries with slightly different
+    // titles, URLs, and image names. in order to cut these "duplicates" down,
+    // assign a "signature" based on author name, chapter number, and genres
+    // if all of those are the same, then it it's the same manga
+    override fun popularMangaParse(response: Response): MangasPage {
+        val doc = response.asJsoup()
+
+        val mangas = doc.select(popularMangaSelector())
+            .map {
+                SMangaDTO(
+                    it.select("h4 a").attr("abs:href"),
+                    it.select("h4 a").text(),
+                    it.select("img").attr("abs:src"),
+                    it.toSignature()
+                )
+            }
+            .distinctBy { it.signature }
+            .map {
+                SManga.create().apply {
+                    setUrlWithoutDomain(it.url)
+                    title = it.title
+                    thumbnail_url = it.thumbnailUrl
+                }
+            }
+        return MangasPage(mangas, doc.select(popularMangaNextPageSelector()).isNotEmpty())
+    }
+
     override fun popularMangaSelector() = ".col-sm-6:not(:has(a:contains(Yaoi)))"
 
     override fun popularMangaFromElement(element: Element): SManga {
-        return SManga.create().apply {
-            setUrlWithoutDomain(element.select("h4 a").attr("abs:href"))
-            title = element.select("h4 a").text()
-            thumbnail_url = element.select("img").attr("abs:src")
-        }
+        throw UnsupportedOperationException()
     }
 
     override fun popularMangaNextPageSelector() = "ul.pager li.next > a"
@@ -153,10 +191,14 @@ abstract class MangaHub(
         return GET("$baseUrl/updates/page/$page", headers)
     }
 
+    override fun latestUpdatesParse(response: Response): MangasPage {
+        return popularMangaParse(response)
+    }
+
     override fun latestUpdatesSelector() = popularMangaSelector()
 
     override fun latestUpdatesFromElement(element: Element): SManga {
-        return popularMangaFromElement(element)
+        throw UnsupportedOperationException()
     }
 
     override fun latestUpdatesNextPageSelector() = popularMangaNextPageSelector()
@@ -184,34 +226,11 @@ abstract class MangaHub(
     override fun searchMangaSelector() = popularMangaSelector()
 
     override fun searchMangaFromElement(element: Element): SManga {
-        return popularMangaFromElement(element)
+        throw UnsupportedOperationException()
     }
 
-    // not sure if this still works, some duplicates i found is also using different thumbnail_url
     override fun searchMangaParse(response: Response): MangasPage {
-        val document = response.asJsoup()
-
-        /*
-         * To remove duplicates we group by the thumbnail_url, which is
-         * common between duplicates. The duplicates have a suffix in the
-         * url "-by-{name}". Here we select the shortest url, to avoid
-         * removing manga that has "by" in the title already.
-         * Example:
-         * /manga/tales-of-demons-and-gods (kept)
-         * /manga/tales-of-demons-and-gods-by-mad-snail (removed)
-         * /manga/leveling-up-by-only-eating (kept)
-         */
-        val mangas = document.select(searchMangaSelector()).map { element ->
-            searchMangaFromElement(element)
-        }.groupBy { it.thumbnail_url }.mapValues { (_, values) ->
-            values.minByOrNull { it.url.length }!!
-        }.values.toList()
-
-        val hasNextPage = searchMangaNextPageSelector().let { selector ->
-            document.select(selector).first()
-        } != null
-
-        return MangasPage(mangas, hasNextPage)
+        return popularMangaParse(response)
     }
 
     override fun searchMangaNextPageSelector() = popularMangaNextPageSelector()
@@ -330,6 +349,13 @@ abstract class MangaHub(
                         "MangaHub" -> "m01"
                         "MangaReader.site" -> "mr01"
                         "MangaPanda.onl" -> "mr02"
+                        "1Manga.co" -> "mn03"
+                        "MangaFox.fun" -> "mf01"
+                        "MangaHere.onl", "OneManga.info" -> "mh01"
+                        "Mangakakalot.fun" -> "mn01"
+                        "MangaNel" -> "mn05"
+                        "MangaOnline.fun" -> "m02"
+                        "MangaToday" -> "m03"
                         else -> null
                     }
                     val chapterUrl = chapter.url.split("/")

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangahub/MangaHub.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangahub/MangaHub.kt
@@ -41,6 +41,7 @@ abstract class MangaHub(
     override val name: String,
     final override val baseUrl: String,
     override val lang: String,
+    private val mangaSource: String,
     private val dateFormat: SimpleDateFormat = SimpleDateFormat("MM-dd-yyyy", Locale.US),
 ) : ParsedHttpSource() {
 
@@ -345,19 +346,6 @@ abstract class MangaHub(
             put(
                 "variables",
                 buildJsonObject {
-                    val mangaSource = when (name) {
-                        "MangaHub" -> "m01"
-                        "MangaReader.site" -> "mr01"
-                        "MangaPanda.onl" -> "mr02"
-                        "1Manga.co" -> "mn03"
-                        "MangaFox.fun" -> "mf01"
-                        "MangaHere.onl", "OneManga.info" -> "mh01"
-                        "Mangakakalot.fun" -> "mn01"
-                        "MangaNel" -> "mn05"
-                        "MangaOnline.fun" -> "m02"
-                        "MangaToday" -> "m03"
-                        else -> null
-                    }
                     val chapterUrl = chapter.url.split("/")
 
                     put("mangaSource", mangaSource)

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangahub/MangaHub.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangahub/MangaHub.kt
@@ -135,7 +135,7 @@ abstract class MangaHub(
         val url: String,
         val title: String,
         val thumbnailUrl: String,
-        val signature: String
+        val signature: String,
     )
 
     private fun Element.toSignature(): String {
@@ -164,7 +164,7 @@ abstract class MangaHub(
                     it.select("h4 a").attr("abs:href"),
                     it.select("h4 a").text(),
                     it.select("img").attr("abs:src"),
-                    it.toSignature()
+                    it.toSignature(),
                 )
             }
             .distinctBy { it.signature }

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangahub/MangaHubGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangahub/MangaHubGenerator.kt
@@ -9,22 +9,20 @@ class MangaHubGenerator : ThemeSourceGenerator {
 
     override val themeClass = "MangaHub"
 
-    override val baseVersionCode: Int = 25
+    override val baseVersionCode: Int = 26
 
     override val sources = listOf(
-//        SingleLang("1Manga.co", "https://1manga.co", "en", isNsfw = true, className = "OneMangaCo"),
-//        SingleLang("MangaFox.fun", "https://mangafox.fun", "en", isNsfw = true, className = "MangaFoxFun"),
-//        SingleLang("MangaHere.onl", "https://mangahere.onl", "en", isNsfw = true, className = "MangaHereOnl"),
+        SingleLang("1Manga.co", "https://1manga.co", "en", isNsfw = true, className = "OneMangaCo"),
+        SingleLang("MangaFox.fun", "https://mangafox.fun", "en", isNsfw = true, className = "MangaFoxFun"),
+        SingleLang("MangaHere.onl", "https://mangahere.onl", "en", isNsfw = true, className = "MangaHereOnl"),
         SingleLang("MangaHub", "https://mangahub.io", "en", isNsfw = true, overrideVersionCode = 10, className = "MangaHubIo"),
-//        SingleLang("Mangakakalot.fun", "https://mangakakalot.fun", "en", isNsfw = true, className = "MangakakalotFun"),
-//        SingleLang("MangaNel", "https://manganel.me", "en", isNsfw = true),
-//        SingleLang("MangaOnline.fun", "https://mangaonline.fun", "en", isNsfw = true, className = "MangaOnlineFun"),
+        SingleLang("Mangakakalot.fun", "https://mangakakalot.fun", "en", isNsfw = true, className = "MangakakalotFun"),
+        SingleLang("MangaNel", "https://manganel.me", "en", isNsfw = true),
+        SingleLang("MangaOnline.fun", "https://mangaonline.fun", "en", isNsfw = true, className = "MangaOnlineFun"),
         SingleLang("MangaPanda.onl", "https://mangapanda.onl", "en", className = "MangaPandaOnl"),
         SingleLang("MangaReader.site", "https://mangareader.site", "en", className = "MangaReaderSite"),
-//        SingleLang("MangaToday", "https://mangatoday.fun", "en", isNsfw = true),
-//        SingleLang("MangaTown (unoriginal)", "https://manga.town", "en", isNsfw = true, className = "MangaTownHub"),
-        // SingleLang("MF Read Online", "https://mangafreereadonline.com", "en", isNsfw = true), // different pageListParse logic
-        // SingleLang("OneManga.info", "https://onemanga.info", "en", isNsfw = true, className = "OneMangaInfo"), // Some chapters link to 1manga.co, hard to filter
+        SingleLang("MangaToday", "https://mangatoday.fun", "en", isNsfw = true),
+        SingleLang("OneManga.info", "https://onemanga.info", "en", isNsfw = true, className = "OneMangaInfo"), // Some chapters link to 1manga.co, hard to filter
     )
 
     companion object {


### PR DESCRIPTION
Closes #99 

Changed how we deal with sources' duplicate entries. Re-enabled most of the commented-out sources except for two (dead sites). Didn't make icons for the re-enabled sources; but hey, that's what default icons are for.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
