### PR TITLE
Add build files for lib-multisrc migration

### DIFF
--- a/buildSrc/.gitignore
+++ b/buildSrc/.gitignore
@@ -1,2 +1,0 @@
-.gradle/
-build/

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,5 +3,14 @@ plugins {
 }
 
 repositories {
+    gradlePluginPortal()
     mavenCentral()
+    google()
+}
+
+dependencies {
+    implementation(libs.gradle.agp)
+    implementation(libs.gradle.kotlin)
+    implementation(libs.gradle.serialization)
+    implementation(libs.gradle.kotlinter)
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/Extensions.kt
+++ b/buildSrc/src/main/kotlin/Extensions.kt
@@ -1,0 +1,6 @@
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.kotlin.dsl.extra
+
+var ExtensionAware.baseVersionCode: Int
+    get() = extra.get("baseVersionCode") as Int
+    set(value) = extra.set("baseVersionCode", value)

--- a/buildSrc/src/main/kotlin/lib-multisrc.gradle.kts
+++ b/buildSrc/src/main/kotlin/lib-multisrc.gradle.kts
@@ -1,0 +1,62 @@
+plugins {
+    id("com.android.library")
+    kotlin("android")
+    id("kotlinx-serialization")
+    id("org.jmailen.kotlinter")
+}
+
+android {
+    compileSdk = AndroidConfig.compileSdk
+
+    defaultConfig {
+        minSdk = AndroidConfig.minSdk
+    }
+
+    namespace = "eu.kanade.tachiyomi.multisrc.${project.name}"
+
+    sourceSets {
+        named("main") {
+            manifest.srcFile("AndroidManifest.xml")
+            java.setSrcDirs(listOf("src"))
+            res.setSrcDirs(listOf("res"))
+            assets.setSrcDirs(listOf("assets"))
+        }
+    }
+
+    buildFeatures {
+        resValues = false
+        shaders = false
+    }
+
+    kotlinOptions {
+        freeCompilerArgs += "-opt-in=kotlinx.serialization.ExperimentalSerializationApi"
+    }
+}
+
+kotlinter {
+    experimentalRules = true
+    disabledRules = arrayOf(
+        "experimental:argument-list-wrapping", // Doesn't play well with Android Studio
+        "experimental:comment-wrapping",
+    )
+}
+
+repositories {
+    mavenCentral()
+}
+
+// TODO: use versionCatalogs.named("libs") in Gradle 8.5
+val libs = project.extensions.getByType<VersionCatalogsExtension>().named("libs")
+dependencies {
+    compileOnly(libs.findBundle("common").get())
+}
+
+tasks {
+    preBuild {
+        dependsOn(lintKotlin)
+    }
+
+    lintKotlin {
+        dependsOn(formatKotlin)
+    }
+}

--- a/common.gradle
+++ b/common.gradle
@@ -8,6 +8,8 @@ assert !ext.has("libVersion")
 
 assert extName.chars().max().asInt < 0x180 : "Extension name should be romanized"
 
+Project theme = ext.has("themePkg") ? project(":lib-multisrc:$themePkg") : null
+
 android {
     compileSdk AndroidConfig.compileSdk
 
@@ -25,7 +27,7 @@ android {
         minSdk AndroidConfig.minSdk
         targetSdk AndroidConfig.targetSdk
         applicationIdSuffix project.parent.name + "." + project.name
-        versionCode extVersionCode
+        versionCode theme == null ? extVersionCode : theme.baseVersionCode + overrideVersionCode
         versionName "1.4.$versionCode"
         base {
             archivesName = "tachiyomi-$applicationIdSuffix-v$versionName"
@@ -34,8 +36,18 @@ android {
         manifestPlaceholders = [
                 appName : "Tachiyomi: $extName",
                 extClass: extClass,
-                nsfw: project.ext.find("isNsfw") ? 1 : 0,
+                nsfw    : project.ext.find("isNsfw") ? 1 : 0,
         ]
+        String baseUrl = project.ext.find("baseUrl") ?: ""
+        if (theme != null && !baseUrl.isEmpty()) {
+            def split = baseUrl.split("://")
+            assert split.length == 2
+            def path = split[1].split("/")
+            manifestPlaceholders += [
+                    SOURCEHOST  : path[0],
+                    SOURCESCHEME: split[0],
+            ]
+        }
     }
 
     signingConfigs {
@@ -88,6 +100,7 @@ repositories {
 }
 
 dependencies {
+    if (theme != null) implementation(theme) // Overrides core launcher icons
     implementation(project(":core"))
     compileOnly(libs.bundles.common)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,9 @@ include(":core")
 // Load all modules under /lib
 File(rootDir, "lib").eachDir { include("lib:${it.name}") }
 
+// Load all modules under /lib-multisrc
+File(rootDir, "lib-multisrc").eachDir { include("lib-multisrc:${it.name}") }
+
 if (System.getenv("CI") == null || System.getenv("CI_MODULE_GEN") == "true") {
     // Local development (full project build)
 
@@ -88,5 +91,10 @@ fun File.getChunk(chunk: Int, chunkSize: Int): List<File>? {
 }
 
 fun File.eachDir(block: (File) -> Unit) {
-    listFiles()?.filter { it.isDirectory }?.forEach { block(it) }
+    val files = listFiles() ?: return
+    for (file in files) {
+        if (file.isDirectory && file.name != ".gradle" && file.name != "build") {
+            block(file)
+        }
+    }
 }


### PR DESCRIPTION
Reviewed in #1200

References #265

- Used Kotlin DSL and precompiled script plugin
- Retained the variable names: `baseVersionCode`, `overrideVersionCode`, `themePkg`
- Extension properties/functions in `buildSrc/src/main/kotlin/Extensions.kt`
- `baseUrl` trailing slash warnings will be implemented in build audit scripts