### PR TITLE
Add filters to Hitomi Extension

### DIFF
--- a/src/all/hitomi/build.gradle
+++ b/src/all/hitomi/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hitomi'
     extClass = '.HitomiFactory'
-    extVersionCode = 26
+    extVersionCode = 27
     isNsfw = true
 }
 

--- a/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Filters.kt
+++ b/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Filters.kt
@@ -1,0 +1,81 @@
+package eu.kanade.tachiyomi.extension.all.hitomi
+
+import eu.kanade.tachiyomi.source.model.Filter
+import eu.kanade.tachiyomi.source.model.FilterList
+
+typealias OrderType = Pair<String?, String>
+typealias ParsedFilter = Pair<String, OrderType>
+
+private fun parseFilter(query: StringBuilder, tag: String, filterState: String) {
+    filterState
+        .trim()
+        .split(',')
+        .filter { it.isNotBlank() }
+        .forEach {
+            val trimmed = it.trim()
+            val negativePrefix = if (trimmed.startsWith("-")) "-" else ""
+            query.append(" $negativePrefix$tag:${trimmed.removePrefix("-").replace(" ", "_")}")
+        }
+}
+
+fun parseFilters(filters: FilterList): ParsedFilter {
+    val query = StringBuilder()
+    var order: OrderType = Pair("date", "added")
+    filters.forEach { filter ->
+        when (filter) {
+            is SortFilter -> {
+                order = filter.getOrder
+            }
+            is CategoryFilter -> {
+                parseFilter(query, filter.getTagName, filter.state)
+            }
+            else -> { /* Do Nothing */ }
+        }
+    }
+    return Pair(query.toString(), order)
+}
+
+private class OrderFilter(val name: String, val order: OrderType) {
+    val getFilterName: String
+        get() = name
+    val getOrder: OrderType
+        get() = order
+}
+
+private class SortFilter : UriPartFilter(
+    "Sort By",
+    arrayOf(
+        OrderFilter("Date Added", Pair(null, "index")),
+        OrderFilter("Date Published", Pair("date", "published")),
+        OrderFilter("Popular: Today", Pair("popular", "today")),
+        OrderFilter("Popular: Week", Pair("popular", "week")),
+        OrderFilter("Popular: Month", Pair("popular", "month")),
+        OrderFilter("Popular: Year", Pair("popular", "year")),
+    ),
+)
+
+private open class UriPartFilter(displayName: String, val vals: Array<OrderFilter>) :
+    Filter.Select<String>(displayName, vals.map { it.getFilterName }.toTypedArray()) {
+    val getOrder: OrderType
+        get() = vals[state].getOrder
+}
+
+private class CategoryFilter(displayName: String, val tagName: String) :
+    Filter.Text(displayName) {
+    val getTagName: String
+        get() = tagName
+}
+
+fun getFilterListInternal(): FilterList = FilterList(
+    SortFilter(),
+    Filter.Header("Separate tags with commas (,)"),
+    Filter.Header("Prepend with dash (-) to exclude"),
+    CategoryFilter("Artist(s)", "artist"),
+    CategoryFilter("Character(s)", "character"),
+    CategoryFilter("Group(s)", "group"),
+    CategoryFilter("Series", "series"),
+    CategoryFilter("Female Tag(s)", "female"),
+    CategoryFilter("Male Tag(s)", "male"),
+    Filter.Header("Don't put Female/Male tags here, they won't work!"),
+    CategoryFilter("Tag(s)", "tag"),
+)

--- a/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Filters.kt
+++ b/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Filters.kt
@@ -6,7 +6,7 @@ import eu.kanade.tachiyomi.source.model.FilterList
 typealias OrderType = Pair<String?, String>
 typealias ParsedFilter = Pair<String, OrderType>
 
