### PR TITLE
NineHentai: update domain

### DIFF
--- a/src/en/ninehentai/AndroidManifest.xml
+++ b/src/en/ninehentai/AndroidManifest.xml
@@ -14,7 +14,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:host="9hentai.to"
+                    android:host="9hentai.com"
                     android:pathPattern="/g/..*"
                     android:scheme="https" />
             </intent-filter>

--- a/src/en/ninehentai/build.gradle
+++ b/src/en/ninehentai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'NineHentai'
     extClass = '.NineHentai'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/en/ninehentai/src/eu/kanade/tachiyomi/extension/en/ninehentai/NineHentai.kt
+++ b/src/en/ninehentai/src/eu/kanade/tachiyomi/extension/en/ninehentai/NineHentai.kt
@@ -33,7 +33,7 @@ import java.util.Calendar
 
 class NineHentai : HttpSource() {
 
-    override val baseUrl = "https://9hentai.to"
+    override val baseUrl = "https://9hentai.com"
 
     override val name = "NineHentai"
 

--- a/src/en/ninehentai/src/eu/kanade/tachiyomi/extension/en/ninehentai/NineHentaiUrlActivity.kt
+++ b/src/en/ninehentai/src/eu/kanade/tachiyomi/extension/en/ninehentai/NineHentaiUrlActivity.kt
@@ -8,7 +8,7 @@ import android.util.Log
 import kotlin.system.exitProcess
 
 /**
- * Springboard that accepts https://9hentai.to/g/xxxxxx intents and redirects them to
+ * Springboard that accepts https://9hentai.com/g/xxxxxx intents and redirects them to
  * the main Tachiyomi process.
  */
 class NineHentaiUrlActivity : Activity() {


### PR DESCRIPTION
Closes #2046

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
