### PR TITLE
Update debugger instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -720,6 +720,9 @@ And for a release build of Tachiyomi:
 
 ### Android Debugger
 
+> [!IMPORTANT]
+> Rooted device required. If you are using an emulator instead, make sure you choose a profile without Google Play.
+
 You can leverage the Android Debugger to step through your extension while debugging.
 
 You *cannot* simply use Android Studio's `Debug 'module.name'` -> this will most likely result in an

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -721,7 +721,7 @@ And for a release build of Tachiyomi:
 ### Android Debugger
 
 > [!IMPORTANT]
-> Rooted device required. If you are using an emulator instead, make sure you choose a profile without Google Play.
+> Rooted device required. If you are using an emulator instead, make sure you choose a profile **without** Google Play.
 
 You can leverage the Android Debugger to step through your extension while debugging.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -721,7 +721,7 @@ And for a release build of Tachiyomi:
 ### Android Debugger
 
 > [!IMPORTANT]
-> If you didn't build Tachiyomi from source with debug enabled and are using a release/beta APK, you **need** a rooted device.
+> If you didn't build the main app from source with debug enabled and are using a release/beta APK, you **need** a rooted device.
 > If you are using an emulator instead, make sure you choose a profile **without** Google Play.
 
 You can leverage the Android Debugger to step through your extension while debugging.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -721,7 +721,8 @@ And for a release build of Tachiyomi:
 ### Android Debugger
 
 > [!IMPORTANT]
-> Rooted device required. If you are using an emulator instead, make sure you choose a profile **without** Google Play.
+> If you didn't build Tachiyomi from source with debug enabled and are using a release/beta APK, you **need** a rooted device.
+> If you are using an emulator instead, make sure you choose a profile **without** Google Play.
 
 You can leverage the Android Debugger to step through your extension while debugging.
 


### PR DESCRIPTION
A small change to the Android debugger section. The method mentioned only works on:
* Rooted devices
* Emulated devices without Google play (Google play enabled devices do not have su)

Reference:
https://developer.android.com/studio/debug#attach-debugger