### PR TITLE
Anchira: Fix API changes

### DIFF
--- a/src/en/anchira/build.gradle
+++ b/src/en/anchira/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anchira'
     extClass = '.Anchira'
-    extVersionCode = 13
+    extVersionCode = 14
     isNsfw = true
 }
 

--- a/src/en/anchira/src/eu/kanade/tachiyomi/extension/en/anchira/Anchira.kt
+++ b/src/en/anchira/src/eu/kanade/tachiyomi/extension/en/anchira/Anchira.kt
@@ -44,7 +44,7 @@ class Anchira : HttpSource(), ConfigurableSource {
 
     override val baseUrl = "https://anchira.to"
 
-    private val apiUrl = "https://api.anchira.to"
+    private val apiUrl = baseUrl.replace("://", "://api.")
 
     private val libraryUrl = "$apiUrl/library"
 
@@ -66,8 +66,8 @@ class Anchira : HttpSource(), ConfigurableSource {
     }
 
     override fun headersBuilder() = super.headersBuilder()
-        .add("Referer", "https://anchira.to/")
-        .add("Origin", "https://anchira.to")
+        .add("Referer", "$baseUrl/")
+        .add("Origin", baseUrl)
 
     // Latest
 

--- a/src/en/anchira/src/eu/kanade/tachiyomi/extension/en/anchira/AnchiraHelper.kt
+++ b/src/en/anchira/src/eu/kanade/tachiyomi/extension/en/anchira/AnchiraHelper.kt
@@ -50,6 +50,8 @@ object AnchiraHelper {
             }
         }
 
+    fun getCdn(page: Int) = if (page % 2 == 0) "https://kisakisexo.xyz" else "https://aronasexo.xyz"
+
     private fun String.titleCase() = replaceFirstChar {
         if (it.isLowerCase()) {
             it.titlecase(Locale.getDefault())


### PR DESCRIPTION
Closes #3079

---

Also added an interceptor for when it fails to load a resampled image, added the new CDN url for odd numbered pages and changed the data JSON url.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
