### PR TITLE
HentaiEra: fix 302 redirect and headers

### DIFF
--- a/src/all/hentaiera/build.gradle
+++ b/src/all/hentaiera/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.HentaiEraFactory'
     themePkg = 'galleryadults'
     baseUrl = 'https://hentaiera.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/all/hentaiera/src/eu/kanade/tachiyomi/extension/all/hentaiera/HentaiEra.kt
+++ b/src/all/hentaiera/src/eu/kanade/tachiyomi/extension/all/hentaiera/HentaiEra.kt
@@ -38,7 +38,7 @@ class HentaiEra(
 
     override fun popularMangaRequest(page: Int): Request {
         // Only for query string or multiple tags
-        val url = "$baseUrl/search".toHttpUrl().newBuilder().apply {
+        val url = "$baseUrl/search/".toHttpUrl().newBuilder().apply {
             addQueryParameter("pp", "1")
 
             getLanguageURIs().forEach { pair ->
@@ -50,7 +50,8 @@ class HentaiEra(
 
             addPageUri(page)
         }
-        return GET(url.build())
+
+        return GET(url.build(), headers)
     }
 
     /* Details */


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
