### PR TITLE
Happymh: Add referer header for image requests

### DIFF
--- a/src/zh/happymh/build.gradle
+++ b/src/zh/happymh/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Happymh'
     extClass = '.Happymh'
-    extVersionCode = 8
+    extVersionCode = 9
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/zh/happymh/src/eu/kanade/tachiyomi/extension/zh/happymh/Happymh.kt
+++ b/src/zh/happymh/src/eu/kanade/tachiyomi/extension/zh/happymh/Happymh.kt
@@ -154,6 +154,13 @@ class Happymh : HttpSource(), ConfigurableSource {
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
 
+    override fun imageRequest(page: Page): Request {
+        val header = headersBuilder()
+            .set("Referer", "$baseUrl/")
+            .build()
+        return GET(page.imageUrl!!, header)
+    }
+
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         val context = screen.context
 


### PR DESCRIPTION
This is required to pass Cloudflare’s check. (cf_clearance from the base URL domain won’t work, for unknown reasons)

Might fix #1913

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
