### PR TITLE
MajorScans: fix double image

### DIFF
--- a/src/tr/majorscans/build.gradle
+++ b/src/tr/majorscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MajorScans'
     themePkg = 'mangathemesia'
     baseUrl = 'https://www.majorscans.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/tr/majorscans/src/eu/kanade/tachiyomi/extension/tr/majorscans/MajorScans.kt
+++ b/src/tr/majorscans/src/eu/kanade/tachiyomi/extension/tr/majorscans/MajorScans.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.extension.tr.majorscans
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import eu.kanade.tachiyomi.source.model.SManga
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -9,4 +10,17 @@ class MajorScans : MangaThemesia(
     "https://www.majorscans.com",
     "tr",
     dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("tr")),
-)
+) {
+    override val seriesStatusSelector = ".imptdt:contains(Durumu) i"
+
+    override val pageSelector = "div#readerarea img:not(noscript img)"
+
+    override fun String?.parseStatus(): Int = when {
+        this == null -> SManga.UNKNOWN
+        listOf("devam ediyor", "güncel").any { this.contains(it, ignoreCase = true) } -> SManga.ONGOING
+        this.contains("tamamlandı", ignoreCase = true) -> SManga.COMPLETED
+        this.contains("bırakıldı", ignoreCase = true) -> SManga.CANCELLED
+        this.contains("sezon finali", ignoreCase = true) -> SManga.ON_HIATUS
+        else -> SManga.UNKNOWN
+    }
+}


### PR DESCRIPTION
Closes #1558

```
@TheKages, can you verify that this is correct?
Site → Extension:
devam ediyor → Devam ediyor (Ongoing)
güncel → Devam ediyor (Ongoing)
tamamlandı → Tamamlandı (Completed)
bırakıldı → İptal edildi (Cancelled)
sezon finali → Molada (On Hiatus)

Other usable values:
Lisanslı (Licensed)
Yayımı tamamlandı (Publishing Finished)
```

No response, so should be fine to merge.


Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
