### PR TITLE
fix ru.MangaLib getMangaUrl generation

### DIFF
--- a/src/ru/mangalib/build.gradle
+++ b/src/ru/mangalib/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaLib'
     themePkg = 'libgroup'
     baseUrl = 'https://mangalib.me'
-    overrideVersionCode = 74
+    overrideVersionCode = 75
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ru/mangalib/src/eu/kanade/tachiyomi/extension/ru/mangalib/MangaLib.kt
+++ b/src/ru/mangalib/src/eu/kanade/tachiyomi/extension/ru/mangalib/MangaLib.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import android.widget.Toast
 import androidx.preference.EditTextPreference
 import eu.kanade.tachiyomi.multisrc.libgroup.LibGroup
+import eu.kanade.tachiyomi.source.model.SManga
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -34,6 +35,8 @@ class MangaLib : LibGroup("MangaLib", "https://mangalib.me", "ru") {
             }
         }.let(screen::addPreference)
     }
+
+    override fun getMangaUrl(manga: SManga): String = "$baseUrl${manga.url}"
 
     companion object {
         private const val DOMAIN_PREF = "MangaLibDomain"


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz") - don't have 
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
