### PR TITLE
SussyScan: Fix load mangas

### DIFF
--- a/src/pt/sussyscan/build.gradle
+++ b/src/pt/sussyscan/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.SussyScan'
     themePkg = 'madara'
     baseUrl = 'https://sussyscan.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/sussyscan/src/eu/kanade/tachiyomi/extension/pt/sussyscan/SussyScan.kt
+++ b/src/pt/sussyscan/src/eu/kanade/tachiyomi/extension/pt/sussyscan/SussyScan.kt
@@ -16,6 +16,4 @@ class SussyScan : Madara(
         .build()
 
     override val useNewChapterEndpoint = true
-
-    override val mangaSubString = "sus"
 }

--- a/src/pt/sussyscan/src/eu/kanade/tachiyomi/extension/pt/sussyscan/SussyScan.kt
+++ b/src/pt/sussyscan/src/eu/kanade/tachiyomi/extension/pt/sussyscan/SussyScan.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.extension.pt.sussyscan
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -17,6 +18,10 @@ class SussyScan : Madara(
 
     override val useNewChapterEndpoint = true
 
-    // There's no manga thumbnail in manga page, keeps thumbnail from popular, latest and search
-    override val mangaDetailsSelectorThumbnail = "#thumbnail-empty"
+    override val mangaDetailsSelectorThumbnail = "head meta[property='og:image']"
+
+    override fun imageFromElement(element: Element): String? {
+        return super.imageFromElement(element)?.takeIf { it.isNotEmpty() }
+            ?: element.attr("content") // Thumbnail from <head>
+    }
 }

--- a/src/pt/sussyscan/src/eu/kanade/tachiyomi/extension/pt/sussyscan/SussyScan.kt
+++ b/src/pt/sussyscan/src/eu/kanade/tachiyomi/extension/pt/sussyscan/SussyScan.kt
@@ -9,7 +9,6 @@ class SussyScan : Madara(
     "Sussy Scan",
     "https://sussyscan.com",
     "pt-BR",
-    SimpleDateFormat("MMMMM dd, yyyy", Locale("pt", "BR")),
 ) {
     override val client = super.client.newBuilder()
         .rateLimit(2)

--- a/src/pt/sussyscan/src/eu/kanade/tachiyomi/extension/pt/sussyscan/SussyScan.kt
+++ b/src/pt/sussyscan/src/eu/kanade/tachiyomi/extension/pt/sussyscan/SussyScan.kt
@@ -2,11 +2,14 @@ package eu.kanade.tachiyomi.extension.pt.sussyscan
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 class SussyScan : Madara(
     "Sussy Scan",
     "https://sussyscan.com",
     "pt-BR",
+    SimpleDateFormat("MMMM dd, yyyy", Locale("pt", "BR"))
 ) {
     override val client = super.client.newBuilder()
         .rateLimit(2)

--- a/src/pt/sussyscan/src/eu/kanade/tachiyomi/extension/pt/sussyscan/SussyScan.kt
+++ b/src/pt/sussyscan/src/eu/kanade/tachiyomi/extension/pt/sussyscan/SussyScan.kt
@@ -9,7 +9,7 @@ class SussyScan : Madara(
     "Sussy Scan",
     "https://sussyscan.com",
     "pt-BR",
-    SimpleDateFormat("MMMM dd, yyyy", Locale("pt", "BR"))
+    SimpleDateFormat("MMMM dd, yyyy", Locale("pt", "BR")),
 ) {
     override val client = super.client.newBuilder()
         .rateLimit(2)

--- a/src/pt/sussyscan/src/eu/kanade/tachiyomi/extension/pt/sussyscan/SussyScan.kt
+++ b/src/pt/sussyscan/src/eu/kanade/tachiyomi/extension/pt/sussyscan/SussyScan.kt
@@ -16,4 +16,7 @@ class SussyScan : Madara(
         .build()
 
     override val useNewChapterEndpoint = true
+
+    // There's no manga thumbnail in manga page, keeps thumbnail from popular, latest and search
+    override val mangaDetailsSelectorThumbnail = "#thumbnail-empty"
 }

--- a/src/pt/sussyscan/src/eu/kanade/tachiyomi/extension/pt/sussyscan/SussyScan.kt
+++ b/src/pt/sussyscan/src/eu/kanade/tachiyomi/extension/pt/sussyscan/SussyScan.kt
@@ -2,8 +2,6 @@ package eu.kanade.tachiyomi.extension.pt.sussyscan
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 class SussyScan : Madara(
     "Sussy Scan",


### PR DESCRIPTION
Closes #2869

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
