### PR TITLE
Comick: show error message from API

### DIFF
--- a/src/all/comickfun/build.gradle
+++ b/src/all/comickfun/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comick'
     extClass = '.ComickFactory'
-    extVersionCode = 43
+    extVersionCode = 44
     isNsfw = true
 }
 

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Dto.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Dto.kt
@@ -197,3 +197,9 @@ class ChapterPageData(
 class Page(
     val url: String? = null,
 )
+
+@Serializable
+class Error(
+    val statusCode: Int,
+    val message: String,
+)


### PR DESCRIPTION
Closes #1642

The root issue was that the API doesn't allow you to go to page >30. This PR shows the error in a toast, making the issue more obvious. To address the actual issue; this is a limitation of Comick and not fixable from the extension.

In action:
![image of toast containing error message](https://github.com/keiyoushi/extensions-source/assets/13540478/8114949c-bfdb-4345-95e7-3643630b0a68)




Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
