### PR TITLE
MANGARAW+: update domain

### DIFF
--- a/src/ja/mangarawplus/build.gradle
+++ b/src/ja/mangarawplus/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'MANGARAW+'
     extClass = '.MangaRawPlus'
     themePkg = 'madara'
-    baseUrl = 'https://mangarawpedia.com'
-    overrideVersionCode = 4
+    baseUrl = 'https://mangafenxi.net'
+    overrideVersionCode = 5
     isNsfw = true
 }
 

--- a/src/ja/mangarawplus/src/eu/kanade/tachiyomi/extension/ja/mangarawplus/MangaRawPlus.kt
+++ b/src/ja/mangarawplus/src/eu/kanade/tachiyomi/extension/ja/mangarawplus/MangaRawPlus.kt
@@ -1,14 +1,43 @@
 package eu.kanade.tachiyomi.extension.ja.mangarawplus
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SManga
+import okhttp3.Request
 import org.jsoup.nodes.Element
 
-class MangaRawPlus : Madara("MANGARAW+", "https://mangarawpedia.com", "ja") {
+class MangaRawPlus : Madara("MANGARAW+", "https://mangafenxi.net", "ja") {
+    override fun popularMangaSelector() = searchMangaSelector()
+
+    override fun popularMangaRequest(page: Int) =
+        GET("$baseUrl/?s&post_type=wp-manga&m_orderby=views", headers)
+
+    override fun latestUpdatesSelector() = searchMangaSelector()
+
+    override fun latestUpdatesRequest(page: Int) =
+        GET("$baseUrl/?s&post_type=wp-manga&m_orderby=latest", headers)
+
+    override fun popularMangaFromElement(element: Element): SManga {
+        return super.popularMangaFromElement(element).apply {
+            thumbnail_url = thumbnail_url?.replaceFirst("-193x278", "")
+        }
+    }
+
     override fun imageFromElement(element: Element): String? {
         return when {
             element.hasAttr("data-src-img") -> element.absUrl("data-src-img")
             else -> super.imageFromElement(element)
         }
     }
+
+    override fun imageRequest(page: Page): Request {
+        val imgHeaders = headersBuilder().apply {
+            removeAll("Referer")
+        }.build()
+        return GET(page.imageUrl!!, imgHeaders)
+    }
+
+    override val useLoadMoreRequest = LoadMoreStrategy.Never
     override val useNewChapterEndpoint = false
 }


### PR DESCRIPTION
Cover images are broken on the site, fixing this by requesting the full res cover instead.

Closes #4232

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
