### PR TITLE
YaoiLib: fix UrlActivity

### DIFF
--- a/src/ru/yaoilib/AndroidManifest.xml
+++ b/src/ru/yaoilib/AndroidManifest.xml
@@ -15,7 +15,7 @@
 
                 <!-- LibUrlActivity sites can be added here. -->
                 <data
-                    android:host="v1.slashlib.me"
+                    android:host="v2.slashlib.me"
                     android:pathPattern="/..*/v..*"
                     android:scheme="https" />
             </intent-filter>

--- a/src/ru/yaoilib/build.gradle
+++ b/src/ru/yaoilib/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.YaoiLib'
     themePkg = 'libgroup'
     baseUrl = 'https://v2.slashlib.me'
-    overrideVersionCode = 3
+    overrideVersionCode = 4
     isNsfw = true
 }
 


### PR DESCRIPTION
Regression from #2073

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
