### PR TITLE
Happymh: fix referer for pageListRequest

### DIFF
--- a/src/zh/happymh/build.gradle
+++ b/src/zh/happymh/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Happymh'
     extClass = '.Happymh'
-    extVersionCode = 10
+    extVersionCode = 11
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/zh/happymh/src/eu/kanade/tachiyomi/extension/zh/happymh/Happymh.kt
+++ b/src/zh/happymh/src/eu/kanade/tachiyomi/extension/zh/happymh/Happymh.kt
@@ -142,10 +142,12 @@ class Happymh : HttpSource(), ConfigurableSource {
 
     override fun pageListRequest(chapter: SChapter): Request {
         val url = baseUrl + chapter.url
+        val comicId = chapter.url.substringAfter("code=").substringBefore("&")
+        val chapterId = chapter.url.substringAfter("cid=").substringBefore("&")
         // Some chapters return 403 without this header
         val header = headersBuilder()
             .add("X-Requested-With", "XMLHttpRequest")
-            .set("Referer", url)
+            .set("Referer", "$baseUrl/reads/$comicId/$chapterId")
             .build()
         return GET(url, header)
     }


### PR DESCRIPTION
Closes #2346

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
