### PR TITLE
Elarc Toon: update mangaUrlDirectory

### DIFF
--- a/src/en/elarcpage/build.gradle
+++ b/src/en/elarcpage/build.gradle
@@ -3,7 +3,8 @@ ext {
     extClass = '.ElarcPage'
     themePkg = 'mangathemesia'
     baseUrl = 'https://elarctoon.com'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/elarcpage/src/eu/kanade/tachiyomi/extension/en/elarcpage/ElarcPage.kt
+++ b/src/en/elarcpage/src/eu/kanade/tachiyomi/extension/en/elarcpage/ElarcPage.kt
@@ -6,7 +6,7 @@ class ElarcPage : MangaThemesia(
     "Elarc Toon",
     "https://elarctoon.com",
     "en",
-    "/series",
+    "/readtoons98111",
 ) {
     override val id = 5482125641807211052
 }


### PR DESCRIPTION
Closes #1337

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
