### PR TITLE
PeachScans: Fix image can't be loaded

### DIFF
--- a/lib-multisrc/peachscan/build.gradle.kts
+++ b/lib-multisrc/peachscan/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 6
+baseVersionCode = 7
 
 dependencies {
     compileOnly("com.github.tachiyomiorg:image-decoder:e08e9be535")

--- a/lib-multisrc/peachscan/src/eu/kanade/tachiyomi/multisrc/peachscan/PeachScan.kt
+++ b/lib-multisrc/peachscan/src/eu/kanade/tachiyomi/multisrc/peachscan/PeachScan.kt
@@ -198,7 +198,7 @@ abstract class PeachScan(
                 val entryIndex = splitEntryName.first().toInt()
                 val entryType = splitEntryName.last()
 
-                val imageData = if (entryType == "avif") {
+                val imageData = if (entryType == "avif" || splitEntryName.size == 1) {
                     zis.readBytes()
                 } else {
                     val svgBytes = zis.readBytes()


### PR DESCRIPTION
Closes #3088 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
