### PR TITLE
Mangaku: update domain

### DIFF
--- a/src/id/mangaku/build.gradle
+++ b/src/id/mangaku/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Mangaku'
     extClass = '.Mangaku'
-    extVersionCode = 9
+    extVersionCode = 10
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/mangaku/src/eu/kanade/tachiyomi/extension/id/mangaku/Mangaku.kt
+++ b/src/id/mangaku/src/eu/kanade/tachiyomi/extension/id/mangaku/Mangaku.kt
@@ -39,7 +39,7 @@ class Mangaku : ParsedHttpSource() {
 
     override val name = "Mangaku"
 
-    override val baseUrl = "https://mangaku.mom"
+    override val baseUrl = "https://mangaku.lat"
 
     override val lang = "id"
 


### PR DESCRIPTION
Closes #2145

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
