### PR TITLE
StoneScape cleanup

### DIFF
--- a/multisrc/overrides/madara/stonescape/src/StoneScape.kt
+++ b/multisrc/overrides/madara/stonescape/src/StoneScape.kt
@@ -1,4 +1,4 @@
-package eu.kanade.tachiyomi.extension.ar.stonescape
+package eu.kanade.tachiyomi.extension.en.stonescape
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import java.text.SimpleDateFormat
@@ -11,4 +11,5 @@ class StoneScape : Madara(
     SimpleDateFormat("MMMM dd, yyyy", Locale("en")),
 ) {
     override val mangaSubString = "series"
+    override val chapterUrlSelector = "div + a"
 }


### PR DESCRIPTION
Fixes package name. Added a fix for chapter names while I was at it.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
