### PR TITLE
NineManga: Fix wrong pages

### DIFF
--- a/src/all/ninemanga/build.gradle
+++ b/src/all/ninemanga/build.gradle
@@ -5,3 +5,7 @@ ext {
 }
 
 apply from: "$rootDir/common.gradle"
+
+dependencies {
+    implementation(project(":lib:cookieinterceptor"))
+}

--- a/src/all/ninemanga/build.gradle
+++ b/src/all/ninemanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'NineManga'
     extClass = '.NineMangaFactory'
-    extVersionCode = 19
+    extVersionCode = 20
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/ninemanga/src/eu/kanade/tachiyomi/extension/all/ninemanga/NineManga.kt
+++ b/src/all/ninemanga/src/eu/kanade/tachiyomi/extension/all/ninemanga/NineManga.kt
@@ -97,7 +97,6 @@ open class NineManga(
         element.select("a.chapter_list_a").let {
             name = it.text().replace(mangaTitleForCleaning, "", true)
             url = it.attr("href").substringAfter(baseUrl).replace("%20", " ")
-                .substringBeforeLast(".html") + "-1-1.html"
         }
         date_upload = parseChapterDate(element.select("span").text())
     }
@@ -126,6 +125,10 @@ open class NineManga(
             }
         }
         return 0L
+    }
+
+    override fun pageListRequest(chapter: SChapter): Request {
+        return GET(baseUrl + chapter.url.replace(".html", "-1.html"), headers)
     }
 
     override fun pageListParse(document: Document): List<Page> = mutableListOf<Page>().apply {

--- a/src/all/ninemanga/src/eu/kanade/tachiyomi/extension/all/ninemanga/NineManga.kt
+++ b/src/all/ninemanga/src/eu/kanade/tachiyomi/extension/all/ninemanga/NineManga.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.extension.all.ninemanga
 
+import eu.kanade.tachiyomi.lib.cookieinterceptor.CookieInterceptor
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
@@ -26,6 +27,8 @@ open class NineManga(
 
     override val supportsLatest: Boolean = true
 
+    private val cookieInterceptor = CookieInterceptor(baseUrl.substringAfter("://"), "ninemanga_list_num" to "1")
+
     override val client: OkHttpClient = network.client.newBuilder()
         .addInterceptor { chain ->
             val request = chain.request()
@@ -37,7 +40,9 @@ open class NineManga(
                 return@addInterceptor chain.proceed(newRequest)
             }
             chain.proceed(request)
-        }.build()
+        }
+        .addNetworkInterceptor(cookieInterceptor)
+        .build()
 
     override fun headersBuilder(): Headers.Builder = Headers.Builder()
         .add("Accept-Language", "es-ES,es;q=0.9,en;q=0.8,gl;q=0.7")
@@ -125,10 +130,6 @@ open class NineManga(
             }
         }
         return 0L
-    }
-
-    override fun pageListRequest(chapter: SChapter): Request {
-        return GET(baseUrl + chapter.url.replace(".html", "-1.html"), headers)
     }
 
     override fun pageListParse(document: Document): List<Page> = mutableListOf<Page>().apply {


### PR DESCRIPTION
This will break the downloaded chapters.

Closes #2569

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
