### PR TITLE
ArgosComics: bugfix

### DIFF
--- a/src/pt/argoscomics/build.gradle
+++ b/src/pt/argoscomics/build.gradle
@@ -4,7 +4,6 @@ ext {
     themePkg = 'madara'
     baseUrl = 'https://argoscomics.com'
     overrideVersionCode = 2
-    isNsfw = true
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/argoscomics/build.gradle
+++ b/src/pt/argoscomics/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ArgosComics'
     themePkg = 'madara'
     baseUrl = 'https://argoscomics.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/pt/argoscomics/src/eu/kanade/tachiyomi/extension/pt/argoscomics/ArgosComics.kt
+++ b/src/pt/argoscomics/src/eu/kanade/tachiyomi/extension/pt/argoscomics/ArgosComics.kt
@@ -12,6 +12,8 @@ class ArgosComics : Madara(
     "pt-BR",
     SimpleDateFormat("MMMMM dd, yyyy", Locale("pt", "BR")),
 ) {
+    override val mangaSubString = "comics"
+
     override fun latestUpdatesSelector() = "div.wp-block-wp-manga-gutenberg-manga-sliders-block:nth-child(2)"
 
     override fun latestUpdatesRequest(page: Int): Request = GET(baseUrl, headers)

--- a/src/pt/argoscomics/src/eu/kanade/tachiyomi/extension/pt/argoscomics/ArgosComics.kt
+++ b/src/pt/argoscomics/src/eu/kanade/tachiyomi/extension/pt/argoscomics/ArgosComics.kt
@@ -2,7 +2,6 @@ package eu.kanade.tachiyomi.extension.pt.argoscomics
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
-import okhttp3.OkHttpClient
 import java.text.SimpleDateFormat
 import java.util.Locale
 

--- a/src/pt/argoscomics/src/eu/kanade/tachiyomi/extension/pt/argoscomics/ArgosComics.kt
+++ b/src/pt/argoscomics/src/eu/kanade/tachiyomi/extension/pt/argoscomics/ArgosComics.kt
@@ -1,8 +1,8 @@
 package eu.kanade.tachiyomi.extension.pt.argoscomics
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
-import eu.kanade.tachiyomi.network.GET
-import okhttp3.Request
+import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import okhttp3.OkHttpClient
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -14,9 +14,7 @@ class ArgosComics : Madara(
 ) {
     override val mangaSubString = "comics"
 
-    override fun latestUpdatesSelector() = "div.wp-block-wp-manga-gutenberg-manga-sliders-block:nth-child(2)"
-
-    override fun latestUpdatesRequest(page: Int): Request = GET(baseUrl, headers)
-
-    override fun latestUpdatesNextPageSelector() = null
+    override val client = super.client.newBuilder()
+        .rateLimit(3)
+        .build()
 }


### PR DESCRIPTION
Closes  #3392

NSFW content moved to #3398

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
