### PR TITLE
HentaiMode: update browse selector

### DIFF
--- a/src/es/hentaimode/build.gradle
+++ b/src/es/hentaimode/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'HentaiMode'
     extClass = '.HentaiMode'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/es/hentaimode/src/eu/kanade/tachiyomi/extension/es/hentaimode/HentaiMode.kt
+++ b/src/es/hentaimode/src/eu/kanade/tachiyomi/extension/es/hentaimode/HentaiMode.kt
@@ -35,7 +35,7 @@ class HentaiMode : ParsedHttpSource() {
     // ============================== Popular ===============================
     override fun popularMangaRequest(page: Int) = GET(baseUrl, headers)
 
-    override fun popularMangaSelector() = "div.row div.book-list > a"
+    override fun popularMangaSelector() = "div.row div[class*=\"book-list\"] > a"
 
     override fun popularMangaFromElement(element: Element) = SManga.create().apply {
         setUrlWithoutDomain(element.absUrl("href"))


### PR DESCRIPTION
Closes #1980

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
