### PR TITLE
Jiangzaitoon: update domain

### DIFF
--- a/src/tr/jiangzaitoon/build.gradle
+++ b/src/tr/jiangzaitoon/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Jiangzaitoon'
     extClass = '.Jiangzaitoon'
     themePkg = 'madara'
-    baseUrl = 'https://jiangzaitoon.info'
-    overrideVersionCode = 4
+    baseUrl = 'https://jiangzaitoon.dev'
+    overrideVersionCode = 5
     isNsfw = true
 }
 

--- a/src/tr/jiangzaitoon/src/eu/kanade/tachiyomi/extension/tr/jiangzaitoon/Jiangzaitoon.kt
+++ b/src/tr/jiangzaitoon/src/eu/kanade/tachiyomi/extension/tr/jiangzaitoon/Jiangzaitoon.kt
@@ -8,10 +8,11 @@ import java.util.concurrent.TimeUnit
 
 class Jiangzaitoon : Madara(
     "Jiangzaitoon",
-    "https://jiangzaitoon.info",
+    "https://jiangzaitoon.dev",
     "tr",
     SimpleDateFormat("d MMM yyy", Locale("tr")),
 ) {
+    override val useLoadMoreRequest = LoadMoreStrategy.Always
     override val useNewChapterEndpoint = false
 
     override val client: OkHttpClient by lazy {


### PR DESCRIPTION
Closes #2885

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
