### PR TITLE
OppaiStream: update selectors

### DIFF
--- a/src/en/oppaistream/build.gradle
+++ b/src/en/oppaistream/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Oppai Stream'
     extClass = '.OppaiStream'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 


### PR DESCRIPTION
closes  #1298

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
