### PR TITLE
HentaiNexus: set thumbnail on manga parse

### DIFF
--- a/src/en/hentainexus/build.gradle
+++ b/src/en/hentainexus/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = "HentaiNexus"
     extClass = ".HentaiNexus"
-    extVersionCode = 10
+    extVersionCode = 11
     isNsfw = true
 }
 

--- a/src/en/hentainexus/src/eu/kanade/tachiyomi/extension/en/hentainexus/HentaiNexus.kt
+++ b/src/en/hentainexus/src/eu/kanade/tachiyomi/extension/en/hentainexus/HentaiNexus.kt
@@ -122,6 +122,8 @@ class HentaiNexus : ParsedHttpSource() {
         }
         update_strategy = UpdateStrategy.ONLY_FETCH_ONCE
         status = SManga.COMPLETED
+
+        thumbnail_url = document.selectFirst("figure.image img")?.attr("src")
     }
 
     override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> {


### PR DESCRIPTION
Closes #3562

A manual update will restore the thumbnail.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
