### PR TITLE
Comick: attempt cache busting

### DIFF
--- a/src/all/comickfun/build.gradle
+++ b/src/all/comickfun/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comick'
     extClass = '.ComickFactory'
-    extVersionCode = 46
+    extVersionCode = 47
     isNsfw = true
 }
 

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
@@ -463,7 +463,16 @@ abstract class Comick(
 
     override fun pageListParse(response: Response): List<Page> {
         val result = response.parseAs<PageList>()
-        return result.chapter.images.mapIndexedNotNull { index, data ->
+        val images = result.chapter.images.ifEmpty {
+            // cache busting
+            val url = response.request.url.newBuilder()
+                .addQueryParameter("_", System.currentTimeMillis().toString())
+                .build()
+
+            client.newCall(GET(url, headers)).execute()
+                .parseAs<PageList>().chapter.images
+        }
+        return images.mapIndexedNotNull { index, data ->
             if (data.url == null) null else Page(index = index, imageUrl = data.url)
         }
     }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
