### PR TITLE
LaviniaFansub: Fix chapter name

### DIFF
--- a/src/tr/laviniafansub/build.gradle
+++ b/src/tr/laviniafansub/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.LaviniaFansub'
     themePkg = 'madara'
     baseUrl = 'https://laviniafansub.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/tr/laviniafansub/src/eu/kanade/tachiyomi/extension/tr/laviniafansub/LaviniaFansub.kt
+++ b/src/tr/laviniafansub/src/eu/kanade/tachiyomi/extension/tr/laviniafansub/LaviniaFansub.kt
@@ -13,7 +13,10 @@ class LaviniaFansub : Madara(
     dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.ROOT),
 ) {
     override val useLoadMoreRequest = LoadMoreStrategy.Always
+
     override val useNewChapterEndpoint = true
+
+    override val chapterUrlSelector = "a:not(:has(img))"
 
     override fun pageListParse(document: Document): List<Page> {
         val pageList = super.pageListParse(document)


### PR DESCRIPTION
Closes #3994

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
