### PR TITLE
Reset Scans: update domain

### DIFF
--- a/src/en/resetscans/build.gradle
+++ b/src/en/resetscans/build.gradle
@@ -2,8 +2,9 @@ ext {
     extName = 'Reset Scans'
     extClass = '.ResetScans'
     themePkg = 'madara'
-    baseUrl = 'https://reset-scans.xyz'
-    overrideVersionCode = 1
+    baseUrl = 'https://resetscan.com'
+    overrideVersionCode = 2
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
+++ b/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
@@ -1,7 +1,15 @@
 package eu.kanade.tachiyomi.extension.en.resetscans
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import java.text.SimpleDateFormat
+import java.util.Locale
 
-class ResetScans : Madara("Reset Scans", "https://reset-scans.xyz", "en") {
+class ResetScans : Madara(
+    "Reset Scans",
+    "https://resetscan.com",
+    "en",
+    dateFormat = SimpleDateFormat("MMM dd", Locale("en")),
+) {
+    override val useLoadMoreRequest = LoadMoreStrategy.Always
     override val useNewChapterEndpoint = true
     override val chapterUrlSelector = ".li__text > a"
 }


### PR DESCRIPTION
Closes #3585

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
