### PR TITLE
akuma: fix chapter urls

### DIFF
--- a/src/all/akuma/build.gradle
+++ b/src/all/akuma/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Akuma'
     extClass = '.AkumaFactory'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
+++ b/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
@@ -266,7 +266,7 @@ class Akuma(
 
         return listOf(
             SChapter.create().apply {
-                url = "${response.request.url}/1"
+                setUrlWithoutDomain("${response.request.url}/1")
                 name = "Chapter"
                 date_upload = try {
                     dateFormat.parse(document.select(".date .value>time").text())!!.time
@@ -288,6 +288,8 @@ class Akuma(
         for (i in 1..totalPages) {
             pageList.add(Page(i, "$url/$i"))
         }
+
+        pageList[0].imageUrl = imageUrlParse(document)
 
         return pageList
     }


### PR DESCRIPTION
closes #3470

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
