### PR TITLE
newtoki: fix crash when changing sort filter

### DIFF
--- a/src/ko/newtoki/build.gradle
+++ b/src/ko/newtoki/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'NewToki / ManaToki'
     extClass = '.TokiFactory'
-    extVersionCode = 30
+    extVersionCode = 31
     isNsfw = true
 }
 

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/ManaToki.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/ManaToki.kt
@@ -57,7 +57,7 @@ object ManaToki : NewToki("ManaToki", "comic", manaTokiPreferences) {
                 }
 
                 is SearchSortTypeList -> {
-                    val state = filter.state ?: return@forEach
+                    val state = filter.state!!
                     url.addQueryParameter("sst", arrayOf("wr_datetime", "wr_hit", "wr_good", "as_update")[state.index])
                     url.addQueryParameter("sod", if (state.ascending) "asc" else "desc")
                 }

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/ManaToki.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/ManaToki.kt
@@ -161,6 +161,7 @@ object ManaToki : NewToki("ManaToki", "comic", manaTokiPreferences) {
             "추천순",
             "업데이트순",
         ),
+        Selection(0, false),
     )
 
     override fun getFilterList() = FilterList(

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewTokiWebtoon.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewTokiWebtoon.kt
@@ -23,7 +23,7 @@ object NewTokiWebtoon : NewToki("NewToki", "webtoon", newTokiPreferences) {
                 }
 
                 is SearchSortTypeList -> {
-                    val state = filter.state ?: return@forEach
+                    val state = filter.state!!
                     url.addQueryParameter("sst", arrayOf("as_update", "wr_hit", "wr_good")[state.index])
                     url.addQueryParameter("sod", if (state.ascending) "asc" else "desc")
                 }

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewTokiWebtoon.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewTokiWebtoon.kt
@@ -132,6 +132,7 @@ object NewTokiWebtoon : NewToki("NewToki", "webtoon", newTokiPreferences) {
             "인기순",
             "추천순",
         ),
+        Selection(0, false),
     )
 
     override fun getFilterList() = FilterList(


### PR DESCRIPTION
Closes #1428

Default is set so it behaves the same as if no sort was set

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
