### PR TITLE
Komga: README, chapter timestamp shenanigans, refactor

### DIFF
--- a/src/all/komga/README.md
+++ b/src/all/komga/README.md
@@ -1,0 +1,41 @@
+# Komga
+
+Table of Content
+- [FAQ](#FAQ)
+    - [Why do I see no manga?](#why-do-i-see-no-manga)
+    - [Where can I get more information about Komga?](#where-can-i-get-more-information-about-komga)
+    - [The Komga extension stopped working?](#the-komga-extension-stopped-working)
+    - [Can I add more than one Komga server or user?](#can-i-add-more-than-one-komga-server-or-user)
+    - [Can I test the Komga extension before setting up my own server?](#can-i-test-the-komga-extension-before-setting-up-my-own-server)
+- [Guides](#Guides)
+    - [How do I add my Komga server to the app?](#how-do-i-add-my-komga-server-to-the-app)
+
+## FAQ
+
+### Why do I see no manga?
+Komga is a self-hosted comic/manga media server.
+
+### Where can I get more information about Komga?
+You can visit the [Komga](https://komga.org/) website for for more information.
+
+### The Komga extension stopped working?
+Make sure that your Komga server and extension are on the newest version.
+
+### Can I add more than one Komga server or user?
+Yes, currently you can add up to 11 different Komga instances to the app. The number of instances
+available can be customized in extension settings.
+
+### Can I test the Komga extension before setting up my own server?
+Yes, you can try it out with the DEMO server `https://demo.komga.org`, username `demo@komga.org` and
+password `komga-demo`.
+
+### Why are EPUB chapters/books missing?
+Mihon/Tachiyomi does not support reading text. EPUB files containing only images will be available
+if your Komga server version is [1.9.0](https://github.com/gotson/komga/releases/tag/1.9.0)
+or newer.
+
+## Guides
+
+### How do I add my Komga server to the app?
+Go into the settings of the Komga extension (under Browse -> Extensions) and fill in your server
+address and login details.

--- a/src/all/komga/build.gradle
+++ b/src/all/komga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Komga'
     extClass = '.KomgaFactory'
-    extVersionCode = 55
+    extVersionCode = 56
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/Komga.kt
+++ b/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/Komga.kt
@@ -355,7 +355,7 @@ open class Komga(private val suffix: String = "") : ConfigurableSource, Unmetere
         screen.addEditTextPreference(
             title = "Password",
             default = "",
-            summary = if (password.isBlank()) "The user account password" else "*".repeat(8),
+            summary = if (password.isBlank()) "The user account password" else "*".repeat(password.length),
             inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD,
             key = PREF_PASSWORD,
             restartRequired = true,

--- a/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/Komga.kt
+++ b/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/Komga.kt
@@ -428,6 +428,7 @@ open class Komga(private val suffix: String = "") : ConfigurableSource, Unmetere
 
     private var fetchFilterStatus = FetchFilterStatus.NOT_FETCHED
     private var fetchFiltersAttempts = 0
+    private val scope = CoroutineScope(Dispatchers.IO)
 
     private fun fetchFilterOptions() {
         if (baseUrl.isBlank() || fetchFilterStatus != FetchFilterStatus.NOT_FETCHED || fetchFiltersAttempts >= 3) {
@@ -435,8 +436,9 @@ open class Komga(private val suffix: String = "") : ConfigurableSource, Unmetere
         }
 
         fetchFilterStatus = FetchFilterStatus.FETCHING
+        fetchFiltersAttempts++
 
-        CoroutineScope(Dispatchers.IO).launch {
+        scope.launch {
             try {
                 libraries = client.newCall(GET("$baseUrl/api/v1/libraries")).await().parseAs()
                 collections = client
@@ -456,8 +458,6 @@ open class Komga(private val suffix: String = "") : ConfigurableSource, Unmetere
             } catch (e: Exception) {
                 fetchFilterStatus = FetchFilterStatus.NOT_FETCHED
                 Log.e(logTag, "Failed to fetch filtering options", e)
-            } finally {
-                fetchFiltersAttempts++
             }
         }
     }

--- a/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/KomgaFactory.kt
+++ b/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/KomgaFactory.kt
@@ -6,9 +6,17 @@ import eu.kanade.tachiyomi.source.SourceFactory
 class KomgaFactory : SourceFactory {
     override fun createSources(): List<Source> {
         val firstKomga = Komga("")
-        val komgaCount = firstKomga.preferences.getString(Komga.PREF_EXTRA_SOURCES_COUNT, Komga.PREF_EXTRA_SOURCES_DEFAULT)!!.toInt()
+        val komgaCount = firstKomga.preferences
+            .getString(Komga.PREF_EXTRA_SOURCES_COUNT, Komga.PREF_EXTRA_SOURCES_DEFAULT)!!
+            .toInt()
 
         // Komga(""), Komga("2"), Komga("3"), ...
-        return listOf(firstKomga) + (0 until komgaCount).map { Komga("${it + 2}") }
+        return buildList(komgaCount) {
+            add(firstKomga)
+
+            for (i in 0 until komgaCount) {
+                add(Komga("${i + 2}"))
+            }
+        }
     }
 }

--- a/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/KomgaFilters.kt
+++ b/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/KomgaFilters.kt
@@ -98,6 +98,8 @@ internal class AuthorGroup(
     }
 }
 
-internal class CollectionSelect(val collections: List<CollectionFilterEntry>) : Filter.Select<String>("Collection", collections.map { it.name }.toTypedArray())
+internal class CollectionSelect(
+    val collections: List<CollectionFilterEntry>,
+) : Filter.Select<String>("Collection", collections.map { it.name }.toTypedArray())
 
 internal data class CollectionFilterEntry(val name: String, val id: String? = null)

--- a/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/KomgaUtils.kt
+++ b/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/KomgaUtils.kt
@@ -6,176 +6,89 @@ import android.widget.Button
 import android.widget.Toast
 import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.extension.all.komga.KomgaUtils.toSManga
-import eu.kanade.tachiyomi.extension.all.komga.dto.BookDto
-import eu.kanade.tachiyomi.extension.all.komga.dto.PageWrapperDto
-import eu.kanade.tachiyomi.extension.all.komga.dto.ReadListDto
-import eu.kanade.tachiyomi.extension.all.komga.dto.SeriesDto
-import eu.kanade.tachiyomi.source.model.MangasPage
-import eu.kanade.tachiyomi.source.model.SManga
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.json.Json
-import okhttp3.Response
-import org.apache.commons.text.StringSubstitutor
-import uy.kohesive.injekt.injectLazy
+import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
 
-internal object KomgaUtils {
-    private val json: Json by injectLazy()
+val formatterDate = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+    .apply { timeZone = TimeZone.getTimeZone("UTC") }
+val formatterDateTime = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US)
+    .apply { timeZone = TimeZone.getTimeZone("UTC") }
 
-    val formatterDate = SimpleDateFormat("yyyy-MM-dd", Locale.US)
-        .apply { timeZone = TimeZone.getTimeZone("UTC") }
-    val formatterDateTime = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US)
-        .apply { timeZone = TimeZone.getTimeZone("UTC") }
-    val formatterDateTimeMilli = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.S", Locale.US)
-        .apply { timeZone = TimeZone.getTimeZone("UTC") }
+fun parseDate(date: String): Long = try {
+    formatterDate.parse(date)!!.time
+} catch (_: ParseException) {
+    0L
+}
 
-    fun parseDate(date: String?): Long = runCatching {
-        formatterDate.parse(date!!)!!.time
-    }.getOrDefault(0L)
+fun parseDateTime(date: String) = try {
+    formatterDateTime.parse(date)!!.time
+} catch (_: ParseException) {
+    0L
+}
 
-    fun parseDateTime(date: String?) = if (date == null) {
-        0L
-    } else {
-        runCatching {
-            formatterDateTime.parse(date)!!.time
-        }
-            .getOrElse {
-                formatterDateTimeMilli.parse(date)?.time ?: 0L
-            }
-    }
+fun PreferenceScreen.addEditTextPreference(
+    title: String,
+    default: String,
+    summary: String,
+    dialogMessage: String? = null,
+    inputType: Int? = null,
+    validate: ((String) -> Boolean)? = null,
+    validationMessage: String? = null,
+    key: String = title,
+    restartRequired: Boolean = false,
+) {
+    EditTextPreference(context).apply {
+        this.key = key
+        this.title = title
+        this.summary = summary
+        this.setDefaultValue(default)
+        dialogTitle = title
+        this.dialogMessage = dialogMessage
 
-    fun Response.isFromReadList() = request.url.toString().contains("/api/v1/readlists")
-
-    fun processSeriesPage(response: Response, baseUrl: String): MangasPage {
-        return if (response.isFromReadList()) {
-            val data = response.parseAs<PageWrapperDto<ReadListDto>>()
-
-            MangasPage(data.content.map { it.toSManga(baseUrl) }, !data.last)
-        } else {
-            val data = response.parseAs<PageWrapperDto<SeriesDto>>()
-
-            MangasPage(data.content.map { it.toSManga(baseUrl) }, !data.last)
-        }
-    }
-
-    fun formatChapterName(book: BookDto, chapterNameTemplate: String, isFromReadList: Boolean): String {
-        val values = hashMapOf(
-            "title" to book.metadata.title,
-            "seriesTitle" to book.seriesTitle,
-            "number" to book.metadata.number,
-            "createdDate" to book.created,
-            "releaseDate" to book.metadata.releaseDate,
-            "size" to book.size,
-            "sizeBytes" to book.sizeBytes.toString(),
-        )
-        val sub = StringSubstitutor(values, "{", "}")
-
-        return buildString {
-            if (isFromReadList) {
-                append(book.seriesTitle)
-                append(" ")
+        setOnBindEditTextListener { editText ->
+            if (inputType != null) {
+                editText.inputType = inputType
             }
 
-            append(sub.replace(chapterNameTemplate))
-        }
-    }
+            if (validate != null) {
+                editText.addTextChangedListener(
+                    object : TextWatcher {
+                        override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
 
-    fun SeriesDto.toSManga(baseUrl: String): SManga =
-        SManga.create().apply {
-            title = metadata.title
-            url = "$baseUrl/api/v1/series/$id"
-            thumbnail_url = "$url/thumbnail"
-            status = when {
-                metadata.status == "ENDED" && metadata.totalBookCount != null && booksCount < metadata.totalBookCount -> SManga.PUBLISHING_FINISHED
-                metadata.status == "ENDED" -> SManga.COMPLETED
-                metadata.status == "ONGOING" -> SManga.ONGOING
-                metadata.status == "ABANDONED" -> SManga.CANCELLED
-                metadata.status == "HIATUS" -> SManga.ON_HIATUS
-                else -> SManga.UNKNOWN
-            }
-            genre = (metadata.genres + metadata.tags + booksMetadata.tags).distinct().joinToString(", ")
-            description = metadata.summary.ifBlank { booksMetadata.summary }
-            booksMetadata.authors.groupBy({ it.role }, { it.name }).let { map ->
-                author = map["writer"]?.distinct()?.joinToString()
-                artist = map["penciller"]?.distinct()?.joinToString()
+                        override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+
+                        override fun afterTextChanged(editable: Editable?) {
+                            requireNotNull(editable)
+
+                            val text = editable.toString()
+
+                            val isValid = text.isBlank() || validate(text)
+
+                            editText.error = if (!isValid) validationMessage else null
+                            editText.rootView.findViewById<Button>(android.R.id.button1)
+                                ?.isEnabled = editText.error == null
+                        }
+                    },
+                )
             }
         }
 
-    fun ReadListDto.toSManga(baseUrl: String): SManga =
-        SManga.create().apply {
-            title = name
-            description = summary
-            url = "$baseUrl/api/v1/readlists/$id"
-            thumbnail_url = "$url/thumbnail"
-            status = SManga.UNKNOWN
-        }
+        setOnPreferenceChangeListener { _, newValue ->
+            try {
+                val text = newValue as String
+                val result = text.isBlank() || validate?.invoke(text) ?: true
 
-    fun PreferenceScreen.addEditTextPreference(
-        title: String,
-        default: String,
-        summary: String,
-        inputType: Int? = null,
-        validate: ((String) -> Boolean)? = null,
-        validationMessage: String? = null,
-        key: String = title,
-        restartRequired: Boolean = false,
-    ) {
-        EditTextPreference(context).apply {
-            this.key = key
-            this.title = title
-            this.summary = summary
-            this.setDefaultValue(default)
-            dialogTitle = title
-
-            setOnBindEditTextListener { editText ->
-                if (inputType != null) {
-                    editText.inputType = inputType
+                if (restartRequired && result) {
+                    Toast.makeText(context, "Restart Tachiyomi to apply new setting.", Toast.LENGTH_LONG).show()
                 }
 
-                if (validate != null) {
-                    editText.addTextChangedListener(
-                        object : TextWatcher {
-                            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
-
-                            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
-
-                            override fun afterTextChanged(editable: Editable?) {
-                                requireNotNull(editable)
-
-                                val text = editable.toString()
-
-                                val isValid = text.isBlank() || validate(text)
-
-                                editText.error = if (!isValid) validationMessage else null
-                                editText.rootView.findViewById<Button>(android.R.id.button1)
-                                    ?.isEnabled = editText.error == null
-                            }
-                        },
-                    )
-                }
+                result
+            } catch (e: Exception) {
+                e.printStackTrace()
+                false
             }
-
-            setOnPreferenceChangeListener { _, _ ->
-                try {
-                    val result = text.isBlank() || validate?.invoke(text) ?: true
-
-                    if (restartRequired && result) {
-                        Toast.makeText(context, "Restart Tachiyomi to apply new setting.", Toast.LENGTH_LONG).show()
-                    }
-
-                    result
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                    false
-                }
-            }
-        }.also(::addPreference)
-    }
-
-    inline fun <reified T> Response.parseAs(): T {
-        return json.decodeFromString(body.string())
-    }
+        }
+    }.also(::addPreference)
 }

--- a/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/dto/PageWrapperDto.kt
+++ b/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/dto/PageWrapperDto.kt
@@ -3,7 +3,7 @@ package eu.kanade.tachiyomi.extension.all.komga.dto
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class PageWrapperDto<T>(
+class PageWrapperDto<T>(
     val content: List<T>,
     val empty: Boolean,
     val first: Boolean,


### PR DESCRIPTION
Changes:
- Add a README, mentioning that EPUBs are not available in a manga reader.
- Move extension functions from `KomgaUtils` back to the main file/their respective classes
- Validate that chapter name format is correct
- un-`data` the `class`
- Fetch filtering options in `getFilterList`/`setupPreferenceScreen` (the latter is required to load options for default libraries)
- Moved private `const val` out of companion object

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
