### PR TITLE
Sussy Scan: update domain

### DIFF
--- a/src/pt/sussyscan/build.gradle
+++ b/src/pt/sussyscan/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Sussy Scan'
     extClass = '.SussyScan'
     themePkg = 'madara'
-    baseUrl = 'https://sussyscan.com'
-    overrideVersionCode = 1
+    baseUrl = 'https://old.sussytoons.com'
+    overrideVersionCode = 2
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/sussyscan/src/eu/kanade/tachiyomi/extension/pt/sussyscan/SussyScan.kt
+++ b/src/pt/sussyscan/src/eu/kanade/tachiyomi/extension/pt/sussyscan/SussyScan.kt
@@ -8,7 +8,7 @@ import java.util.Locale
 
 class SussyScan : Madara(
     "Sussy Scan",
-    "https://sussyscan.com",
+    "https://old.sussytoons.com",
     "pt-BR",
     SimpleDateFormat("MMMM dd, yyyy", Locale("pt", "BR")),
 ) {
@@ -16,8 +16,11 @@ class SussyScan : Madara(
         .rateLimit(2)
         .build()
 
+    override val useLoadMoreRequest = LoadMoreStrategy.Never
     override val useNewChapterEndpoint = true
 
+    override val mangaDetailsSelectorAuthor = "div.manga-authors > a"
+    override val mangaDetailsSelectorDescription = ".manga-about.manga-info"
     override val mangaDetailsSelectorThumbnail = "head meta[property='og:image']"
 
     override fun imageFromElement(element: Element): String? {


### PR DESCRIPTION
Closes #3567

The non-old domain is under maintenance ¯\\\_(ツ)\_/¯

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
