### PR TITLE
ArthurScan: Fix images content type

### DIFF
--- a/src/pt/arthurscan/build.gradle
+++ b/src/pt/arthurscan/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ArthurScan'
     themePkg = 'madara'
     baseUrl = 'https://arthurscan.xyz'
-    overrideVersionCode = 4
+    overrideVersionCode = 5
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/arthurscan/src/eu/kanade/tachiyomi/extension/pt/arthurscan/ArthurScan.kt
+++ b/src/pt/arthurscan/src/eu/kanade/tachiyomi/extension/pt/arthurscan/ArthurScan.kt
@@ -2,7 +2,9 @@ package eu.kanade.tachiyomi.extension.pt.arthurscan
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
+import okhttp3.ResponseBody.Companion.toResponseBody
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.concurrent.TimeUnit
@@ -16,6 +18,19 @@ class ArthurScan : Madara(
 
     override val client: OkHttpClient = super.client.newBuilder()
         .rateLimit(1, 2, TimeUnit.SECONDS)
+        .addInterceptor { chain ->
+            val response = chain.proceed(chain.request())
+            val mime = response.headers["Content-Type"]
+            if (response.isSuccessful) {
+                if (mime == "application/octet-stream" || mime == null) {
+                    val type = "image/jpeg".toMediaType()
+                    val body = response.body.bytes().toResponseBody(type)
+                    return@addInterceptor response.newBuilder().body(body)
+                        .header("Content-Type", "image/jpeg").build()
+                }
+            }
+            response
+        }
         .build()
 
     override val useNewChapterEndpoint = true


### PR DESCRIPTION
Closes #3809

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
