### PR TITLE
Sussy Scan: update domain

### DIFF
--- a/src/pt/sussyscan/build.gradle
+++ b/src/pt/sussyscan/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Sussy Scan'
     extClass = '.SussyScan'
     themePkg = 'madara'
-    baseUrl = 'https://old.sussytoons.com'
-    overrideVersionCode = 2
+    baseUrl = 'https://oldi.sussytoons.com'
+    overrideVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/sussyscan/src/eu/kanade/tachiyomi/extension/pt/sussyscan/SussyScan.kt
+++ b/src/pt/sussyscan/src/eu/kanade/tachiyomi/extension/pt/sussyscan/SussyScan.kt
@@ -8,7 +8,7 @@ import java.util.Locale
 
 class SussyScan : Madara(
     "Sussy Scan",
-    "https://old.sussytoons.com",
+    "https://oldi.sussytoons.com",
     "pt-BR",
     SimpleDateFormat("MMMM dd, yyyy", Locale("pt", "BR")),
 ) {


### PR DESCRIPTION
Closes  #3636

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
