### PR TITLE
Ikigai Mangas: update domain, skip chapter redir

### DIFF
--- a/src/es/ikigaimangas/build.gradle
+++ b/src/es/ikigaimangas/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Ikigai Mangas'
     extClass = '.IkigaiMangas'
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = true
 }
 

--- a/src/es/ikigaimangas/src/eu/kanade/tachiyomi/extension/es/ikigaimangas/IkigaiMangas.kt
+++ b/src/es/ikigaimangas/src/eu/kanade/tachiyomi/extension/es/ikigaimangas/IkigaiMangas.kt
@@ -24,7 +24,7 @@ import kotlin.concurrent.thread
 
 class IkigaiMangas : HttpSource() {
 
-    override val baseUrl: String = "https://ikigaimangas.com"
+    override val baseUrl: String = "https://visorikigai.net"
     private val apiBaseUrl: String = "https://panel.ikigaimangas.com"
 
     override val lang: String = "es"

--- a/src/es/ikigaimangas/src/eu/kanade/tachiyomi/extension/es/ikigaimangas/IkigaiMangasDto.kt
+++ b/src/es/ikigaimangas/src/eu/kanade/tachiyomi/extension/es/ikigaimangas/IkigaiMangasDto.kt
@@ -91,7 +91,7 @@ class ChapterDto(
     @SerialName("published_at") val date: String,
 ) {
     fun toSChapter(dateFormat: SimpleDateFormat) = SChapter.create().apply {
-        url = "/capitulo/$id"
+        url = "/capitulo/$id/"
         name = "Capítulo ${this@ChapterDto.name}"
         date_upload = try {
             dateFormat.parse(date)?.time ?: 0L


### PR DESCRIPTION
Closes #2717

Skips a 302 redirect. Checked if read chapter state is kept, which it is, at least for the 9 most popular manga.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
