### PR TITLE
ci: create repo `index.html` lising apk

### DIFF
--- a/.github/scripts/commit-repo.sh
+++ b/.github/scripts/commit-repo.sh
@@ -11,7 +11,6 @@ if [ -n "$(git status --porcelain)" ]; then
     git push
 
     curl https://purge.jsdelivr.net/gh/keiyoushi/extensions@repo/index.min.json
-    curl https://purge.jsdelivr.net/gh/keiyoushi/extensions@repo/index.html
 else
     echo "No changes to commit"
 fi

--- a/.github/scripts/commit-repo.sh
+++ b/.github/scripts/commit-repo.sh
@@ -11,6 +11,7 @@ if [ -n "$(git status --porcelain)" ]; then
     git push
 
     curl https://purge.jsdelivr.net/gh/keiyoushi/extensions@repo/index.min.json
+    curl https://purge.jsdelivr.net/gh/keiyoushi/extensions@repo/index.html
 else
     echo "No changes to commit"
 fi

--- a/.github/scripts/create-repo.py
+++ b/.github/scripts/create-repo.py
@@ -112,5 +112,6 @@ with (REPO_DIR / "index.html").open("w", encoding="utf-8") as f:
     f.write('<!DOCTYPE html>\n<html>\n<head>\n<meta charset="UTF-8">\n<title>apks</title>\n</head>\n<body>\n<pre>\n')
     for entry in index_data:
         apk_escaped = 'apk/' + html.escape(entry["apk"])
-        f.write(f'<a href="{apk_escaped}">{apk_escaped}</a>\n')
+        name_escaped = html.escape(entry["name"])
+        f.write(f'<a href="{apk_escaped}">{name_escaped}</a>\n')
     f.write('</pre>\n</body>\n</html>\n')

--- a/.github/scripts/create-repo.py
+++ b/.github/scripts/create-repo.py
@@ -1,3 +1,4 @@
+import html
 import json
 import os
 import re
@@ -106,3 +107,10 @@ with (REPO_DIR / "index.json").open("w", encoding="utf-8") as f:
 
 with (REPO_DIR / "index.min.json").open("w", encoding="utf-8") as f:
     json.dump(index_min_data, f, ensure_ascii=False, separators=(",", ":"))
+
+with (REPO_DIR / "index.html").open("w", encoding="utf-8") as f:
+    f.write('<!DOCTYPE html>\n<html>\n<head>\n<meta charset="UTF-8">\n<title>apks</title>\n</head>\n<body>\n<pre>\n')
+    for entry in index_data:
+        apk_escaped = 'apk/' + html.escape(entry["apk"])
+        f.write(f'<a href="{apk_escaped}">{apk_escaped}</a>\n')
+    f.write('</pre>\n</body>\n</html>\n')


### PR DESCRIPTION
I'd like to use https://github.com/ImranR98/Obtainium to track and install these extensions. For this all we need is a directory listing rendered in html index with links to the apk files.

Unfortunately the directory listing on [github](https://github.com/keiyoushi/extensions/tree/repo/apk/) and [jsdelivr](https://cdn.jsdelivr.net/gh/keiyoushi/extensions@repo/apk/) cause errors because of the large number of apk files.

The proposed change creates a listing of the apk files at `index.html` in ci.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
