### PR TITLE
Komiktap: update domain

### DIFF
--- a/src/id/komiktap/build.gradle
+++ b/src/id/komiktap/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Komiktap'
     extClass = '.Komiktap'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://komiktap.me'
-    overrideVersionCode = 1
+    baseUrl = 'https://komiktap.info'
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/id/komiktap/src/eu/kanade/tachiyomi/extension/id/komiktap/Komiktap.kt
+++ b/src/id/komiktap/src/eu/kanade/tachiyomi/extension/id/komiktap/Komiktap.kt
@@ -8,7 +8,7 @@ import okhttp3.Interceptor
 import okhttp3.Response
 import java.io.IOException
 
-class Komiktap : MangaThemesia("Komiktap", "https://komiktap.me", "id") {
+class Komiktap : MangaThemesia("Komiktap", "https://komiktap.info", "id") {
     override val client = super.client.newBuilder().addInterceptor(::sucuriInterceptor).build()
 
     // Taken from es/ManhwasNet


### PR DESCRIPTION
Closes #3799

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
