### PR TITLE
Luminous Scans: Update domain

### DIFF
--- a/multisrc/overrides/mangathemesia/luminousscans/src/LuminousScans.kt
+++ b/multisrc/overrides/mangathemesia/luminousscans/src/LuminousScans.kt
@@ -20,7 +20,7 @@ import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.io.IOException
 
-class LuminousScans : MangaThemesia("Luminous Scans", "https://luminousscans.net", "en", mangaUrlDirectory = "/series") {
+class LuminousScans : MangaThemesia("Luminous Scans", "https://luminousscans.gg", "en", mangaUrlDirectory = "/series") {
     override val client = super.client.newBuilder()
         .addInterceptor(::urlChangeInterceptor)
         .rateLimit(2)

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaGenerator.kt
@@ -80,7 +80,7 @@ class MangaThemesiaGenerator : ThemeSourceGenerator {
         SingleLang("Legacy Scans", "https://legacy-scans.com", "fr", pkgName = "flamescansfr"),
         SingleLang("Lelmanga", "https://www.lelmanga.com", "fr"),
         SingleLang("LianScans", "https://www.lianscans.my.id", "id", isNsfw = true),
-        SingleLang("Luminous Scans", "https://luminousscans.net", "en", overrideVersionCode = 1),
+        SingleLang("Luminous Scans", "https://luminousscans.gg", "en", overrideVersionCode = 2),
         SingleLang("Lunar Scans", "https://lunarscan.org", "en", isNsfw = true, overrideVersionCode = 1),
         SingleLang("Magus Manga", "https://magusmanga.com", "en", overrideVersionCode = 1),
         SingleLang("Makimaaaaa", "https://makimaaaaa.com", "th", isNsfw = true),


### PR DESCRIPTION
Closes #1113

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
