### PR TITLE
get original image quality

### DIFF
--- a/lib-multisrc/gravureblogger/build.gradle.kts
+++ b/lib-multisrc/gravureblogger/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 3
+baseVersionCode = 4

--- a/lib-multisrc/gravureblogger/src/eu/kanade/tachiyomi/multisrc/gravureblogger/GravureBlogger.kt
+++ b/lib-multisrc/gravureblogger/src/eu/kanade/tachiyomi/multisrc/gravureblogger/GravureBlogger.kt
@@ -130,8 +130,8 @@ abstract class GravureBlogger(
     override fun pageListParse(response: Response): List<Page> {
         val document = response.asJsoup()
 
-        return document.select("div.post-body img").mapIndexed { i, it ->
-            Page(i, imageUrl = it.absUrl("src"))
+        return document.select("div.post-body a:has(> img)").mapIndexed { i, it ->
+            Page(i, imageUrl = it.absUrl("href"))
         }
     }
 


### PR DESCRIPTION
closes #3999

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
