### PR TITLE
algodao doce url

### DIFF
--- a/src/pt/algodaodoce/build.gradle
+++ b/src/pt/algodaodoce/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Algodão Doce'
     extClass = '.AlgodaoDoce'
     themePkg = 'madara'
-    baseUrl = 'https://algodaodocescan.com.br'
-    overrideVersionCode = 0
+    baseUrl = 'https://xn--algododoce-j5a.com'
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/pt/algodaodoce/src/eu/kanade/tachiyomi/extension/pt/algodaodoce/AlgodaoDoce.kt
+++ b/src/pt/algodaodoce/src/eu/kanade/tachiyomi/extension/pt/algodaodoce/AlgodaoDoce.kt
@@ -6,7 +6,7 @@ import java.util.Locale
 
 class AlgodaoDoce : Madara(
     "Algodão Doce",
-    "https://algodaodocescan.com.br",
+    "https://xn--algododoce-j5a.com",
     "pt-BR",
     dateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("pt", "BR")),
 ) {


### PR DESCRIPTION
closes #3962
I don't know how the site was able to use a special character like ã in the url, but when testing it out with the url with the ã, I've noticed that in the webview it was using the https://xn--algododoce-j5a.com site instead. So I tried it out and it worked
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
