### PR TITLE
ReadM - update domain

### DIFF
--- a/src/en/readm/build.gradle
+++ b/src/en/readm/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ReadM'
     extClass = '.ReadM'
-    extVersionCode = 7
+    extVersionCode = 8
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/readm/src/eu/kanade/tachiyomi/extension/en/readm/ReadM.kt
+++ b/src/en/readm/src/eu/kanade/tachiyomi/extension/en/readm/ReadM.kt
@@ -26,7 +26,7 @@ class ReadM : ParsedHttpSource() {
 
     // Info
     override val name: String = "ReadM"
-    override val baseUrl: String = "https://readm.org"
+    override val baseUrl: String = "https://readm.today"
     override val lang: String = "en"
     override val supportsLatest: Boolean = true
     override val client: OkHttpClient = network.cloudflareClient.newBuilder()
@@ -102,7 +102,7 @@ class ReadM : ParsedHttpSource() {
         status = parseStatus(document.select("div.series-genres .series-status").firstOrNull()?.ownText())
     }
 
-    protected fun parseStatus(element: String?): Int = when {
+    private fun parseStatus(element: String?): Int = when {
         element == null -> SManga.UNKNOWN
         listOf("ongoing").any { it.contains(element, ignoreCase = true) } -> SManga.ONGOING
         listOf("completed").any { it.contains(element, ignoreCase = true) } -> SManga.COMPLETED


### PR DESCRIPTION
Closes #1068, search issue seems resolved with domain update.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension


