### PR TITLE
update extraction for mangaUrlDirectory

### DIFF
--- a/src/en/elarcpage/build.gradle
+++ b/src/en/elarcpage/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ElarcPage'
     themePkg = 'mangathemesia'
     baseUrl = 'https://elarctoons.com'
-    overrideVersionCode = 6
+    overrideVersionCode = 7
     isNsfw = false
 }
 

--- a/src/en/elarcpage/src/eu/kanade/tachiyomi/extension/en/elarcpage/ElarcPage.kt
+++ b/src/en/elarcpage/src/eu/kanade/tachiyomi/extension/en/elarcpage/ElarcPage.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.extension.en.elarcpage
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import eu.kanade.tachiyomi.network.GET
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.Response
 import org.jsoup.Jsoup
@@ -63,12 +64,10 @@ class ElarcPage : MangaThemesia(
             request.url.toString(),
         )
 
-        document.select("#menu-item-14 > a, a:contains(All Series), #main-menu a, .mm a")
-            .reversed()
-            .map { it.attr("href") }
-            .lastOrNull { it.length >= 2 && it[0] == '/' }
+        document.selectFirst(".serieslist > ul > li a.series")
             ?.let {
-                setMangaUrlDirectory(it)
+                val mangaUrlDirectory = it.attr("abs:href").toHttpUrl().pathSegments.first()
+                setMangaUrlDirectory("/$mangaUrlDirectory")
                 dynamicUrlUpdated = timeNow
             }
 


### PR DESCRIPTION
Closes #2518

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
