### PR TITLE
Update GalleryAdults

### DIFF
--- a/lib-multisrc/galleryadults/build.gradle.kts
+++ b/lib-multisrc/galleryadults/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 1
+baseVersionCode = 2

--- a/lib-multisrc/galleryadults/src/eu/kanade/tachiyomi/multisrc/galleryadults/GalleryAdults.kt
+++ b/lib-multisrc/galleryadults/src/eu/kanade/tachiyomi/multisrc/galleryadults/GalleryAdults.kt
@@ -294,7 +294,7 @@ abstract class GalleryAdults(
         val categoryFilters = filters.filterIsInstance<CategoryFilters>().firstOrNull()
 
         // Only for query string or multiple tags
-        val url = "$baseUrl/search".toHttpUrl().newBuilder().apply {
+        val url = "$baseUrl/search/".toHttpUrl().newBuilder().apply {
             getSortOrderURIs().forEachIndexed { index, pair ->
                 addQueryParameter(pair.second, toBinary(sortOrderFilter?.state == index))
             }
@@ -310,7 +310,7 @@ abstract class GalleryAdults(
             addEncodedQueryParameter(intermediateSearchKey, buildQueryString(selectedGenres.map { it.name }, query))
             addPageUri(page)
         }
-        return GET(url.build())
+        return GET(url.build(), headers)
     }
 
     protected open val advancedSearchKey = "key"
@@ -331,7 +331,7 @@ abstract class GalleryAdults(
         // Advanced search
         val advancedSearchFilters = filters.filterIsInstance<AdvancedTextFilter>()
 
-        val url = "$baseUrl/$advancedSearchUri".toHttpUrl().newBuilder().apply {
+        val url = "$baseUrl/$advancedSearchUri/".toHttpUrl().newBuilder().apply {
             getSortOrderURIs().forEachIndexed { index, pair ->
                 addQueryParameter(pair.second, toBinary(sortOrderFilter?.state == index))
             }
@@ -379,7 +379,7 @@ abstract class GalleryAdults(
             addEncodedQueryParameter(advancedSearchKey, keys.joinToString("+"))
             addPageUri(page)
         }
-        return GET(url.build())
+        return GET(url.build(), headers)
     }
 
     /**

--- a/src/all/asmhentai/src/eu/kanade/tachiyomi/extension/all/asmhentai/AsmHentai.kt
+++ b/src/all/asmhentai/src/eu/kanade/tachiyomi/extension/all/asmhentai/AsmHentai.kt
@@ -18,16 +18,21 @@ class AsmHentai(
     lang = lang,
 ) {
     override val supportsLatest = mangaLang.isNotBlank()
+    override val supportSpeechless: Boolean = true
+
+    override fun Element.mangaLang() =
+        select("a:has(.flag)").attr("href")
+            .removeSuffix("/").substringAfterLast("/")
+            .let {
+                // Include Speechless in search results
+                if (it == LANGUAGE_SPEECHLESS) mangaLang else it
+            }
 
     override fun Element.mangaUrl() =
         selectFirst(".image a")?.attr("abs:href")
 
     override fun Element.mangaThumbnail() =
         selectFirst(".image img")?.imgAttr()
-
-    override fun Element.mangaLang() =
-        select("a:has(.flag)").attr("href")
-            .removeSuffix("/").substringAfterLast("/")
 
     override fun popularMangaSelector() = ".preview_item"
 


### PR DESCRIPTION
- Fix 302 redirects & header
- AsmHentai: support Speechless
 
Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
