### PR TITLE
all/SimplyHentai: Fix http 404 

### DIFF
--- a/src/all/simplyhentai/build.gradle
+++ b/src/all/simplyhentai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Simply Hentai'
     extClass = '.SimplyHentaiFactory'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = true
 }
 

--- a/src/all/simplyhentai/src/eu/kanade/tachiyomi/extension/all/simplyhentai/SimplyHentai.kt
+++ b/src/all/simplyhentai/src/eu/kanade/tachiyomi/extension/all/simplyhentai/SimplyHentai.kt
@@ -32,6 +32,8 @@ open class SimplyHentai(
 
     override val supportsLatest = true
 
+    override val client = network.cloudflareClient
+
     override val versionId = 2
 
     private val apiUrl = "https://api.simply-hentai.com/v3"

--- a/src/all/simplyhentai/src/eu/kanade/tachiyomi/extension/all/simplyhentai/SimplyHentai.kt
+++ b/src/all/simplyhentai/src/eu/kanade/tachiyomi/extension/all/simplyhentai/SimplyHentai.kt
@@ -66,12 +66,10 @@ open class SimplyHentai(
         }
 
     override fun latestUpdatesRequest(page: Int) =
-        Uri.parse("$apiUrl/albums").buildUpon().run {
-            appendQueryParameter("si", "0")
-            appendQueryParameter("locale", lang)
-            appendQueryParameter("language", langName)
-            appendQueryParameter("sort", "newest")
+        Uri.parse("$apiUrl/tag/$langName").buildUpon().run {
+            appendQueryParameter("type", "language")
             appendQueryParameter("page", page.toString())
+            appendQueryParameter("sort", "newest")
             GET(build().toString(), headers)
         }
 

--- a/src/all/simplyhentai/src/eu/kanade/tachiyomi/extension/all/simplyhentai/SimplyHentai.kt
+++ b/src/all/simplyhentai/src/eu/kanade/tachiyomi/extension/all/simplyhentai/SimplyHentai.kt
@@ -141,7 +141,6 @@ open class SimplyHentai(
         SChapter.create().apply {
             val album = response.decode<SHAlbum>().data
             name = "Chapter"
-            chapter_number = -1F
             url = "${album.path}/all-pages"
             scanlator = album.translators.joinToString { it.title }
             date_upload = dateFormat.parse(album.created_at)?.time ?: 0L

--- a/src/all/simplyhentai/src/eu/kanade/tachiyomi/extension/all/simplyhentai/SimplyHentai.kt
+++ b/src/all/simplyhentai/src/eu/kanade/tachiyomi/extension/all/simplyhentai/SimplyHentai.kt
@@ -78,18 +78,16 @@ open class SimplyHentai(
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList) =
         Uri.parse("$apiUrl/search/complex").buildUpon().run {
-            appendQueryParameter("si", "0")
-            appendQueryParameter("locale", lang)
             appendQueryParameter("query", query)
             appendQueryParameter("page", page.toString())
             appendQueryParameter("blacklist", blacklist)
-            appendQueryParameter("filter[languages][0]", langName)
+            appendQueryParameter("filter[language][0]", langName.replaceFirstChar(Char::uppercase))
             filters.forEach { filter ->
                 when (filter) {
                     is SortFilter -> {
                         appendQueryParameter("sort", filter.orders[filter.state])
                     }
-                    is SeriesFilter -> filter.value?.let {
+                    is SeriesFilter -> filter.value?.also {
                         appendQueryParameter("filter[series_title][0]", it)
                     }
                     is TagsFilter -> filter.value?.forEachIndexed { idx, tag ->

--- a/src/all/simplyhentai/src/eu/kanade/tachiyomi/extension/all/simplyhentai/SimplyHentai.kt
+++ b/src/all/simplyhentai/src/eu/kanade/tachiyomi/extension/all/simplyhentai/SimplyHentai.kt
@@ -136,9 +136,9 @@ open class SimplyHentai(
             title = album.title
             description = buildString {
                 if (!album.description.isNullOrEmpty()) {
-                    append("${album.description}\n\n")
+                    append(album.description, "\n\n")
                 }
-                append("Series: ${album.series.title}\n")
+                append("Series: ", album.series.title, "\n")
                 album.characters.joinTo(this, prefix = "Characters: ") { it.title }
             }
             thumbnail_url = album.preview.sizes.thumb
@@ -149,10 +149,8 @@ open class SimplyHentai(
         }
 
     override fun chapterListRequest(manga: SManga) =
-        Uri.parse("$apiUrl/album").buildUpon().run {
+        Uri.parse("$apiUrl/manga").buildUpon().run {
             appendEncodedPath(manga.url.split('/')[2])
-            appendQueryParameter("si", "0")
-            appendQueryParameter("locale", lang)
             GET(build().toString(), headers)
         }
 
@@ -160,18 +158,16 @@ open class SimplyHentai(
         SChapter.create().apply {
             val album = response.decode<SHAlbum>().data
             name = "Chapter"
-            chapter_number = -1f
+            chapter_number = -1F
             url = "${album.path}/all-pages"
             scanlator = album.translators.joinToString { it.title }
             date_upload = dateFormat.parse(album.created_at)?.time ?: 0L
         }.let(::listOf)
 
     override fun pageListRequest(chapter: SChapter) =
-        Uri.parse("$apiUrl/album").buildUpon().run {
+        Uri.parse("$apiUrl/manga").buildUpon().run {
             appendEncodedPath(chapter.url.split('/')[2])
-            appendEncodedPath("/pages")
-            appendQueryParameter("si", "0")
-            appendQueryParameter("locale", lang)
+            appendEncodedPath("pages")
             GET(build().toString(), headers)
         }
 

--- a/src/all/simplyhentai/src/eu/kanade/tachiyomi/extension/all/simplyhentai/SimplyHentaiAPI.kt
+++ b/src/all/simplyhentai/src/eu/kanade/tachiyomi/extension/all/simplyhentai/SimplyHentaiAPI.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.extension.all.simplyhentai
 
+import eu.kanade.tachiyomi.source.model.SManga
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -21,7 +22,11 @@ data class SHObject(
     val slug: String,
     val title: String,
 ) {
-    val path by lazy { "/${series.slug}/$slug" }
+    fun toSManga() = SManga.create().apply {
+        url = "/${series.slug}/$slug"
+        title = this@SHObject.title
+        thumbnail_url = preview.sizes.thumb
+    }
 }
 
 @Serializable

--- a/src/all/simplyhentai/src/eu/kanade/tachiyomi/extension/all/simplyhentai/SimplyHentaiAPI.kt
+++ b/src/all/simplyhentai/src/eu/kanade/tachiyomi/extension/all/simplyhentai/SimplyHentaiAPI.kt
@@ -3,13 +3,16 @@ package eu.kanade.tachiyomi.extension.all.simplyhentai
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class SHList<T>(val pagination: SHPagination, val data: List<T>)
+data class SHList<T>(val pagination: SHPagination, val data: T)
 
 @Serializable
 data class SHPagination(val next: Int?)
 
 @Serializable
 data class SHWrapper(val `object`: SHObject)
+
+@Serializable
+data class SHDataAlbum(val albums: List<SHObject>)
 
 @Serializable
 data class SHObject(

--- a/src/all/simplyhentai/src/eu/kanade/tachiyomi/extension/all/simplyhentai/SimplyHentaiFactory.kt
+++ b/src/all/simplyhentai/src/eu/kanade/tachiyomi/extension/all/simplyhentai/SimplyHentaiFactory.kt
@@ -4,20 +4,15 @@ import eu.kanade.tachiyomi.source.SourceFactory
 
 class SimplyHentaiFactory : SourceFactory {
     override fun createSources() = listOf(
-        SimplyHentai("en"),
-        SimplyHentai("ja"),
-        SimplyHentai("zh"),
-        SimplyHentai("ko"),
-        SimplyHentai("es"),
-        SimplyHentai("ru"),
-        SimplyHentai("fr"),
-        SimplyHentai("de"),
-        object : SimplyHentai("pt-BR") {
-            // The site uses a Portugal flag for the language,
-            // but the contents are in Brazilian Portuguese.
-            override val id = 23032005200449651
-        },
-        SimplyHentai("it"),
-        SimplyHentai("pl"),
+        SimplyHentai("en", "english"),
+        SimplyHentai("ja", "japanese"),
+        SimplyHentai("zh", "chinese"),
+        SimplyHentai("ko", "korean"),
+        SimplyHentai("es", "spanish"),
+        SimplyHentai("ru", "russian"),
+        SimplyHentai("fr", "french"),
+        SimplyHentai("de", "german"),
+        SimplyHentai("it", "italian"),
+        SimplyHentai("pl", "polish"),
     )
 }


### PR DESCRIPTION
Closes #580

Note: This PR removes the `pt-BR` (Brazillian Portuguese) language from the extension, as the source itself has removed it.
\>imagine bater pra desenho

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
