### PR TITLE
Dark Scans: update domain

### DIFF
--- a/src/en/darkscans/build.gradle
+++ b/src/en/darkscans/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Dark Scans'
     extClass = '.DarkScans'
     themePkg = 'madara'
-    baseUrl = 'https://darkscans.com'
-    overrideVersionCode = 1
+    baseUrl = 'https://rightdark-scan.com'
+    overrideVersionCode = 2
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/darkscans/src/eu/kanade/tachiyomi/extension/en/darkscans/DarkScans.kt
+++ b/src/en/darkscans/src/eu/kanade/tachiyomi/extension/en/darkscans/DarkScans.kt
@@ -4,13 +4,13 @@ import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import okhttp3.OkHttpClient
 
-class DarkScans : Madara("Dark Scans", "https://darkscans.com", "en") {
-
+class DarkScans : Madara("Dark Scans", "https://rightdark-scan.com", "en") {
     override val client: OkHttpClient = super.client.newBuilder()
         .rateLimit(20, 4)
         .build()
 
-    override val mangaSubString = "all-series"
+    override val mangaDetailsSelectorStatus = "div.summary-heading:contains(Status) + div.summary-content"
 
-    override val filterNonMangaItems = false
+    override val useLoadMoreRequest = LoadMoreStrategy.Never
+    override val useNewChapterEndpoint = true
 }


### PR DESCRIPTION
Closes #3642

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
