### PR TITLE
BlackoutComics: Fix  selectors

### DIFF
--- a/src/pt/blackoutcomics/build.gradle
+++ b/src/pt/blackoutcomics/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Blackout Comics'
     extClass = '.BlackoutComics'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/pt/blackoutcomics/src/eu/kanade/tachiyomi/extension/pt/blackoutcomics/BlackoutComics.kt
+++ b/src/pt/blackoutcomics/src/eu/kanade/tachiyomi/extension/pt/blackoutcomics/BlackoutComics.kt
@@ -48,7 +48,7 @@ class BlackoutComics : ParsedHttpSource() {
 
     override fun popularMangaFromElement(element: Element) = SManga.create().apply {
         setUrlWithoutDomain(element.attr("href"))
-        thumbnail_url = element.selectFirst("img.custom-image:not(.hidden)")?.absUrl("src")
+        thumbnail_url = element.selectFirst("img.custom-image:not(.hidden), img.img-comics")?.absUrl("src")
         title = element.selectFirst("p.image-name:not(.hidden), span.text-comic")!!.text()
     }
 
@@ -96,9 +96,11 @@ class BlackoutComics : ParsedHttpSource() {
 
     // =========================== Manga Details ============================
     override fun mangaDetailsParse(document: Document) = SManga.create().apply {
-        val row = document.selectFirst(".row")!!
-        thumbnail_url = row.selectFirst("img:not(.tachiyomikappa)")?.absUrl("src")
-        title = row.selectFirst("h2:not(.tachiyomikappa)")!!.text()
+        val row = document.selectFirst("div.special-edition")!!
+        thumbnail_url = row.selectFirst("img:last-child")?.absUrl("src")
+        title = row.select("h2")
+            .first { it.classNames().isEmpty() }!!
+            .text()
 
         with(row.selectFirst("div.trailer-content:has(h3:containsOwn(Detalhes))")!!) {
             println(outerHtml())

--- a/src/pt/blackoutcomics/src/eu/kanade/tachiyomi/extension/pt/blackoutcomics/BlackoutComics.kt
+++ b/src/pt/blackoutcomics/src/eu/kanade/tachiyomi/extension/pt/blackoutcomics/BlackoutComics.kt
@@ -48,8 +48,8 @@ class BlackoutComics : ParsedHttpSource() {
 
     override fun popularMangaFromElement(element: Element) = SManga.create().apply {
         setUrlWithoutDomain(element.attr("href"))
-        thumbnail_url = element.selectFirst("img:not(.hidden)")?.absUrl("src")
-        title = element.selectFirst("p:not(.hidden), span.text-comic")!!.text()
+        thumbnail_url = element.selectFirst("img.custom-image:not(.hidden)")?.absUrl("src")
+        title = element.selectFirst("p.image-name:not(.hidden), span.text-comic")!!.text()
     }
 
     override fun popularMangaNextPageSelector() = null
@@ -97,8 +97,8 @@ class BlackoutComics : ParsedHttpSource() {
     // =========================== Manga Details ============================
     override fun mangaDetailsParse(document: Document) = SManga.create().apply {
         val row = document.selectFirst("section > div.container > div.row")!!
-        thumbnail_url = row.selectFirst("img:not(.hidden)")?.absUrl("src")
-        title = row.selectFirst("div.trailer-content > h2:not(.hidden)")!!.text()
+        thumbnail_url = row.selectFirst("img.img-recen-add2")?.absUrl("src")
+        title = row.selectFirst("div.trailer-content > h2:not(.tachiyomikappa)")!!.text()
 
         with(row.selectFirst("div.trailer-content:has(h3:containsOwn(Detalhes))")!!) {
             println(outerHtml())
@@ -153,7 +153,7 @@ class BlackoutComics : ParsedHttpSource() {
 
     // =============================== Pages ================================
     override fun pageListParse(document: Document): List<Page> {
-        return document.select("div.chapter-image-ofc canvas").mapIndexed { index, item ->
+        return document.select("div.chapter-image canvas").mapIndexed { index, item ->
             Page(index, "", item.absUrl("data-src"))
         }
     }

--- a/src/pt/blackoutcomics/src/eu/kanade/tachiyomi/extension/pt/blackoutcomics/BlackoutComics.kt
+++ b/src/pt/blackoutcomics/src/eu/kanade/tachiyomi/extension/pt/blackoutcomics/BlackoutComics.kt
@@ -96,9 +96,9 @@ class BlackoutComics : ParsedHttpSource() {
 
     // =========================== Manga Details ============================
     override fun mangaDetailsParse(document: Document) = SManga.create().apply {
-        val row = document.selectFirst("section > div.container > div.row")!!
-        thumbnail_url = row.selectFirst("img.img-recen-add2")?.absUrl("src")
-        title = row.selectFirst("div.trailer-content > h2:not(.tachiyomikappa)")!!.text()
+        val row = document.selectFirst(".row")!!
+        thumbnail_url = row.selectFirst("img:not(.tachiyomikappa)")?.absUrl("src")
+        title = row.selectFirst("h2:not(.tachiyomikappa)")!!.text()
 
         with(row.selectFirst("div.trailer-content:has(h3:containsOwn(Detalhes))")!!) {
             println(outerHtml())


### PR DESCRIPTION
Closes #2275

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
