### PR TITLE
Luminous Scans: update domain

### DIFF
--- a/src/en/luminousscans/build.gradle
+++ b/src/en/luminousscans/build.gradle
@@ -2,8 +2,9 @@ ext {
     extName = 'Luminous Scans'
     extClass = '.LuminousScans'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://lumitoon.com'
-    overrideVersionCode = 5
+    baseUrl = 'https://luminouscomics.org'
+    overrideVersionCode = 6
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/luminousscans/src/eu/kanade/tachiyomi/extension/en/luminousscans/LuminousScans.kt
+++ b/src/en/luminousscans/src/eu/kanade/tachiyomi/extension/en/luminousscans/LuminousScans.kt
@@ -7,7 +7,7 @@ import okhttp3.Request
 
 class LuminousScans : MangaThemesiaAlt(
     "Luminous Scans",
-    "https://lumitoon.com",
+    "https://luminouscomics.org",
     "en",
     mangaUrlDirectory = "/series",
     randomUrlPrefKey = "pref_permanent_manga_url_2_en",


### PR DESCRIPTION
Closes #2630

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
