### PR TITLE
Nitro Manga -> Nitro Scans: update domain

### DIFF
--- a/src/en/nitroscans/build.gradle
+++ b/src/en/nitroscans/build.gradle
@@ -1,9 +1,10 @@
 ext {
-    extName = 'Nitro Manga'
+    extName = 'Nitro Scans'
     extClass = '.NitroScans'
     themePkg = 'madara'
-    baseUrl = 'https://nitromanga.com'
-    overrideVersionCode = 1
+    baseUrl = 'https://nitroscans.net'
+    overrideVersionCode = 2
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/nitroscans/src/eu/kanade/tachiyomi/extension/en/nitroscans/NitroScans.kt
+++ b/src/en/nitroscans/src/eu/kanade/tachiyomi/extension/en/nitroscans/NitroScans.kt
@@ -2,12 +2,13 @@ package eu.kanade.tachiyomi.extension.en.nitroscans
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 
-class NitroScans : Madara("Nitro Manga", "https://nitromanga.com", "en") {
+class NitroScans : Madara("Nitro Scans", "https://nitroscans.net", "en") {
     override val id = 1310352166897986481
 
     override val mangaSubString = "mangas"
 
     override val filterNonMangaItems = false
 
+    override val useLoadMoreRequest = LoadMoreStrategy.Always
     override val useNewChapterEndpoint = true
 }


### PR DESCRIPTION
Closes #2904

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
