### PR TITLE
LoadingArtist: Fix json parser

### DIFF
--- a/src/en/loadingartist/build.gradle
+++ b/src/en/loadingartist/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Loading Artist'
     extClass = '.LoadingArtist'
-    extVersionCode = 2
+    extVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/loadingartist/src/eu/kanade/tachiyomi/extension/en/loadingartist/LoadingArtist.kt
+++ b/src/en/loadingartist/src/eu/kanade/tachiyomi/extension/en/loadingartist/LoadingArtist.kt
@@ -10,9 +10,8 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.decodeFromJsonElement
-import kotlinx.serialization.json.jsonObject
 import okhttp3.Request
 import okhttp3.Response
 import rx.Observable
@@ -89,9 +88,7 @@ class LoadingArtist : HttpSource() {
     }
 
     override fun chapterListParse(response: Response): List<SChapter> {
-        val comics = json.parseToJsonElement(response.body.string()).jsonObject.map {
-            json.decodeFromJsonElement<Comic>(it.value)
-        }
+        val comics = json.decodeFromString<List<Comic>>(response.body.string())
         val validTypes = listOf("comic", "game", "art")
         return comics.filter { validTypes.any { type -> it.section == type } }.map {
             SChapter.create().apply {


### PR DESCRIPTION
Closes  #3354

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
