### PR TITLE
Remove unnecessary files in generated APKs

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -63,6 +63,7 @@ android {
         release {
             signingConfig signingConfigs.release
             minifyEnabled false
+            vcsInfo.include false
         }
     }
 
@@ -72,6 +73,10 @@ android {
 
     buildFeatures {
         buildConfig true
+    }
+
+    packaging {
+        resources.excludes.add("kotlin-tooling-metadata.json")
     }
 
     compileOptions {


### PR DESCRIPTION
* Removed `kotlin-tooling-metadata.json`, see https://togithub.com/Kotlin/kotlinx.coroutines/issues/3158#issuecomment-1023151105
  This file includes Gradle version code, so Gradle updates will no longer cause binary changes.

* Removed "META-INF/version-control-info.textproto" introduced in AGP 8.4.1, which causes the binaries to change on each commit.

AGP updates will still cause binaries changes because it produces a required `app-metadata.properties` under `META-INF`,
and the `META-INF/MANIFEST.MF` file in the signature includes AGP version.

It is possible to empty `app-metadata.properties`: https://stackoverflow.com/questions/77745443/how-to-stop-gradle-from-generating-app-metadata-properties-at-compile-time
