### PR TITLE
Mangago: support external chapters

### DIFF
--- a/src/en/mangago/build.gradle
+++ b/src/en/mangago/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Mangago'
     extClass = '.Mangago'
-    extVersionCode = 13
+    extVersionCode = 14
     isNsfw = true
 }
 

--- a/src/en/mangago/src/eu/kanade/tachiyomi/extension/en/mangago/Mangago.kt
+++ b/src/en/mangago/src/eu/kanade/tachiyomi/extension/en/mangago/Mangago.kt
@@ -175,7 +175,8 @@ class Mangago : ParsedHttpSource() {
     override fun chapterFromElement(element: Element) = SChapter.create().apply {
         val link = element.select("a.chico")
 
-        setUrlWithoutDomain(link.attr("href"))
+        val urlOriginal = link.attr("href")
+        if (urlOriginal.startsWith("http")) url = urlOriginal else setUrlWithoutDomain(urlOriginal)
         name = link.text().trim()
         date_upload = runCatching {
             dateFormat.parse(element.select("td:last-child").text().trim())?.time
@@ -240,6 +241,13 @@ class Mangago : ParsedHttpSource() {
 
                 Page(idx, imageUrl = url)
             }
+    }
+
+    override fun pageListRequest(chapter: SChapter): Request {
+        if (chapter.url.startsWith("http")) {
+            return GET(chapter.url, headers)
+        }
+        return super.pageListRequest(chapter)
     }
 
     override fun imageUrlParse(document: Document): String =


### PR DESCRIPTION
Closes  #2024

Test case: `Here U Are - Ch.139 : Extra**`

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
