### PR TITLE
NoblesseTranslations: Update domain and add override preference

### DIFF
--- a/src/es/noblessetranslations/build.gradle
+++ b/src/es/noblessetranslations/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Noblesse Translations'
     extClass = '.NoblesseTranslations'
     themePkg = 'madara'
-    baseUrl = 'https://www.nobledicion.com'
-    overrideVersionCode = 3
+    baseUrl = 'https://www.actualizamrd.com'
+    overrideVersionCode = 4
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/noblessetranslations/src/eu/kanade/tachiyomi/extension/es/noblessetranslations/NoblesseTranslations.kt
+++ b/src/es/noblessetranslations/src/eu/kanade/tachiyomi/extension/es/noblessetranslations/NoblesseTranslations.kt
@@ -1,15 +1,32 @@
 package eu.kanade.tachiyomi.extension.es.noblessetranslations
 
+import android.app.Application
+import android.content.SharedPreferences
+import android.widget.Toast
+import androidx.preference.EditTextPreference
+import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.source.ConfigurableSource
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class NoblesseTranslations : Madara(
-    "Noblesse Translations",
-    "https://www.nobledicion.com",
-    "es",
-    dateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("es")),
-) {
+class NoblesseTranslations :
+    Madara(
+        "Noblesse Translations",
+        "https://www.actualizamrd.com",
+        "es",
+        dateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("es")),
+    ),
+    ConfigurableSource {
+
+    private val preferences: SharedPreferences by lazy {
+        Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
+    }
+
+    override val baseUrl by lazy { getPrefBaseUrl() }
+
     override val useNewChapterEndpoint = true
     override val useLoadMoreRequest = LoadMoreStrategy.Always
     override val mangaSubString = "manga"
@@ -17,4 +34,40 @@ class NoblesseTranslations : Madara(
     override val mangaDetailsSelectorDescription = "div.summary_content > div.post-content div.manga-summary"
     override val mangaDetailsSelectorStatus = "div.summary_content > div.post-content div.post-content_item:has(div.summary-heading:contains(Status)) div.summary-content"
     override val mangaDetailsSelectorTag = "div.tags-content a.notUsed" // Site uses this for the scanlator
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        EditTextPreference(screen.context).apply {
+            key = BASE_URL_PREF
+            title = BASE_URL_PREF_TITLE
+            summary = BASE_URL_PREF_SUMMARY
+            dialogTitle = BASE_URL_PREF_TITLE
+            dialogMessage = "URL por defecto:\n${super.baseUrl}"
+            setDefaultValue(super.baseUrl)
+            setOnPreferenceChangeListener { _, newValue ->
+                Toast.makeText(screen.context, RESTART_APP_MESSAGE, Toast.LENGTH_LONG).show()
+                true
+            }
+        }.also { screen.addPreference(it) }
+    }
+
+    private fun getPrefBaseUrl(): String = preferences.getString(BASE_URL_PREF, super.baseUrl)!!
+
+    companion object {
+        private const val BASE_URL_PREF = "overrideBaseUrl"
+        private const val BASE_URL_PREF_TITLE = "Editar URL de la fuente"
+        private const val BASE_URL_PREF_SUMMARY = "Para uso temporal, si la extensión se actualiza se perderá el cambio."
+        private const val DEFAULT_BASE_URL_PREF = "defaultBaseUrl"
+        private const val RESTART_APP_MESSAGE = "Reinicie la aplicación para aplicar los cambios"
+    }
+
+    init {
+        preferences.getString(DEFAULT_BASE_URL_PREF, null).let { defaultBaseUrl ->
+            if (defaultBaseUrl != super.baseUrl) {
+                preferences.edit()
+                    .putString(BASE_URL_PREF, super.baseUrl)
+                    .putString(DEFAULT_BASE_URL_PREF, super.baseUrl)
+                    .apply()
+            }
+        }
+    }
 }

--- a/src/es/noblessetranslations/src/eu/kanade/tachiyomi/extension/es/noblessetranslations/NoblesseTranslations.kt
+++ b/src/es/noblessetranslations/src/eu/kanade/tachiyomi/extension/es/noblessetranslations/NoblesseTranslations.kt
@@ -21,9 +21,8 @@ class NoblesseTranslations :
     ),
     ConfigurableSource {
 
-    private val preferences: SharedPreferences by lazy {
+    private val preferences: SharedPreferences =
         Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
-    }
 
     override val baseUrl by lazy { getPrefBaseUrl() }
 


### PR DESCRIPTION
Closes #3667 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
