### PR TITLE
MangaTop -> MangaScans: update domain

### DIFF
--- a/src/en/mangatop/build.gradle
+++ b/src/en/mangatop/build.gradle
@@ -1,7 +1,7 @@
 ext {
-    extName = 'MangaTop'
-    extClass = '.MangaTop'
-    extVersionCode = 1
+    extName = 'MangaScans'
+    extClass = '.MangaScans'
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/en/mangatop/src/eu/kanade/tachiyomi/extension/en/mangatop/MangaScans.kt
+++ b/src/en/mangatop/src/eu/kanade/tachiyomi/extension/en/mangatop/MangaScans.kt
@@ -28,15 +28,17 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
 
-class MangaTop : ParsedHttpSource() {
+class MangaScans : ParsedHttpSource() {
 
-    override val name = "MangaTop"
+    override val name = "MangaScans"
 
-    override val baseUrl = "https://mangatop.to"
+    override val baseUrl = "https://mangascans.to"
 
     override val lang = "en"
 
     override val supportsLatest = true
+
+    override val id = 85127596998931837
 
     override val client = network.cloudflareClient.newBuilder()
         .addInterceptor(::tokenInterceptor)


### PR DESCRIPTION
closes  #4445

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
