### PR TITLE
Comick tags filter fix

### DIFF
--- a/src/all/comickfun/build.gradle
+++ b/src/all/comickfun/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comick'
     extClass = '.ComickFactory'
-    extVersionCode = 42
+    extVersionCode = 43
     isNsfw = true
 }
 

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
@@ -301,7 +301,7 @@ abstract class Comick(
                     is TagFilter -> {
                         if (it.state.isNotEmpty()) {
                             it.state.split(",").forEach {
-                                addQueryParameter("tags", it.trim().lowercase().replace(Regex("[ /]"), "-").replace("'-", "-and-039-").replace("'", "-and-039-"))
+                                addQueryParameter("tags", it.trim().lowercase().replace(SPACE_AND_SLASH_REGEX, "-").replace("'-", "-and-039-").replace("'", "-and-039-"))
                             }
                         }
                     }
@@ -453,6 +453,7 @@ abstract class Comick(
 
     companion object {
         const val SLUG_SEARCH_PREFIX = "id:"
+        private val SPACE_AND_SLASH_REGEX = Regex("[ /]")
         private const val IGNORED_GROUPS_PREF = "IgnoredGroups"
         private const val INCLUDE_MU_TAGS_PREF = "IncludeMangaUpdatesTags"
         private const val INCLUDE_MU_TAGS_DEFAULT = false

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
@@ -301,7 +301,7 @@ abstract class Comick(
                     is TagFilter -> {
                         if (it.state.isNotEmpty()) {
                             it.state.split(",").forEach {
-                                addQueryParameter("tags", it.trim().replace(Regex("[ /]"), "-"))
+                                addQueryParameter("tags", it.trim().lowercase().replace(Regex("[ /]"), "-").replace("'-", "-and-039-").replace("'", "-and-039-"))
                             }
                         }
                     }

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
@@ -301,7 +301,7 @@ abstract class Comick(
                     is TagFilter -> {
                         if (it.state.isNotEmpty()) {
                             it.state.split(",").forEach {
-                                addQueryParameter("tags", it.trim())
+                                addQueryParameter("tags", it.trim().replace(Regex("[ /]"), "-"))
                             }
                         }
                     }


### PR DESCRIPTION
**Comick's tags filter doesn't recognize:** Spaces, slashes, and single quotation marks. Uppercase letters.
**Problem:** Comick will ignore those kind of tags.
**Examples:** `Borderline H`, `Special Ability/s`, `Parent's Work Plays A Big Role`, and `Girls' Love as a Subplot`.

_I apologize If I'm wrong. Please let me know if I've missed anything. Thank you._

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
