### PR TITLE
LuraToon: bypass chapter link redirect

### DIFF
--- a/src/pt/randomscan/build.gradle
+++ b/src/pt/randomscan/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.LuraToon'
     themePkg = 'peachscan'
     baseUrl = 'https://luratoons.com'
-    overrideVersionCode = 43
+    overrideVersionCode = 44
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/randomscan/src/eu/kanade/tachiyomi/extension/pt/randomscan/LuraToon.kt
+++ b/src/pt/randomscan/src/eu/kanade/tachiyomi/extension/pt/randomscan/LuraToon.kt
@@ -10,6 +10,8 @@ import eu.kanade.tachiyomi.lib.randomua.setRandomUserAgent
 import eu.kanade.tachiyomi.multisrc.peachscan.PeachScan
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.source.ConfigurableSource
+import eu.kanade.tachiyomi.source.model.SChapter
+import org.jsoup.nodes.Element
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -35,5 +37,17 @@ class LuraToon :
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         addRandomUAPreferenceToScreen(screen)
+    }
+
+    override fun chapterFromElement(element: Element): SChapter {
+        val mangaUrl = element.ownerDocument()!!.location()
+
+        return super.chapterFromElement(element).apply {
+            val num = url.removeSuffix("/")
+                .substringAfterLast("/")
+            val chapUrl = mangaUrl.removeSuffix("/") + "/$num/"
+
+            setUrlWithoutDomain(chapUrl)
+        }
     }
 }


### PR DESCRIPTION
closes  #3358

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
