### PR TITLE
MANGARAW+: update domain

### DIFF
--- a/src/ja/mangarawplus/build.gradle
+++ b/src/ja/mangarawplus/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'MANGARAW+'
     extClass = '.MangaRawPlus'
     themePkg = 'madara'
-    baseUrl = 'https://mangarawplus.org'
-    overrideVersionCode = 1
+    baseUrl = 'https://newmangaraw.com'
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/ja/mangarawplus/src/eu/kanade/tachiyomi/extension/ja/mangarawplus/MangaRawPlus.kt
+++ b/src/ja/mangarawplus/src/eu/kanade/tachiyomi/extension/ja/mangarawplus/MangaRawPlus.kt
@@ -4,6 +4,5 @@ import eu.kanade.tachiyomi.multisrc.madara.Madara
 
 class MangaRawPlus : Madara("MANGARAW+", "https://newmangaraw.com", "ja") {
     override val mangaSubString = "sp"
-    override val useLoadMoreRequest = LoadMoreStrategy.Never
     override val useNewChapterEndpoint = false
 }

--- a/src/ja/mangarawplus/src/eu/kanade/tachiyomi/extension/ja/mangarawplus/MangaRawPlus.kt
+++ b/src/ja/mangarawplus/src/eu/kanade/tachiyomi/extension/ja/mangarawplus/MangaRawPlus.kt
@@ -2,7 +2,8 @@ package eu.kanade.tachiyomi.extension.ja.mangarawplus
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 
-class MangaRawPlus : Madara("MANGARAW+", "https://mangarawplus.org", "ja") {
+class MangaRawPlus : Madara("MANGARAW+", "https://newmangaraw.com", "ja") {
     override val mangaSubString = "sp"
-    override val useLoadMoreRequest = LoadMoreStrategy.Always
+    override val useLoadMoreRequest = LoadMoreStrategy.Never
+    override val useNewChapterEndpoint = false
 }


### PR DESCRIPTION
Closes #2342

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
