### PR TITLE
Manhastro: fix chapter images

### DIFF
--- a/src/pt/manhastro/build.gradle
+++ b/src/pt/manhastro/build.gradle
@@ -3,7 +3,8 @@ ext {
     extClass = '.Manhastro'
     themePkg = 'madara'
     baseUrl = 'https://manhastro.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
+    isNsfw = true
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/manhastro/src/eu/kanade/tachiyomi/extension/pt/manhastro/Manhastro.kt
+++ b/src/pt/manhastro/src/eu/kanade/tachiyomi/extension/pt/manhastro/Manhastro.kt
@@ -1,8 +1,12 @@
 package eu.kanade.tachiyomi.extension.pt.manhastro
 
+import android.util.Base64
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.source.model.Page
+import kotlinx.serialization.decodeFromString
 import okhttp3.OkHttpClient
+import org.jsoup.nodes.Document
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.concurrent.TimeUnit
@@ -19,4 +23,16 @@ class Manhastro : Madara(
         .build()
 
     override val useNewChapterEndpoint = true
+
+    override fun pageListParse(document: Document): List<Page> {
+        return document.selectFirst("script:containsData(imageLinks)")?.data()
+            ?.let { imageLinksPattern.find(it)?.groups?.get(1)?.value }
+            ?.let { json.decodeFromString<List<String>>(it) }
+            ?.mapIndexed { i, imageUrlEncoded ->
+                val imageUrl = String(Base64.decode(imageUrlEncoded, Base64.DEFAULT))
+                Page(i, imageUrl = imageUrl)
+            } ?: emptyList()
+    }
+
+    private val imageLinksPattern = """var\s+?imageLinks\s*?=\s*?(\[.*]);""".toRegex()
 }

--- a/src/pt/manhastro/src/eu/kanade/tachiyomi/extension/pt/manhastro/Manhastro.kt
+++ b/src/pt/manhastro/src/eu/kanade/tachiyomi/extension/pt/manhastro/Manhastro.kt
@@ -30,7 +30,7 @@ class Manhastro : Madara(
             ?.let { json.decodeFromString<List<String>>(it) }
             ?.mapIndexed { i, imageUrlEncoded ->
                 val imageUrl = String(Base64.decode(imageUrlEncoded, Base64.DEFAULT))
-                Page(i, imageUrl = imageUrl)
+                Page(i, document.location(), imageUrl)
             } ?: emptyList()
     }
 


### PR DESCRIPTION
Closes #1347

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
