### PR TITLE
Add condition to only run codeberg_mirror on keiyoushi repo...

### DIFF
--- a/.github/workflows/codeberg_mirror.yml
+++ b/.github/workflows/codeberg_mirror.yml
@@ -10,14 +10,13 @@ on:
 
 jobs:
   codeberg:
+    if: "github.repository == 'keiyoushi/extensions-source'"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-        if: "github.repository == 'keiyoushi/extensions-source'"
         with:
           fetch-depth: 0
       - uses: pixta-dev/repository-mirroring-action@674e65a7d483ca28dafaacba0d07351bdcc8bd75 # v1
-        if: "github.repository == 'keiyoushi/extensions-source'"
         with:
           target_repo_url: "git@codeberg.org:keiyoushi/extensions-source.git"
           ssh_private_key: ${{ secrets.CODEBERG_SSH }}

--- a/.github/workflows/codeberg_mirror.yml
+++ b/.github/workflows/codeberg_mirror.yml
@@ -13,9 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        if: "github.repository == 'keiyoushi/extensions-source'"
         with:
           fetch-depth: 0
       - uses: pixta-dev/repository-mirroring-action@674e65a7d483ca28dafaacba0d07351bdcc8bd75 # v1
+        if: "github.repository == 'keiyoushi/extensions-source'"
         with:
           target_repo_url: "git@codeberg.org:keiyoushi/extensions-source.git"
           ssh_private_key: ${{ secrets.CODEBERG_SSH }}


### PR DESCRIPTION
… instead of other forks

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
