### PR TITLE
Happymh: revert to headers custom UA

### DIFF
--- a/src/zh/happymh/build.gradle
+++ b/src/zh/happymh/build.gradle
@@ -1,11 +1,7 @@
 ext {
     extName = 'Happymh'
     extClass = '.Happymh'
-    extVersionCode = 7
+    extVersionCode = 8
 }
 
 apply from: "$rootDir/common.gradle"
-
-dependencies {
-    implementation(project(":lib:randomua"))
-}


### PR DESCRIPTION
Closes #1181

Partially reverts #957

Current random UA isn't added to headers, thus not picked up by WebView.
Adding to header functionality might cause `headers` to execute HTTP request, so lint rules must be
added to force override `getMangaUrl()` and `getChapterUrl()` to avoid triggering I/O on main thread.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
