### PR TITLE
Shinigami: update baseurl

### DIFF
--- a/src/id/shinigami/build.gradle
+++ b/src/id/shinigami/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Shinigami'
     extClass = '.Shinigami'
     themePkg = 'madara'
-    baseUrl = 'https://shinigamitoon.com'
-    overrideVersionCode = 16
+    baseUrl = 'https://s1.shinigami.cx'
+    overrideVersionCode = 17
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/shinigami/src/eu/kanade/tachiyomi/extension/id/shinigami/Shinigami.kt
+++ b/src/id/shinigami/src/eu/kanade/tachiyomi/extension/id/shinigami/Shinigami.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.decodeFromString
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 
-class Shinigami : Madara("Shinigami", "https://shinigamitoon.com", "id") {
+class Shinigami : Madara("Shinigami", "https://s1.shinigami.cx", "id") {
     // moved from Reaper Scans (id) to Shinigami (id)
     override val id = 3411809758861089969
 


### PR DESCRIPTION
Closes #1497

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
