### PR TITLE
SummerToon: update domain

### DIFF
--- a/src/tr/summertoon/build.gradle
+++ b/src/tr/summertoon/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'SummerToon'
     extClass = '.SummerToon'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://summertoon.net'
-    overrideVersionCode = 1
+    baseUrl = 'https://summertoon.me'
+    overrideVersionCode = 2
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/tr/summertoon/build.gradle
+++ b/src/tr/summertoon/build.gradle
@@ -4,6 +4,7 @@ ext {
     themePkg = 'mangathemesia'
     baseUrl = 'https://summertoon.me'
     overrideVersionCode = 2
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/tr/summertoon/src/eu/kanade/tachiyomi/extension/tr/summertoon/SummerToon.kt
+++ b/src/tr/summertoon/src/eu/kanade/tachiyomi/extension/tr/summertoon/SummerToon.kt
@@ -7,7 +7,7 @@ import java.util.Locale
 
 class SummerToon : MangaThemesia(
     "SummerToon",
-    "https://summertoon.net",
+    "https://summertoon.me",
     "tr",
     dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("tr")),
 ) {


### PR DESCRIPTION
Closes #2051

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
