### PR TITLE
Scylla Comics: update domain

### DIFF
--- a/src/en/scyllascans/build.gradle
+++ b/src/en/scyllascans/build.gradle
@@ -1,8 +1,8 @@
 ext {
-    extName = 'Scylla Scans'
-    extClass = '.ScyllaScans'
+    extName = 'Scylla Comics'
+    extClass = '.ScyllaComics'
     themePkg = 'fuzzydoodle'
-    overrideVersionCode = 9
+    overrideVersionCode = 10
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/scyllascans/src/eu/kanade/tachiyomi/extension/en/scyllascans/ScyllaComics.kt
+++ b/src/en/scyllascans/src/eu/kanade/tachiyomi/extension/en/scyllascans/ScyllaComics.kt
@@ -2,7 +2,7 @@ package eu.kanade.tachiyomi.extension.en.scyllascans
 
 import eu.kanade.tachiyomi.multisrc.fuzzydoodle.FuzzyDoodle
 
-class ScyllaScans : FuzzyDoodle("Scylla Scans", "https://scyllascans.org", "en") {
+class ScyllaComics : FuzzyDoodle("Scylla Comics", "https://scyllacomics.xyz", "en") {
 
     // readerfront -> fuzzydoodle
     override val versionId = 2


### PR DESCRIPTION
closes  #2347

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
