### PR TITLE
MangaOni: Fix bad base64

### DIFF
--- a/src/es/mangamx/build.gradle
+++ b/src/es/mangamx/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaOni'
     extClass = '.MangaOni'
-    extVersionCode = 15
+    extVersionCode = 16
     isNsfw = true
 }
 

--- a/src/es/mangamx/src/eu/kanade/tachiyomi/extension/es/mangamx/MangaOni.kt
+++ b/src/es/mangamx/src/eu/kanade/tachiyomi/extension/es/mangamx/MangaOni.kt
@@ -188,7 +188,7 @@ open class MangaOni : ConfigurableSource, ParsedHttpSource() {
 
     override fun pageListParse(document: Document): List<Page> {
         val encoded = document.select("script:containsData(unicap)").firstOrNull()
-            ?.data()?.substringAfter("'")?.substringBefore("'")?.reversed()
+            ?.data()?.substringAfter("'")?.substringBefore("'")
             ?: throw Exception("unicap not found")
         val drop = encoded.length % 4
         val decoded = Base64.decode(encoded.dropLast(drop), Base64.DEFAULT).toString(Charset.defaultCharset())


### PR DESCRIPTION
Closes #2441

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
