### PR TITLE
Shinigami: add baseUrl override

### DIFF
--- a/src/id/shinigami/build.gradle
+++ b/src/id/shinigami/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Shinigami'
     extClass = '.Shinigami'
     themePkg = 'madara'
-    baseUrl = 'https://shinigami02.com'
-    overrideVersionCode = 24
+    baseUrl = 'https://shinigami03.com'
+    overrideVersionCode = 25
     isNsfw = false
 }
 


### PR DESCRIPTION
Closes #4142 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
