### PR TITLE
MonarcaManga: update domain

### DIFF
--- a/src/es/monarcamanga/build.gradle
+++ b/src/es/monarcamanga/build.gradle
@@ -2,8 +2,9 @@ ext {
     extName = 'MonarcaManga'
     extClass = '.MonarcaManga'
     themePkg = 'madara'
-    baseUrl = 'https://monarcamanga.com'
-    overrideVersionCode = 0
+    baseUrl = 'https://visormonarca.com'
+    overrideVersionCode = 1
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/monarcamanga/build.gradle
+++ b/src/es/monarcamanga/build.gradle
@@ -1,6 +1,6 @@
 ext {
-    extName = 'MonarcaManga'
-    extClass = '.MonarcaManga'
+    extName = 'Visormonarca'
+    extClass = '.Visormonarca'
     themePkg = 'madara'
     baseUrl = 'https://visormonarca.com'
     overrideVersionCode = 1

--- a/src/es/monarcamanga/src/eu/kanade/tachiyomi/extension/es/monarcamanga/MonarcaManga.kt
+++ b/src/es/monarcamanga/src/eu/kanade/tachiyomi/extension/es/monarcamanga/MonarcaManga.kt
@@ -6,7 +6,7 @@ import java.util.Locale
 
 class MonarcaManga : Madara(
     "MonarcaManga",
-    "https://monarcamanga.com",
+    "https://visormonarca.com",
     "es",
     SimpleDateFormat("MMM d, yyy", Locale("es")),
 ) {

--- a/src/es/monarcamanga/src/eu/kanade/tachiyomi/extension/es/monarcamanga/Visormonarca.kt
+++ b/src/es/monarcamanga/src/eu/kanade/tachiyomi/extension/es/monarcamanga/Visormonarca.kt
@@ -4,8 +4,8 @@ import eu.kanade.tachiyomi.multisrc.madara.Madara
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class MonarcaManga : Madara(
-    "MonarcaManga",
+class Visormonarca : Madara(
+    "Visormonarca",
     "https://visormonarca.com",
     "es",
     SimpleDateFormat("MMM d, yyy", Locale("es")),


### PR DESCRIPTION
Closes #2172

Same logo, so kept the name.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
