### PR TITLE
HentaiRead: fix page parsing

### DIFF
--- a/src/en/hentairead/build.gradle
+++ b/src/en/hentairead/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Hentairead'
     themePkg = 'madara'
     baseUrl = 'https://hentairead.com'
-    overrideVersionCode = 4
+    overrideVersionCode = 5
     isNsfw = true
 }
 

--- a/src/en/hentairead/src/eu/kanade/tachiyomi/extension/en/hentairead/Hentairead.kt
+++ b/src/en/hentairead/src/eu/kanade/tachiyomi/extension/en/hentairead/Hentairead.kt
@@ -78,9 +78,16 @@ class Hentairead : Madara("HentaiRead", "https://hentairead.com", "en", dateForm
     }
 
     override fun pageListRequest(chapter: SChapter): Request {
-        // There's like 2 non-English entries where this breaks
-        chapter.url = "${chapter.url}english/p/1/"
-        return super.pageListRequest(chapter)
+        // Making a copy in case the caller propagates changes
+        val chapterCopy = SChapter.create().apply {
+            // There's like 2 non-English entries where this breaks
+            url = "${chapter.url}english/p/1/"
+            name = chapter.name
+            date_upload = chapter.date_upload
+            chapter_number = chapter.chapter_number
+            scanlator = chapter.scanlator
+        }
+        return super.pageListRequest(chapterCopy)
     }
 }
 

--- a/src/en/hentairead/src/eu/kanade/tachiyomi/extension/en/hentairead/Hentairead.kt
+++ b/src/en/hentairead/src/eu/kanade/tachiyomi/extension/en/hentairead/Hentairead.kt
@@ -9,7 +9,6 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import org.jsoup.nodes.Document
@@ -18,8 +17,6 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 
 class Hentairead : Madara("HentaiRead", "https://hentairead.com", "en", dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.US)) {
-
-    override val json = Json { ignoreUnknownKeys = true }
 
     override val versionId: Int = 2
 
@@ -74,11 +71,18 @@ class Hentairead : Madara("HentaiRead", "https://hentairead.com", "en", dateForm
             listOf(
                 SChapter.create().apply {
                     name = "Chapter"
-                    // There's like 2 non-English entries where this breaks
-                    url = "${manga.url}english/p/1/"
+                    url = manga.url
                 },
             ),
         )
+    }
+
+    override fun pageListRequest(chapter: SChapter): Request {
+        // There's like 2 non-English entries where this breaks
+        chapter.url = chapter.url
+            .takeIf { it.endsWith("english/p/1/") }
+            ?: "${chapter.url}english/p/1/"
+        return super.pageListRequest(chapter)
     }
 }
 

--- a/src/en/hentairead/src/eu/kanade/tachiyomi/extension/en/hentairead/Hentairead.kt
+++ b/src/en/hentairead/src/eu/kanade/tachiyomi/extension/en/hentairead/Hentairead.kt
@@ -78,16 +78,13 @@ class Hentairead : Madara("HentaiRead", "https://hentairead.com", "en", dateForm
     }
 
     override fun pageListRequest(chapter: SChapter): Request {
-        // Making a copy in case the caller propagates changes
-        val chapterCopy = SChapter.create().apply {
-            // There's like 2 non-English entries where this breaks
-            url = "${chapter.url}english/p/1/"
-            name = chapter.name
-            date_upload = chapter.date_upload
-            chapter_number = chapter.chapter_number
-            scanlator = chapter.scanlator
+        // There's like 2 non-English entries where this breaks
+        val url = "${chapter.url}english/p/1/"
+
+        if (url.startsWith("http")) {
+            return GET(url, headers)
         }
-        return super.pageListRequest(chapterCopy)
+        return GET(baseUrl + url, headers)
     }
 }
 

--- a/src/en/hentairead/src/eu/kanade/tachiyomi/extension/en/hentairead/Hentairead.kt
+++ b/src/en/hentairead/src/eu/kanade/tachiyomi/extension/en/hentairead/Hentairead.kt
@@ -79,9 +79,7 @@ class Hentairead : Madara("HentaiRead", "https://hentairead.com", "en", dateForm
 
     override fun pageListRequest(chapter: SChapter): Request {
         // There's like 2 non-English entries where this breaks
-        chapter.url = chapter.url
-            .takeIf { it.endsWith("english/p/1/") }
-            ?: "${chapter.url}english/p/1/"
+        chapter.url = "${chapter.url}english/p/1/"
         return super.pageListRequest(chapter)
     }
 }

--- a/src/en/hentairead/src/eu/kanade/tachiyomi/extension/en/hentairead/Hentairead.kt
+++ b/src/en/hentairead/src/eu/kanade/tachiyomi/extension/en/hentairead/Hentairead.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.extension.en.hentairead
 
-import android.net.Uri
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.FilterList
@@ -8,6 +7,9 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import org.jsoup.nodes.Document
@@ -16,6 +18,8 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 
 class Hentairead : Madara("HentaiRead", "https://hentairead.com", "en", dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.US)) {
+
+    override val json = Json { ignoreUnknownKeys = true }
 
     override val versionId: Int = 2
 
@@ -50,19 +54,18 @@ class Hentairead : Madara("HentaiRead", "https://hentairead.com", "en", dateForm
         }
     }
 
+    // From ManhwaHentai - modified
     override fun pageListParse(document: Document): List<Page> {
         launchIO { countViews(document) }
 
-        return document.select(pageListParseSelector).mapIndexed { index, element ->
-            val pageUri: String? = element.selectFirst("img")!!.let {
-                it.absUrl(if (it.hasAttr("data-src")) "data-src" else "src")
-            }
-            Page(
-                index,
-                document.location(),
-                Uri.parse(pageUri).buildUpon().clearQuery().appendQueryParameter("ssl", "1")
-                    .appendQueryParameter("w", "1100").build().toString(),
-            )
+        val pages = document.selectFirst("#chapter_preloaded_images")?.data()
+            ?.substringAfter("chapter_preloaded_images = ")
+            ?.substringBefore("],")
+            ?.let { json.decodeFromString<List<PageDto>>("$it]") }
+            ?: throw Exception("Failed to find page list. Non-English entries are not supported.")
+
+        return pages.mapIndexed { idx, page ->
+            Page(idx, document.location(), page.src)
         }
     }
 
@@ -71,9 +74,15 @@ class Hentairead : Madara("HentaiRead", "https://hentairead.com", "en", dateForm
             listOf(
                 SChapter.create().apply {
                     name = "Chapter"
-                    url = manga.url
+                    // There's like 2 non-English entries where this breaks
+                    url = "${manga.url}english/p/1/"
                 },
             ),
         )
     }
 }
+
+@Serializable
+class PageDto(
+    val src: String,
+)


### PR DESCRIPTION
Closes  #2902

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
