### PR TITLE
readsnk: fix chapter list and update domain

### DIFF
--- a/src/en/readattackontitanshingekinokyojinmanga/build.gradle
+++ b/src/en/readattackontitanshingekinokyojinmanga/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Read Attack on Titan Shingeki no Kyojin Manga'
     extClass = '.ReadAttackOnTitanShingekiNoKyojinManga'
     themePkg = 'mangacatalog'
-    baseUrl = 'https://ww8.readsnk.com'
-    overrideVersionCode = 4
+    baseUrl = 'https://ww9.readsnk.com'
+    overrideVersionCode = 5
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/readattackontitanshingekinokyojinmanga/src/eu/kanade/tachiyomi/extension/en/readattackontitanshingekinokyojinmanga/ReadAttackOnTitanShingekiNoKyojinManga.kt
+++ b/src/en/readattackontitanshingekinokyojinmanga/src/eu/kanade/tachiyomi/extension/en/readattackontitanshingekinokyojinmanga/ReadAttackOnTitanShingekiNoKyojinManga.kt
@@ -4,7 +4,7 @@ import eu.kanade.tachiyomi.multisrc.mangacatalog.MangaCatalog
 import eu.kanade.tachiyomi.source.model.SChapter
 import org.jsoup.nodes.Element
 
-class ReadAttackOnTitanShingekiNoKyojinManga : MangaCatalog("Read Attack on Titan Shingeki no Kyojin Manga", "https://ww8.readsnk.com", "en") {
+class ReadAttackOnTitanShingekiNoKyojinManga : MangaCatalog("Read Attack on Titan Shingeki no Kyojin Manga", "https://ww9.readsnk.com", "en") {
     override val sourceList = listOf(
         Pair("Shingeki No Kyojin", "$baseUrl/manga/shingeki-no-kyojin/"),
         Pair("Colored", "$baseUrl/manga/shingeki-no-kyojin-colored/"),
@@ -20,7 +20,7 @@ class ReadAttackOnTitanShingekiNoKyojinManga : MangaCatalog("Read Attack on Tita
         Pair("No Regrets Colored", "$baseUrl/manga/attack-on-titan-no-regrets-colored/"),
     ).sortedBy { it.first }.distinctBy { it.second }
 
-    override fun chapterListSelector(): String = "div.w-full div.grid div.col-span-3"
+    override fun chapterListSelector(): String = "div.w-full div.grid div.col-span-4"
 
     override fun chapterFromElement(element: Element): SChapter = SChapter.create().apply {
         val urlElement = element.selectFirst("a")!!


### PR DESCRIPTION
closes #2243

why do we even have these sources...

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
