### PR TITLE
Traducciones Moonlight: Change theme to MangaEsp

### DIFF
--- a/src/es/traduccionesmoonlight/build.gradle
+++ b/src/es/traduccionesmoonlight/build.gradle
@@ -1,9 +1,9 @@
 ext {
     extName = 'Traducciones Moonlight'
     extClass = '.TraduccionesMoonlight'
-    themePkg = 'mangathemesia'
+    themePkg = 'mangaesp'
     baseUrl = 'https://traduccionesmoonlight.com'
-    overrideVersionCode = 8
+    overrideVersionCode = 38
     isNsfw = true
 }
 

--- a/src/es/traduccionesmoonlight/src/eu/kanade/tachiyomi/extension/es/traduccionesmoonlight/TraduccionesMoonlight.kt
+++ b/src/es/traduccionesmoonlight/src/eu/kanade/tachiyomi/extension/es/traduccionesmoonlight/TraduccionesMoonlight.kt
@@ -1,27 +1,12 @@
 package eu.kanade.tachiyomi.extension.es.traduccionesmoonlight
 
-import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
-import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
-import okhttp3.HttpUrl.Companion.toHttpUrl
-import java.text.SimpleDateFormat
-import java.util.Locale
+import eu.kanade.tachiyomi.multisrc.mangaesp.MangaEsp
 
-class TraduccionesMoonlight : MangaThemesia(
+class TraduccionesMoonlight : MangaEsp(
     "Traducciones Moonlight",
     "https://traduccionesmoonlight.com",
     "es",
-    dateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("es")),
 ) {
-    // Site moved from Madara to MangaThemesia
+    // Mangathemesia -> MangaEsp
     override val versionId = 2
-
-    override val client = super.client.newBuilder()
-        .rateLimitHost(baseUrl.toHttpUrl(), 2, 1)
-        .build()
-
-    override val seriesAuthorSelector = ".tsinfo .imptdt:contains(autor) i"
-    override val seriesStatusSelector = ".tsinfo .imptdt:contains(estado) i"
-
-    // Filter out novels
-    override fun searchMangaSelector() = ".utao .uta .imgu:not(:has(.novelabel)), .listupd .bs .bsx:not(:has(.novelabel)), .listo .bs .bsx:not(:has(.novelabel))"
 }

--- a/src/es/traduccionesmoonlight/src/eu/kanade/tachiyomi/extension/es/traduccionesmoonlight/TraduccionesMoonlight.kt
+++ b/src/es/traduccionesmoonlight/src/eu/kanade/tachiyomi/extension/es/traduccionesmoonlight/TraduccionesMoonlight.kt
@@ -8,5 +8,5 @@ class TraduccionesMoonlight : MangaEsp(
     "es",
 ) {
     // Mangathemesia -> MangaEsp
-    override val versionId = 2
+    override val versionId = 3
 }


### PR DESCRIPTION
User will have to migrate from `Traducciones Moonlight` to `Traducciones Moonlight`

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
