### PR TITLE
Komiku: use new API endpoint

### DIFF
--- a/src/id/komiku/build.gradle
+++ b/src/id/komiku/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Komiku'
     extClass = '.Komiku'
-    extVersionCode = 17
+    extVersionCode = 18
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/komiku/src/eu/kanade/tachiyomi/extension/id/komiku/Komiku.kt
+++ b/src/id/komiku/src/eu/kanade/tachiyomi/extension/id/komiku/Komiku.kt
@@ -21,7 +21,7 @@ class Komiku : ParsedHttpSource() {
 
     override val baseUrl = "https://komiku.id"
 
-    private val baseUrlData = "https://data.komiku.id"
+    private val baseUrlApi = "https://api.komiku.id"
 
     override val lang = "id"
 
@@ -34,9 +34,9 @@ class Komiku : ParsedHttpSource() {
 
     override fun popularMangaRequest(page: Int): Request {
         return if (page == 1) {
-            GET("$baseUrl/other/hot/?orderby=meta_value_num", headers)
+            GET("$baseUrlApi/other/hot/?orderby=meta_value_num", headers)
         } else {
-            GET("$baseUrl/other/hot/page/$page/?orderby=meta_value_num", headers)
+            GET("$baseUrlApi/other/hot/page/$page/?orderby=meta_value_num", headers)
         }
     }
 
@@ -51,25 +51,25 @@ class Komiku : ParsedHttpSource() {
 
         // scraped image doesn't make for a good cover; so try to transform it
         // make it take bad cover instead of null if it contains upload date as those URLs aren't very useful
-        if (element.select("img").attr("data-src").contains(coverUploadRegex)) {
-            manga.thumbnail_url = element.select("img").attr("data-src")
+        if (element.select("img").attr("abs:src").contains(coverUploadRegex)) {
+            manga.thumbnail_url = element.select("img").attr("abs:src")
         } else {
-            manga.thumbnail_url = element.select("img").attr("data-src").substringBeforeLast("?").replace(coverRegex, "/Komik-")
+            manga.thumbnail_url = element.select("img").attr("abs:src").substringBeforeLast("?").replace(coverRegex, "/Komik-")
         }
 
         return manga
     }
 
-    override fun popularMangaNextPageSelector() = ".pag-nav a.next"
+    override fun popularMangaNextPageSelector() = "#hxloading + [hx-trigger=revealed]"
 
     // latest
     override fun latestUpdatesSelector() = popularMangaSelector()
 
     override fun latestUpdatesRequest(page: Int): Request {
         return if (page == 1) {
-            GET("$baseUrlData/cari/?post_type=manga&s=&orderby=modified", headers)
+            GET("$baseUrlApi/other/hot/?orderby=modified&category_name=", headers)
         } else {
-            GET("$baseUrlData/cari/page/$page/?post_type=manga&s=&orderby=modified", headers)
+            GET("$baseUrlApi/other/hot/page/$page/?orderby=modified&category_name=", headers)
         }
     }
 
@@ -81,7 +81,7 @@ class Komiku : ParsedHttpSource() {
     override fun searchMangaSelector() = popularMangaSelector()
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        var url = "$baseUrlData/page/$page/?post_type=manga".toHttpUrl().newBuilder().addQueryParameter("s", query)
+        var url = "$baseUrlApi/page/$page/?post_type=manga".toHttpUrl().newBuilder().addQueryParameter("s", query)
         (if (filters.isEmpty()) getFilterList() else filters).forEach { filter ->
             when (filter) {
                 is CategoryNames -> {


### PR DESCRIPTION
Closes  #2884

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
