### PR TITLE
Top Manhua: update domain

### DIFF
--- a/src/en/topmanhua/build.gradle
+++ b/src/en/topmanhua/build.gradle
@@ -2,8 +2,9 @@ ext {
     extName = 'Top Manhua'
     extClass = '.TopManhua'
     themePkg = 'madara'
-    baseUrl = 'https://topmanhua.com'
-    overrideVersionCode = 3
+    baseUrl = 'https://mangatop.org'
+    overrideVersionCode = 4
+    isNsfw = true
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/topmanhua/src/eu/kanade/tachiyomi/extension/en/topmanhua/TopManhua.kt
+++ b/src/en/topmanhua/src/eu/kanade/tachiyomi/extension/en/topmanhua/TopManhua.kt
@@ -5,7 +5,7 @@ import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class TopManhua : Madara("Top Manhua", "https://topmanhua.com", "en", SimpleDateFormat("MM/dd/yy", Locale.US)) {
+class TopManhua : Madara("Top Manhua", "https://mangatop.org", "en", SimpleDateFormat("MM/dd/yy", Locale.US)) {
     override val client = super.client.newBuilder()
         .rateLimit(2)
         .build()


### PR DESCRIPTION
Closes #2605

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
