### PR TITLE
Fix Photos18 parsing image’s url

### DIFF
--- a/src/all/photos18/build.gradle
+++ b/src/all/photos18/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Photos18'
     extClass = '.Photos18'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/all/photos18/src/eu/kanade/tachiyomi/extension/all/photos18/Photos18.kt
+++ b/src/all/photos18/src/eu/kanade/tachiyomi/extension/all/photos18/Photos18.kt
@@ -51,7 +51,7 @@ class Photos18 : HttpSource(), ConfigurableSource {
             SManga.create().apply {
                 url = link.attr("href").stripLang()
                 title = link.ownText()
-                thumbnail_url = baseUrl + it.selectFirst(Evaluator.Tag("img"))!!.attr("data-src")
+                thumbnail_url = baseUrl + it.selectFirst(Evaluator.Tag("img"))!!.attr("src")
                 genre = cardBody.selectFirst(Evaluator.Tag("label"))!!.ownText()
                 status = SManga.COMPLETED
                 initialized = true
@@ -100,7 +100,7 @@ class Photos18 : HttpSource(), ConfigurableSource {
         val document = response.asJsoup()
         val images = document.selectFirst(Evaluator.Id("content"))!!.select(Evaluator.Tag("img"))
         return images.mapIndexed { index, image ->
-            Page(index, imageUrl = image.attr("data-src"))
+            Page(index, imageUrl = image.attr("src"))
         }
     }
 


### PR DESCRIPTION
Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
