### PR TITLE
Toonily: fix page selector

### DIFF
--- a/src/en/toonily/build.gradle
+++ b/src/en/toonily/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Toonily'
     themePkg = 'madara'
     baseUrl = 'https://toonily.com'
-    overrideVersionCode = 11
+    overrideVersionCode = 12
     isNsfw = true
 }
 

--- a/src/en/toonily/src/eu/kanade/tachiyomi/extension/en/toonily/Toonily.kt
+++ b/src/en/toonily/src/eu/kanade/tachiyomi/extension/en/toonily/Toonily.kt
@@ -67,8 +67,6 @@ class Toonily : Madara(
 
     override fun searchMangaSelector() = "div.page-item-detail.manga"
 
-    override val pageListParseSelector = "div.reading-content div"
-
     override fun parseChapterDate(date: String?): Long {
         val formattedDate = if (date?.contains("UP") == true) "today" else date
         return super.parseChapterDate(formattedDate)


### PR DESCRIPTION
Restored back to default Madara behavior - this will make it so the "Chapters have been replaced for better quality." banner isn't read as an image.

Can be tested with: Weak Point - Chapter 1

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
