### PR TITLE
Update Asura Scans Base URL

### DIFF
--- a/src/en/asurascans/build.gradle
+++ b/src/en/asurascans/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Asura Scans'
     extClass = '.AsuraScans'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://asuratoon.com'
-    overrideVersionCode = 3
+    baseUrl = 'https://asuracomics.net'
+    overrideVersionCode = 4
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScans.kt
+++ b/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScans.kt
@@ -11,7 +11,7 @@ import java.util.Locale
 
 class AsuraScans : MangaThemesiaAlt(
     "Asura Scans",
-    "https://asuratoon.com",
+    "https://asuracomic.net/",
     "en",
     dateFormat = SimpleDateFormat("MMM d, yyyy", Locale.US),
     randomUrlPrefKey = "pref_permanent_manga_url_2_en",


### PR DESCRIPTION
Asura Scans extension is broken. Any asuratoon URLs automatically redirect to home page of new asuracomic.net homepage, causing null pointer exceptions and broken sources.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
