### PR TITLE
Emperor Scan: update domain

### DIFF
--- a/src/es/emperorscan/build.gradle
+++ b/src/es/emperorscan/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Emperor Scan'
     extClass = '.EmperorScan'
     themePkg = 'madara'
-    baseUrl = 'https://emperorscan.com'
-    overrideVersionCode = 2
+    baseUrl = 'https://emperorscan.org'
+    overrideVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/emperorscan/src/eu/kanade/tachiyomi/extension/es/emperorscan/EmperorScan.kt
+++ b/src/es/emperorscan/src/eu/kanade/tachiyomi/extension/es/emperorscan/EmperorScan.kt
@@ -19,7 +19,7 @@ import java.util.Locale
 class EmperorScan :
     Madara(
         "Emperor Scan",
-        "https://emperorscan.com",
+        "https://emperorscan.org",
         "es",
         SimpleDateFormat("MMMM dd, yyyy", Locale("es")),
     ),


### PR DESCRIPTION
Closes #2533

The current domain redirects to the new domain, but the old domain is geo-blocked.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
