### PR TITLE
ColoredManga: Fixed Error when Requesting Mangas

### DIFF
--- a/src/en/coloredmanga/build.gradle
+++ b/src/en/coloredmanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ColoredManga'
     extClass = '.ColoredManga'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/en/coloredmanga/src/eu/kanade/tachiyomi/extension/en/coloredmanga/ColoredManga.kt
+++ b/src/en/coloredmanga/src/eu/kanade/tachiyomi/extension/en/coloredmanga/ColoredManga.kt
@@ -191,7 +191,7 @@ class ColoredManga : HttpSource() {
         val mangasJson = mangasRaw
             .replace(Regex("""\\([\\"])"""), "$1")
             .replaceBefore("\"data\":[", "{")
-            .removeSuffix("]}]\\n\"])")
+            .replaceFrom("}]}]}]", "}]}")
 
         return mangasJson.parseAs<MangasList>().data
     }
@@ -402,8 +402,14 @@ class ColoredManga : HttpSource() {
             chain.proceed(chain.request())
         }
     }
+
     private inline fun <reified T> String.parseAs(): T {
         return json.decodeFromString(this)
+    }
+
+    private fun String.replaceFrom(prefix: String, replacement: String): String {
+        val index = this.indexOf(prefix)
+        return if (index == -1) this else this.substring(0, index) + replacement
     }
 
     private inline fun <reified T> Response.parseAs(): T {


### PR DESCRIPTION
Closes #3915

Checklist:
- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
