### PR TITLE
ArgosComics: Update domain

### DIFF
--- a/src/pt/argoscomics/build.gradle
+++ b/src/pt/argoscomics/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Argos Comics'
     extClass = '.ArgosComics'
     themePkg = 'madara'
-    baseUrl = 'https://argoscomics.com'
-    overrideVersionCode = 2
+    baseUrl = 'https://argoscomic.com'
+    overrideVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/argoscomics/src/eu/kanade/tachiyomi/extension/pt/argoscomics/ArgosComics.kt
+++ b/src/pt/argoscomics/src/eu/kanade/tachiyomi/extension/pt/argoscomics/ArgosComics.kt
@@ -7,13 +7,15 @@ import java.util.Locale
 
 class ArgosComics : Madara(
     "Argos Comics",
-    "https://argoscomics.com",
+    "https://argoscomic.com",
     "pt-BR",
-    SimpleDateFormat("MMMMM dd, yyyy", Locale("pt", "BR")),
+    SimpleDateFormat("MMM dd, yyyy", Locale("pt", "BR")),
 ) {
-    override val mangaSubString = "comics"
-
     override val client = super.client.newBuilder()
         .rateLimit(3)
         .build()
+
+    override val useLoadMoreRequest = LoadMoreStrategy.Always
+
+    override val useNewChapterEndpoint = true
 }


### PR DESCRIPTION
Closes  #3651

The old mangaSubString is redirected to the default mangaSubString.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
