### PR TITLE
id/mangaku: added override baseUrl setting

### DIFF
--- a/src/id/mangaku/build.gradle
+++ b/src/id/mangaku/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Mangaku'
     extClass = '.Mangaku'
-    extVersionCode = 9
+    extVersionCode = 10
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/mangaku/src/eu/kanade/tachiyomi/extension/id/mangaku/Mangaku.kt
+++ b/src/id/mangaku/src/eu/kanade/tachiyomi/extension/id/mangaku/Mangaku.kt
@@ -12,7 +12,6 @@ import android.webkit.WebViewClient
 import android.widget.Toast
 import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.AppInfo
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.asObservableSuccess
@@ -45,6 +44,10 @@ class Mangaku : ParsedHttpSource(), ConfigurableSource {
 
     override val name = "Mangaku"
 
+    private val preferences: SharedPreferences by lazy {
+        Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
+    }
+
     override val baseUrl = preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)!!
 
     override val lang = "id"
@@ -54,10 +57,6 @@ class Mangaku : ParsedHttpSource(), ConfigurableSource {
     override val client = network.cloudflareClient
 
     private lateinit var directory: Elements
-
-    private val preferences: SharedPreferences by lazy {
-        Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
-    }
 
     override fun headersBuilder(): Headers.Builder =
         super.headersBuilder().add("Referer", "$baseUrl/")
@@ -264,7 +263,7 @@ class Mangaku : ParsedHttpSource(), ConfigurableSource {
     }
 
     companion object {
-        private val PREF_DOMAIN_KEY = "preferred_domain_name_v${AppInfo.getVersionName()}"
+        private const val PREF_DOMAIN_KEY = "mangakuUrlPreference"
         private const val PREF_DOMAIN_TITLE = "Override BaseUrl"
         private const val PREF_DOMAIN_DEFAULT = "https://mangaku.bio"
         private const val PREF_DOMAIN_SUMMARY = "Override default domain with a different one"

--- a/src/id/mangaku/src/eu/kanade/tachiyomi/extension/id/mangaku/Mangaku.kt
+++ b/src/id/mangaku/src/eu/kanade/tachiyomi/extension/id/mangaku/Mangaku.kt
@@ -45,7 +45,7 @@ class Mangaku : ParsedHttpSource(), ConfigurableSource {
 
     override val name = "Mangaku"
 
-    override val baseUrl by lazy { preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)!! }
+    override val baseUrl = preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)!!
 
     override val lang = "id"
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
