### PR TITLE
Elarc Toon: Skip responses that do not start with "text/html"

### DIFF
--- a/src/en/elarcpage/build.gradle
+++ b/src/en/elarcpage/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ElarcPage'
     themePkg = 'mangathemesia'
     baseUrl = 'https://elarctoons.com'
-    overrideVersionCode = 5
+    overrideVersionCode = 6
     isNsfw = false
 }
 

--- a/src/en/elarcpage/src/eu/kanade/tachiyomi/extension/en/elarcpage/ElarcPage.kt
+++ b/src/en/elarcpage/src/eu/kanade/tachiyomi/extension/en/elarcpage/ElarcPage.kt
@@ -52,6 +52,12 @@ class ElarcPage : MangaThemesia(
 
         // Always update URL
         val response = chain.proceed(request)
+
+        // Skip responses that do not start with "text/html"
+        if (response.header("content-type")?.startsWith("text/html") != true) {
+            return response
+        }
+        
         val document = Jsoup.parse(
             response.peekBody(Long.MAX_VALUE).string(),
             request.url.toString(),

--- a/src/en/elarcpage/src/eu/kanade/tachiyomi/extension/en/elarcpage/ElarcPage.kt
+++ b/src/en/elarcpage/src/eu/kanade/tachiyomi/extension/en/elarcpage/ElarcPage.kt
@@ -57,7 +57,7 @@ class ElarcPage : MangaThemesia(
         if (response.header("content-type")?.startsWith("text/html") != true) {
             return response
         }
-        
+
         val document = Jsoup.parse(
             response.peekBody(Long.MAX_VALUE).string(),
             request.url.toString(),


### PR DESCRIPTION
Skip responses that do not start with "text/html", such as responses of image types, to improve extension performance.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
