### PR TITLE
Shinigami: update domain

### DIFF
--- a/src/id/shinigami/build.gradle
+++ b/src/id/shinigami/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Shinigami'
     extClass = '.Shinigami'
     themePkg = 'madara'
-    baseUrl = 'https://shinigamitoon.id'
-    overrideVersionCode = 21
+    baseUrl = 'https://shinigamitoon.app'
+    overrideVersionCode = 22
     isNsfw = false
 }
 

--- a/src/id/shinigami/src/eu/kanade/tachiyomi/extension/id/shinigami/Shinigami.kt
+++ b/src/id/shinigami/src/eu/kanade/tachiyomi/extension/id/shinigami/Shinigami.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.decodeFromString
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 
-class Shinigami : Madara("Shinigami", "https://shinigamitoon.id", "id") {
+class Shinigami : Madara("Shinigami", "https://shinigamitoon.app", "id") {
     // moved from Reaper Scans (id) to Shinigami (id)
     override val id = 3411809758861089969
 


### PR DESCRIPTION
Closes #3737 (don't worry, if the domain continues to change I will still make a pull request, if I have time 🗿)

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
