### PR TITLE
Hentai2Read: fix broken covers

### DIFF
--- a/src/en/hentai2read/build.gradle
+++ b/src/en/hentai2read/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hentai2Read'
     extClass = '.Hentai2Read'
-    extVersionCode = 14
+    extVersionCode = 15
     isNsfw = true
 }
 

--- a/src/en/hentai2read/src/eu/kanade/tachiyomi/extension/en/hentai2read/Hentai2Read.kt
+++ b/src/en/hentai2read/src/eu/kanade/tachiyomi/extension/en/hentai2read/Hentai2Read.kt
@@ -57,7 +57,7 @@ class Hentai2Read : ParsedHttpSource() {
 
     override fun popularMangaFromElement(element: Element): SManga {
         return SManga.create().apply {
-            thumbnail_url = element.select("img").attr("abs:data-src")
+            thumbnail_url = element.select("img").attr("abs:src")
             element.select("div.overlay-title a").let {
                 title = it.text()
                 setUrlWithoutDomain(it.attr("href"))


### PR DESCRIPTION
Closes #1776

Checklist:
* [x]  Updated `extVersionCode` value in `build.gradle` for individual extensions
* [ ]  Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
* [x]  Referenced all related issues in the PR body (e.g. "Closes #xyz")
* [ ]  Added the `isNsfw = true` flag in `build.gradle` when appropriate
* [x]  Have not changed source names
* [ ]  Have explicitly kept the `id` if a source's name or language were changed
* [x]  Have tested the modifications by compiling and running the extension through Android Studio
* [ ]  Have removed `web_hi_res_512.png` when adding a new extension