### PR TITLE
komiktap: correct image mime type

### DIFF
--- a/src/id/komiktap/build.gradle
+++ b/src/id/komiktap/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Komiktap'
     themePkg = 'mangathemesia'
     baseUrl = 'https://komiktap.info'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
     isNsfw = true
 }
 


### PR DESCRIPTION
closes #4425

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
