### PR TITLE
Mangasusu: fix page parser

### DIFF
--- a/src/id/mangasusu/build.gradle
+++ b/src/id/mangasusu/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Mangasusu'
     themePkg = 'mangathemesia'
     baseUrl = 'https://mangasusuku.xyz'
-    overrideVersionCode = 3
+    overrideVersionCode = 4
     isNsfw = true
 }
 


### PR DESCRIPTION
Closes #1866

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
