### PR TITLE
Galaxy Manga: updatre manga / chapter / page URL format

### DIFF
--- a/src/ar/galaxymanga/build.gradle
+++ b/src/ar/galaxymanga/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.GalaxyManga'
     themePkg = 'flixscans'
     baseUrl = 'https://flixscans.com'
-    overrideVersionCode = 26
+    overrideVersionCode = 27
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/galaxymanga/src/eu/kanade/tachiyomi/extension/ar/galaxymanga/GalaxyManga.kt
+++ b/src/ar/galaxymanga/src/eu/kanade/tachiyomi/extension/ar/galaxymanga/GalaxyManga.kt
@@ -1,6 +1,10 @@
 package eu.kanade.tachiyomi.extension.ar.galaxymanga
 
 import eu.kanade.tachiyomi.multisrc.flixscans.FlixScans
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import okhttp3.Request
 
 class GalaxyManga : FlixScans(
     "جالاكسي مانجا",
@@ -9,4 +13,22 @@ class GalaxyManga : FlixScans(
     "https://ar.flixscans.site/api/v1",
 ) {
     override val versionId = 2
+
+    override fun mangaDetailsRequest(manga: SManga): Request {
+        val (prefix, id) = getPrefixIdFromUrl(manga.url)
+
+        return GET("$apiUrl/series/$id/$prefix", headers)
+    }
+
+    override fun chapterListRequest(manga: SManga): Request {
+        val (prefix, id) = getPrefixIdFromUrl(manga.url)
+
+        return GET("$apiUrl/chapters/$id-desc#$prefix", headers)
+    }
+
+    override fun pageListRequest(chapter: SChapter): Request {
+        val (prefix, id) = getPrefixIdFromUrl(chapter.url)
+
+        return GET("$apiUrl/chapters/webtoon/$id/$prefix", headers)
+    }
 }


### PR DESCRIPTION
Closes #2849

For comparison:
```
mangaDetailsRequest():
$apiUrl/webtoon/series/$id/$prefix
$apiUrl/series/$id/$prefix

chapterListRequest():
$apiUrl/webtoon/chapters/$id-desc#$prefix
$apiUrl/chapters/$id-desc#$prefix

pageListRequest():
$apiUrl/webtoon/chapters/chapter/$id/$prefix
$apiUrl/chapters/webtoon/$id/$prefix
```


Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
