### PR TITLE
KakuseiProject: Fix domain

### DIFF
--- a/src/pt/kakuseiproject/build.gradle
+++ b/src/pt/kakuseiproject/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Kakusei Project'
     extClass = '.KakuseiProject'
     themePkg = 'madara'
-    baseUrl = 'https://kakuseiproject.com.br'
-    overrideVersionCode = 0
+    baseUrl = 'https://kakuseiproject.com'
+    overrideVersionCode = 1
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/kakuseiproject/src/eu/kanade/tachiyomi/extension/pt/kakuseiproject/KakuseiProject.kt
+++ b/src/pt/kakuseiproject/src/eu/kanade/tachiyomi/extension/pt/kakuseiproject/KakuseiProject.kt
@@ -19,4 +19,6 @@ class KakuseiProject : Madara(
         .build()
 
     override val useNewChapterEndpoint = true
+
+    override val useLoadMoreRequest = LoadMoreStrategy.Always
 }

--- a/src/pt/kakuseiproject/src/eu/kanade/tachiyomi/extension/pt/kakuseiproject/KakuseiProject.kt
+++ b/src/pt/kakuseiproject/src/eu/kanade/tachiyomi/extension/pt/kakuseiproject/KakuseiProject.kt
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeUnit
 
 class KakuseiProject : Madara(
     "Kakusei Project",
-    "https://kakuseiproject.com.br",
+    "https://kakuseiproject.com",
     "pt-BR",
     SimpleDateFormat("MMMMM dd, yyyy", Locale("pt", "BR")),
 ) {


### PR DESCRIPTION
Closes #2808
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
