### PR TITLE
LXHentai: Update domain

### DIFF
--- a/src/vi/lxhentai/AndroidManifest.xml
+++ b/src/vi/lxhentai/AndroidManifest.xml
@@ -14,7 +14,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:host="lxmanga.icu"
+                    android:host="lxmanga.life"
                     android:pathPattern="/truyen/..*"
                     android:scheme="https" />
             </intent-filter>

--- a/src/vi/lxhentai/build.gradle
+++ b/src/vi/lxhentai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'LXHentai'
     extClass = '.LxHentai'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = true
 }
 

--- a/src/vi/lxhentai/src/eu/kanade/tachiyomi/extension/vi/lxhentai/LxHentai.kt
+++ b/src/vi/lxhentai/src/eu/kanade/tachiyomi/extension/vi/lxhentai/LxHentai.kt
@@ -23,7 +23,7 @@ class LxHentai : ParsedHttpSource() {
 
     override val name = "LXHentai"
 
-    override val baseUrl = "https://lxmanga.cfd"
+    override val baseUrl = "https://lxmanga.life"
 
     override val lang = "vi"
 


### PR DESCRIPTION
Closes #3995

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
