### PR TITLE
webnovel: fix relative date parsing

### DIFF
--- a/src/en/webnovel/build.gradle
+++ b/src/en/webnovel/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'WebNovel'
     extClass = '.WebNovel'
-    extVersionCode = 10
+    extVersionCode = 11
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/webnovel/src/eu/kanade/tachiyomi/extension/en/webnovel/WebNovel.kt
+++ b/src/en/webnovel/src/eu/kanade/tachiyomi/extension/en/webnovel/WebNovel.kt
@@ -162,15 +162,13 @@ class WebNovel : HttpSource() {
         }
             .getOrDefault(emptyMap())
 
-        val updateTimes = chapters.map { accurateUpdateTimes[it.id] ?: it.publishTime.toDate() }
-
         // You can pay to get some chapter earlier than others. This privilege is divided into some tiers
         // We check if user's tier same or more than chapter's.
         val filteredChapters = chapters.filter { it.userLevel >= it.chapterLevel }
 
         // When new privileged chapter is released oldest privileged chapter becomes normal one (in most cases)
         // but since those normal chapter retain the original upload time we improvise. (This isn't optimal but meh)
-        return filteredChapters.zip(updateTimes) { chapter, updateTime ->
+        return filteredChapters.map { chapter ->
             val namePrefix = when {
                 chapter.isPremium && !chapter.isAccessibleByUser -> "\uD83D\uDD12 "
                 else -> ""
@@ -178,7 +176,7 @@ class WebNovel : HttpSource() {
             SChapter.create().apply {
                 name = namePrefix + chapter.name
                 url = "${comic.id}:${chapter.id}"
-                date_upload = updateTime
+                date_upload = accurateUpdateTimes[comic.id] ?: chapter.publishTime.toDate()
             }
         }.toList()
     }
@@ -193,11 +191,11 @@ class WebNovel : HttpSource() {
 
         val number = DIGIT_REGEX.find(this)?.value?.toIntOrNull() ?: return 0
         val field = when {
-            contains("yr") -> Calendar.YEAR
-            contains("mth") -> Calendar.MONTH
-            contains("d") -> Calendar.DAY_OF_MONTH
-            contains("h") -> Calendar.HOUR
-            contains("min") -> Calendar.MINUTE
+            contains("year") -> Calendar.YEAR
+            contains("month") -> Calendar.MONTH
+            contains("day") -> Calendar.DAY_OF_MONTH
+            contains("hour") -> Calendar.HOUR
+            contains("minute") -> Calendar.MINUTE
             else -> return 0
         }
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
