### PR TITLE
NetTruyen/NhatTruyen: avoid return un-relevant searching results

### DIFF
--- a/lib-multisrc/wpcomics/build.gradle.kts
+++ b/lib-multisrc/wpcomics/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 4
+baseVersionCode = 5

--- a/lib-multisrc/wpcomics/build.gradle.kts
+++ b/lib-multisrc/wpcomics/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 5
+baseVersionCode = 4

--- a/lib-multisrc/wpcomics/src/eu/kanade/tachiyomi/multisrc/wpcomics/WPComics.kt
+++ b/lib-multisrc/wpcomics/src/eu/kanade/tachiyomi/multisrc/wpcomics/WPComics.kt
@@ -72,6 +72,7 @@ abstract class WPComics(
     // Search
 
     protected open val searchPath = "tim-truyen"
+    protected open val queryParam = "keyword"
 
     protected open fun String.replaceSearchPath() = this
 
@@ -91,7 +92,7 @@ abstract class WPComics(
             }
 
             url.apply {
-                addQueryParameter("keyword", query)
+                addQueryParameter(queryParam, query)
                 addQueryParameter("page", page.toString())
                 addQueryParameter("sort", "0")
             }

--- a/src/vi/nettruyen/build.gradle
+++ b/src/vi/nettruyen/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.NetTruyen'
     themePkg = 'wpcomics'
     baseUrl = 'https://www.nettruyenss.com'
-    overrideVersionCode = 22
+    overrideVersionCode = 23
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/vi/nettruyen/src/eu/kanade/tachiyomi/extension/vi/nettruyen/NetTruyen.kt
+++ b/src/vi/nettruyen/src/eu/kanade/tachiyomi/extension/vi/nettruyen/NetTruyen.kt
@@ -1,11 +1,24 @@
 package eu.kanade.tachiyomi.extension.vi.nettruyen
 
 import eu.kanade.tachiyomi.multisrc.wpcomics.WPComics
+import eu.kanade.tachiyomi.source.model.MangasPage
+import okhttp3.Response
 import java.text.SimpleDateFormat
 import java.util.Locale
 
 class NetTruyen : WPComics("NetTruyen", "https://www.nettruyenss.com", "vi", SimpleDateFormat("dd/MM/yy", Locale.getDefault()), null) {
     override fun String.replaceSearchPath() = replace("/$searchPath?status=2&", "/truyen-full?")
+
+    /**
+     * NetTruyen/NhatTruyen redirect back to catalog page if searching query is not found.
+     * That makes both sites always return un-relevant results when searching should return empty.
+     */
+    override fun searchMangaParse(response: Response): MangasPage {
+        if (response.request.url.queryParameter(name = queryParam) == null) {
+            return MangasPage(mangas = listOf(), hasNextPage = false)
+        }
+        return super.searchMangaParse(response)
+    }
 
     override fun getGenreList(): Array<Pair<String?, String>> = arrayOf(
         null to "Tất cả",

--- a/src/vi/nhattruyen/build.gradle
+++ b/src/vi/nhattruyen/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.NhatTruyen'
     themePkg = 'wpcomics'
     baseUrl = 'https://nhattruyento.com'
-    overrideVersionCode = 14
+    overrideVersionCode = 15
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/vi/nhattruyen/src/eu/kanade/tachiyomi/extension/vi/nhattruyen/NhatTruyen.kt
+++ b/src/vi/nhattruyen/src/eu/kanade/tachiyomi/extension/vi/nhattruyen/NhatTruyen.kt
@@ -1,11 +1,24 @@
 package eu.kanade.tachiyomi.extension.vi.nhattruyen
 
 import eu.kanade.tachiyomi.multisrc.wpcomics.WPComics
+import eu.kanade.tachiyomi.source.model.MangasPage
+import okhttp3.Response
 import java.text.SimpleDateFormat
 import java.util.Locale
 
 class NhatTruyen : WPComics("NhatTruyen", "https://nhattruyento.com", "vi", SimpleDateFormat("dd/MM/yy", Locale.getDefault()), null) {
     override val searchPath = "the-loai"
+
+    /**
+     * NetTruyen/NhatTruyen redirect back to catalog page if searching query is not found.
+     * That makes both sites always return un-relevant results when searching should return empty.
+     */
+    override fun searchMangaParse(response: Response): MangasPage {
+        if (response.request.url.queryParameter(name = queryParam) == null) {
+            return MangasPage(mangas = listOf(), hasNextPage = false)
+        }
+        return super.searchMangaParse(response)
+    }
 
     override fun getGenreList(): Array<Pair<String?, String>> = arrayOf(
         null to "Tất cả",


### PR DESCRIPTION
They redirect back to catalog page if searching query is not found. That makes both sites always return un-relevant results when searching should have returned empty.

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [X] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [X] Have removed `web_hi_res_512.png` when adding a new extension
