### PR TITLE
MangaClick -> MangaHall: update domain

### DIFF
--- a/src/en/mangaclick/build.gradle
+++ b/src/en/mangaclick/build.gradle
@@ -1,9 +1,9 @@
 ext {
-    extName = 'MangaClick'
-    extClass = '.MangaClick'
+    extName = 'MangaHall'
+    extClass = '.MangaHall'
     themePkg = 'madara'
-    baseUrl = 'https://mangaclick.org'
-    overrideVersionCode = 0
+    baseUrl = 'https://mangahall.org'
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/en/mangaclick/src/eu/kanade/tachiyomi/extension/en/mangaclick/MangaHall.kt
+++ b/src/en/mangaclick/src/eu/kanade/tachiyomi/extension/en/mangaclick/MangaHall.kt
@@ -2,11 +2,12 @@ package eu.kanade.tachiyomi.extension.en.mangaclick
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 
-class MangaClick : Madara(
-    "MangaClick",
-    "https://mangaclick.org",
+class MangaHall : Madara(
+    "MangaHall",
+    "https://mangahall.org",
     "en",
 ) {
+    override val id = 1234573178818746503
     override val useLoadMoreRequest = LoadMoreStrategy.Always
     override val useNewChapterEndpoint = false
 }


### PR DESCRIPTION
closes #4466

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
