### PR TITLE
MangaFire: Fix volume entries

### DIFF
--- a/src/all/mangafire/build.gradle
+++ b/src/all/mangafire/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaFireFactory'
     themePkg = 'mangareader'
     baseUrl = 'https://mangafire.to'
-    overrideVersionCode = 4
+    overrideVersionCode = 5
     isNsfw = true
 }
 

--- a/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/MangaFire.kt
+++ b/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/MangaFire.kt
@@ -138,13 +138,13 @@ open class MangaFire(
     override fun parseChapterElements(response: Response, isVolume: Boolean): List<Element> {
         val result = json.decodeFromString<ResponseDto<String>>(response.body.string()).result
         val document = Jsoup.parse(result)
-
-        val elements = document.select("ul li")
+        val selector = if (isVolume) "div.unit" else "ul li"
+        val elements = document.select(selector)
         if (elements.size > 0) {
             val linkToFirstChapter = elements[0].selectFirst(Evaluator.Tag("a"))!!.attr("href")
             val mangaId = linkToFirstChapter.toString().substringAfter('.').substringBefore('/')
-
-            val request = GET("$baseUrl/ajax/read/$mangaId/chapter/$langCode", headers)
+            val type = if (isVolume) volumeType else chapterType
+            val request = GET("$baseUrl/ajax/read/$mangaId/$type/$langCode", headers)
             val response = client.newCall(request).execute()
             val res = json.decodeFromString<ResponseDto<ChapterIdsDto>>(response.body.string()).result.html
             val chapterInfoDocument = Jsoup.parse(res)


### PR DESCRIPTION
Closes #2520 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
