### PR TITLE
NetTruyen: update domain

### DIFF
--- a/src/vi/nettruyen/build.gradle
+++ b/src/vi/nettruyen/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'NetTruyen'
     extClass = '.NetTruyen'
     themePkg = 'wpcomics'
-    baseUrl = 'https://www.nettruyentt.com'
-    overrideVersionCode = 29
+    baseUrl = 'https://www.nettruyenvv.com'
+    overrideVersionCode = 30
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/vi/nettruyen/src/eu/kanade/tachiyomi/extension/vi/nettruyen/NetTruyen.kt
+++ b/src/vi/nettruyen/src/eu/kanade/tachiyomi/extension/vi/nettruyen/NetTruyen.kt
@@ -15,7 +15,7 @@ import java.util.Locale
 
 class NetTruyen : WPComics(
     "NetTruyen",
-    "https://www.nettruyentt.com",
+    "https://www.nettruyenvv.com",
     "vi",
     dateFormat = SimpleDateFormat("dd/MM/yy", Locale.getDefault()),
     gmtOffset = null,


### PR DESCRIPTION
Closes #2599

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
