### PR TITLE
Sekaikomik: update domain

### DIFF
--- a/src/id/sekaikomik/build.gradle
+++ b/src/id/sekaikomik/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Sekaikomik'
     extClass = '.Sekaikomik'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://sekaikomik.bio'
-    overrideVersionCode = 11
+    baseUrl = 'https://sekaikomik.guru'
+    overrideVersionCode = 12
     isNsfw = true
 }
 

--- a/src/id/sekaikomik/src/eu/kanade/tachiyomi/extension/id/sekaikomik/Sekaikomik.kt
+++ b/src/id/sekaikomik/src/eu/kanade/tachiyomi/extension/id/sekaikomik/Sekaikomik.kt
@@ -8,7 +8,7 @@ import java.util.Locale
 
 class Sekaikomik : MangaThemesia(
     "Sekaikomik",
-    "https://sekaikomik.bio",
+    "https://sekaikomik.guru",
     "id",
     dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("id")),
 ) {


### PR DESCRIPTION
Closes #2043

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
