### PR TITLE
HouseMangas: Rebrand to "Visor Mangas"

### DIFF
--- a/src/es/housemangas/build.gradle
+++ b/src/es/housemangas/build.gradle
@@ -1,9 +1,9 @@
 ext {
-    extName = 'HouseMangas'
-    extClass = '.HouseMangas'
+    extName = 'Visor Mangas'
+    extClass = '.VisorMangas'
     themePkg = 'madara'
-    baseUrl = 'https://housemangas.com'
-    overrideVersionCode = 0
+    baseUrl = 'https://visormanga.xyz'
+    overrideVersionCode = 1
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/housemangas/src/eu/kanade/tachiyomi/extension/es/housemangas/VisorMangas.kt
+++ b/src/es/housemangas/src/eu/kanade/tachiyomi/extension/es/housemangas/VisorMangas.kt
@@ -6,11 +6,11 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
-class HouseMangas : Madara(
-    "HouseMangas",
-    "https://housemangas.com",
+class VisorMangas : Madara(
+    "Visor Mangas",
+    "https://visormanga.xyz",
     "es",
-    dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("es")),
+    dateFormat = SimpleDateFormat("dd 'de' MMMM 'de' yyyy", Locale("es")),
 ) {
     override val client = super.client.newBuilder()
         .rateLimit(2, 1, TimeUnit.SECONDS)
@@ -19,5 +19,5 @@ class HouseMangas : Madara(
     override val useNewChapterEndpoint = true
     override val useLoadMoreRequest = LoadMoreStrategy.Always
 
-    override val mangaDetailsSelectorStatus = "div.post-content_item:contains(Estado) > div.summary-content"
+    override val popularMangaUrlSelector = "div.post-title a[href^=$baseUrl]"
 }


### PR DESCRIPTION
Not keeping the old id because the new site has different content and slugs

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
