### PR TITLE
MANGARAW+: update domain 

### DIFF
--- a/src/ja/mangarawplus/build.gradle
+++ b/src/ja/mangarawplus/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'MANGARAW+'
     extClass = '.MangaRawPlus'
     themePkg = 'madara'
-    baseUrl = 'https://newmangaraw.net'
-    overrideVersionCode = 3
+    baseUrl = 'https://mangarawpedia.com'
+    overrideVersionCode = 4
     isNsfw = true
 }
 

--- a/src/ja/mangarawplus/src/eu/kanade/tachiyomi/extension/ja/mangarawplus/MangaRawPlus.kt
+++ b/src/ja/mangarawplus/src/eu/kanade/tachiyomi/extension/ja/mangarawplus/MangaRawPlus.kt
@@ -3,8 +3,7 @@ package eu.kanade.tachiyomi.extension.ja.mangarawplus
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import org.jsoup.nodes.Element
 
-class MangaRawPlus : Madara("MANGARAW+", "https://newmangaraw.net", "ja") {
-    override val mangaSubString = "ts"
+class MangaRawPlus : Madara("MANGARAW+", "https://mangarawpedia.com", "ja") {
     override fun imageFromElement(element: Element): String? {
         return when {
             element.hasAttr("data-src-img") -> element.absUrl("data-src-img")


### PR DESCRIPTION
Closes: #3719

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
