### PR TITLE
Dream Scan: Fix language locale

### DIFF
--- a/src/pt/dreamscan/build.gradle
+++ b/src/pt/dreamscan/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.DreamScan'
     themePkg = 'madara'
     baseUrl = 'https://dreamscan.com.br'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/dreamscan/src/eu/kanade/tachiyomi/extension/pt/dreamscan/DreamScan.kt
+++ b/src/pt/dreamscan/src/eu/kanade/tachiyomi/extension/pt/dreamscan/DreamScan.kt
@@ -7,8 +7,10 @@ import java.util.Locale
 class DreamScan : Madara(
     "Dream Scan",
     "https://dreamscan.com.br",
-    "pt-br",
-    SimpleDateFormat("MMMM d, yyyy", Locale("pt", "br")),
+    "pt-BR",
+    SimpleDateFormat("MMMM d, yyyy", Locale("pt", "BR")),
 ) {
+    override val id: Long = 2058412298484770949
+
     override val useNewChapterEndpoint = true
 }


### PR DESCRIPTION
Fix mishap with "br" instead of "BR"

* Closes #3362 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
