### PR TITLE
Changed Japscan, fixed the thumbnail problem 

### DIFF
--- a/src/fr/japscan/build.gradle
+++ b/src/fr/japscan/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Japscan'
     extClass = '.Japscan'
-    extVersionCode = 45
+    extVersionCode = 46
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -88,11 +88,15 @@ class Japscan : ConfigurableSource, ParsedHttpSource() {
 
     override fun popularMangaFromElement(element: Element): SManga {
         val manga = SManga.create()
-        element.select("a").first()!!.let {
-            manga.setUrlWithoutDomain(it.attr("href"))
-            manga.title = it.text()
-            manga.thumbnail_url = "$baseUrl/imgs/${it.attr("href").replace(Regex("/$"),".jpg").replace("manga","mangas")}".lowercase(Locale.ROOT)
+        element.select("a").first()?.let { anchorElement ->
+            manga.setUrlWithoutDomain(anchorElement.attr("href"))
+            manga.title = anchorElement.select("strong.name").text()
+            anchorElement.select("img").first()?.let { imgElement ->
+                val imageUrl = imgElement.attr("abs:data-src").ifEmpty { imgElement.attr("abs:src") }
+                manga.thumbnail_url = imageUrl.lowercase(Locale.ROOT)
+            }
         }
+
         return manga
     }
 

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -91,7 +91,7 @@ class Japscan : ConfigurableSource, ParsedHttpSource() {
         element.selectFirst("a")!!.let { anchorElement ->
             manga.setUrlWithoutDomain(anchorElement.attr("href"))
             manga.title = anchorElement.select("strong.name").text()
-            anchorElement.select("img").first()?.let { imgElement ->
+            anchorElement.selectFirst("img")?.let { imgElement ->
                 val imageUrl = imgElement.attr("abs:data-src").ifEmpty { imgElement.attr("abs:src") }
                 manga.thumbnail_url = imageUrl.lowercase(Locale.ROOT)
             }

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -88,7 +88,7 @@ class Japscan : ConfigurableSource, ParsedHttpSource() {
 
     override fun popularMangaFromElement(element: Element): SManga {
         val manga = SManga.create()
-        element.select("a").first()?.let { anchorElement ->
+        element.selectFirst("a")!!.let { anchorElement ->
             manga.setUrlWithoutDomain(anchorElement.attr("href"))
             manga.title = anchorElement.select("strong.name").text()
             anchorElement.select("img").first()?.let { imgElement ->


### PR DESCRIPTION
Changed Japscan, fixed the image problem which loaded an obscene image (because of the pop on the screen) now we use a better selector to avoid this kind of problem

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
