### PR TITLE
MangaGeko: fixed latest next page selector

### DIFF
--- a/src/en/mangarawclub/build.gradle
+++ b/src/en/mangarawclub/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaGeko'
     extClass = '.MangaRawClub'
-    extVersionCode = 21
+    extVersionCode = 22
     isNsfw = true
 }
 

--- a/src/en/mangarawclub/src/eu/kanade/tachiyomi/extension/en/mangarawclub/MangaRawClub.kt
+++ b/src/en/mangarawclub/src/eu/kanade/tachiyomi/extension/en/mangarawclub/MangaRawClub.kt
@@ -60,7 +60,7 @@ class MangaRawClub : ParsedHttpSource() {
 
     override fun searchMangaNextPageSelector() = "ul.pagination > li:last-child > a"
     override fun popularMangaNextPageSelector() = searchMangaNextPageSelector()
-    override fun latestUpdatesNextPageSelector() = searchMangaNextPageSelector()
+    override fun latestUpdatesNextPageSelector() = ".paging .mg-pagination-chev:last-child:not(.chev-disabled)"
 
     override fun mangaDetailsParse(document: Document): SManga {
         if (document.select(".novel-header").first() == null) {


### PR DESCRIPTION
Closes #3000 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
