### PR TITLE
resetscans: update baseurl

### DIFF
--- a/src/en/resetscans/build.gradle
+++ b/src/en/resetscans/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Reset Scans'
     extClass = '.ResetScans'
     themePkg = 'madara'
-    baseUrl = 'https://reset-scans.us'
-    overrideVersionCode = 0
+    baseUrl = 'https://reset-scans.xyz'
+    overrideVersionCode = 1
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
+++ b/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
@@ -1,7 +1,7 @@
 package eu.kanade.tachiyomi.extension.en.resetscans
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 
-class ResetScans : Madara("Reset Scans", "https://reset-scans.us", "en") {
+class ResetScans : Madara("Reset Scans", "https://reset-scans.xyz", "en") {
     override val useNewChapterEndpoint = true
     override val chapterUrlSelector = ".li__text > a"
 }


### PR DESCRIPTION
Closes #1500

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
