### PR TITLE
Gmanga multisrc: filter out novel & fix null

### DIFF
--- a/lib-multisrc/gmanga/build.gradle.kts
+++ b/lib-multisrc/gmanga/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 2
+baseVersionCode = 3

--- a/lib-multisrc/gmanga/src/eu/kanade/tachiyomi/multisrc/gmanga/Dto.kt
+++ b/lib-multisrc/gmanga/src/eu/kanade/tachiyomi/multisrc/gmanga/Dto.kt
@@ -84,7 +84,7 @@ class Manga(
             else -> SManga.UNKNOWN
         }
         genre = buildList {
-            add(type.title)
+            add(type.title ?: "")
             add(type.name)
             categories.forEach { add(it.name) }
         }.joinToString()

--- a/lib-multisrc/gmanga/src/eu/kanade/tachiyomi/multisrc/gmanga/Dto.kt
+++ b/lib-multisrc/gmanga/src/eu/kanade/tachiyomi/multisrc/gmanga/Dto.kt
@@ -30,6 +30,7 @@ class BrowseManga(
     private val id: Int,
     private val title: String,
     private val cover: String? = null,
+    @SerialName("is_novel") val isNovel: Boolean,
 ) {
     fun toSManga(createThumbnail: (String, String) -> String) = SManga.create().apply {
         url = "/mangas/$id"
@@ -123,7 +124,7 @@ class NameDto(val name: String)
 @Serializable
 class TypeDto(
     val name: String,
-    val title: String,
+    val title: String?,
 )
 
 @Serializable

--- a/lib-multisrc/gmanga/src/eu/kanade/tachiyomi/multisrc/gmanga/Dto.kt
+++ b/lib-multisrc/gmanga/src/eu/kanade/tachiyomi/multisrc/gmanga/Dto.kt
@@ -84,7 +84,7 @@ class Manga(
             else -> SManga.UNKNOWN
         }
         genre = buildList {
-            add(type.title ?: "")
+            type.title?.let { add(it) }
             add(type.name)
             categories.forEach { add(it.name) }
         }.joinToString()

--- a/lib-multisrc/gmanga/src/eu/kanade/tachiyomi/multisrc/gmanga/Gmanga.kt
+++ b/lib-multisrc/gmanga/src/eu/kanade/tachiyomi/multisrc/gmanga/Gmanga.kt
@@ -49,6 +49,7 @@ abstract class Gmanga(
 
     override fun latestUpdatesParse(response: Response): MangasPage {
         val releases = response.parseAs<LatestChaptersDto>().releases
+            .filterNot { it.manga.isNovel }
 
         val entries = releases.map { it.manga.toSManga(::createThumbnail) }
             .distinctBy { it.url }


### PR DESCRIPTION
Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
