### PR TITLE
Mangalink: update domain

### DIFF
--- a/src/ar/mangalink/build.gradle
+++ b/src/ar/mangalink/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Mangalink'
     extClass = '.Mangalink'
     themePkg = 'madara'
-    baseUrl = 'https://manga-link.com'
-    overrideVersionCode = 2
+    baseUrl = 'https://link-manga.com'
+    overrideVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/mangalink/src/eu/kanade/tachiyomi/extension/ar/mangalink/Mangalink.kt
+++ b/src/ar/mangalink/src/eu/kanade/tachiyomi/extension/ar/mangalink/Mangalink.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import android.content.SharedPreferences
 import android.widget.Toast
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.extension.BuildConfig
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import uy.kohesive.injekt.Injekt
@@ -15,7 +14,7 @@ import java.util.Locale
 class Mangalink :
     Madara(
         "مانجا لينك",
-        "https://manga-link.com",
+        "https://link-manga.com",
         "ar",
         SimpleDateFormat("MMMM dd, yyyy", Locale("ar")),
     ),
@@ -23,7 +22,7 @@ class Mangalink :
 
     override val chapterUrlSuffix = ""
     override val useLoadMoreRequest = LoadMoreStrategy.Always
-    private val defaultBaseUrl = "https://manga-link.com"
+    private val defaultBaseUrl = "https://link-manga.com"
     override val baseUrl by lazy { getPrefBaseUrl() }
 
     private val preferences: SharedPreferences by lazy {
@@ -33,7 +32,7 @@ class Mangalink :
     companion object {
         private const val RESTART_TACHIYOMI = ".لتطبيق الإعدادات الجديدة Tachiyomi أعد تشغيل"
         private const val BASE_URL_PREF_TITLE = "تعديل الرابط"
-        private const val BASE_URL_PREF = "overrideBaseUrl_v${BuildConfig.VERSION_CODE}"
+        private const val BASE_URL_PREF = "overrideBaseUrl_v38"
         private const val BASE_URL_PREF_SUMMARY = ".للاستخدام المؤقت. تحديث التطبيق سيؤدي الى حذف الإعدادات"
     }
 

--- a/src/ar/mangalink/src/eu/kanade/tachiyomi/extension/ar/mangalink/Mangalink.kt
+++ b/src/ar/mangalink/src/eu/kanade/tachiyomi/extension/ar/mangalink/Mangalink.kt
@@ -22,7 +22,6 @@ class Mangalink :
 
     override val chapterUrlSuffix = ""
     override val useLoadMoreRequest = LoadMoreStrategy.Always
-    private val defaultBaseUrl = "https://link-manga.com"
     override val baseUrl by lazy { getPrefBaseUrl() }
 
     private val preferences: SharedPreferences by lazy {
@@ -32,7 +31,8 @@ class Mangalink :
     companion object {
         private const val RESTART_TACHIYOMI = ".لتطبيق الإعدادات الجديدة Tachiyomi أعد تشغيل"
         private const val BASE_URL_PREF_TITLE = "تعديل الرابط"
-        private const val BASE_URL_PREF = "overrideBaseUrl_v38"
+        private const val BASE_URL_PREF = "overrideBaseUrl"
+        private const val DEFAULT_BASE_URL_PREF = "defaultBaseUrl"
         private const val BASE_URL_PREF_SUMMARY = ".للاستخدام المؤقت. تحديث التطبيق سيؤدي الى حذف الإعدادات"
     }
 
@@ -41,9 +41,9 @@ class Mangalink :
             key = BASE_URL_PREF
             title = BASE_URL_PREF_TITLE
             summary = BASE_URL_PREF_SUMMARY
-            this.setDefaultValue(defaultBaseUrl)
+            this.setDefaultValue(super.baseUrl)
             dialogTitle = BASE_URL_PREF_TITLE
-            dialogMessage = "Default: $defaultBaseUrl"
+            dialogMessage = "Default: ${super.baseUrl}"
 
             setOnPreferenceChangeListener { _, _ ->
                 Toast.makeText(screen.context, RESTART_TACHIYOMI, Toast.LENGTH_LONG).show()
@@ -52,5 +52,16 @@ class Mangalink :
         }
         screen.addPreference(baseUrlPref)
     }
-    private fun getPrefBaseUrl(): String = preferences.getString(BASE_URL_PREF, defaultBaseUrl)!!
+    private fun getPrefBaseUrl(): String = preferences.getString(BASE_URL_PREF, super.baseUrl)!!
+
+    init {
+        preferences.getString(DEFAULT_BASE_URL_PREF, null).let { prefDefaultBaseUrl ->
+            if (prefDefaultBaseUrl != super.baseUrl) {
+                preferences.edit()
+                    .putString(BASE_URL_PREF, super.baseUrl)
+                    .putString(DEFAULT_BASE_URL_PREF, super.baseUrl)
+                    .apply()
+            }
+        }
+    }
 }


### PR DESCRIPTION
Closes #3261

Also made the 'override URL' option not depend on the extension version.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
