### PR TITLE
Utoon: filter paid chapters

### DIFF
--- a/src/en/utoon/build.gradle
+++ b/src/en/utoon/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Utoon'
     themePkg = 'madara'
     baseUrl = 'https://utoon.net'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/utoon/src/eu/kanade/tachiyomi/extension/en/utoon/Utoon.kt
+++ b/src/en/utoon/src/eu/kanade/tachiyomi/extension/en/utoon/Utoon.kt
@@ -17,6 +17,8 @@ class Utoon : Madara(
 
     override val useLoadMoreRequest = LoadMoreStrategy.Always
 
+    override fun chapterListSelector() = "li.wp-manga-chapter:not(.premium-block)"
+
     override val chapterUrlSelector = "div > a"
 
     override fun chapterFromElement(element: Element): SChapter {


### PR DESCRIPTION
closes #4428

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
