### PR TITLE
Fix Adu Manga URL & date format

### DIFF
--- a/src/tr/adumanga/build.gradle
+++ b/src/tr/adumanga/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.AduManga'
     themePkg = 'mangathemesia'
     baseUrl = 'https://adumanga.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/tr/adumanga/src/eu/kanade/tachiyomi/extension/tr/adumanga/AduManga.kt
+++ b/src/tr/adumanga/src/eu/kanade/tachiyomi/extension/tr/adumanga/AduManga.kt
@@ -6,7 +6,7 @@ import java.util.Locale
 
 class AduManga : MangaThemesia(
     "Adu Manga",
-    "https://www.mangacim.com",
+    "https://adumanga.com",
     "tr",
     dateFormat = SimpleDateFormat("MMMM d, yyy", Locale("tr")),
 )

--- a/src/tr/adumanga/src/eu/kanade/tachiyomi/extension/tr/adumanga/AduManga.kt
+++ b/src/tr/adumanga/src/eu/kanade/tachiyomi/extension/tr/adumanga/AduManga.kt
@@ -8,5 +8,5 @@ class AduManga : MangaThemesia(
     "Adu Manga",
     "https://adumanga.com",
     "tr",
-    dateFormat = SimpleDateFormat("MMMM d, yyy", Locale("tr")),
+    dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("en")),
 )

--- a/src/tr/adumanga/src/eu/kanade/tachiyomi/extension/tr/adumanga/AduManga.kt
+++ b/src/tr/adumanga/src/eu/kanade/tachiyomi/extension/tr/adumanga/AduManga.kt
@@ -1,12 +1,9 @@
 package eu.kanade.tachiyomi.extension.tr.adumanga
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 class AduManga : MangaThemesia(
     "Adu Manga",
     "https://adumanga.com",
     "tr",
-    dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("en")),
 )


### PR DESCRIPTION
Closes #3762 

* Replaced link with correct link
* ~~Swapped out `tr` locale to `en`~~ Removed `dateFormat` override since site uses English month names

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
