### PR TITLE
IkigaiMangas: Fix http 404 when reading a chapter

### DIFF
--- a/src/es/ikigaimangas/build.gradle
+++ b/src/es/ikigaimangas/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Ikigai Mangas'
     extClass = '.IkigaiMangas'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = true
 }
 

--- a/src/es/ikigaimangas/src/eu/kanade/tachiyomi/extension/es/ikigaimangas/IkigaiMangas.kt
+++ b/src/es/ikigaimangas/src/eu/kanade/tachiyomi/extension/es/ikigaimangas/IkigaiMangas.kt
@@ -9,6 +9,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.util.asJsoup
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -141,14 +142,13 @@ class IkigaiMangas : HttpSource() {
         return mangas
     }
 
-    override fun pageListRequest(chapter: SChapter): Request {
-        val id = chapter.url.substringAfter("/capitulo/")
-        return GET("$apiBaseUrl/api/swf/chapters/$id", headers)
-    }
+    override fun pageListRequest(chapter: SChapter): Request =
+        GET(baseUrl + chapter.url.substringBefore("#"), headers)
 
     override fun pageListParse(response: Response): List<Page> {
-        return json.decodeFromString<PayloadPagesDto>(response.body.string()).chapter.pages.mapIndexed { i, img ->
-            Page(i, "", img)
+        val document = response.asJsoup()
+        return document.select("section > div.img > img").mapIndexed { i, element ->
+            Page(i, imageUrl = element.attr("abs:src"))
         }
     }
 

--- a/src/es/ikigaimangas/src/eu/kanade/tachiyomi/extension/es/ikigaimangas/IkigaiMangasDto.kt
+++ b/src/es/ikigaimangas/src/eu/kanade/tachiyomi/extension/es/ikigaimangas/IkigaiMangasDto.kt
@@ -110,16 +110,6 @@ class ChapterMetaDto(
 }
 
 @Serializable
-class PayloadPagesDto(
-    val chapter: PageDto,
-)
-
-@Serializable
-class PageDto(
-    val pages: List<String>,
-)
-
-@Serializable
 class SeriesStatusDto(
     val id: Long,
 )


### PR DESCRIPTION
Rip pages endpoint. Closes #2510 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
