### PR TITLE
AquaManga: Update domain

### DIFF
--- a/src/en/aquamanga/build.gradle
+++ b/src/en/aquamanga/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Aqua Manga'
     extClass = '.AquaManga'
     themePkg = 'madara'
-    baseUrl = 'https://aquamanga.org'
-    overrideVersionCode = 8
+    baseUrl = 'https://aquareader.net'
+    overrideVersionCode = 9
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/aquamanga/src/eu/kanade/tachiyomi/extension/en/aquamanga/AquaManga.kt
+++ b/src/en/aquamanga/src/eu/kanade/tachiyomi/extension/en/aquamanga/AquaManga.kt
@@ -5,8 +5,8 @@ import eu.kanade.tachiyomi.multisrc.madara.Madara
 import okhttp3.Headers
 import kotlin.random.Random
 
-class AquaManga : Madara("Aqua Manga", "https://aquamanga.org", "en") {
-    override val useNewChapterEndpoint = false
+class AquaManga : Madara("Aqua Manga", "https://aquareader.net", "en") {
+    override val useLoadMoreRequest = LoadMoreStrategy.Always
 
     override fun headersBuilder(): Headers.Builder = super.headersBuilder()
         .add("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")


### PR DESCRIPTION
Closes #3408

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
