### PR TITLE
Keyoapp: filter dummy pages

### DIFF
--- a/lib-multisrc/keyoapp/build.gradle.kts
+++ b/lib-multisrc/keyoapp/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 3
+baseVersionCode = 4

--- a/lib-multisrc/keyoapp/src/eu/kanade/tachiyomi/multisrc/keyoapp/Keyoapp.kt
+++ b/lib-multisrc/keyoapp/src/eu/kanade/tachiyomi/multisrc/keyoapp/Keyoapp.kt
@@ -223,10 +223,15 @@ abstract class Keyoapp(
     // Image list
 
     override fun pageListParse(document: Document): List<Page> {
-        return document.select("#pages > img:not(.hidden)").mapIndexed { index, img ->
-            Page(index, document.location(), img.imgAttr())
-        }
+        return document.select("#pages > img")
+            .map { it.imgAttr() }
+            .filter { it.contains(imgCdnRegex) }
+            .mapIndexed { index, img ->
+                Page(index, document.location(), img)
+            }
     }
+
+    private val imgCdnRegex = Regex("""^(https?:)?//cdn\d*\.keyoapp\.com""")
 
     override fun imageUrlParse(document: Document) = ""
 


### PR DESCRIPTION
closes #3045

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
