### PR TITLE
Earlym: Fix unexpected JSON token 

### DIFF
--- a/src/en/earlymanga/build.gradle
+++ b/src/en/earlymanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'EarlyManga'
     extClass = '.EarlyManga'
-    extVersionCode = 24
+    extVersionCode = 25
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/earlymanga/src/eu/kanade/tachiyomi/extension/en/earlymanga/EarlyMangaDto.kt
+++ b/src/en/earlymanga/src/eu/kanade/tachiyomi/extension/en/earlymanga/EarlyMangaDto.kt
@@ -59,7 +59,7 @@ data class Chapter(
     val id: Int,
     val manga_id: Int,
     val slug: String,
-    val on_disk: Int,
+    val on_disk: Int?,
     val images: List<String>,
 )
 


### PR DESCRIPTION
Edge case, Closes #1107

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
