### PR TITLE
Manga District: fix thumbnail

### DIFF
--- a/src/en/mangadistrict/build.gradle
+++ b/src/en/mangadistrict/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaDistrict'
     themePkg = 'madara'
     baseUrl = 'https://mangadistrict.com'
-    overrideVersionCode = 4
+    overrideVersionCode = 5
     isNsfw = true
 }
 

--- a/src/en/mangadistrict/src/eu/kanade/tachiyomi/extension/en/mangadistrict/MangaDistrict.kt
+++ b/src/en/mangadistrict/src/eu/kanade/tachiyomi/extension/en/mangadistrict/MangaDistrict.kt
@@ -92,7 +92,7 @@ class MangaDistrict :
 
     override fun imageFromElement(element: Element): String? {
         return when {
-            element.hasAttr("data-wpfc-original-src") -> element.attr("data-wpfc-original-src")
+            element.hasAttr("data-wpfc-original-src") -> element.attr("abs:data-wpfc-original-src")
             else -> super.imageFromElement(element)
         }
     }

--- a/src/en/mangadistrict/src/eu/kanade/tachiyomi/extension/en/mangadistrict/MangaDistrict.kt
+++ b/src/en/mangadistrict/src/eu/kanade/tachiyomi/extension/en/mangadistrict/MangaDistrict.kt
@@ -90,6 +90,13 @@ class MangaDistrict :
         }.let(screen::addPreference)
     }
 
+    override fun imageFromElement(element: Element): String? {
+        return when {
+            element.hasAttr("data-wpfc-original-src") -> element.attr("data-wpfc-original-src")
+            else -> super.imageFromElement(element)
+        }
+    }
+
     companion object {
         private const val REMOVE_TITLE_VERSION_PREF = "REMOVE_TITLE_VERSION"
 


### PR DESCRIPTION
Closes #3126

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
