### PR TITLE
DrakeScans: Remove Jetpack CDN from pages

### DIFF
--- a/src/en/drakescans/build.gradle
+++ b/src/en/drakescans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.DrakeScans'
     themePkg = 'mangathemesia'
     baseUrl = 'https://drake-scans.com'
-    overrideVersionCode = 11
+    overrideVersionCode = 12
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/drakescans/src/eu/kanade/tachiyomi/extension/en/drakescans/DrakeScans.kt
+++ b/src/en/drakescans/src/eu/kanade/tachiyomi/extension/en/drakescans/DrakeScans.kt
@@ -1,6 +1,11 @@
 package eu.kanade.tachiyomi.extension.en.drakescans
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
+import eu.kanade.tachiyomi.source.model.Page
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Request
+import java.util.concurrent.TimeUnit
 
 class DrakeScans : MangaThemesia(
     "Drake Scans",
@@ -9,4 +14,19 @@ class DrakeScans : MangaThemesia(
 ) {
     // madara -> mangathemesia
     override val versionId = 2
+
+    override val client = super.client.newBuilder()
+        .rateLimitHost(baseUrl.toHttpUrl(), 3, 1, TimeUnit.SECONDS)
+        .build()
+
+    override fun imageRequest(page: Page): Request {
+        val newUrl = page.imageUrl!!.replace(JETPACK_CDN_REGEX, "https://")
+        return super.imageRequest(page).newBuilder()
+            .url(newUrl)
+            .build()
+    }
+
+    companion object {
+        val JETPACK_CDN_REGEX = """^https:\/\/i[0-9]\.wp\.com\/""".toRegex()
+    }
 }


### PR DESCRIPTION
Closes #2968 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
