### PR TITLE
Voyce.Me: Switch from http to https

### DIFF
--- a/src/en/voyceme/build.gradle
+++ b/src/en/voyceme/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'Voyce.Me'
     extClass = '.VoyceMe'
-    extVersionCode = 3
+    extVersionCode = 4
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/voyceme/src/eu/kanade/tachiyomi/extension/en/voyceme/VoyceMe.kt
+++ b/src/en/voyceme/src/eu/kanade/tachiyomi/extension/en/voyceme/VoyceMe.kt
@@ -29,7 +29,7 @@ class VoyceMe : HttpSource() {
 
     override val name = "VoyceMe"
 
-    override val baseUrl = "http://voyce.me"
+    override val baseUrl = "https://www.voyce.me"
 
     override val lang = "en"
 


### PR DESCRIPTION
The baseUrl is only used:
- in headers
- for WebView button

The change does not affect any existing users, as all URLs are set without the domain in VoyceMeDto.kt

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
