### PR TITLE
MangaTale: Fix pages not found in downloads

### DIFF
--- a/src/id/mangatale/build.gradle
+++ b/src/id/mangatale/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaTale'
     themePkg = 'mangathemesia'
     baseUrl = 'https://mangatale.co'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/mangatale/src/eu/kanade/tachiyomi/extension/id/mangatale/MangaTale.kt
+++ b/src/id/mangatale/src/eu/kanade/tachiyomi/extension/id/mangatale/MangaTale.kt
@@ -2,13 +2,27 @@ package eu.kanade.tachiyomi.extension.id.mangatale
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.jsoup.nodes.Document
 
 class MangaTale : MangaThemesia("MangaTale", "https://mangatale.co", "id") {
 
     override val client: OkHttpClient = super.client.newBuilder()
         .rateLimit(20, 5)
+        .addInterceptor { chain ->
+            val request = chain.request()
+            val response = chain.proceed(request)
+            if (response.headers("Content-Type").contains("application/octet-stream") && response.request.url.toString().endsWith(".jpg")) {
+                val newBody = response.body.bytes().toResponseBody("image/jpeg".toMediaTypeOrNull())
+                response.newBuilder()
+                    .body(newBody)
+                    .build()
+            } else {
+                response
+            }
+        }
         .build()
 
     override val seriesTitleSelector = ".ts-breadcrumb li:last-child span"


### PR DESCRIPTION
Closes #3060 

Idk if should handle other image types, I only see jpg images in the site

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
