### PR TITLE
Webtoon Hatti: update page selector

### DIFF
--- a/src/tr/webtoonhatti/build.gradle
+++ b/src/tr/webtoonhatti/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.WebtoonHatti'
     themePkg = 'madara'
     baseUrl = 'https://webtoonhatti.net'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/tr/webtoonhatti/src/eu/kanade/tachiyomi/extension/tr/webtoonhatti/WebtoonHatti.kt
+++ b/src/tr/webtoonhatti/src/eu/kanade/tachiyomi/extension/tr/webtoonhatti/WebtoonHatti.kt
@@ -15,5 +15,5 @@ class WebtoonHatti : Madara(
     // Skip fake image
     // OK: <div class="page-break no-gaps">
     // NG: <div style="display:none" class="page-break no-gaps">
-    override val pageListParseSelector = "div.page-break:not([style*=\"display:\"])"
+    override val pageListParseSelector = "div.page-break:not([style*=display:]):not([style*=visibility:])"
 }


### PR DESCRIPTION
closes #3212

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
