### PR TITLE
LuraToon: move to PeachScan

### DIFF
--- a/src/pt/randomscan/build.gradle
+++ b/src/pt/randomscan/build.gradle
@@ -1,9 +1,9 @@
 ext {
     extName = 'Lura Toon'
     extClass = '.LuraToon'
-    themePkg = 'madara'
+    themePkg = 'peachscan'
     baseUrl = 'https://luratoon.com'
-    overrideVersionCode = 7
+    overrideVersionCode = 39
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/randomscan/src/eu/kanade/tachiyomi/extension/pt/randomscan/LuraToon.kt
+++ b/src/pt/randomscan/src/eu/kanade/tachiyomi/extension/pt/randomscan/LuraToon.kt
@@ -1,24 +1,10 @@
 package eu.kanade.tachiyomi.extension.pt.randomscan
 
-import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.multisrc.peachscan.PeachScan
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
-import okhttp3.OkHttpClient
-import java.text.SimpleDateFormat
-import java.util.Locale
-import java.util.concurrent.TimeUnit
 
-class LuraToon : Madara(
-    "Lura Toon",
-    "https://luratoon.com",
-    "pt-BR",
-    SimpleDateFormat("MMMMM dd, yyyy", Locale("pt", "BR")),
-) {
-    // Name changed from Random Scan to Lura Toon and Domain change
-    override val id: Long = 8295593204533043008
-
-    override val client: OkHttpClient = super.client.newBuilder()
-        .rateLimit(1, 2, TimeUnit.SECONDS)
+class LuraToon : PeachScan("Lura Toon", "https://luratoon.com", "pt-BR") {
+    override val client = super.client.newBuilder()
+        .rateLimit(1, 2)
         .build()
-
-    override val useNewChapterEndpoint = true
 }


### PR DESCRIPTION
closes #2260

removed explicit id override to generate new one

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
