### PR TITLE
ManhwaHentai.me: Fix Search

### DIFF
--- a/src/en/manhwahentaime/build.gradle
+++ b/src/en/manhwahentaime/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ManhwahentaiMe'
     themePkg = 'madara'
     baseUrl = 'https://manhwahentai.me'
-    overrideVersionCode = 4
+    overrideVersionCode = 5
     isNsfw = true
 }
 

--- a/src/en/manhwahentaime/src/eu/kanade/tachiyomi/extension/en/manhwahentaime/ManhwahentaiMe.kt
+++ b/src/en/manhwahentaime/src/eu/kanade/tachiyomi/extension/en/manhwahentaime/ManhwahentaiMe.kt
@@ -32,4 +32,5 @@ class ManhwahentaiMe : Madara("Manhwahentai.me", "https://manhwahentai.me", "en"
 
         return chapterElements.map(::chapterFromElement)
     }
+    override fun searchMangaSelector() = "div.page-item-detail"
 }


### PR DESCRIPTION
Closes #4259

Checklist:
- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
