### PR TITLE
LxHentai: Update domain and fix deep linking

### DIFF
--- a/src/vi/lxhentai/AndroidManifest.xml
+++ b/src/vi/lxhentai/AndroidManifest.xml
@@ -14,7 +14,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:host="lxmanga.club"
+                    android:host="lxmanga.icu"
                     android:pathPattern="/truyen/..*"
                     android:scheme="https" />
             </intent-filter>

--- a/src/vi/lxhentai/build.gradle
+++ b/src/vi/lxhentai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'LXHentai'
     extClass = '.LxHentai'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/vi/lxhentai/src/eu/kanade/tachiyomi/extension/vi/lxhentai/LxHentai.kt
+++ b/src/vi/lxhentai/src/eu/kanade/tachiyomi/extension/vi/lxhentai/LxHentai.kt
@@ -58,12 +58,9 @@ class LxHentai : ParsedHttpSource() {
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
         return when {
             query.startsWith(PREFIX_ID_SEARCH) -> {
-                val id = query.removePrefix(PREFIX_ID_SEARCH).trim()
-                fetchMangaDetails(
-                    SManga.create().apply {
-                        url = "/truyen/$id"
-                    },
-                )
+                val slug = query.substringAfter(PREFIX_ID_SEARCH)
+                val mangaUrl = "/truyen/$slug"
+                fetchMangaDetails(SManga.create().apply { url = mangaUrl })
                     .map { MangasPage(listOf(it), false) }
             }
             else -> super.fetchSearchManga(page, query, filters)
@@ -157,6 +154,8 @@ class LxHentai : ParsedHttpSource() {
             "Đang tiến hành" -> SManga.ONGOING
             else -> SManga.UNKNOWN
         }
+
+        setUrlWithoutDomain(document.location())
     }
 
     override fun chapterListSelector(): String = "ul.overflow-y-auto.overflow-x-hidden a"

--- a/src/vi/lxhentai/src/eu/kanade/tachiyomi/extension/vi/lxhentai/LxHentai.kt
+++ b/src/vi/lxhentai/src/eu/kanade/tachiyomi/extension/vi/lxhentai/LxHentai.kt
@@ -23,7 +23,7 @@ class LxHentai : ParsedHttpSource() {
 
     override val name = "LXHentai"
 
-    override val baseUrl = "https://lxmanga.club"
+    override val baseUrl = "https://lxmanga.icu"
 
     override val lang = "vi"
 


### PR DESCRIPTION
Closes #3215

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
