### PR TITLE
Manga1000: Fix page list parse

### DIFF
--- a/multisrc/overrides/fmreader/manga1000/src/Manga1000.kt
+++ b/multisrc/overrides/fmreader/manga1000/src/Manga1000.kt
@@ -59,12 +59,12 @@ class Manga1000 : FMReader("Manga1000", "https://manga1000.top", "ja") {
     }
 
     override fun pageListParse(document: Document): List<Page> {
-        return document.select("script:containsData(imgsListchap)")
+        return document.select("script:containsData(imgsChapter)")
             .html()
             .substringAfter("(")
             .substringBefore(",")
             .let { cid ->
-                client.newCall(GET("$baseUrl/app/manga/controllers/cont.imgsList.php?cid=$cid", headers)).execute().asJsoup()
+                client.newCall(GET("$baseUrl/app/manga/controllers/cont.Showimage.php?cid=$cid", headers)).execute().asJsoup()
             }
             .select(".lazyload")
             .mapIndexed { i, e ->

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/fmreader/FMReaderGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/fmreader/FMReaderGenerator.kt
@@ -14,7 +14,7 @@ class FMReaderGenerator : ThemeSourceGenerator {
     override val sources = listOf(
         SingleLang("KissLove", "https://klz9.com", "ja", isNsfw = true, overrideVersionCode = 5),
         SingleLang("Manga-TR", "https://manga-tr.com", "tr", className = "MangaTR", overrideVersionCode = 3),
-        SingleLang("Manga1000", "https://manga1000.top", "ja"),
+        SingleLang("Manga1000", "https://manga1000.top", "ja", overrideVersionCode = 1),
         SingleLang("Nicomanga", "https://nicomanga.com", "ja", isNsfw = true),
         SingleLang("WeLoveManga", "https://weloma.art", "ja", pkgName = "rawlh", isNsfw = true, overrideVersionCode = 5),
         SingleLang("WeLoveMangaOne", "https://welovemanga.one", "ja", isNsfw = true, overrideVersionCode = 1),


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
