### PR TITLE
Galaxy (AR): update domain

### DIFF
--- a/src/all/galaxy/build.gradle
+++ b/src/all/galaxy/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Galaxy'
     extClass = '.GalaxyFactory'
-    extVersionCode = 2
+    extVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/galaxy/src/eu/kanade/tachiyomi/extension/all/galaxy/GalaxyFactory.kt
+++ b/src/all/galaxy/src/eu/kanade/tachiyomi/extension/all/galaxy/GalaxyFactory.kt
@@ -8,7 +8,7 @@ class GalaxyFactory : SourceFactory {
         override val id = 2602904659965278831
     }
 
-    class GalaxyManga : Galaxy("Galaxy Manga", "https://ayoub-zrr.xyz", "ar") {
+    class GalaxyManga : Galaxy("Galaxy Manga", "https://hojdy.xyz", "ar") {
         override val id = 2729515745226258240
     }
 

--- a/src/all/galaxy/src/eu/kanade/tachiyomi/extension/all/galaxy/GalaxyFactory.kt
+++ b/src/all/galaxy/src/eu/kanade/tachiyomi/extension/all/galaxy/GalaxyFactory.kt
@@ -8,7 +8,7 @@ class GalaxyFactory : SourceFactory {
         override val id = 2602904659965278831
     }
 
-    class GalaxyManga : Galaxy("Galaxy Manga", "https://hojdy.xyz", "ar") {
+    class GalaxyManga : Galaxy("Galaxy Manga", "https://galaxymanga.net", "ar") {
         override val id = 2729515745226258240
     }
 


### PR DESCRIPTION
closes #3984

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
