### PR TITLE
Mangapark: duplicate chapters & unblock site blocked genres

### DIFF
--- a/src/all/mangapark/build.gradle
+++ b/src/all/mangapark/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaPark'
     extClass = '.MangaParkFactory'
-    extVersionCode = 19
+    extVersionCode = 20
     isNsfw = true
 }
 

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaPark.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaPark.kt
@@ -18,6 +18,9 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -95,8 +98,6 @@ class MangaPark(
     }
 
     override fun searchMangaParse(response: Response): MangasPage {
-        runCatching(::getGenres)
-
         val result = response.parseAs<SearchResponse>()
 
         val entries = result.data.searchComics.items.map { it.data.toSManga() }
@@ -131,6 +132,10 @@ class MangaPark(
     }
 
     override fun getFilterList(): FilterList {
+        CoroutineScope(Dispatchers.IO).launch {
+            runCatching(::getGenres)
+        }
+
         val filters = mutableListOf<Filter<*>>(
             SortFilter(),
             OriginalLanguageFilter(),

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkDto.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkDto.kt
@@ -113,6 +113,7 @@ class MangaParkChapter(
     private val dateModify: Long? = null,
     private val urlPath: String,
     private val srcTitle: String? = null,
+    private val userNode: Data<Name>? = null,
     val dupChapters: List<Data<MangaParkChapter>> = emptyList(),
 ) {
     fun toSChapter() = SChapter.create().apply {
@@ -122,9 +123,12 @@ class MangaParkChapter(
             title?.let { append(": ", it) }
         }
         date_upload = dateModify ?: dateCreate ?: 0L
-        scanlator = srcTitle ?: "Unknown"
+        scanlator = userNode?.data?.name ?: srcTitle ?: "Unknown"
     }
 }
+
+@Serializable
+class Name(val name: String)
 
 @Serializable
 class ChapterPages(

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkDto.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkDto.kt
@@ -12,34 +12,34 @@ typealias ChapterListResponse = Data<ChapterList>
 typealias PageListResponse = Data<ChapterPages>
 
 @Serializable
-data class Data<T>(val data: T)
+class Data<T>(val data: T)
 
 @Serializable
-data class Items<T>(val items: List<T>)
+class Items<T>(val items: List<T>)
 
 @Serializable
-data class SearchComics(
+class SearchComics(
     @SerialName("get_searchComic") val searchComics: Items<Data<MangaParkComic>>,
 )
 
 @Serializable
-data class ComicNode(
+class ComicNode(
     @SerialName("get_comicNode") val comic: Data<MangaParkComic>,
 )
 
 @Serializable
-data class MangaParkComic(
-    val id: String,
-    val name: String,
-    val altNames: List<String>? = null,
-    val authors: List<String>? = null,
-    val artists: List<String>? = null,
-    val genres: List<String>? = null,
-    val originalStatus: String? = null,
-    val uploadStatus: String? = null,
-    val summary: String? = null,
-    @SerialName("urlCoverOri") val cover: String? = null,
-    val urlPath: String,
+class MangaParkComic(
+    private val id: String,
+    private val name: String,
+    private val altNames: List<String>? = null,
+    private val authors: List<String>? = null,
+    private val artists: List<String>? = null,
+    private val genres: List<String>? = null,
+    private val originalStatus: String? = null,
+    private val uploadStatus: String? = null,
+    private val summary: String? = null,
+    @SerialName("urlCoverOri") private val cover: String? = null,
+    private val urlPath: String,
 ) {
     fun toSManga() = SManga.create().apply {
         url = "$urlPath#$id"
@@ -100,18 +100,20 @@ data class MangaParkComic(
 }
 
 @Serializable
-data class ChapterList(
+class ChapterList(
     @SerialName("get_comicChapterList") val chapterList: List<Data<MangaParkChapter>>,
 )
 
 @Serializable
-data class MangaParkChapter(
-    val id: String,
-    @SerialName("dname") val displayName: String,
-    val title: String? = null,
-    val dateCreate: Long? = null,
-    val dateModify: Long? = null,
-    val urlPath: String,
+class MangaParkChapter(
+    private val id: String,
+    @SerialName("dname") private val displayName: String,
+    private val title: String? = null,
+    private val dateCreate: Long? = null,
+    private val dateModify: Long? = null,
+    private val urlPath: String,
+    private val srcTitle: String? = null,
+    val dupChapters: List<Data<MangaParkChapter>> = emptyList(),
 ) {
     fun toSChapter() = SChapter.create().apply {
         url = "$urlPath#$id"
@@ -120,20 +122,21 @@ data class MangaParkChapter(
             title?.let { append(": ", it) }
         }
         date_upload = dateModify ?: dateCreate ?: 0L
+        scanlator = srcTitle ?: "Unknown"
     }
 }
 
 @Serializable
-data class ChapterPages(
+class ChapterPages(
     @SerialName("get_chapterNode") val chapterPages: Data<ImageFiles>,
 )
 
 @Serializable
-data class ImageFiles(
+class ImageFiles(
     val imageFile: UrlList,
 )
 
 @Serializable
-data class UrlList(
+class UrlList(
     val urlList: List<String>,
 )

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkPayloadDto.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkPayloadDto.kt
@@ -4,28 +4,28 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class GraphQL<T>(
-    val variables: T,
-    val query: String,
+class GraphQL<T>(
+    private val variables: T,
+    private val query: String,
 )
 
 @Serializable
-data class SearchVariables(val select: SearchPayload)
+class SearchVariables(private val select: SearchPayload)
 
 @Serializable
-data class SearchPayload(
-    @SerialName("word") val query: String? = null,
-    val incGenres: List<String>? = null,
-    val excGenres: List<String>? = null,
-    val incTLangs: List<String>? = null,
-    val incOLangs: List<String>? = null,
-    val sortby: String? = null,
-    val chapCount: String? = null,
-    val origStatus: String? = null,
-    val siteStatus: String? = null,
-    val page: Int,
-    val size: Int,
+class SearchPayload(
+    @SerialName("word") private val query: String? = null,
+    private val incGenres: List<String>? = null,
+    private val excGenres: List<String>? = null,
+    private val incTLangs: List<String>? = null,
+    private val incOLangs: List<String>? = null,
+    private val sortby: String? = null,
+    private val chapCount: String? = null,
+    private val origStatus: String? = null,
+    private val siteStatus: String? = null,
+    private val page: Int,
+    private val size: Int,
 )
 
 @Serializable
-data class IdVariables(val id: String)
+class IdVariables(private val id: String)

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkQueries.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkQueries.kt
@@ -75,6 +75,18 @@ val CHAPTERS_QUERY = buildQuery {
                     dateModify
                     dateCreate
                     urlPath
+                    srcTitle
+                    dupChapters {
+                        data {
+                            id
+                            dname
+                            title
+                            dateModify
+                            dateCreate
+                            urlPath
+                            srcTitle
+                        }
+                    }
                 }
             }
         }

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkQueries.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkQueries.kt
@@ -76,6 +76,11 @@ val CHAPTERS_QUERY = buildQuery {
                     dateCreate
                     urlPath
                     srcTitle
+                    userNode {
+                        data {
+                            name
+                        }
+                    }
                     dupChapters {
                         data {
                             id

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkQueries.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkQueries.kt
@@ -85,6 +85,11 @@ val CHAPTERS_QUERY = buildQuery {
                             dateCreate
                             urlPath
                             srcTitle
+                            userNode {
+                                data {
+                                    name
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
closes #3023
closes #1785

- preference to either show all chapters (duplicates) or only the primary chapters, which site shows by default
- add username or bot name in scanlator field
- save necessary cookies to unblock Hentai genre

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
