### PR TITLE
Manhuagold: update domain

### DIFF
--- a/src/en/comickiba/build.gradle
+++ b/src/en/comickiba/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Manhuagold'
     extClass = '.Manhuagold'
     themePkg = 'mangareader'
-    baseUrl = 'https://manhuagold.com'
-    overrideVersionCode = 33
+    baseUrl = 'https://manhuagold.top'
+    overrideVersionCode = 34
     isNsfw = true
 }
 

--- a/src/en/comickiba/src/eu/kanade/tachiyomi/extension/en/comickiba/Manhuagold.kt
+++ b/src/en/comickiba/src/eu/kanade/tachiyomi/extension/en/comickiba/Manhuagold.kt
@@ -28,7 +28,7 @@ class Manhuagold : MangaReader() {
 
     override val lang = "en"
 
-    override val baseUrl = "https://manhuagold.com"
+    override val baseUrl = "https://manhuagold.top"
 
     override val client = network.cloudflareClient.newBuilder()
         .rateLimit(2)


### PR DESCRIPTION
Closes #1946

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
