### PR TITLE
Fix BlackoutComics selectors

### DIFF
--- a/src/pt/blackoutcomics/build.gradle
+++ b/src/pt/blackoutcomics/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Blackout Comics'
     extClass = '.BlackoutComics'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/pt/blackoutcomics/src/eu/kanade/tachiyomi/extension/pt/blackoutcomics/BlackoutComics.kt
+++ b/src/pt/blackoutcomics/src/eu/kanade/tachiyomi/extension/pt/blackoutcomics/BlackoutComics.kt
@@ -49,7 +49,7 @@ class BlackoutComics : ParsedHttpSource() {
     override fun popularMangaFromElement(element: Element) = SManga.create().apply {
         setUrlWithoutDomain(element.attr("href"))
         thumbnail_url = element.selectFirst("img:not(.hidden)")?.absUrl("src")
-        title = element.selectFirst("p:not(.hidden), span.text-comic")?.text() ?: "Manga"
+        title = element.selectFirst("p:not(.hidden), span.text-comic")!!.text()
     }
 
     override fun popularMangaNextPageSelector() = null

--- a/src/pt/blackoutcomics/src/eu/kanade/tachiyomi/extension/pt/blackoutcomics/BlackoutComics.kt
+++ b/src/pt/blackoutcomics/src/eu/kanade/tachiyomi/extension/pt/blackoutcomics/BlackoutComics.kt
@@ -98,7 +98,7 @@ class BlackoutComics : ParsedHttpSource() {
     override fun mangaDetailsParse(document: Document) = SManga.create().apply {
         val row = document.selectFirst("section > div.container > div.row")!!
         thumbnail_url = row.selectFirst("img:not(.hidden)")?.absUrl("src")
-        title = row.selectFirst("div.trailer-content > h2:not(.hidden)")?.text() ?: "Manga"
+        title = row.selectFirst("div.trailer-content > h2:not(.hidden)")!!.text()
 
         with(row.selectFirst("div.trailer-content:has(h3:containsOwn(Detalhes))")!!) {
             println(outerHtml())

--- a/src/pt/blackoutcomics/src/eu/kanade/tachiyomi/extension/pt/blackoutcomics/BlackoutComics.kt
+++ b/src/pt/blackoutcomics/src/eu/kanade/tachiyomi/extension/pt/blackoutcomics/BlackoutComics.kt
@@ -48,8 +48,8 @@ class BlackoutComics : ParsedHttpSource() {
 
     override fun popularMangaFromElement(element: Element) = SManga.create().apply {
         setUrlWithoutDomain(element.attr("href"))
-        thumbnail_url = element.selectFirst("img")?.absUrl("src")
-        title = element.selectFirst("p, span.text-comic")?.text() ?: "Manga"
+        thumbnail_url = element.selectFirst("img:not(.hidden)")?.absUrl("src")
+        title = element.selectFirst("p:not(.hidden), span.text-comic")?.text() ?: "Manga"
     }
 
     override fun popularMangaNextPageSelector() = null
@@ -97,8 +97,8 @@ class BlackoutComics : ParsedHttpSource() {
     // =========================== Manga Details ============================
     override fun mangaDetailsParse(document: Document) = SManga.create().apply {
         val row = document.selectFirst("section > div.container > div.row")!!
-        thumbnail_url = row.selectFirst("img")?.absUrl("src")
-        title = row.selectFirst("div.trailer-content > h2")?.text() ?: "Manga"
+        thumbnail_url = row.selectFirst("img:not(.hidden)")?.absUrl("src")
+        title = row.selectFirst("div.trailer-content > h2:not(.hidden)")?.text() ?: "Manga"
 
         with(row.selectFirst("div.trailer-content:has(h3:containsOwn(Detalhes))")!!) {
             println(outerHtml())
@@ -153,7 +153,7 @@ class BlackoutComics : ParsedHttpSource() {
 
     // =============================== Pages ================================
     override fun pageListParse(document: Document): List<Page> {
-        return document.select("div.chapter-image canvas").mapIndexed { index, item ->
+        return document.select("div.chapter-image-ofc canvas").mapIndexed { index, item ->
             Page(index, "", item.absUrl("data-src"))
         }
     }


### PR DESCRIPTION
Closes #1402 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
