### PR TITLE
Jobsibe: Disable non-manga items filter

### DIFF
--- a/src/es/jobsibe/build.gradle
+++ b/src/es/jobsibe/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Jobsibe'
     themePkg = 'madara'
     baseUrl = 'https://jobsibe.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = false
 }
 

--- a/src/es/jobsibe/src/eu/kanade/tachiyomi/extension/es/jobsibe/Jobsibe.kt
+++ b/src/es/jobsibe/src/eu/kanade/tachiyomi/extension/es/jobsibe/Jobsibe.kt
@@ -15,6 +15,8 @@ class Jobsibe : Madara(
     override val useLoadMoreRequest = LoadMoreStrategy.Always
     override val useNewChapterEndpoint = true
 
+    override val filterNonMangaItems = false
+
     override val client: OkHttpClient = super.client.newBuilder()
         .rateLimit(2)
         .build()


### PR DESCRIPTION
Closes #1983 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
