### PR TITLE
Manhua Espanol: update domain

### DIFF
--- a/src/es/manhuaespanol/build.gradle
+++ b/src/es/manhuaespanol/build.gradle
@@ -2,8 +2,9 @@ ext {
     extName = 'Manhua Espanol'
     extClass = '.ManhuaEspanol'
     themePkg = 'madara'
-    baseUrl = 'https://manhuaespanol.com'
-    overrideVersionCode = 0
+    baseUrl = 'https://lectorespanol.com'
+    overrideVersionCode = 1
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/manhuaespanol/src/eu/kanade/tachiyomi/extension/es/manhuaespanol/ManhuaEspanol.kt
+++ b/src/es/manhuaespanol/src/eu/kanade/tachiyomi/extension/es/manhuaespanol/ManhuaEspanol.kt
@@ -6,7 +6,7 @@ import java.util.Locale
 
 class ManhuaEspanol : Madara(
     "Manhua Español",
-    "https://manhuaespanol.com",
+    "https://lectorespanol.com",
     "es",
     dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale("es")),
 ) {


### PR DESCRIPTION
Closes #3770

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
