### PR TITLE
MangaOwl.to: Fix manga’s URL for other mirrors

### DIFF
--- a/src/en/mangaowlto/build.gradle
+++ b/src/en/mangaowlto/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaOwl.To'
     extClass = '.MangaOwlToFactory'
-    extVersionCode = 1
+    extVersionCode = 2
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/mangaowlto/src/eu/kanade/tachiyomi/extension/en/mangaowlto/MangaOwlTo.kt
+++ b/src/en/mangaowlto/src/eu/kanade/tachiyomi/extension/en/mangaowlto/MangaOwlTo.kt
@@ -110,7 +110,7 @@ class MangaOwlTo(
         json.decodeFromString<MangaOwlToStory>(response.body.string()).toSManga()
 
     override fun getMangaUrl(manga: SManga): String {
-        return "$baseUrl/10-comic/${manga.url}"
+        return "$baseUrl/comic/${manga.url}"
     }
 
     // Chapters


### PR DESCRIPTION
Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [X] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [X] Have removed `web_hi_res_512.png` when adding a new extension
