### PR TITLE
I Roved Out: Fix downloads not finishing

### DIFF
--- a/src/en/irovedout/build.gradle
+++ b/src/en/irovedout/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'I Roved Out'
     extClass = '.IRovedOut'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/en/irovedout/src/eu/kanade/tachiyomi/extension/en/irovedout/IRovedOut.kt
+++ b/src/en/irovedout/src/eu/kanade/tachiyomi/extension/en/irovedout/IRovedOut.kt
@@ -90,8 +90,6 @@ class IRovedOut : HttpSource() {
         return Observable.just(pages)
     }
 
-    override fun pageListRequest(chapter: SChapter): Request = throw UnsupportedOperationException()
-
     override fun pageListParse(response: Response): List<Page> = throw UnsupportedOperationException()
 
     override fun fetchPopularManga(page: Int): Observable<MangasPage> {


### PR DESCRIPTION
Downloads were stuck because of a redundant unimplemented override.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
