### PR TITLE
SlimeRead: Fix api url

### DIFF
--- a/src/pt/slimeread/build.gradle
+++ b/src/pt/slimeread/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'SlimeRead'
     extClass = '.SlimeRead'
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = true
 }
 

--- a/src/pt/slimeread/src/eu/kanade/tachiyomi/extension/pt/slimeread/SlimeRead.kt
+++ b/src/pt/slimeread/src/eu/kanade/tachiyomi/extension/pt/slimeread/SlimeRead.kt
@@ -31,7 +31,7 @@ class SlimeRead : HttpSource() {
 
     override val baseUrl = "https://slimeread.com"
 
-    private val apiUrl = "https://aishiteru-dear-dev-f0cc1f0a-4900-493e-acd5-9f3df303a1b5.slimeread.com:8443"
+    private val apiUrl = "https://aishiteru-dear-dev-17a224de-78b5-4770-b7a2-9f30e24b5e6d.slimeread.com:8443"
 
     override val lang = "pt-BR"
 


### PR DESCRIPTION
Closes #2706

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
