### PR TITLE
MangaWT: move to Madara

### DIFF
--- a/src/tr/mangawt/build.gradle
+++ b/src/tr/mangawt/build.gradle
@@ -1,9 +1,9 @@
 ext {
     extName = 'MangaWT'
     extClass = '.MangaWT'
-    themePkg = 'mangathemesia'
+    themePkg = 'madara'
     baseUrl = 'https://mangawt.com'
-    overrideVersionCode = 5
+    overrideVersionCode = 1
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/tr/mangawt/src/eu/kanade/tachiyomi/extension/tr/mangawt/MangaWT.kt
+++ b/src/tr/mangawt/src/eu/kanade/tachiyomi/extension/tr/mangawt/MangaWT.kt
@@ -1,7 +1,11 @@
 package eu.kanade.tachiyomi.extension.tr.mangawt
 
-import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
-import java.text.SimpleDateFormat
-import java.util.Locale
+import eu.kanade.tachiyomi.multisrc.madara.Madara
 
-class MangaWT : MangaThemesia("MangaWT", "https://mangawt.com", "tr", dateFormat = SimpleDateFormat("MMM d, yyyy", Locale("tr")))
+class MangaWT : Madara(
+    "MangaWT",
+    "https://mangawt.com",
+    "tr",
+) {
+    override val useNewChapterEndpoint = true
+}


### PR DESCRIPTION
closes #930

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
