### PR TITLE
AquaScans: Fix cloudflare on chapter open

### DIFF
--- a/src/en/manhwaworld/build.gradle
+++ b/src/en/manhwaworld/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ManhwaWorld'
     themePkg = 'madara'
     baseUrl = 'https://aquascans.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/manhwaworld/src/eu/kanade/tachiyomi/extension/en/manhwaworld/ManhwaWorld.kt
+++ b/src/en/manhwaworld/src/eu/kanade/tachiyomi/extension/en/manhwaworld/ManhwaWorld.kt
@@ -1,7 +1,19 @@
 package eu.kanade.tachiyomi.extension.en.manhwaworld
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
+import okhttp3.HttpUrl.Companion.toHttpUrl
 
-class ManhwaWorld : Madara("AQUA Scans", "https://aquascans.com", "en") {
+class ManhwaWorld : Madara(
+    "AQUA Scans",
+    "https://aquascans.com",
+    "en",
+) {
     override val id = 8857833474626810640
+
+    override val client = super.client.newBuilder()
+        .rateLimitHost(baseUrl.toHttpUrl(), 3, 1)
+        .build()
+
+    override val chapterUrlSuffix = ""
 }


### PR DESCRIPTION
Users will have to update the chapter list due to the url change
Closes #3550 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
