### PR TITLE
AsuraScans: Update domain

### DIFF
--- a/src/en/asurascans/build.gradle
+++ b/src/en/asurascans/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Asura Scans'
     extClass = '.AsuraScans'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://asuratoon.com'
-    overrideVersionCode = 3
+    baseUrl = 'https://asuracomic.net'
+    overrideVersionCode = 4
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScans.kt
+++ b/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScans.kt
@@ -11,7 +11,7 @@ import java.util.Locale
 
 class AsuraScans : MangaThemesiaAlt(
     "Asura Scans",
-    "https://asuratoon.com",
+    "https://asuracomic.net",
     "en",
     dateFormat = SimpleDateFormat("MMM d, yyyy", Locale.US),
     randomUrlPrefKey = "pref_permanent_manga_url_2_en",


### PR DESCRIPTION
Site only redirects on USA network
For others is supposed to redirect with javascript, but fetch fails
![image](https://github.com/keiyoushi/extensions-source/assets/90949336/075e4359-9647-4feb-ad13-3ae69a1dfd7e)

Closes #2778 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
