### PR TITLE
Fix Madara was unable to reset Genre’s checkbox

### DIFF
--- a/lib-multisrc/madara/build.gradle.kts
+++ b/lib-multisrc/madara/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 35
+baseVersionCode = 36
 
 dependencies {
     api(project(":lib:cryptoaes"))

--- a/lib-multisrc/madara/build.gradle.kts
+++ b/lib-multisrc/madara/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 36
+baseVersionCode = 35
 
 dependencies {
     api(project(":lib:cryptoaes"))

--- a/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
+++ b/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
@@ -515,8 +515,9 @@ abstract class Madara(
         options.toTypedArray(),
     )
 
-    protected class GenreList(title: String, genres: List<Genre>) : Filter.Group<Genre>(title, genres)
-    class Genre(name: String, val id: String = name) : Filter.CheckBox(name)
+    protected class GenreList(title: String, genres: List<Genre>) : Filter.Group<GenreCheckBox>(title, genres.map { GenreCheckBox(it.name, it.id) })
+    class GenreCheckBox(name: String, val id: String = name) : Filter.CheckBox(name)
+    class Genre(val name: String, val id: String = name)
 
     override fun getFilterList(): FilterList {
         launchIO { fetchGenres() }


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [X] Have removed `web_hi_res_512.png` when adding a new extension
