### PR TITLE
Manhastro - Fix nullpointer when manga title is set

### DIFF
--- a/src/pt/manhastro/build.gradle
+++ b/src/pt/manhastro/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Manhastro'
     themePkg = 'madara'
     baseUrl = 'https://manhastro.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/pt/manhastro/src/eu/kanade/tachiyomi/extension/pt/manhastro/Manhastro.kt
+++ b/src/pt/manhastro/src/eu/kanade/tachiyomi/extension/pt/manhastro/Manhastro.kt
@@ -24,6 +24,8 @@ class Manhastro : Madara(
 
     override val useNewChapterEndpoint = true
 
+    override val mangaDetailsSelectorTitle = "div.summary_content h2"
+
     override fun pageListParse(document: Document): List<Page> {
         return document.selectFirst("script:containsData(imageLinks)")?.data()
             ?.let { imageLinksPattern.find(it)?.groups?.get(1)?.value }


### PR DESCRIPTION
Closes #1416

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
