### PR TITLE
MNS: Fix mangaId

### DIFF
--- a/src/es/mangasnosekai/build.gradle
+++ b/src/es/mangasnosekai/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangasNoSekai'
     themePkg = 'madara'
     baseUrl = 'https://mangasnosekai.com'
-    overrideVersionCode = 9
+    overrideVersionCode = 10
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/mangasnosekai/src/eu/kanade/tachiyomi/extension/es/mangasnosekai/MangasNoSekai.kt
+++ b/src/es/mangasnosekai/src/eu/kanade/tachiyomi/extension/es/mangasnosekai/MangasNoSekai.kt
@@ -202,6 +202,8 @@ class MangasNoSekai : Madara(
 
         val mangaId = document.selectFirst("script#wp-manga-js-extra")?.data()
             ?.let { MANGA_ID_REGEX.find(it)?.groupValues?.get(1) }
+            ?: document.selectFirst("script#manga_disqus_embed-js-extra")?.data()
+                ?.let { POST_ID_REGEX.find(it)?.groupValues?.get(1) }
             ?: throw Exception("No se pudo obtener el id del manga")
 
         val chapterElements = mutableListOf<Element>()
@@ -228,5 +230,6 @@ class MangasNoSekai : Madara(
     companion object {
         val ACTION_REGEX = """function\s+loadMoreChapters[\s\S]*?\$.ajax[\s\S]*?data[\s\S]*?action:\s*(?:["'](.*?)["'])""".toRegex()
         val MANGA_ID_REGEX = """\"manga_id"\s*:\s*"(.*)\"""".toRegex()
+        val POST_ID_REGEX = """\"postId"\s*:\s*"(.*)\"""".toRegex()
     }
 }


### PR DESCRIPTION
At this point they are breaking their site

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
