### PR TITLE
GravureBlogger: fix incomplete results due to incorrect totalResults field

### DIFF
--- a/lib-multisrc/gravureblogger/build.gradle.kts
+++ b/lib-multisrc/gravureblogger/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 2
+baseVersionCode = 3

--- a/lib-multisrc/gravureblogger/src/eu/kanade/tachiyomi/multisrc/gravureblogger/BloggerDto.kt
+++ b/lib-multisrc/gravureblogger/src/eu/kanade/tachiyomi/multisrc/gravureblogger/BloggerDto.kt
@@ -10,9 +10,6 @@ class BloggerDto(
 
 @Serializable
 class BloggerFeedDto(
-    @SerialName("openSearch\$totalResults") val totalResults: BloggerTextDto,
-    @SerialName("openSearch\$startIndex") val startIndex: BloggerTextDto,
-    @SerialName("openSearch\$itemsPerPage") val itemsPerPage: BloggerTextDto,
     val category: List<BloggerCategoryDto> = emptyList(),
     val entry: List<BloggerFeedEntryDto> = emptyList(),
 )

--- a/lib-multisrc/gravureblogger/src/eu/kanade/tachiyomi/multisrc/gravureblogger/GravureBlogger.kt
+++ b/lib-multisrc/gravureblogger/src/eu/kanade/tachiyomi/multisrc/gravureblogger/GravureBlogger.kt
@@ -65,7 +65,7 @@ abstract class GravureBlogger(
                 initialized = true
             }
         }
-        val hasNextPage = (data.feed.startIndex.t.toInt() + data.feed.itemsPerPage.t.toInt()) <= data.feed.totalResults.t.toInt()
+        val hasNextPage = data.feed.entry.size == MAX_RESULTS
 
         return MangasPage(manga, hasNextPage)
     }


### PR DESCRIPTION
closes #1520
closes #1521

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
