### PR TITLE
Sandra and Woo: Switch from http to https

### DIFF
--- a/src/all/sandraandwoo/build.gradle
+++ b/src/all/sandraandwoo/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'Sandra and Woo'
     extClass = '.SandraAndWooFactory'
-    extVersionCode = 1
+    extVersionCode = 2
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/sandraandwoo/src/eu/kanade/tachiyomi/extension/all/sandraandwoo/SandraAndWoo.kt
+++ b/src/all/sandraandwoo/src/eu/kanade/tachiyomi/extension/all/sandraandwoo/SandraAndWoo.kt
@@ -17,7 +17,7 @@ import java.util.Locale
 import kotlin.math.floor
 
 abstract class SandraAndWoo(
-    final override val baseUrl: String = "http://www.sandraandwoo.com",
+    final override val baseUrl: String = "https://www.sandraandwoo.com",
     final override val lang: String,
 ) : ParsedHttpSource() {
     override val supportsLatest = false

--- a/src/all/sandraandwoo/src/eu/kanade/tachiyomi/extension/all/sandraandwoo/translations/SandraAndWooDE.kt
+++ b/src/all/sandraandwoo/src/eu/kanade/tachiyomi/extension/all/sandraandwoo/translations/SandraAndWooDE.kt
@@ -10,6 +10,6 @@ class SandraAndWooDE : SandraAndWoo(lang = "de") {
     override val synopsis = "Sandra und Woo ist ein Comedy-Webcomic mit dem zwölfjährigen Mädchen Sandra North und ihrem Waschbären Woo in den Hauptrollen. Zwar sollen die meisten Strips einfach nur lustig oder gewitzt sein, gelegentlich werden aber auch ernste Themen wie die Missachtung von Menschenrechten in Burma oder die Zerstörung der Natur angesprochen. Wir wollen außerdem zeigen, was es für Sandra und ihre Schulfreunde Cloud und Larisa bedeutet, erwachsen zu werden. Nicht vergessen werden sollten außerdem Woos Ausflüge in den nahen Wald um dort seine tierischen Freunde Shadow, ein Fuchs, und Sid, ein Eichhörnchen, zu treffen. Als weiteres Alleinstellungsmerkmal des Comics darf gelten, dass sich immer wieder einzelne Strips oder sogar längere Geschichten um die Nebenfiguren drehen."
     override val genres = "Comedy"
     override val state = SManga.ON_HIATUS
-    override val thumbnail = "http://www.sandraandwoo.com/images/fanart/fanart-contest-2014/pictures/zheng-qu-01-color-corrected.jpg"
+    override val thumbnail = "https://www.sandraandwoo.com/images/fanart/fanart-contest-2014/pictures/zheng-qu-01-color-corrected.jpg"
     override val archive = "/woode/archiv"
 }

--- a/src/all/sandraandwoo/src/eu/kanade/tachiyomi/extension/all/sandraandwoo/translations/SandraAndWooEN.kt
+++ b/src/all/sandraandwoo/src/eu/kanade/tachiyomi/extension/all/sandraandwoo/translations/SandraAndWooEN.kt
@@ -10,6 +10,6 @@ class SandraAndWooEN : SandraAndWoo(lang = "en") {
     override val synopsis = "Sandra and Woo is a comedy comic strip featuring the 13-year-old girl Sandra North and her mischievous pet raccoon Woo. While most strips are just supposed to be funny or tell an exciting story, some also deal with more serious topics. We also want to show what growing up means for Sandra and her best friends in middle school, Cloud and Larisa. Another regular feature of the comic are Woo’s trips to the forest to meet his furry friends Shadow (a fox) and Sid (a squirrel) and his love interest Lily."
     override val genres = "Comedy"
     override val state = SManga.ON_HIATUS
-    override val thumbnail = "http://www.sandraandwoo.com/images/fanart/fanart-contest-2014/pictures/zheng-qu-01-color-corrected.jpg"
+    override val thumbnail = "https://www.sandraandwoo.com/images/fanart/fanart-contest-2014/pictures/zheng-qu-01-color-corrected.jpg"
     override val archive = "/archive"
 }


### PR DESCRIPTION
Did not change `archive` URL, as that would require migration, or show the manga as not your library. The current 301 redirect is fine. If it really matters I can add an interceptor for it.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
