### PR TITLE
Manhwa18cc: Latest Updates "fix"

### DIFF
--- a/src/all/manhwa18cc/build.gradle
+++ b/src/all/manhwa18cc/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Manhwa18CcFactory'
     themePkg = 'madara'
     baseUrl = 'https://manhwa18.cc'
-    overrideVersionCode = 4
+    overrideVersionCode = 5
     isNsfw = true
 }
 

--- a/src/all/manhwa18cc/src/eu/kanade/tachiyomi/extension/all/manhwa18cc/Manhwa18CcFactory.kt
+++ b/src/all/manhwa18cc/src/eu/kanade/tachiyomi/extension/all/manhwa18cc/Manhwa18CcFactory.kt
@@ -47,7 +47,7 @@ abstract class Manhwa18Cc(
 
     override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/webtoons/$page?orderby=trending")
 
-    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/webtoons/$page?orderby=latest")
+    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/webtoons/$page")
 
     override fun searchMangaSelector() = popularMangaSelector()
 


### PR DESCRIPTION
Mentioned by Discord member how Latest Updates in extension doesn't reflect homepage of source's Latest list

* Use unordered page instead of order by latest for Latest Updates

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
