### PR TITLE
Arabs Hentai: fix search title + only manga, cover

### DIFF
--- a/src/ar/arabshentai/build.gradle
+++ b/src/ar/arabshentai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Arabs Hentai'
     extClass = '.ArabsHentai'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/ar/arabshentai/src/eu/kanade/tachiyomi/extension/ar/arabshentai/ArabsHentai.kt
+++ b/src/ar/arabshentai/src/eu/kanade/tachiyomi/extension/ar/arabshentai/ArabsHentai.kt
@@ -87,13 +87,13 @@ class ArabsHentai : ParsedHttpSource() {
         return GET(url.build(), headers)
     }
 
-    override fun searchMangaSelector() = ".search-page .result-item article"
+    override fun searchMangaSelector() = ".search-page .result-item article:not(:has(.tvshows))"
 
     override fun searchMangaFromElement(element: Element) =
         SManga.create().apply {
             element.selectFirst(".details .title")!!.run {
                 setUrlWithoutDomain(selectFirst("a")!!.absUrl("href"))
-                title = ownText()
+                title = text()
             }
             thumbnail_url = element.selectFirst(".image .thumbnail a img")?.imgAttr()
         }
@@ -171,6 +171,7 @@ class ArabsHentai : ParsedHttpSource() {
             hasAttr("data-cfsrc") -> attr("abs:data-cfsrc")
             hasAttr("data-src") -> attr("abs:data-src")
             hasAttr("data-lazy-src") -> attr("abs:data-lazy-src")
+            hasAttr("bv-data-src") -> attr("bv-data-src")
             else -> attr("abs:src")
         }
     }


### PR DESCRIPTION
Closes #3040

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
