### PR TITLE
LectorTMO: Add preference for save the last CF url

### DIFF
--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/lectortmo/LectorTmoGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/lectortmo/LectorTmoGenerator.kt
@@ -9,7 +9,7 @@ class LectorTmoGenerator : ThemeSourceGenerator {
 
     override val themeClass = "LectorTmo"
 
-    override val baseVersionCode: Int = 2
+    override val baseVersionCode: Int = 3
 
     override val sources = listOf(
         SingleLang("LectorManga", "https://lectormanga.com", "es", isNsfw = true, overrideVersionCode = 34),


### PR DESCRIPTION
Some chapters page list are protected by Cloudflare, and the users can't open in WebView because it redirects to Google due to the redirect chain changes the Referer and the app set a static Referer. This pref should help.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
