### PR TITLE
Manga Demon: update domain

### DIFF
--- a/src/en/mangademon/build.gradle
+++ b/src/en/mangademon/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Manga Demon'
     extClass = '.MangaDemon'
-    extVersionCode = 11
+    extVersionCode = 12
     isNsfw = false
 }
 

--- a/src/en/mangademon/src/eu/kanade/tachiyomi/extension/en/mangademon/MangaDemon.kt
+++ b/src/en/mangademon/src/eu/kanade/tachiyomi/extension/en/mangademon/MangaDemon.kt
@@ -28,7 +28,7 @@ class MangaDemon : ParsedHttpSource() {
     override val lang = "en"
     override val supportsLatest = true
     override val name = "Manga Demon"
-    override val baseUrl = "https://comicdemons.com"
+    override val baseUrl = "https://mgdemon.org"
 
     override val client = network.cloudflareClient.newBuilder()
         .rateLimit(1)


### PR DESCRIPTION
Closes #3778

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
