### PR TITLE
[RU] Nude-moon new domain

### DIFF
--- a/src/ru/nudemoon/build.gradle
+++ b/src/ru/nudemoon/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Nude-Moon'
     extClass = '.Nudemoon'
-    extVersionCode = 17
+    extVersionCode = 18
     isNsfw = true
 }
 

--- a/src/ru/nudemoon/src/eu/kanade/tachiyomi/extension/ru/nudemoon/Nudemoon.kt
+++ b/src/ru/nudemoon/src/eu/kanade/tachiyomi/extension/ru/nudemoon/Nudemoon.kt
@@ -24,7 +24,7 @@ class Nudemoon : ParsedHttpSource() {
 
     override val name = "Nude-Moon"
 
-    override val baseUrl = "https://x.nude-moon.fun"
+    override val baseUrl = "https://a.nude-moon.fun"
 
     override val lang = "ru"
 


### PR DESCRIPTION
Closes https://github.com/keiyoushi/extensions-source/issues/1633

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
