### PR TITLE
LibGroup: fix crash on null token

### DIFF
--- a/lib-multisrc/libgroup/build.gradle.kts
+++ b/lib-multisrc/libgroup/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 29
+baseVersionCode = 30

--- a/lib-multisrc/libgroup/src/eu/kanade/tachiyomi/multisrc/libgroup/LibGroup.kt
+++ b/lib-multisrc/libgroup/src/eu/kanade/tachiyomi/multisrc/libgroup/LibGroup.kt
@@ -188,7 +188,11 @@ abstract class LibGroup(
                             } else {
                                 it.replace("\\", "")
                             }
-                            returnValue = str.parseAs<AuthToken>()
+                            str.parseAs<AuthToken>().let { auth ->
+                                if (auth.auth != null) {
+                                    returnValue = auth
+                                }
+                            }
                         }
                         latch.countDown()
                     }

--- a/lib-multisrc/libgroup/src/eu/kanade/tachiyomi/multisrc/libgroup/LibGroupDto.kt
+++ b/lib-multisrc/libgroup/src/eu/kanade/tachiyomi/multisrc/libgroup/LibGroupDto.kt
@@ -266,7 +266,7 @@ class Pages(
 
 @Serializable
 class AuthToken(
-    private val auth: Auth,
+    val auth: Auth?,
     private val token: Token,
 ) {
     @Serializable
@@ -290,5 +290,5 @@ class AuthToken(
 
     fun getToken(): String = "${token.tokenType} ${token.accessToken}"
 
-    fun getUserId(): Int = auth.id
+    fun getUserId(): Int = auth!!.id
 }


### PR DESCRIPTION
can't really test without account...

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
