### PR TITLE
Hitomi: Fix language filter in searching

### DIFF
--- a/src/all/hitomi/build.gradle
+++ b/src/all/hitomi/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hitomi'
     extClass = '.HitomiFactory'
-    extVersionCode = 29
+    extVersionCode = 30
     isNsfw = true
 }
 

--- a/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Hitomi.kt
+++ b/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Hitomi.kt
@@ -229,7 +229,10 @@ class Hitomi(
         query: String,
         language: String = "all",
     ): MutableList<Int> {
-        query.replace("_", " ").let {
+        query
+            .let { if (language != "all") query + " language:$nozomiLang" else query }
+            .replace("_", " ")
+            .let {
             if (it.indexOf(':') > -1) {
                 val sides = it.split(":")
                 val ns = sides[0]

--- a/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Hitomi.kt
+++ b/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Hitomi.kt
@@ -229,10 +229,7 @@ class Hitomi(
         query: String,
         language: String = "all",
     ): MutableList<Int> {
-        query
-            .let { if (language != "all") query + " language:$nozomiLang" else query }
-            .replace("_", " ")
-            .let {
+        query.let { if (language != "all") query + " language:$nozomiLang" else query }.replace("_", " ").let {
             if (it.indexOf(':') > -1) {
                 val sides = it.split(":")
                 val ns = sides[0]

--- a/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Hitomi.kt
+++ b/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Hitomi.kt
@@ -133,6 +133,7 @@ class Hitomi(
 
             val terms = query
                 .trim()
+                .let { if (language != "all") query + " language:$nozomiLang" else query }
                 .replace(Regex("""^\?"""), "")
                 .lowercase()
                 .split(Regex("\\s+"))
@@ -229,7 +230,7 @@ class Hitomi(
         query: String,
         language: String = "all",
     ): MutableList<Int> {
-        query.let { if (language != "all") query + " language:$nozomiLang" else query }.replace("_", " ").let {
+        query.replace("_", " ").let {
             if (it.indexOf(':') > -1) {
                 val sides = it.split(":")
                 val ns = sides[0]


### PR DESCRIPTION
As my test, Hitomi extension can filter by language in popular and recent, but failed in search. But that can be solved by adding `langauge:specific` to query to solve. That what I do.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension