### PR TITLE
PussyToons: fix duplicate entries

### DIFF
--- a/src/pt/pussytoons/build.gradle
+++ b/src/pt/pussytoons/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.PussyToons'
     themePkg = 'madara'
     baseUrl = 'https://pussy.sussytoons.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/pt/pussytoons/src/eu/kanade/tachiyomi/extension/pt/pussytoons/PussyToons.kt
+++ b/src/pt/pussytoons/src/eu/kanade/tachiyomi/extension/pt/pussytoons/PussyToons.kt
@@ -12,4 +12,6 @@ class PussyToons : Madara(
 ) {
     override val useLoadMoreRequest = LoadMoreStrategy.Never
     override val useNewChapterEndpoint = true
+
+    override fun popularMangaSelector() = ".main-col-inner div.page-item-detail"
 }


### PR DESCRIPTION
Closes #4413

The default selector included entries from some unrelated widget, guarding this with `.main-col-inner`.

Site's CSS is also hiding the last 2 entries for each page. Other parts of the site indicate that those entries should be there, so I haven't excluded them in this PR.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
