### PR TITLE
zh/boylove: Update and remove obsolete mirror links

### DIFF
--- a/src/zh/boylove/build.gradle
+++ b/src/zh/boylove/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'BoyLove'
     extClass = '.BoyLove'
-    extVersionCode = 10
+    extVersionCode = 11
     isNsfw = true
 }
 

--- a/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLove.kt
+++ b/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLove.kt
@@ -207,7 +207,7 @@ class BoyLove : HttpSource(), ConfigurableSource {
 
         // redirect URL: https://fuhouse.club/bl
         // link source URL: https://boylovepage.github.io/boylove_page
-        private val MIRRORS get() = arrayOf("boylove1.mobi", "boylove3.cc", "boyloves.space", "boylove4.xyz", "boyloves.fun", "boylove.today", "fuzai.one", "xxfuzai.xyz", "boylove.cc", "fuzai.cc")
-        private val MIRRORS_DESC get() = arrayOf("boylove1.mobi", "boylove3.cc", "boyloves.space", "boylove4.xyz", "boyloves.fun", "boylove.today", "fuzai.one", "xxfuzai.xyz", "boylove.cc（非大陆）", "fuzai.cc（非大陆）")
+        private val MIRRORS get() = arrayOf("boylove1.mobi", "boylove3.cc", "boylove.cc", "boyloves.space", "boylove4.xyz", "boyloves.fun", "boylove.today", "fuzai.one", "xxfuzai.xyz", "fuzai.cc")
+        private val MIRRORS_DESC get() = arrayOf("boylove1.mobi", "boylove3.cc", "boylove.cc（非大陆）", "boyloves.space", "boylove4.xyz", "boyloves.fun", "boylove.today", "fuzai.one", "xxfuzai.xyz", "fuzai.cc（非大陆）")
     }
 }

--- a/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLove.kt
+++ b/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLove.kt
@@ -207,7 +207,7 @@ class BoyLove : HttpSource(), ConfigurableSource {
 
         // redirect URL: https://fuhouse.club/bl
         // link source URL: https://boylovepage.github.io/boylove_page
-        private val MIRRORS get() = arrayOf("boylove.cc", "fuzai.cc", "boylove1.mobi", "boylove3.cc", "boyloves.space", "boylove4.xyz", "boyloves.fun", "boylove.today", "fuzai.one", "xxfuzai.xyz")
-        private val MIRRORS_DESC get() = arrayOf("boylove.cc（非大陆）", "fuzai.cc（非大陆）", "boylove1.mobi", "boylove3.cc", "boyloves.space", "boylove4.xyz", "boyloves.fun", "boylove.today", "fuzai.one", "xxfuzai.xyz")
+        private val MIRRORS get() = arrayOf("boylove1.mobi", "boylove3.cc", "boyloves.space", "boylove4.xyz", "boyloves.fun", "boylove.today", "fuzai.one", "xxfuzai.xyz", "boylove.cc", "fuzai.cc")
+        private val MIRRORS_DESC get() = arrayOf("boylove1.mobi", "boylove3.cc", "boyloves.space", "boylove4.xyz", "boyloves.fun", "boylove.today", "fuzai.one", "xxfuzai.xyz", "boylove.cc（非大陆）", "fuzai.cc（非大陆）")
     }
 }

--- a/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLove.kt
+++ b/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLove.kt
@@ -206,7 +206,8 @@ class BoyLove : HttpSource(), ConfigurableSource {
         private const val MIRROR_PREF = "MIRROR"
 
         // redirect URL: https://fuhouse.club/bl
-        private val MIRRORS get() = arrayOf("boylov.xyz", "boylove3.cc", "boylove.cc", "boylove1.cc", "boylove2.cc", "boylove.today")
-        private val MIRRORS_DESC get() = arrayOf("boylov.xyz", "boylove3.cc", "boylove.cc (非大陆地区)", "boylove1.cc", "boylove2.cc", "boylove.today")
+        // link source URL: https://boylovepage.github.io/boylove_page
+        private val MIRRORS get() = arrayOf("boylove.cc", "fuzai.cc", "boylove1.mobi", "boylove3.cc", "boyloves.space", "boylove4.xyz", "boyloves.fun", "boylove.today", "fuzai.one", "xxfuzai.xyz")
+        private val MIRRORS_DESC get() = arrayOf("boylove.cc（非大陆）", "fuzai.cc（非大陆）", "boylove1.mobi", "boylove3.cc", "boyloves.space", "boylove4.xyz", "boyloves.fun", "boylove.today", "fuzai.one", "xxfuzai.xyz")
     }
 }


### PR DESCRIPTION
This PR remove and update the obsolete mirrors for Boylove/香香腐宅

New links are coming from https://boylovepage.github.io/boylove_page/, their default redirect page since Jan 2024. 

For the time being, the original boylove.cc server has raised its protection level, which causes the extension to be unable to bypass Cloudflare in some areas. The new links may solve this temporarily.


Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
