### PR TITLE
Japscan: fix browse, thumbnail, pagination

### DIFF
--- a/src/fr/japscan/build.gradle
+++ b/src/fr/japscan/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Japscan'
     extClass = '.Japscan'
-    extVersionCode = 44
+    extVersionCode = 45
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -10,7 +10,6 @@ import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
-import eu.kanade.tachiyomi.network.asObservableSuccess
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.Filter
@@ -33,7 +32,6 @@ import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
-import rx.Observable
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
@@ -81,23 +79,12 @@ class Japscan : ConfigurableSource, ParsedHttpSource() {
 
     // Popular
     override fun popularMangaRequest(page: Int): Request {
-        return GET("$baseUrl/mangas/", headers)
+        return GET("$baseUrl/mangas/?sort=popular&p=$page", headers)
     }
 
-    override fun popularMangaParse(response: Response): MangasPage {
-        val document = response.asJsoup()
-        pageNumberDoc = document
+    override fun popularMangaNextPageSelector() = ".pagination > li:last-child:not(.disabled)"
 
-        val mangas = document.select(popularMangaSelector()).map { element ->
-            popularMangaFromElement(element)
-        }
-        val hasNextPage = false
-        return MangasPage(mangas, hasNextPage)
-    }
-
-    override fun popularMangaNextPageSelector(): String? = null
-
-    override fun popularMangaSelector() = "#top_mangas_week li"
+    override fun popularMangaSelector() = ".mangas-list .manga-block:not(:has(a[href='']))"
 
     override fun popularMangaFromElement(element: Element): SManga {
         val manga = SManga.create()
@@ -110,47 +97,15 @@ class Japscan : ConfigurableSource, ParsedHttpSource() {
     }
 
     // Latest
-    private lateinit var latestDirectory: List<Element>
-
-    override fun fetchLatestUpdates(page: Int): Observable<MangasPage> {
-        return if (page == 1) {
-            client.newCall(latestUpdatesRequest(page))
-                .asObservableSuccess()
-                .map { latestUpdatesParse(it) }
-        } else {
-            Observable.just(parseLatestDirectory(page))
-        }
-    }
-
     override fun latestUpdatesRequest(page: Int): Request {
-        return GET(baseUrl, headers)
+        return GET("$baseUrl/mangas/?sort=updated&p=$page", headers)
     }
 
-    override fun latestUpdatesParse(response: Response): MangasPage {
-        val document = response.asJsoup()
-
-        latestDirectory = document.select(latestUpdatesSelector())
-            .distinctBy { element -> element.select("a").attr("href") }
-
-        return parseLatestDirectory(1)
-    }
-
-    private fun parseLatestDirectory(page: Int): MangasPage {
-        val manga = mutableListOf<SManga>()
-        val end = ((page * 24) - 1).let { if (it <= latestDirectory.lastIndex) it else latestDirectory.lastIndex }
-
-        for (i in (((page - 1) * 24)..end)) {
-            manga.add(latestUpdatesFromElement(latestDirectory[i]))
-        }
-
-        return MangasPage(manga, end < latestDirectory.lastIndex)
-    }
-
-    override fun latestUpdatesSelector() = "#chapters h3.mb-0"
+    override fun latestUpdatesSelector() = popularMangaSelector()
 
     override fun latestUpdatesFromElement(element: Element): SManga = popularMangaFromElement(element)
 
-    override fun latestUpdatesNextPageSelector(): String = throw UnsupportedOperationException()
+    override fun latestUpdatesNextPageSelector(): String = popularMangaNextPageSelector()
 
     // Search
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
@@ -180,7 +135,7 @@ class Japscan : ConfigurableSource, ParsedHttpSource() {
         }
     }
 
-    override fun searchMangaNextPageSelector(): String = "li.page-item:last-child:not(li.active)"
+    override fun searchMangaNextPageSelector(): String = popularMangaSelector()
 
     override fun searchMangaSelector(): String = "div.card div.p-2"
 
@@ -225,7 +180,8 @@ class Japscan : ConfigurableSource, ParsedHttpSource() {
         val infoElement = document.selectFirst("#main .card-body")!!
 
         val manga = SManga.create()
-        manga.thumbnail_url = infoElement.select("img").attr("abs:src")
+        val path = document.location().replaceFirst("$baseUrl/", "")
+        manga.thumbnail_url = "$baseUrl/imgs/${path.replace(Regex("/$"),".jpg").replace("manga","mangas")}".lowercase(Locale.ROOT)
 
         val infoRows = infoElement.select(".row, .d-flex")
         infoRows.select("p").forEach { el ->
@@ -340,28 +296,6 @@ class Japscan : ConfigurableSource, ParsedHttpSource() {
     private class TextField(name: String) : Filter.Text(name)
 
     private class PageList(pages: Array<Int>) : Filter.Select<Int>("Page #", arrayOf(0, *pages))
-
-    override fun getFilterList(): FilterList {
-        val totalPages = pageNumberDoc?.select("li.page-item:last-child a")?.text()
-        val pageList = mutableListOf<Int>()
-        return if (!totalPages.isNullOrEmpty()) {
-            for (i in 0 until totalPages.toInt()) {
-                pageList.add(i + 1)
-            }
-            FilterList(
-                Filter.Header("Page alphabétique"),
-                PageList(pageList.toTypedArray()),
-            )
-        } else {
-            FilterList(
-                Filter.Header("Page alphabétique"),
-                TextField("Page #"),
-                Filter.Header("Appuyez sur reset pour la liste"),
-            )
-        }
-    }
-
-    private var pageNumberDoc: Document? = null
 
     // Prefs
     override fun setupPreferenceScreen(screen: androidx.preference.PreferenceScreen) {


### PR DESCRIPTION
Also removed the 'page number' filter - would have to reimplement it with the new format, which seems like effort. Also, such features are better suited for the app to implement directly.

Closes #905
Closes #1952

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
