### PR TITLE
Galaxy Manga: update domain

### DIFF
--- a/src/ar/galaxymanga/build.gradle
+++ b/src/ar/galaxymanga/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.GalaxyManga'
     themePkg = 'flixscans'
     baseUrl = 'https://flixscans.net'
-    overrideVersionCode = 27
+    overrideVersionCode = 28
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/galaxymanga/build.gradle
+++ b/src/ar/galaxymanga/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Galaxy Manga'
     extClass = '.GalaxyManga'
     themePkg = 'flixscans'
-    baseUrl = 'https://flixscans.com'
+    baseUrl = 'https://flixscans.net'
     overrideVersionCode = 27
 }
 

--- a/src/ar/galaxymanga/src/eu/kanade/tachiyomi/extension/ar/galaxymanga/GalaxyManga.kt
+++ b/src/ar/galaxymanga/src/eu/kanade/tachiyomi/extension/ar/galaxymanga/GalaxyManga.kt
@@ -8,7 +8,7 @@ import okhttp3.Request
 
 class GalaxyManga : FlixScans(
     "جالاكسي مانجا",
-    "https://flixscans.com",
+    "https://flixscans.net",
     "ar",
     "https://ar.flixscans.site/api/v1",
 ) {


### PR DESCRIPTION
Closes #3264

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
