### PR TITLE
Fix possible crash in interceptors

### DIFF
--- a/src/all/comickfun/build.gradle
+++ b/src/all/comickfun/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comick'
     extClass = '.ComickFactory'
-    extVersionCode = 45
+    extVersionCode = 46
     isNsfw = true
 }
 

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
@@ -27,6 +27,7 @@ import okhttp3.Response
 import rx.Observable
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.io.IOException
 import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -182,8 +183,8 @@ abstract class Comick(
         }
 
         error?.run {
-            throw Exception("$name error $statusCode: $message")
-        } ?: throw Exception("HTTP error ${response.code}")
+            throw IOException("$name error $statusCode: $message")
+        } ?: throw IOException("HTTP error ${response.code}")
     }
 
     /** Popular Manga **/

--- a/src/en/readcomiconline/build.gradle
+++ b/src/en/readcomiconline/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ReadComicOnline'
     extClass = '.Readcomiconline'
-    extVersionCode = 19
+    extVersionCode = 20
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
@@ -28,6 +28,7 @@ import rx.Observable
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
+import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.concurrent.TimeUnit
@@ -55,7 +56,7 @@ class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
         val location = response.header("Location")
         if (location?.startsWith("/Special/AreYouHuman") == true) {
             captchaUrl = "$baseUrl/Special/AreYouHuman"
-            throw Exception("Solve captcha in WebView")
+            throw IOException("Solve captcha in WebView")
         }
 
         return response

--- a/src/zh/jinmantiantang/build.gradle
+++ b/src/zh/jinmantiantang/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Jinman Tiantang'
     extClass = '.Jinmantiantang'
-    extVersionCode = 42
+    extVersionCode = 43
     isNsfw = true
 }
 

--- a/src/zh/jinmantiantang/src/eu/kanade/tachiyomi/extension/zh/jinmantiantang/JinmantiantangPreferences.kt
+++ b/src/zh/jinmantiantang/src/eu/kanade/tachiyomi/extension/zh/jinmantiantang/JinmantiantangPreferences.kt
@@ -131,7 +131,7 @@ class UpdateUrlInterceptor(private val preferences: SharedPreferences) : Interce
             response.close()
             Result.success(response)
         } catch (e: Throwable) {
-            if (chain.call().isCanceled() || e.message?.contains("Cloudflare") == true) throw e
+            if (chain.call().isCanceled() || e.message?.contains("Cloudflare") == true) throw IOException(e.message, e)
             Result.failure(e)
         }
 

--- a/src/zh/wnacg/build.gradle
+++ b/src/zh/wnacg/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'WNACG'
     extClass = '.wnacg'
-    extVersionCode = 15
+    extVersionCode = 16
     isNsfw = true
 }
 

--- a/src/zh/wnacg/src/eu/kanade/tachiyomi/extension/zh/wnacg/Preferences.kt
+++ b/src/zh/wnacg/src/eu/kanade/tachiyomi/extension/zh/wnacg/Preferences.kt
@@ -75,7 +75,7 @@ class UpdateUrlInterceptor(private val preferences: SharedPreferences) : Interce
             response.close()
             Result.success(response)
         } catch (e: Throwable) {
-            if (chain.call().isCanceled()) throw e
+            if (chain.call().isCanceled()) throw IOException(e.message, e)
             Result.failure(e)
         }
 


### PR DESCRIPTION
Only `IOException` can be safely thrown in OkHttp interceptors. I have found all instances where something is thrown, but it's not `IOException`.

The remaining ones are already `IOException`, just rethrown and should be safe:
```bash
vetle@abc ~/d/keiyoushi-extensions (tmp182)> rg --pcre2 -U '^( +)(?:.*fun.*Interceptor|\.addInterceptor \{)(?:.|\\n)+?^\\1[^ ]' | rg --pcre2 -B1 'throw (?!IOException)'
src/zh/zerobyw/src/eu/kanade/tachiyomi/extension/zh/zerobyw/UpdateUrl.kt:        } catch (e: IOException) {
src/zh/zerobyw/src/eu/kanade/tachiyomi/extension/zh/zerobyw/UpdateUrl.kt:            if (chain.call().isCanceled()) throw e
--
src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/DomainNumber.kt:        } catch (e: IOException) {
src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/DomainNumber.kt:            if (chain.call().isCanceled()) throw e
vetle@abc ~/d/keiyoushi-extensions (tmp182)> 
```


Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
