### PR TITLE
LuaScans: set js cookie

### DIFF
--- a/src/en/luascans/build.gradle
+++ b/src/en/luascans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.LuaScans'
     themePkg = 'mangathemesia'
     baseUrl = 'https://luascans.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/luascans/src/eu/kanade/tachiyomi/extension/en/luascans/LuaScans.kt
+++ b/src/en/luascans/src/eu/kanade/tachiyomi/extension/en/luascans/LuaScans.kt
@@ -2,7 +2,11 @@ package eu.kanade.tachiyomi.extension.en.luascans
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import okhttp3.Cookie
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
+import okhttp3.Response
+import org.jsoup.Jsoup
 
 class LuaScans : MangaThemesia(
     "Lua Scans",
@@ -10,6 +14,35 @@ class LuaScans : MangaThemesia(
     "en",
 ) {
     override val client: OkHttpClient = super.client.newBuilder()
-        .rateLimit(4)
+        .addInterceptor(::wafffCookieInterceptor)
+        .rateLimit(2)
         .build()
+
+    private fun wafffCookieInterceptor(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val response = chain.proceed(request)
+
+        val document = Jsoup.parse(
+            response.peekBody(Long.MAX_VALUE).string(),
+            response.request.url.toString(),
+        )
+
+        return if (document.selectFirst("script:containsData(wafff)") != null) {
+            val script = document.selectFirst("script:containsData(wafff)")!!.data()
+
+            val cookie = script.substringAfter("document.cookie=\"")
+                .substringBefore("\"")
+
+            client.cookieJar.saveFromResponse(
+                request.url,
+                listOfNotNull(Cookie.parse(request.url, cookie)),
+            )
+
+            response.close()
+
+            chain.proceed(request)
+        } else {
+            response
+        }
+    }
 }


### PR DESCRIPTION
closes #3352

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
