### PR TITLE
override mangaSubString for "GateManga"

### DIFF
--- a/multisrc/overrides/madara/gatemanga/src/Gatemanga.kt
+++ b/multisrc/overrides/madara/gatemanga/src/Gatemanga.kt
@@ -1,0 +1,14 @@
+package eu.kanade.tachiyomi.extension.ar.gatemanga
+
+import eu.kanade.tachiyomi.multisrc.madara.Madara
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+class Gatemanga : Madara(
+    "Gatemanga",
+    "https://gatemanga.com",
+    "ar",
+    dateFormat = SimpleDateFormat("d MMMM، yyyy", Locale("ar")),
+) {
+    override val mangaSubString = "ar"
+}

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -98,7 +98,7 @@ class MadaraGenerator : ThemeSourceGenerator {
         SingleLang("FreeMangaTop", "https://freemangatop.com", "en", overrideVersionCode = 2),
         SingleLang("FreeWebtoonCoins", "https://freewebtooncoins.com", "en", overrideVersionCode = 1),
         SingleLang("GalaxyDegenScans", "https://gdscans.com", "en", overrideVersionCode = 4),
-        SingleLang("Gatemanga", "https://gatemanga.com", "ar", overrideVersionCode = 1),
+        SingleLang("Gatemanga", "https://gatemanga.com", "ar", overrideVersionCode = 2),
         SingleLang("Gekkou Scans", "https://gekkou.site", "pt-BR", isNsfw = true, pkgName = "gekkouscan", overrideVersionCode = 2),
         SingleLang("Ghost Scan", "https://ghostscan.com.br", "pt-BR", isNsfw = true),
         SingleLang("Girls Love Manga!", "https://glmanga.com", "en", isNsfw = true, className = "GirlsLoveManga"),


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
