### PR TITLE
Japscan: update chapter data selector

### DIFF
--- a/src/fr/japscan/build.gradle
+++ b/src/fr/japscan/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Japscan'
     extClass = '.Japscan'
-    extVersionCode = 45
+    extVersionCode = 46
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -230,7 +230,7 @@ class Japscan : ConfigurableSource, ParsedHttpSource() {
         val interfaceName = randomString()
         val zjsElement = document.selectFirst("script[src*=/zjs/]")
             ?: throw Exception("ZJS not found")
-        val dataElement = document.selectFirst("#data")
+        val dataElement = document.selectFirst("[id^=data]")
             ?: throw Exception("Chapter data not found")
         val minDoc = Document.createShell(document.location())
         val minDocBody = minDoc.body()


### PR DESCRIPTION
closes #3256

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
