### PR TITLE
NepNep - conditionally add scanlator info

### DIFF
--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/nepnep/NepNepGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/nepnep/NepNepGenerator.kt
@@ -9,7 +9,7 @@ class NepNepGenerator : ThemeSourceGenerator {
 
     override val themeClass = "NepNep"
 
-    override val baseVersionCode: Int = 11
+    override val baseVersionCode: Int = 12
 
     override val sources = listOf(
         SingleLang("MangaSee", "https://mangasee123.com", "en", overrideVersionCode = 24),


### PR DESCRIPTION
Useful in some cases where a user would like to filter out certain chapters of a manga.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension