### PR TITLE
RocksManga: fix selectors and domain

### DIFF
--- a/src/ar/rocksmanga/build.gradle
+++ b/src/ar/rocksmanga/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Rocks Manga'
     extClass = '.RocksManga'
     themePkg = 'madara'
-    baseUrl = 'https://rocks-manga.com'
-    overrideVersionCode = 0
+    baseUrl = 'https://rocksmanga.com'
+    overrideVersionCode = 1
     isNsfw = false
 }
 

--- a/src/ar/rocksmanga/src/eu/kanade/tachiyomi/extension/ar/rocksmanga/RocksManga.kt
+++ b/src/ar/rocksmanga/src/eu/kanade/tachiyomi/extension/ar/rocksmanga/RocksManga.kt
@@ -2,39 +2,65 @@ package eu.kanade.tachiyomi.extension.ar.rocksmanga
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
 
 class RocksManga : Madara(
     "Rocks Manga",
-    "https://rocks-manga.com",
+    "https://rocksmanga.com",
     "ar",
     dateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("ar")),
 ) {
 
-    override fun popularMangaSelector() = ".shido-manga"
-    override val popularMangaUrlSelector = "a.s-manga-title"
-    override val mangaDetailsSelectorTitle = ".title"
-    override val mangaDetailsSelectorAuthor = ".heading:contains(المؤلف:) + .content a"
-    override val mangaDetailsSelectorArtist = ".heading:contains(الرسام:) + .content a"
+    override fun popularMangaSelector() = "div.page-content-listing > .manga"
+    override val popularMangaUrlSelector = "div.manga-poster a"
+
+    override fun popularMangaFromElement(element: Element): SManga {
+        return super.popularMangaFromElement(element).apply {
+            title = element.selectFirst(popularMangaUrlSelector)!!.attr("title")
+        }
+    }
+
+    override fun searchMangaSelector() = "#manga-search-results .manga-item"
+
+    override fun searchMangaFromElement(element: Element): SManga {
+        val manga = SManga.create()
+
+        with(element) {
+            selectFirst("a.cover")!!.let {
+                manga.setUrlWithoutDomain(it.attr("abs:href"))
+                manga.title = it.attr("title")
+            }
+            selectFirst("img")?.let {
+                manga.thumbnail_url = imageFromElement(it)
+            }
+        }
+
+        return manga
+    }
+
+    override val mangaDetailsSelectorTitle = ".manga-title"
+    override val mangaDetailsSelectorAuthor = "div.meta span:contains(المؤلف:) + span a"
+    override val mangaDetailsSelectorArtist = "div.meta span:contains(الرسام:) + span a"
     override val mangaDetailsSelectorStatus = ".status"
-    override val mangaDetailsSelectorDescription = ".story"
-    override val mangaDetailsSelectorThumbnail = ".profile-manga .poster img"
-    override val mangaDetailsSelectorGenre = ".heading:contains(التصنيف:) + .content a"
-    override val altNameSelector = ".other-name"
-    override fun chapterListSelector() = "#chapter-list li.chapter-item"
-    override fun chapterDateSelector() = ".ch-post-time"
-    override val pageListParseSelector = ".reading-content img"
+    override val mangaDetailsSelectorDescription = "div.description"
+    override val mangaDetailsSelectorThumbnail = ".manga-poster img"
+    override val mangaDetailsSelectorGenre = "div.meta span:contains(التصنيف:) + span a"
+    override val altNameSelector = "div.alternative"
+    override fun chapterListSelector() = ".chapters-list li.chapter-item"
+    override fun chapterDateSelector() = ".chapter-release-date"
+    override val pageListParseSelector = ".chapter-reading-page img"
 
     override val useLoadMoreRequest = LoadMoreStrategy.Never
     override val useNewChapterEndpoint = false
-
+    override val fetchGenres = false
     override val filterNonMangaItems = false
 
     override fun chapterFromElement(element: Element): SChapter {
         val chapter = super.chapterFromElement(element)
-        chapter.name = element.selectFirst(".detail-ch")!!.text()
+        chapter.name = element.selectFirst(".num")!!.text()
         return chapter
     }
 }


### PR DESCRIPTION
closes #4117

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
