### PR TITLE
Kai Scans: update domain

### DIFF
--- a/src/en/kaiscans/build.gradle
+++ b/src/en/kaiscans/build.gradle
@@ -2,8 +2,9 @@ ext {
     extName = 'Kai Scans'
     extClass = '.KaiScans'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://kaiscans.org'
-    overrideVersionCode = 1
+    baseUrl = 'https://kaiscans.com'
+    overrideVersionCode = 2
+    isNsfw = true
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/kaiscans/src/eu/kanade/tachiyomi/extension/en/kaiscans/KaiScans.kt
+++ b/src/en/kaiscans/src/eu/kanade/tachiyomi/extension/en/kaiscans/KaiScans.kt
@@ -1,9 +1,9 @@
 package eu.kanade.tachiyomi.extension.en.kaiscans
 
-import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesiaAlt
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 
-class KaiScans : MangaThemesia("Kai Scans", "https://kaiscans.com", "en") {
+class KaiScans : MangaThemesiaAlt("Kai Scans", "https://kaiscans.com", "en") {
     override val client = super.client.newBuilder()
         .rateLimit(2)
         .build()

--- a/src/en/kaiscans/src/eu/kanade/tachiyomi/extension/en/kaiscans/KaiScans.kt
+++ b/src/en/kaiscans/src/eu/kanade/tachiyomi/extension/en/kaiscans/KaiScans.kt
@@ -3,7 +3,7 @@ package eu.kanade.tachiyomi.extension.en.kaiscans
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 
-class KaiScans : MangaThemesia("Kai Scans", "https://kaiscans.org", "en") {
+class KaiScans : MangaThemesia("Kai Scans", "https://kaiscans.com", "en") {
     override val client = super.client.newBuilder()
         .rateLimit(2)
         .build()


### PR DESCRIPTION
Closes  #3283

Switch to MangaThemesiaAlt?

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
