### PR TITLE
Hitomi: improve speed

### DIFF
--- a/src/all/hitomi/build.gradle
+++ b/src/all/hitomi/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hitomi'
     extClass = '.HitomiFactory'
-    extVersionCode = 30
+    extVersionCode = 31
     isNsfw = true
 }
 

--- a/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Filters.kt
+++ b/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Filters.kt
@@ -48,5 +48,4 @@ private val getSortsList: List<Triple<String, String?, String>> = listOf(
     Triple("Popular: Week", "popular", "week"),
     Triple("Popular: Month", "popular", "month"),
     Triple("Popular: Year", "popular", "year"),
-    Triple("Random", "popular", "year"),
 )

--- a/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Filters.kt
+++ b/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Filters.kt
@@ -48,4 +48,5 @@ private val getSortsList: List<Triple<String, String?, String>> = listOf(
     Triple("Popular: Week", "popular", "week"),
     Triple("Popular: Month", "popular", "month"),
     Triple("Popular: Year", "popular", "year"),
+    Triple("Random", "popular", "year"),
 )

--- a/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Hitomi.kt
+++ b/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Hitomi.kt
@@ -83,7 +83,7 @@ class Hitomi(
                     query.trim(),
                     filters,
                     nozomiLang,
-                ).toList()
+                )
             }
 
             val end = min(page * 25, searchResponse.size)
@@ -116,9 +116,10 @@ class Hitomi(
         query: String,
         filters: FilterList,
         language: String = "all",
-    ): Set<Int> =
+    ): List<Int> =
         coroutineScope {
             var sortBy: Pair<String?, String> = Pair(null, "index")
+            var random = false
 
             val terms = query
                 .trim()
@@ -133,6 +134,7 @@ class Hitomi(
                 when (it) {
                     is SelectFilter -> {
                         sortBy = Pair(it.getArea(), it.getValue())
+                        random = (it.vals[it.state].first == "Random")
                     }
 
                     is TypeFilter -> {
@@ -226,7 +228,11 @@ class Hitomi(
                 filterNegative(it.await())
             }
 
-            results
+            if (random) {
+                results.toList().shuffled()
+            } else {
+                results.toList()
+            }
         }
 
     // search.js


### PR DESCRIPTION
- revert back to using set for filtering instead of list
- only use cache control on ranged requests

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
