### PR TITLE
WPComics: Add `monthWords` and `yearWords`

### DIFF
--- a/lib-multisrc/wpcomics/build.gradle.kts
+++ b/lib-multisrc/wpcomics/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 5
+baseVersionCode = 6
 
 dependencies {
     api(project(":lib:i18n"))

--- a/lib-multisrc/wpcomics/src/eu/kanade/tachiyomi/multisrc/wpcomics/WPComics.kt
+++ b/lib-multisrc/wpcomics/src/eu/kanade/tachiyomi/multisrc/wpcomics/WPComics.kt
@@ -173,15 +173,8 @@ abstract class WPComics(
                 val calendar = Calendar.getInstance()
 
                 when {
-                    yearWords.doesInclude(trimmedDate[1]) -> calendar.apply {
-                        add(Calendar.YEAR, -trimmedDate[0].toInt())
-                        set(Calendar.DAY_OF_MONTH, 1)
-                        set(Calendar.MONTH, Calendar.JANUARY)
-                    }
-                    monthWords.doesInclude(trimmedDate[1]) -> calendar.apply {
-                        add(Calendar.MONTH, -trimmedDate[0].toInt())
-                        set(Calendar.DAY_OF_MONTH, 1)
-                    }
+                    yearWords.doesInclude(trimmedDate[1]) -> calendar.apply { add(Calendar.YEAR, -trimmedDate[0].toInt()) }
+                    monthWords.doesInclude(trimmedDate[1]) -> calendar.apply { add(Calendar.MONTH, -trimmedDate[0].toInt()) }
                     dayWords.doesInclude(trimmedDate[1]) -> calendar.apply { add(Calendar.DAY_OF_MONTH, -trimmedDate[0].toInt()) }
                     hourWords.doesInclude(trimmedDate[1]) -> calendar.apply { add(Calendar.HOUR_OF_DAY, -trimmedDate[0].toInt()) }
                     minuteWords.doesInclude(trimmedDate[1]) -> calendar.apply { add(Calendar.MINUTE, -trimmedDate[0].toInt()) }

--- a/lib-multisrc/wpcomics/src/eu/kanade/tachiyomi/multisrc/wpcomics/WPComics.kt
+++ b/lib-multisrc/wpcomics/src/eu/kanade/tachiyomi/multisrc/wpcomics/WPComics.kt
@@ -163,6 +163,8 @@ abstract class WPComics(
         val minuteWords = listOf("minute", "phút")
         val hourWords = listOf("hour", "giờ")
         val dayWords = listOf("day", "ngày")
+        val monthWords = listOf("month", "tháng")
+        val yearWords = listOf("year", "năm")
         val agoWords = listOf("ago", "trước")
 
         return try {
@@ -171,6 +173,15 @@ abstract class WPComics(
                 val calendar = Calendar.getInstance()
 
                 when {
+                    yearWords.doesInclude(trimmedDate[1]) -> calendar.apply {
+                        add(Calendar.YEAR, -trimmedDate[0].toInt())
+                        set(Calendar.DAY_OF_MONTH, 1)
+                        set(Calendar.MONTH, Calendar.JANUARY)
+                    }
+                    monthWords.doesInclude(trimmedDate[1]) -> calendar.apply {
+                        add(Calendar.MONTH, -trimmedDate[0].toInt())
+                        set(Calendar.DAY_OF_MONTH, 1)
+                    }
                     dayWords.doesInclude(trimmedDate[1]) -> calendar.apply { add(Calendar.DAY_OF_MONTH, -trimmedDate[0].toInt()) }
                     hourWords.doesInclude(trimmedDate[1]) -> calendar.apply { add(Calendar.HOUR_OF_DAY, -trimmedDate[0].toInt()) }
                     minuteWords.doesInclude(trimmedDate[1]) -> calendar.apply { add(Calendar.MINUTE, -trimmedDate[0].toInt()) }


### PR DESCRIPTION
* Closes #3407 

Since NettruyenCO just lists older chapters as "# months ago" and "# year ago", this sets the dates for these chapters as "MM/01/YYYY" and "01/01/YYYY"

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
