### PR TITLE
StoneScape: hide premium chapters

### DIFF
--- a/src/en/stonescape/build.gradle
+++ b/src/en/stonescape/build.gradle
@@ -3,7 +3,8 @@ ext {
     extClass = '.StoneScape'
     themePkg = 'madara'
     baseUrl = 'https://stonescape.xyz'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/stonescape/src/eu/kanade/tachiyomi/extension/en/stonescape/StoneScape.kt
+++ b/src/en/stonescape/src/eu/kanade/tachiyomi/extension/en/stonescape/StoneScape.kt
@@ -8,8 +8,13 @@ class StoneScape : Madara(
     "StoneScape",
     "https://stonescape.xyz",
     "en",
-    SimpleDateFormat("MMMM dd, yyyy", Locale("en")),
+    SimpleDateFormat("MMMM dd, yyyy", Locale.ENGLISH),
 ) {
     override val mangaSubString = "series"
-    override val chapterUrlSelector = "div + a"
+
+    override val chapterUrlSelector = "li > a"
+
+    override val mangaDetailsSelectorAuthor = ".post-content .manga-authors a"
+
+    override fun chapterListSelector() = "li.wp-manga-chapter:not(.premium-block)"
 }


### PR DESCRIPTION
Closes #2138

Can't check if logging in actually unlocks already paid chapters. I'm checking for the absence of `.premium-block`, which excludes blurred out chapters.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
