### PR TITLE
MangaHub: Update API URL

### DIFF
--- a/lib-multisrc/mangahub/build.gradle.kts
+++ b/lib-multisrc/mangahub/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 27
+baseVersionCode = 28
 
 dependencies {
     implementation(project(":lib:randomua"))

--- a/lib-multisrc/mangahub/src/eu/kanade/tachiyomi/multisrc/mangahub/MangaHub.kt
+++ b/lib-multisrc/mangahub/src/eu/kanade/tachiyomi/multisrc/mangahub/MangaHub.kt
@@ -47,7 +47,7 @@ abstract class MangaHub(
 
     override val supportsLatest = true
 
-    private var baseApiUrl = "$baseUrl/api"
+    private var baseApiUrl = "https://api.mghcdn.com"
     private var baseCdnUrl = "https://imgx.mghcdn.com"
 
     override val client: OkHttpClient = super.client.newBuilder()


### PR DESCRIPTION
Closes #1287

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