-private fun parseFilter(query: StringBuilder, tag: String, filterState: String) {
+private fun parseFilter(query: StringBuilder, area: String, filterState: String) {
     filterState
         .trim()
         .split(',')
@@ -14,7 +14,7 @@ private fun parseFilter(query: StringBuilder, tag: String, filterState: String) 
         .forEach {
             val trimmed = it.trim()
             val negativePrefix = if (trimmed.startsWith("-")) "-" else ""
-            query.append(" $negativePrefix$tag:${trimmed.removePrefix("-").replace(" ", "_")}")
+            query.append(" $negativePrefix$area:${trimmed.removePrefix("-").replace(" ", "_")}")
         }
 }
 
@@ -26,8 +26,8 @@ fun parseFilters(filters: FilterList): ParsedFilter {
             is SortFilter -> {
                 order = filter.getOrder
             }
-            is CategoryFilter -> {
-                parseFilter(query, filter.getTagName, filter.state)
+            is AreaFilter -> {
+                parseFilter(query, filter.getAreaName, filter.state)
             }
             else -> { /* Do Nothing */ }
         }
@@ -60,22 +60,22 @@ private open class UriPartFilter(displayName: String, val vals: Array<OrderFilte
         get() = vals[state].getOrder
 }
 
-private class CategoryFilter(displayName: String, val tagName: String) :
+private class AreaFilter(displayName: String, val areaName: String) :
     Filter.Text(displayName) {
-    val getTagName: String
-        get() = tagName
+    val getAreaName: String
+        get() = areaName
 }
 
 fun getFilterListInternal(): FilterList = FilterList(
     SortFilter(),
     Filter.Header("Separate tags with commas (,)"),
     Filter.Header("Prepend with dash (-) to exclude"),
-    CategoryFilter("Artist(s)", "artist"),
-    CategoryFilter("Character(s)", "character"),
-    CategoryFilter("Group(s)", "group"),
-    CategoryFilter("Series", "series"),
-    CategoryFilter("Female Tag(s)", "female"),
-    CategoryFilter("Male Tag(s)", "male"),
+    AreaFilter("Artist(s)", "artist"),
+    AreaFilter("Character(s)", "character"),
+    AreaFilter("Group(s)", "group"),
+    AreaFilter("Series", "series"),
+    AreaFilter("Female Tag(s)", "female"),
+    AreaFilter("Male Tag(s)", "male"),
     Filter.Header("Don't put Female/Male tags here, they won't work!"),
-    CategoryFilter("Tag(s)", "tag"),
+    AreaFilter("Tag(s)", "tag"),
 )

--- a/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Hitomi.kt
+++ b/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Hitomi.kt
@@ -75,12 +75,56 @@ class Hitomi(
 
     private lateinit var searchResponse: List<Int>
 
+    private fun filterToTag(query: StringBuilder, tag: String, filterState: String) {
+        filterState
+            .trim()
+            .split(',')
+            .filter { it.isNotBlank() }
+            .forEach {
+                val trimmed = it.trim()
+                query.append(" ${if (trimmed.startsWith("-")) "-" else ""}$tag:${trimmed.removePrefix("-").replace(" ", "_")}")
+            }
+    }
+
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = Observable.fromCallable {
+        val filterQueries = StringBuilder()
+        var order: OrderType = Pair("date", "added")
+
+        filters.forEach { filter ->
+            when (filter) {
+                is SortFilter -> {
+                    order = filter.getOrder()
+                }
+                is ArtistFilter -> {
+                    filterToTag(filterQueries, "artist", filter.state)
+                }
+                is CharacterFilter -> {
+                    filterToTag(filterQueries, "character", filter.state)
+                }
+                is GroupFilter -> {
+                    filterToTag(filterQueries, "group", filter.state)
+                }
+                is SeriesFilter -> {
+                    filterToTag(filterQueries, "series", filter.state)
+                }
+                is FemaleTagFilter -> {
+                    filterToTag(filterQueries, "female", filter.state)
+                }
+                is MaleTagFilter -> {
+                    filterToTag(filterQueries, "male", filter.state)
+                }
+                is GenericTagFilter -> {
+                    filterToTag(filterQueries, "tag", filter.state)
+                }
+                else -> { /* Do Nothing */ }
+            }
+        }
+
         runBlocking {
             if (page == 1) {
                 searchResponse = hitomiSearch(
-                    query.trim(),
-                    filters.filterIsInstance<SortFilter>().firstOrNull()?.state == 1,
+                    "$query$filterQueries".trim(),
+                    order,
                     nozomiLang,
                 ).toList()
             }
@@ -93,11 +137,52 @@ class Hitomi(
         }
     }
 
-    private class SortFilter : Filter.Select<String>("Sort By", arrayOf("Updated", "Popularity"))
-
-    override fun getFilterList(): FilterList {
-        return FilterList(SortFilter())
+    private class OrderFilter(val name: String, val order: OrderType) {
+        val getFilterName: String
+            get() = name
+        val getOrder: OrderType
+            get() = order
     }
+
+    private class SortFilter : UriPartFilter(
+        "Sort By",
+        arrayOf(
+            OrderFilter("Date Added", Pair(null, "index")),
+            OrderFilter("Date Published", Pair("date", "published")),
+            OrderFilter("Popular: Today", Pair("popular", "today")),
+            OrderFilter("Popular: Week", Pair("popular", "week")),
+            OrderFilter("Popular: Month", Pair("popular", "month")),
+            OrderFilter("Popular: Year", Pair("popular", "year")),
+        ),
+    )
+
+    private open class UriPartFilter(displayName: String, val vals: Array<OrderFilter>) :
+        Filter.Select<String>(displayName, vals.map { it.getFilterName }.toTypedArray()) {
+        fun getOrder() = vals[state].getOrder
+    }
+
+    private class ArtistFilter(name: String) : Filter.Text(name)
+    private class CharacterFilter(name: String) : Filter.Text(name)
+
+    private class GroupFilter(name: String) : Filter.Text(name)
+    private class SeriesFilter(name: String) : Filter.Text(name)
+    private class FemaleTagFilter(name: String) : Filter.Text(name)
+    private class MaleTagFilter(name: String) : Filter.Text(name)
+    private class GenericTagFilter(name: String) : Filter.Text(name)
+
+    override fun getFilterList(): FilterList = FilterList(
+        SortFilter(),
+        Filter.Header("Separate tags with commas (,)"),
+        Filter.Header("Prepend with dash (-) to exclude"),
+        ArtistFilter("Artist(s)"),
+        CharacterFilter("Character(s)"),
+        GroupFilter("Group(s)"),
+        SeriesFilter("Series"),
+        FemaleTagFilter("Female Tag(s)"),
+        MaleTagFilter("Male Tag(s)"),
+        Filter.Header("Don't put Female/Male tags here, they won't work!"),
+        GenericTagFilter("Tag(s)"),
+    )
 
     private fun Int.nextPageRange(): LongRange {
         val byteOffset = ((this - 1) * 25) * 4L
@@ -117,7 +202,7 @@ class Hitomi(
 
     private suspend fun hitomiSearch(
         query: String,
-        sortByPopularity: Boolean = false,
+        order: OrderType,
         language: String = "all",
     ): Set<Int> =
         coroutineScope {
@@ -126,9 +211,6 @@ class Hitomi(
                 .replace(Regex("""^\?"""), "")
                 .lowercase()
                 .split(Regex("\\s+"))
-                .map {
-                    it.replace('_', ' ')
-                }
 
             val positiveTerms = LinkedList<String>()
             val negativeTerms = LinkedList<String>()
@@ -144,7 +226,7 @@ class Hitomi(
             val positiveResults = positiveTerms.map {
                 async {
                     runCatching {
-                        getGalleryIDsForQuery(it, language)
+                        getGalleryIDsForQuery(it, language, order)
                     }.getOrDefault(emptySet())
                 }
             }
@@ -152,14 +234,13 @@ class Hitomi(
             val negativeResults = negativeTerms.map {
                 async {
                     runCatching {
-                        getGalleryIDsForQuery(it, language)
+                        getGalleryIDsForQuery(it, language, order)
                     }.getOrDefault(emptySet())
                 }
             }
 
             val results = when {
-                sortByPopularity -> getGalleryIDsFromNozomi(null, "popular", language)
-                positiveTerms.isEmpty() -> getGalleryIDsFromNozomi(null, "index", language)
+                positiveTerms.isEmpty() -> getGalleryIDsFromNozomi(order.first, order.second, language)
                 else -> emptySet()
             }.toMutableSet()
 
@@ -191,6 +272,7 @@ class Hitomi(
     private suspend fun getGalleryIDsForQuery(
         query: String,
         language: String = "all",
+        order: OrderType,
     ): Set<Int> {
         query.replace("_", " ").let {
             if (it.indexOf(':') > -1) {
@@ -211,6 +293,20 @@ class Hitomi(
                         lang = tag
                         tag = "index"
                     }
+                }
+
+                if (area != null) {
+                    if (order.first != null) {
+                        area = "$area/${order.first}"
+                        if (tag.isBlank()) {
+                            tag = order.second
+                        } else {
+                            area = "$area/${order.second}"
+                        }
+                    }
+                } else {
+                    area = order.first
+                    tag = order.second
                 }
 
                 return getGalleryIDsFromNozomi(area, tag, lang)

--- a/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/HitomiDto.kt
+++ b/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/HitomiDto.kt
@@ -65,6 +65,8 @@ data class Parody(
     val formatted get() = parody.toCamelCase()
 }
 
+typealias OrderType = Pair<String?, String>
+
 private fun String.toCamelCase(): String {
     val result = StringBuilder(length)
     var capitalize = true

--- a/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/HitomiDto.kt
+++ b/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/HitomiDto.kt
@@ -65,8 +65,6 @@ data class Parody(
     val formatted get() = parody.toCamelCase()
 }
 
-typealias OrderType = Pair<String?, String>
-
 private fun String.toCamelCase(): String {
     val result = StringBuilder(length)
     var capitalize = true


### PR DESCRIPTION
Added filters to the Hitomi Extension as it was little barebones. Should be able to use the filter menu for both positive and negative filters, filtering on artists, characters, Groups, Series, Female specific tags, male specific tags, and general tags. Based off a brief ~~goon sesh~~ test, everything seems to be working as expected.

Not a Kotlin cooder so apoligies if I failed to follow an expected style or pattern.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- ~~[ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions~~
- ~~[ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")~~
- ~~[ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate~~
- [x] Have not changed source names
- ~~[ ] Have explicitly kept the `id` if a source's name or language were changed~~
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- ~~[ ] Have removed `web_hi_res_512.png` when adding a new extension~~
