### PR TITLE
Elarc Toon: update mangaUrlDirectory

### DIFF
--- a/src/en/elarcpage/build.gradle
+++ b/src/en/elarcpage/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ElarcPage'
     themePkg = 'mangathemesia'
     baseUrl = 'https://elarctoon.com'
-    overrideVersionCode = 3
+    overrideVersionCode = 4
     isNsfw = false
 }
 

--- a/src/en/elarcpage/src/eu/kanade/tachiyomi/extension/en/elarcpage/ElarcPage.kt
+++ b/src/en/elarcpage/src/eu/kanade/tachiyomi/extension/en/elarcpage/ElarcPage.kt
@@ -1,12 +1,81 @@
 package eu.kanade.tachiyomi.extension.en.elarcpage
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import eu.kanade.tachiyomi.network.GET
+import okhttp3.Interceptor
+import okhttp3.Response
+import org.jsoup.Jsoup
+import java.io.IOException
 
 class ElarcPage : MangaThemesia(
     "Elarc Toon",
     "https://elarctoon.com",
     "en",
-    "/readtoons98111",
 ) {
     override val id = 5482125641807211052
+
+    override val client = network.cloudflareClient.newBuilder()
+        .addInterceptor(::dynamicUrlInterceptor)
+        .build()
+
+    private var dynamicUrlUpdated: Long = 0
+    private val dynamicUrlValidity: Long = 10 * 60 // 10 minutes
+
+    private fun dynamicUrlInterceptor(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val timeNow = System.currentTimeMillis() / 1000
+
+        // Check if request requires an up-to-date URL
+        if (request.url.pathSegments[0] == mangaUrlDirectory.substring(1)) {
+            // Force update URL if required
+            if (timeNow - dynamicUrlUpdated > dynamicUrlValidity) {
+                client.newCall(GET(baseUrl)).execute()
+                if (timeNow - dynamicUrlUpdated > dynamicUrlValidity) {
+                    throw IOException("Failed to update dynamic url")
+                }
+            }
+
+            if (request.url.pathSegments[0] != mangaUrlDirectory.substring(1)) {
+                // Need to rewrite URL
+
+                val newUrl = request.url.newBuilder()
+                    .setPathSegment(0, mangaUrlDirectory.substring(1))
+                    .build()
+
+                val newRequest = request.newBuilder()
+                    .url(newUrl)
+                    .build()
+
+                return chain.proceed(newRequest)
+            }
+        }
+
+        // Always update URL
+        val response = chain.proceed(request)
+        val document = Jsoup.parse(
+            response.peekBody(Long.MAX_VALUE).string(),
+            request.url.toString(),
+        )
+
+        document.select("#menu-item-14 > a, a:contains(All Series), #main-menu a, .mm a")
+            .reversed()
+            .map { it.attr("href") }
+            .lastOrNull { it.length >= 2 && it[0] == '/' }
+            ?.let {
+                setMangaUrlDirectory(it)
+                dynamicUrlUpdated = timeNow
+            }
+
+        return response
+    }
+
+    private fun setMangaUrlDirectory(mangaUrlDirectory: String) {
+        try {
+            // this is fine
+            val field = this.javaClass.superclass.getDeclaredField("mangaUrlDirectory")
+            field.isAccessible = true
+            field.set(this, mangaUrlDirectory)
+        } catch (_: Exception) {
+        }
+    }
 }


### PR DESCRIPTION
Closes #1412

But at what cost?

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
