### PR TITLE
TresDaosScan: Change theme

### DIFF
--- a/src/es/tresdaosscan/build.gradle
+++ b/src/es/tresdaosscan/build.gradle
@@ -1,9 +1,9 @@
 ext {
     extName = 'Tres Daos Scan'
     extClass = '.TresDaosScan'
-    themePkg = 'madara'
+    themePkg = 'mangathemesia'
     baseUrl = 'https://tresdaos.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 8
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/tresdaosscan/src/eu/kanade/tachiyomi/extension/es/tresdaosscan/TresDaosScan.kt
+++ b/src/es/tresdaosscan/src/eu/kanade/tachiyomi/extension/es/tresdaosscan/TresDaosScan.kt
@@ -1,23 +1,19 @@
 package eu.kanade.tachiyomi.extension.es.tresdaosscan
 
-import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class TresDaosScan : Madara(
+class TresDaosScan : MangaThemesia(
     "Tres Daos Scan",
     "https://tresdaos.com",
     "es",
-    SimpleDateFormat("MMMM dd, yyyy", Locale("es")),
+    dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("es")),
 ) {
-    // Site move from MangaThemesia to Madara
     override val versionId = 4
 
     override val client = super.client.newBuilder()
         .rateLimit(2)
         .build()
-
-    override val useLoadMoreRequest = LoadMoreStrategy.Always
-    override val useNewChapterEndpoint = true
 }


### PR DESCRIPTION
Not updating the id because the slug from Madara is the same as MangaThemesia, but users will have to update the chapter list
Closes #3607

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
