### PR TITLE
ComicExtra - change base URL

### DIFF
--- a/src/en/comicextra/build.gradle
+++ b/src/en/comicextra/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ComicExtra'
     extClass = '.ComicExtra'
-    extVersionCode = 14
+    extVersionCode = 15
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/comicextra/src/eu/kanade/tachiyomi/extension/en/comicextra/ComicExtra.kt
+++ b/src/en/comicextra/src/eu/kanade/tachiyomi/extension/en/comicextra/ComicExtra.kt
@@ -22,7 +22,7 @@ class ComicExtra : ParsedHttpSource() {
 
     override val name = "ComicExtra"
 
-    override val baseUrl = "https://comicextra.me"
+    override val baseUrl = "https://comicextra.org"
 
     override val lang = "en"
 


### PR DESCRIPTION
Very small change. The base url changed to a new one and the redirects were causing issues

Closes #1951

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
