### PR TITLE
Added .to and .xxx to mirror urls and intents of NHentai extension

### DIFF
--- a/src/all/nhentai/AndroidManifest.xml
+++ b/src/all/nhentai/AndroidManifest.xml
@@ -13,8 +13,10 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
+                <data android:host="nhentai.net"/>
+                <data android:host="nhentai.xxx"/>
+                <data android:host="nhentai.to"/>
                 <data
-                    android:host="nhentai.net"
                     android:pathPattern="/g/..*"
                     android:scheme="https" />
             </intent-filter>

--- a/src/all/nhentai/build.gradle
+++ b/src/all/nhentai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'NHentai'
     extClass = '.NHFactory'
-    extVersionCode = 40
+    extVersionCode = 41
     isNsfw = true
 }
 

--- a/src/all/nhentai/src/eu/kanade/tachiyomi/extension/all/nhentai/NHentai.kt
+++ b/src/all/nhentai/src/eu/kanade/tachiyomi/extension/all/nhentai/NHentai.kt
@@ -42,11 +42,10 @@ open class NHentai(
     private val nhLang: String,
 ) : ConfigurableSource, ParsedHttpSource() {
 
-    final override val baseUrl = "https://nhentai.net"
-
     override val id by lazy { if (lang == "all") 7309872737163460316 else super.id }
 
     override val name = "NHentai"
+    override val baseUrl: String = getMirrorPref()!!
 
     override val supportsLatest = true
 
@@ -75,8 +74,8 @@ open class NHentai(
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         ListPreference(screen.context).apply {
-            key = TITLE_PREF
-            title = TITLE_PREF
+            key = "${MIRROR_PREF_KEY}_$lang"
+            title = MIRROR_PREF_TITLE
             entries = arrayOf("Full Title", "Short Title")
             entryValues = arrayOf("full", "short")
             summary = "%s"
@@ -93,6 +92,8 @@ open class NHentai(
 
         addRandomUAPreferenceToScreen(screen)
     }
+
+    private fun getMirrorPref(): String? = preferences.getString("${MIRROR_PREF_KEY}_$lang", MIRROR_PREF_DEFAULT_VALUE)
 
     override fun latestUpdatesRequest(page: Int) = GET(if (nhLang.isBlank()) "$baseUrl/?page=$page" else "$baseUrl/language/$nhLang/?page=$page", headers)
 
@@ -319,5 +320,16 @@ open class NHentai(
     companion object {
         const val PREFIX_ID_SEARCH = "id:"
         private const val TITLE_PREF = "Display manga title as:"
+
+        private const val MIRROR_PREF_KEY = "MIRROR"
+        private const val MIRROR_PREF_TITLE = "Mirror"
+        private val MIRROR_PREF_ENTRIES = arrayOf(
+            "nhentai.net",
+            "nhentai.to",
+            "nhentai.xxx",
+        )
+        private val MIRROR_PREF_ENTRY_VALUES =
+            MIRROR_PREF_ENTRIES.map { "https://$it" }.toTypedArray()
+        private val MIRROR_PREF_DEFAULT_VALUE = MIRROR_PREF_ENTRY_VALUES[0]
     }
 }


### PR DESCRIPTION
Closes #124 
Note: I haven't contributed to any Android Dev projects at all but I tested it in Android Studio, the extension disappears when I click trust in Mihon / TachiJ2K.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
