### PR TITLE
update manhwa freak

### DIFF
--- a/src/en/manhwafreak/build.gradle
+++ b/src/en/manhwafreak/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Manhwa Freak'
     extClass = '.ManhwaFreak'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://manhwa-freak.com'
-    overrideVersionCode = 4
+    baseUrl = 'https://freakcomic.com'
+    overrideVersionCode = 5
     isNsfw = false
 }
 

--- a/src/en/manhwafreak/src/eu/kanade/tachiyomi/extension/en/manhwafreak/ManhwaFreak.kt
+++ b/src/en/manhwafreak/src/eu/kanade/tachiyomi/extension/en/manhwafreak/ManhwaFreak.kt
@@ -11,7 +11,7 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.util.Calendar
 
-class ManhwaFreak : MangaThemesia("Manhwa Freak", "https://freakcomic.com", "en") {
+class ManhwaFreak : MangaThemesia("Manhwa Freak", "https://freakcomic.com", "en")
 
     // they called the theme "mangareaderfix"
 

--- a/src/en/manhwafreak/src/eu/kanade/tachiyomi/extension/en/manhwafreak/ManhwaFreak.kt
+++ b/src/en/manhwafreak/src/eu/kanade/tachiyomi/extension/en/manhwafreak/ManhwaFreak.kt
@@ -11,7 +11,7 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.util.Calendar
 
-class ManhwaFreak : MangaThemesia("Manhwa Freak", "https://manhwa-freak.com", "en") {
+class ManhwaFreak : MangaThemesia("Manhwa Freak", "https://freakcomic.com", "en") {
 
     // they called the theme "mangareaderfix"
 


### PR DESCRIPTION
closes #1648 
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
