### PR TITLE
Manga Flame: update domain (reverts #1931)

### DIFF
--- a/src/ar/mangaflame/build.gradle
+++ b/src/ar/mangaflame/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Manga Flame'
     extClass = '.MangaFlame'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://arisescans.com'
-    overrideVersionCode = 2
+    baseUrl = 'https://mangaflame.org'
+    overrideVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/mangaflame/src/eu/kanade/tachiyomi/extension/ar/mangaflame/MangaFlame.kt
+++ b/src/ar/mangaflame/src/eu/kanade/tachiyomi/extension/ar/mangaflame/MangaFlame.kt
@@ -8,13 +8,9 @@ import java.util.concurrent.TimeUnit
 
 class MangaFlame : MangaThemesia(
     "Manga Flame",
-    "https://arisescans.com",
+    "https://mangaflame.org",
     "ar",
     dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("ar")),
 ) {
     override val id = 1501237443119573205
-
-    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
-        .readTimeout(3, TimeUnit.MINUTES)
-        .build()
 }

--- a/src/ar/mangaflame/src/eu/kanade/tachiyomi/extension/ar/mangaflame/MangaFlame.kt
+++ b/src/ar/mangaflame/src/eu/kanade/tachiyomi/extension/ar/mangaflame/MangaFlame.kt
@@ -1,10 +1,8 @@
 package eu.kanade.tachiyomi.extension.ar.mangaflame
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
-import okhttp3.OkHttpClient
 import java.text.SimpleDateFormat
 import java.util.Locale
-import java.util.concurrent.TimeUnit
 
 class MangaFlame : MangaThemesia(
     "Manga Flame",


### PR DESCRIPTION
Closes #2330

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
