### PR TITLE
mangago add scanlator / remove suffix from titles

### DIFF
--- a/src/en/mangago/build.gradle
+++ b/src/en/mangago/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Mangago'
     extClass = '.Mangago'
-    extVersionCode = 15
+    extVersionCode = 16
     isNsfw = true
 }
 

--- a/src/en/mangago/src/eu/kanade/tachiyomi/extension/en/mangago/Mangago.kt
+++ b/src/en/mangago/src/eu/kanade/tachiyomi/extension/en/mangago/Mangago.kt
@@ -163,7 +163,7 @@ class Mangago : ParsedHttpSource(), ConfigurableSource {
     override fun searchMangaNextPageSelector() = genreListingNextPageSelector
 
     private val titleRegex = Regex("""\(yaoi\)|\{Official\}|«Official»|〘Official〙|\(Official\)|\s\[Official]|\s「Official」|『Official』|\s?/Official\b""", RegexOption.IGNORE_CASE)
-    private fun titleVersion(title: String) = title.replace(titleRegex, "").substringBeforeLast("(").trim()
+    private fun titleVersion(title: String) = title.replace(titleRegex, "").trim()
 
     override fun mangaDetailsParse(document: Document) = SManga.create().apply {
         title = document.selectFirst(".w-title h1")!!.text()

--- a/src/en/mangago/src/eu/kanade/tachiyomi/extension/en/mangago/Mangago.kt
+++ b/src/en/mangago/src/eu/kanade/tachiyomi/extension/en/mangago/Mangago.kt
@@ -171,11 +171,9 @@ class Mangago : ParsedHttpSource(), ConfigurableSource {
         }
         document.getElementById("information")!!.let {
             thumbnail_url = it.selectFirst("img")!!.attr("abs:src")
-            description = buildString {
-                it.selectFirst(".manga_summary")?.let { summary ->
-                    summary.selectFirst("font")?.remove()
-                    append(summary.text())
-                }
+            description = it.selectFirst(".manga_summary")?.let { summary ->
+                summary.selectFirst("font")?.remove()
+                summary.text()
             }
             it.select(".manga_info li, .manga_right tr").forEach { el ->
                 when (el.selectFirst("b, label")!!.text().lowercase()) {

--- a/src/en/mangago/src/eu/kanade/tachiyomi/extension/en/mangago/Mangago.kt
+++ b/src/en/mangago/src/eu/kanade/tachiyomi/extension/en/mangago/Mangago.kt
@@ -1,13 +1,18 @@
 package eu.kanade.tachiyomi.extension.en.mangago
 
+import android.app.Application
+import android.content.SharedPreferences
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.graphics.Rect
 import android.util.Base64
+import androidx.preference.PreferenceScreen
+import androidx.preference.SwitchPreferenceCompat
 import app.cash.quickjs.QuickJs
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.Page
@@ -22,6 +27,8 @@ import okhttp3.Request
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.net.URLEncoder
@@ -31,7 +38,7 @@ import javax.crypto.Cipher
 import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.SecretKeySpec
 
-class Mangago : ParsedHttpSource() {
+class Mangago : ParsedHttpSource(), ConfigurableSource {
 
     override val name = "Mangago"
 
@@ -40,6 +47,10 @@ class Mangago : ParsedHttpSource() {
     override val lang = "en"
 
     override val supportsLatest = true
+
+    private val preferences: SharedPreferences by lazy {
+        Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
+    }
 
     override val client = network.cloudflareClient.newBuilder()
         .rateLimit(1, 2)
@@ -151,17 +162,22 @@ class Mangago : ParsedHttpSource() {
 
     override fun searchMangaNextPageSelector() = genreListingNextPageSelector
 
-    private val descriptionRegex = Regex("""The following content is intended for mature audiences and may contain sexual themes, gore, violence and/or strong language\. Discretion is advised\.""")
-    private fun cleanDescription(description: String) = description.replace(descriptionRegex, "").trim()
-
-    private val titleRegex = Regex("""\(yaoi\)|\{Official\}|«Official»|〘Official〙|\(Official\)|\s\[Official]|\s「Official」|『Official』|\s?/Official\b""")
-    private fun cleanTitle(title: String) = title.replace(titleRegex, "").substringBeforeLast("(").trim()
+    private val titleRegex = Regex("""\(yaoi\)|\{Official\}|«Official»|〘Official〙|\(Official\)|\s\[Official]|\s「Official」|『Official』|\s?/Official\b""", RegexOption.IGNORE_CASE)
+    private fun titleVersion(title: String) = title.replace(titleRegex, "").substringBeforeLast("(").trim()
 
     override fun mangaDetailsParse(document: Document) = SManga.create().apply {
-        title = cleanTitle(document.select(".w-title h1").text())
+        if (isRemoveTitleVersion()) {
+            title = titleVersion(document.select(".w-title h1").text())
+        }
         document.getElementById("information")!!.let {
             thumbnail_url = it.selectFirst("img")!!.attr("abs:src")
-            description = cleanDescription(it.selectFirst(".manga_summary")!!.text())
+            // description = it.selectFirst(".manga_summary")!!.text()
+            description = buildString {
+                it.selectFirst(".manga_summary")?.let { summary ->
+                    summary.selectFirst("font")?.remove()
+                    append(summary.text())
+                }
+            }
             it.select(".manga_info li, .manga_right tr").forEach { el ->
                 when (el.selectFirst("b, label")!!.text().lowercase()) {
                     "alternative:" -> description += "\n\n${el.text()}"
@@ -190,7 +206,7 @@ class Mangago : ParsedHttpSource() {
         }.getOrNull() ?: 0L
         scanlator = element.selectFirst("td.no a, td.uk-table-shrink a")?.text()?.trim()
         if (scanlator.isNullOrBlank()) {
-            scanlator = "Mangago" // Or any name you prefer
+            scanlator = "Unknown"
         }
     }
 
@@ -481,5 +497,21 @@ class Mangago : ParsedHttpSource() {
                 "?",
             )
         }
+    }
+    private fun isRemoveTitleVersion() = preferences.getBoolean(REMOVE_TITLE_VERSION_PREF, false)
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        SwitchPreferenceCompat(screen.context).apply {
+            key = REMOVE_TITLE_VERSION_PREF
+            title = "Remove version information from entry titles"
+            summary = "This removes version tags like “(Official)” or “(Yaoi)” from entry titles " +
+                "and helps identify duplicate entries in your library. " +
+                "To update existing entries, remove them from your library (unfavorite) and refresh manually. " +
+                "You might also want to clear the database in advanced settings."
+            setDefaultValue(false)
+        }.let(screen::addPreference)
+    }
+    companion object {
+        private const val REMOVE_TITLE_VERSION_PREF = "REMOVE_TITLE_VERSION"
     }
 }

--- a/src/en/mangago/src/eu/kanade/tachiyomi/extension/en/mangago/Mangago.kt
+++ b/src/en/mangago/src/eu/kanade/tachiyomi/extension/en/mangago/Mangago.kt
@@ -171,7 +171,6 @@ class Mangago : ParsedHttpSource(), ConfigurableSource {
         }
         document.getElementById("information")!!.let {
             thumbnail_url = it.selectFirst("img")!!.attr("abs:src")
-            // description = it.selectFirst(".manga_summary")!!.text()
             description = buildString {
                 it.selectFirst(".manga_summary")?.let { summary ->
                     summary.selectFirst("font")?.remove()

--- a/src/en/mangago/src/eu/kanade/tachiyomi/extension/en/mangago/Mangago.kt
+++ b/src/en/mangago/src/eu/kanade/tachiyomi/extension/en/mangago/Mangago.kt
@@ -503,7 +503,7 @@ class Mangago : ParsedHttpSource(), ConfigurableSource {
         SwitchPreferenceCompat(screen.context).apply {
             key = REMOVE_TITLE_VERSION_PREF
             title = "Remove version information from entry titles"
-            summary = "This removes version tags like “(Official)” or “(Yaoi)” from entry titles " +
+            summary = "This removes version tags like '(Official)' or '(Yaoi)' from entry titles " +
                 "and helps identify duplicate entries in your library. " +
                 "To update existing entries, remove them from your library (unfavorite) and refresh manually. " +
                 "You might also want to clear the database in advanced settings."

--- a/src/en/mangago/src/eu/kanade/tachiyomi/extension/en/mangago/Mangago.kt
+++ b/src/en/mangago/src/eu/kanade/tachiyomi/extension/en/mangago/Mangago.kt
@@ -166,8 +166,9 @@ class Mangago : ParsedHttpSource(), ConfigurableSource {
     private fun titleVersion(title: String) = title.replace(titleRegex, "").substringBeforeLast("(").trim()
 
     override fun mangaDetailsParse(document: Document) = SManga.create().apply {
+        title = document.selectFirst(".w-title h1")!!.text()
         if (isRemoveTitleVersion()) {
-            title = titleVersion(document.select(".w-title h1").text())
+            title = titleVersion(title)
         }
         document.getElementById("information")!!.let {
             thumbnail_url = it.selectFirst("img")!!.attr("abs:src")


### PR DESCRIPTION
closes #3967 (wasn't able to actually do one of the requests which is removing the author from the titles)
closes #3702

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
