### PR TITLE
Manga1000: Fix Chapter list and Manga details issue

### DIFF
--- a/multisrc/overrides/fmreader/manga1000/src/Manga1000.kt
+++ b/multisrc/overrides/fmreader/manga1000/src/Manga1000.kt
@@ -13,6 +13,9 @@ import rx.Observable
 import java.util.Calendar
 
 class Manga1000 : FMReader("Manga1000", "https://manga1000.top", "ja") {
+
+    override val infoElementSelector = "div.row div.row"
+
     // source is picky about URL format
     private fun mangaRequest(sortBy: String, page: Int): Request {
         return GET("$baseUrl/manga-list.html?listType=pagination&page=$page&artist=&author=&group=&m_status=&name=&genre=&ungenre=&magazine=&sort=$sortBy&sort_type=DESC", headers)

--- a/multisrc/overrides/fmreader/manga1000/src/Manga1000.kt
+++ b/multisrc/overrides/fmreader/manga1000/src/Manga1000.kt
@@ -25,7 +25,7 @@ class Manga1000 : FMReader("Manga1000", "https://manga1000.top", "ja") {
     override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> {
         val slug = manga.url.substringAfter("manga-").substringBefore(".html")
 
-        return client.newCall(GET("$baseUrl/app/manga/controllers/cont.Listchapterapi.php?slug=$slug", headers))
+        return client.newCall(GET("$baseUrl/app/manga/controllers/cont.Listchapter.php?slug=$slug", headers))
             .asObservableSuccess()
             .map { res ->
                 res.asJsoup().select(".at-series a").map {

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/fmreader/FMReaderGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/fmreader/FMReaderGenerator.kt
@@ -14,7 +14,7 @@ class FMReaderGenerator : ThemeSourceGenerator {
     override val sources = listOf(
         SingleLang("KissLove", "https://klz9.com", "ja", isNsfw = true, overrideVersionCode = 5),
         SingleLang("Manga-TR", "https://manga-tr.com", "tr", className = "MangaTR", overrideVersionCode = 3),
-        SingleLang("Manga1000", "https://manga1000.top", "ja", overrideVersionCode = 1),
+        SingleLang("Manga1000", "https://manga1000.top", "ja", overrideVersionCode = 2),
         SingleLang("Nicomanga", "https://nicomanga.com", "ja", isNsfw = true),
         SingleLang("WeLoveManga", "https://weloma.art", "ja", pkgName = "rawlh", isNsfw = true, overrideVersionCode = 5),
         SingleLang("WeLoveMangaOne", "https://welovemanga.one", "ja", isNsfw = true, overrideVersionCode = 1),


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
