### PR TITLE
Asura: add type to genres

### DIFF
--- a/src/en/asurascans/build.gradle
+++ b/src/en/asurascans/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Asura Scans'
     extClass = '.AsuraScans'
-    extVersionCode = 37
+    extVersionCode = 38
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScans.kt
+++ b/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScans.kt
@@ -205,7 +205,12 @@ class AsuraScans : ParsedHttpSource(), ConfigurableSource {
         description = document.selectFirst("span.font-medium.text-sm")?.text()
         author = document.selectFirst("div.grid > div:has(h3:eq(0):containsOwn(Author)) > h3:eq(1)")?.ownText()
         artist = document.selectFirst("div.grid > div:has(h3:eq(0):containsOwn(Artist)) > h3:eq(1)")?.ownText()
-        genre = document.select("div[class^=space] > div.flex > button.text-white").joinToString { it.ownText() }
+        genre = buildList {
+            document.selectFirst("div.flex:has(h3:eq(0):containsOwn(type)) > h3:eq(1)")
+                ?.ownText()?.let(::add)
+            document.select("div[class^=space] > div.flex > button.text-white")
+                .forEach { add(it.ownText()) }
+        }.joinToString()
         status = parseStatus(document.selectFirst("div.flex:has(h3:eq(0):containsOwn(Status)) > h3:eq(1)")?.ownText())
     }
 


### PR DESCRIPTION
For forks that support auto webtoon mode

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
