### PR TITLE
fix liliana page order

### DIFF
--- a/lib-multisrc/liliana/build.gradle.kts
+++ b/lib-multisrc/liliana/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 1
+baseVersionCode = 2

--- a/lib-multisrc/liliana/src/eu/kanade/tachiyomi/multisrc/liliana/Liliana.kt
+++ b/lib-multisrc/liliana/src/eu/kanade/tachiyomi/multisrc/liliana/Liliana.kt
@@ -322,9 +322,17 @@ abstract class Liliana(
     }
 
     override fun pageListParse(document: Document): List<Page> {
-        return document.select("div.separator").mapIndexed { i, page ->
-            val url = page.selectFirst("a")!!.attr("abs:href")
-            Page(i, document.location(), url)
+        return if (document.selectFirst("div.separator[data-index]") == null) {
+            document.select("div.separator").mapIndexed { i, page ->
+                val url = page.selectFirst("a")!!.attr("abs:href")
+                Page(i, document.location(), url)
+            }
+        } else {
+            document.select("div.separator[data-index]").map { page ->
+                val index = page.attr("data-index").toInt()
+                val url = page.selectFirst("a")!!.attr("abs:href")
+                Page(index, document.location(), url)
+            }.sortedBy { it.index }
         }
     }
 

--- a/src/ja/mangakoma/src/eu/kanade/tachiyomi/extension/ja/mangakoma/MangaKoma.kt
+++ b/src/ja/mangakoma/src/eu/kanade/tachiyomi/extension/ja/mangakoma/MangaKoma.kt
@@ -1,15 +1,18 @@
 package eu.kanade.tachiyomi.extension.ja.mangakoma
 
 import eu.kanade.tachiyomi.multisrc.liliana.Liliana
+import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.Page
-import org.jsoup.nodes.Document
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Request
 
 class MangaKoma : Liliana("Manga Koma", "https://mangakoma01.net", "ja") {
-    override fun pageListParse(document: Document): List<Page> {
-        return document.select("div.separator[data-index]").map { page ->
-            val index = page.attr("data-index").toInt()
-            val url = page.selectFirst("a")!!.attr("abs:href")
-            Page(index, document.location(), url)
-        }.sortedBy { it.index }
+    override fun imageRequest(page: Page): Request {
+        val imgHeaders = headersBuilder().apply {
+            add("Accept", "image/avif,image/webp,*/*")
+            add("Host", page.imageUrl!!.toHttpUrl().host)
+            removeAll("Referer")
+        }.build()
+        return GET(page.imageUrl!!, imgHeaders)
     }
 }


### PR DESCRIPTION
Closes #2471

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
