### PR TITLE
MangaDex: set `Origin` header

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaDex'
     extClass = '.MangaDexFactory'
-    extVersionCode = 192
+    extVersionCode = 193
     isNsfw = true
 }
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDex.kt
@@ -10,6 +10,7 @@ import androidx.preference.MultiSelectListPreference
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.AppInfo
+import eu.kanade.tachiyomi.extension.BuildConfig
 import eu.kanade.tachiyomi.extension.all.mangadex.dto.AggregateDto
 import eu.kanade.tachiyomi.extension.all.mangadex.dto.AggregateVolume
 import eu.kanade.tachiyomi.extension.all.mangadex.dto.AtHomeDto
@@ -62,10 +63,12 @@ abstract class MangaDex(final override val lang: String, private val dexLang: St
     final override fun headersBuilder(): Headers.Builder {
         val extraHeader = "Android/${Build.VERSION.RELEASE} " +
             "Tachiyomi/${AppInfo.getVersionName()} " +
-            "MangaDex/1.4.190"
+            "MangaDex/1.4.${BuildConfig.VERSION_CODE} " +
+            "Keiyoushi"
 
         val builder = super.headersBuilder().apply {
             set("Referer", "$baseUrl/")
+            set("Origin", "$baseUrl/")
             set("Extra", extraHeader)
         }
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDex.kt
@@ -68,7 +68,7 @@ abstract class MangaDex(final override val lang: String, private val dexLang: St
 
         val builder = super.headersBuilder().apply {
             set("Referer", "$baseUrl/")
-            set("Origin", "$baseUrl/")
+            set("Origin", baseUrl)
             set("Extra", extraHeader)
         }
 


### PR DESCRIPTION
![image](https://github.com/keiyoushi/extensions-source/assets/48650614/38979056-22ce-4a2a-8a8f-3b2aad59216b)

might help with #2840

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
