### PR TITLE
ManyToons: fix chapter list & search

### DIFF
--- a/src/en/manytoon/build.gradle
+++ b/src/en/manytoon/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ManyToon'
     themePkg = 'madara'
     baseUrl = 'https://manytoon.com'
-    overrideVersionCode = 5
+    overrideVersionCode = 6
     isNsfw = true
 }
 

--- a/src/en/manytoon/src/eu/kanade/tachiyomi/extension/en/manytoon/ManyToon.kt
+++ b/src/en/manytoon/src/eu/kanade/tachiyomi/extension/en/manytoon/ManyToon.kt
@@ -1,10 +1,35 @@
 package eu.kanade.tachiyomi.extension.en.manytoon
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.source.model.SManga
+import okhttp3.FormBody
+import okhttp3.Request
+import org.jsoup.nodes.Element
 
 class ManyToon : Madara("ManyToon", "https://manytoon.com", "en") {
 
     override val mangaSubString = "comic"
 
-    override val useNewChapterEndpoint: Boolean = true
+    override val useNewChapterEndpoint = false
+    override val sendViewCount = false
+    override val fetchGenres = false
+
+    override fun searchMangaSelector() = "li.movie-item > a"
+
+    override fun searchMangaFromElement(element: Element): SManga {
+        return SManga.create().apply {
+            setUrlWithoutDomain(element.absUrl("href"))
+            title = element.attr("title")
+        }
+    }
+
+    override fun oldXhrChaptersRequest(mangaId: String): Request {
+        val form = FormBody.Builder()
+            .add("action", "ajax_chap")
+            .add("post_id", mangaId)
+            .build()
+
+        return POST("$baseUrl/wp-admin/admin-ajax.php", xhrHeaders, form)
+    }
 }


### PR DESCRIPTION
closes #4177

there are no covers on search

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
