### PR TITLE
Hentai2Read: fix cover

### DIFF
--- a/src/en/hentai2read/build.gradle
+++ b/src/en/hentai2read/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hentai2Read'
     extClass = '.Hentai2Read'
-    extVersionCode = 15
+    extVersionCode = 16
     isNsfw = true
 }
 

--- a/src/en/hentai2read/src/eu/kanade/tachiyomi/extension/en/hentai2read/Hentai2Read.kt
+++ b/src/en/hentai2read/src/eu/kanade/tachiyomi/extension/en/hentai2read/Hentai2Read.kt
@@ -162,7 +162,7 @@ class Hentai2Read : ParsedHttpSource() {
         manga.genre = infoElement.select("li:contains(Category) > a, li:contains(Content) > a").joinToString(", ") { it.text() }
         manga.description = buildDescription(infoElement)
         manga.status = infoElement.select("li:contains(Status) > a").text().orEmpty().let { parseStatus(it) }
-        manga.thumbnail_url = document.select("a#js-linkNext > img").attr("src")
+        manga.thumbnail_url = document.select("a#js-linkNext img").attr("src")
         manga.title = document.select("h3.block-title > a").first()!!.ownText().trim()
         return manga
     }


### PR DESCRIPTION
Closes #2102

Advanced > Library > Refresh library covers.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
