### PR TITLE
PeachScan: Update image urls selector

### DIFF
--- a/lib-multisrc/peachscan/build.gradle.kts
+++ b/lib-multisrc/peachscan/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 5
+baseVersionCode = 6
 
 dependencies {
     compileOnly("com.github.tachiyomiorg:image-decoder:e08e9be535")

--- a/lib-multisrc/peachscan/src/eu/kanade/tachiyomi/multisrc/peachscan/PeachScan.kt
+++ b/lib-multisrc/peachscan/src/eu/kanade/tachiyomi/multisrc/peachscan/PeachScan.kt
@@ -153,13 +153,16 @@ abstract class PeachScan(
         }.getOrDefault(0L)
     }
 
+    private val urlsRegex = """const\s+urls\s*=\s*\[(.*?)]\s*;""".toRegex()
+
     override fun pageListParse(document: Document): List<Page> {
-        val scriptElement = document.selectFirst("script:containsData(const urls =[)")
+        val scriptElement = document.selectFirst("script:containsData(const urls)")
             ?: return document.select("#imageContainer img").mapIndexed { i, it ->
                 Page(i, document.location(), it.attr("abs:src"))
             }
 
-        val urls = scriptElement.html().substringAfter("const urls =[").substringBefore("];")
+        val urls = urlsRegex.find(scriptElement.data())?.groupValues?.get(1)
+            ?: throw Exception("Could not find image URLs")
 
         return urls.split(",").mapIndexed { i, it ->
             Page(i, document.location(), baseUrl + it.trim().removeSurrounding("'") + "#page")


### PR DESCRIPTION
Closes #3046

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
