### PR TITLE
NekoScans (es): Change theme to ZeistManga

### DIFF
--- a/src/es/nekoscans/build.gradle
+++ b/src/es/nekoscans/build.gradle
@@ -1,9 +1,9 @@
 ext {
     extName = 'NekoScans'
     extClass = '.NekoScans'
-    themePkg = 'mangathemesia'
-    baseUrl = 'https://nekoscans.com'
-    overrideVersionCode = 0
+    themePkg = 'zeistmanga'
+    baseUrl = 'https://nekoscanlationlector.blogspot.com'
+    overrideVersionCode = 22
     isNsfw = true
 }
 


### PR DESCRIPTION
Users will have to migrate their entries.
Closes #3946

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
