### PR TITLE
SlimeRead: Fix regex

### DIFF
--- a/src/pt/slimeread/build.gradle
+++ b/src/pt/slimeread/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'SlimeRead'
     extClass = '.SlimeRead'
-    extVersionCode = 10
+    extVersionCode = 11
     isNsfw = true
 }
 

--- a/src/pt/slimeread/src/eu/kanade/tachiyomi/extension/pt/slimeread/SlimeRead.kt
+++ b/src/pt/slimeread/src/eu/kanade/tachiyomi/extension/pt/slimeread/SlimeRead.kt
@@ -58,7 +58,7 @@ class SlimeRead : HttpSource() {
         val script = initClient.newCall(GET(scriptUrl, headers)).execute().body.string()
         val apiUrl = FUNCTION_REGEX.find(script)?.value?.let { function ->
             BASEURL_VAL_REGEX.find(function)?.groupValues?.get(1)?.let { baseUrlVar ->
-                val regex = """let.*?$baseUrlVar\s*=.*?(?=\n)""".toRegex(RegexOption.DOT_MATCHES_ALL)
+                val regex = """let.*?$baseUrlVar\s*=.*?(?=,\s*\w\s*=)""".toRegex(RegexOption.DOT_MATCHES_ALL)
                 regex.find(function)?.value?.let { varBlock ->
                     try {
                         QuickJs.create().use {

--- a/src/pt/slimeread/src/eu/kanade/tachiyomi/extension/pt/slimeread/SlimeRead.kt
+++ b/src/pt/slimeread/src/eu/kanade/tachiyomi/extension/pt/slimeread/SlimeRead.kt
@@ -58,7 +58,7 @@ class SlimeRead : HttpSource() {
         val script = initClient.newCall(GET(scriptUrl, headers)).execute().body.string()
         val apiUrl = FUNCTION_REGEX.find(script)?.value?.let { function ->
             BASEURL_VAL_REGEX.find(function)?.groupValues?.get(1)?.let { baseUrlVar ->
-                val regex = """let.*?$baseUrlVar\s*=.*?(?=,)""".toRegex(RegexOption.DOT_MATCHES_ALL)
+                val regex = """let.*?$baseUrlVar\s*=.*?(?=\n)""".toRegex(RegexOption.DOT_MATCHES_ALL)
                 regex.find(function)?.value?.let { varBlock ->
                     try {
                         QuickJs.create().use {


### PR DESCRIPTION
Closes #3348 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
