### PR TITLE
Zinmanga: update domain

### DIFF
--- a/src/en/zinmanga/build.gradle
+++ b/src/en/zinmanga/build.gradle
@@ -2,8 +2,9 @@ ext {
     extName = 'Zinmanga'
     extClass = '.Zinmanga'
     themePkg = 'madara'
-    baseUrl = 'https://zinmanga.com'
-    overrideVersionCode = 1
+    baseUrl = 'https://mangazin.org'
+    overrideVersionCode = 2
+    isNsfw = true
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/zinmanga/src/eu/kanade/tachiyomi/extension/en/zinmanga/Zinmanga.kt
+++ b/src/en/zinmanga/src/eu/kanade/tachiyomi/extension/en/zinmanga/Zinmanga.kt
@@ -2,8 +2,8 @@ package eu.kanade.tachiyomi.extension.en.zinmanga
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 
-class Zinmanga : Madara("Zinmanga", "https://zinmanga.com", "en") {
+class Zinmanga : Madara("Zinmanga", "https://mangazin.org", "en") {
 
-    // The website does not flag the content.
+    // The website does not flag the content consistently.
     override val filterNonMangaItems = false
 }


### PR DESCRIPTION
Closes #2098

The old domain redirects to this domain. Haven't used before, so unsure if migration is necessary.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
