### PR TITLE
Vortex Scans: fix chapter pages

### DIFF
--- a/src/en/arvenscans/build.gradle
+++ b/src/en/arvenscans/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'Vortex Scans'
     extClass = '.VortexScans'
-    extVersionCode = 31
+    extVersionCode = 32
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/arvenscans/src/eu/kanade/tachiyomi/extension/en/arvenscans/VortexScans.kt
+++ b/src/en/arvenscans/src/eu/kanade/tachiyomi/extension/en/arvenscans/VortexScans.kt
@@ -130,7 +130,7 @@ class VortexScans : HttpSource() {
     override fun pageListParse(response: Response): List<Page> {
         val document = response.asJsoup()
 
-        return document.select("main > section > img").mapIndexed { idx, img ->
+        return document.select("main section > img").mapIndexed { idx, img ->
             Page(idx, imageUrl = img.absUrl("src"))
         }
     }


### PR DESCRIPTION
Closes #2973 (both domains work, keeping current)

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
