### PR TITLE
fix kisslove altName

### DIFF
--- a/multisrc/overrides/fmreader/kisslove/src/KissLove.kt
+++ b/multisrc/overrides/fmreader/kisslove/src/KissLove.kt
@@ -11,6 +11,9 @@ import org.jsoup.nodes.Element
 import java.util.Calendar
 
 class KissLove : FMReader("KissLove", "https://klz9.com", "ja") {
+
+    override val altNameSelector = "li:contains(Other name (s))"
+
     override fun latestUpdatesRequest(page: Int) =
         GET("$baseUrl/manga-list.html?page=$page&sort=last_update")
 

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/fmreader/FMReaderGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/fmreader/FMReaderGenerator.kt
@@ -12,7 +12,7 @@ class FMReaderGenerator : ThemeSourceGenerator {
     override val baseVersionCode: Int = 9
 
     override val sources = listOf(
-        SingleLang("KissLove", "https://klz9.com", "ja", isNsfw = true, overrideVersionCode = 4),
+        SingleLang("KissLove", "https://klz9.com", "ja", isNsfw = true, overrideVersionCode = 5),
         SingleLang("Manga-TR", "https://manga-tr.com", "tr", className = "MangaTR", overrideVersionCode = 3),
         SingleLang("Manga1000", "https://manga1000.top", "ja"),
         SingleLang("Nicomanga", "https://nicomanga.com", "ja", isNsfw = true),


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
