### PR TITLE
Komga: Permanent URLs

### DIFF
--- a/src/all/komga/build.gradle
+++ b/src/all/komga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Komga'
     extClass = '.KomgaFactory'
-    extVersionCode = 54
+    extVersionCode = 55
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/Komga.kt
+++ b/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/Komga.kt
@@ -364,7 +364,7 @@ open class Komga(private val suffix: String = "") : ConfigurableSource, Unmetere
         SwitchPreferenceCompat(screen.context).apply {
             key = PREF_PERMANENT_URL
             title = "[BETA] Permanent URLs"
-            summary = "Turns all manga URLs into permanent ones.\nIf this is enabled, the Komga instance used by this source MUST stay the same through address changes.\nMigration MUST be done every time this option is toggled.\nBREAKS ENHANCED TRACKING!"
+            summary = "When enabled, series are automatically migrated when the server address changes, as long as the Komga server stays the same.\nMigration MUST be done every time this option is toggled.\nBREAKS ENHANCED TRACKING!"
 
             setDefaultValue(false)
             setOnPreferenceChangeListener { _, newValue ->

--- a/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/KomgaUtils.kt
+++ b/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/KomgaUtils.kt
@@ -6,7 +6,6 @@ import android.widget.Button
 import android.widget.Toast
 import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.extension.all.komga.KomgaUtils.toSManga
 import eu.kanade.tachiyomi.extension.all.komga.dto.BookDto
 import eu.kanade.tachiyomi.extension.all.komga.dto.PageWrapperDto
 import eu.kanade.tachiyomi.extension.all.komga.dto.ReadListDto
@@ -49,15 +48,15 @@ internal object KomgaUtils {
 
     fun Response.isFromReadList() = request.url.toString().contains("/api/v1/readlists")
 
-    fun processSeriesPage(response: Response, baseUrl: String): MangasPage {
+    fun processSeriesPage(response: Response, baseUrl: String, urlPrefix: String): MangasPage {
         return if (response.isFromReadList()) {
             val data = response.parseAs<PageWrapperDto<ReadListDto>>()
 
-            MangasPage(data.content.map { it.toSManga(baseUrl) }, !data.last)
+            MangasPage(data.content.map { it.toSManga(baseUrl, urlPrefix) }, !data.last)
         } else {
             val data = response.parseAs<PageWrapperDto<SeriesDto>>()
 
-            MangasPage(data.content.map { it.toSManga(baseUrl) }, !data.last)
+            MangasPage(data.content.map { it.toSManga(baseUrl, urlPrefix) }, !data.last)
         }
     }
 
@@ -83,11 +82,11 @@ internal object KomgaUtils {
         }
     }
 
-    fun SeriesDto.toSManga(baseUrl: String): SManga =
+    fun SeriesDto.toSManga(baseUrl: String, urlPrefix: String): SManga =
         SManga.create().apply {
             title = metadata.title
-            url = "$baseUrl/api/v1/series/$id"
-            thumbnail_url = "$url/thumbnail"
+            url = "$urlPrefix/api/v1/series/$id"
+            thumbnail_url = "$baseUrl/api/v1/series/$id/thumbnail"
             status = when {
                 metadata.status == "ENDED" && metadata.totalBookCount != null && booksCount < metadata.totalBookCount -> SManga.PUBLISHING_FINISHED
                 metadata.status == "ENDED" -> SManga.COMPLETED
@@ -104,12 +103,12 @@ internal object KomgaUtils {
             }
         }
 
-    fun ReadListDto.toSManga(baseUrl: String): SManga =
+    fun ReadListDto.toSManga(baseUrl: String, urlPrefix: String): SManga =
         SManga.create().apply {
             title = name
             description = summary
-            url = "$baseUrl/api/v1/readlists/$id"
-            thumbnail_url = "$url/thumbnail"
+            url = "$urlPrefix/api/v1/readlists/$id"
+            thumbnail_url = "$baseUrl/api/v1/readlists/$id/thumbnail"
             status = SManga.UNKNOWN
         }
 

--- a/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/KomgaUtils.kt
+++ b/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/KomgaUtils.kt
@@ -86,7 +86,7 @@ internal object KomgaUtils {
         SManga.create().apply {
             title = metadata.title
             url = "$urlPrefix/api/v1/series/$id"
-            thumbnail_url = "$baseUrl/api/v1/series/$id/thumbnail"
+            thumbnail_url = "${url.replaceFirst(urlPrefix, baseUrl)}/thumbnail"
             status = when {
                 metadata.status == "ENDED" && metadata.totalBookCount != null && booksCount < metadata.totalBookCount -> SManga.PUBLISHING_FINISHED
                 metadata.status == "ENDED" -> SManga.COMPLETED
@@ -108,7 +108,7 @@ internal object KomgaUtils {
             title = name
             description = summary
             url = "$urlPrefix/api/v1/readlists/$id"
-            thumbnail_url = "$baseUrl/api/v1/readlists/$id/thumbnail"
+            thumbnail_url = "${url.replaceFirst(urlPrefix, baseUrl)}/thumbnail"
             status = SManga.UNKNOWN
         }
 


### PR DESCRIPTION
Closes #635 

The approach is to replace the URL with the Komga prefix, e.g. `https://demo.komga.org/api/v1/series/0EBEX4TZ8JXHF` becomes `1/api/v1/series/0EBEX4TZ8JXHF`.

Comments on the approach itself is welcome.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
