### PR TITLE
Anchira: Non-empty Author field

### DIFF
--- a/src/en/anchira/build.gradle
+++ b/src/en/anchira/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anchira'
     extClass = '.Anchira'
-    extVersionCode = 11
+    extVersionCode = 12
     isNsfw = true
 }
 

--- a/src/en/anchira/src/eu/kanade/tachiyomi/extension/en/anchira/Anchira.kt
+++ b/src/en/anchira/src/eu/kanade/tachiyomi/extension/en/anchira/Anchira.kt
@@ -82,8 +82,11 @@ class Anchira : HttpSource(), ConfigurableSource {
                     url = "/g/${it.id}/${it.key}"
                     title = it.title
                     thumbnail_url = "$cdnUrl/${it.id}/${it.key}/m/${it.thumbnailIndex + 1}"
-                    artist = it.tags.filter { it.namespace == 1 }.joinToString(", ") { it.name }
+                    val art = it.tags.filter { it.namespace == 1 }.joinToString(", ") { it.name }
+                        .ifEmpty { null }
+                    artist = art
                     author = it.tags.filter { it.namespace == 2 }.joinToString(", ") { it.name }
+                        .ifEmpty { art }
                     genre = prepareTags(it.tags, preferences.useTagGrouping)
                     update_strategy = UpdateStrategy.ONLY_FETCH_ONCE
                     status = SManga.COMPLETED
@@ -240,8 +243,11 @@ class Anchira : HttpSource(), ConfigurableSource {
                 title = data.title
                 thumbnail_url =
                     "$cdnUrl/${data.id}/${data.key}/b/${data.thumbnailIndex + 1}"
-                artist = data.tags.filter { it.namespace == 1 }.joinToString(", ") { it.name }
+                val art = data.tags.filter { it.namespace == 1 }.joinToString(", ") { it.name }
+                    .ifEmpty { null }
+                artist = art
                 author = data.tags.filter { it.namespace == 2 }.joinToString(", ") { it.name }
+                    .ifEmpty { art }
                 genre = prepareTags(data.tags, preferences.useTagGrouping)
                 update_strategy = UpdateStrategy.ONLY_FETCH_ONCE
                 status = SManga.COMPLETED
@@ -398,7 +404,7 @@ class Anchira : HttpSource(), ConfigurableSource {
 
     private class SortFilter : Filter.Sort(
         "Sort",
-        arrayOf("Title", "Pages", "Date published", "Date uploaded", "Popularity"),
+        arrayOf("Title", "Pages", "Date uploaded", "Date published", "Popularity"),
         Selection(2, false),
     )
 

--- a/src/en/anchira/src/eu/kanade/tachiyomi/extension/en/anchira/AnchiraDto.kt
+++ b/src/en/anchira/src/eu/kanade/tachiyomi/extension/en/anchira/AnchiraDto.kt
@@ -23,7 +23,7 @@ data class Entry(
     val key: String,
     @SerialName("published_at") val publishedAt: Long = 0L,
     val title: String,
-    @SerialName("thumb_index") val thumbnailIndex: Int = 1,
+    @SerialName("thumb_index") val thumbnailIndex: Int = 0,
     val tags: List<Tag> = emptyList(),
     val url: String? = null,
     val pages: Int = 1,


### PR DESCRIPTION
- Author field will return the same value as the Artist field instead of an empty string if there's no Circle tag present.
  - Prevents the `, ` prefix on J2K ( Fixes #2408 ) and hides the Author Field entirely on Mihon and SY
- Swapped the reversed Sort Filters for dates
- When the thumbnail index is undefined, assume first page instead of second. Fixes #2407

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
