### PR TITLE
Manhastro/Madara: Fix nullpointer when manga title is set

### DIFF
--- a/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
+++ b/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
@@ -723,7 +723,7 @@ abstract class Madara(
     }
 
     // Manga Details Selector
-    open val mangaDetailsSelectorTitle = "div.post-title h3, div.post-title h1, #manga-title > h1"
+    open val mangaDetailsSelectorTitle = "div.post-title h3, div.post-title h1, #manga-title > h1, div.summary_content h2"
     open val mangaDetailsSelectorAuthor = "div.author-content > a"
     open val mangaDetailsSelectorArtist = "div.artist-content > a"
     open val mangaDetailsSelectorStatus = "div.summary-content"

--- a/src/pt/manhastro/build.gradle
+++ b/src/pt/manhastro/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Manhastro'
     themePkg = 'madara'
     baseUrl = 'https://manhastro.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = true
 }
 


### PR DESCRIPTION
Closes #1416

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
