### PR TITLE
Madokami: use relative chapter urls

### DIFF
--- a/src/en/madokami/build.gradle
+++ b/src/en/madokami/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Madokami'
     extClass = '.Madokami'
-    extVersionCode = 8
+    extVersionCode = 9
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
+++ b/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
@@ -137,7 +137,8 @@ class Madokami : ConfigurableSource, ParsedHttpSource() {
     override fun chapterFromElement(element: Element): SChapter {
         val el = element.parent()!!.parent()!!
         val chapter = SChapter.create()
-        chapter.url = el.select("td:nth-child(6) a").attr("href")
+        chapter.url = "/reader" + el.select("td:nth-child(6) a").attr("href")
+            .substringAfter("/reader")
         chapter.name = el.select("td:nth-child(1) a").text()
         val date = el.select("td:nth-child(3)").text()
         if (date.endsWith("ago")) {
@@ -162,7 +163,10 @@ class Madokami : ConfigurableSource, ParsedHttpSource() {
         return chapter
     }
 
-    override fun pageListRequest(chapter: SChapter) = authenticate(GET(chapter.url, headers))
+    override fun pageListRequest(chapter: SChapter): Request {
+        require(chapter.url.startsWith("/")) { "Refresh chapter list" }
+        return authenticate(GET(baseUrl + chapter.url, headers))
+    }
 
     override fun pageListParse(document: Document): List<Page> {
         val element = document.select("div#reader")


### PR DESCRIPTION
Closes #4360

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
