### PR TITLE
miaoshang -> miaoqu (unoriginal): update domain

### DIFF
--- a/src/zh/miaoshang/build.gradle
+++ b/src/zh/miaoshang/build.gradle
@@ -1,9 +1,9 @@
 ext {
-    extName = 'Miaoshang Manhua'
-    extClass = '.Miaoshang'
+    extName = 'Miaoqu Manhua'
+    extClass = '.Miaoqu'
     themePkg = 'mccms'
-    baseUrl = 'https://www.miaoshangmanhua.com'
-    overrideVersionCode = 1
+    baseUrl = 'https://www.miaoqumh.com'
+    overrideVersionCode = 2
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/zh/miaoshang/src/eu/kanade/tachiyomi/extension/zh/miaoshang/Miaoqu.kt
+++ b/src/zh/miaoshang/src/eu/kanade/tachiyomi/extension/zh/miaoshang/Miaoqu.kt
@@ -10,14 +10,16 @@ import okhttp3.Response
 import org.jsoup.Jsoup
 
 class Miaoshang : MCCMS(
-    "喵上漫画",
-    "https://www.miaoshangmanhua.com",
+    "喵趣漫画",
+    "https://www.miaoqumh.com",
     "zh",
-    MiaoshangMCCMSConfig(),
+    MiaoquMCCMSConfig(),
 ) {
     override val client = network.cloudflareClient.newBuilder()
         .rateLimitHost(baseUrl.toHttpUrl(), 2)
         .build()
+
+    override val id = 589887691505478724
 
     private class MiaoshangMCCMSConfig : MCCMSConfig(
         textSearchOnlyPageOne = true,

--- a/src/zh/miaoshang/src/eu/kanade/tachiyomi/extension/zh/miaoshang/Miaoqu.kt
+++ b/src/zh/miaoshang/src/eu/kanade/tachiyomi/extension/zh/miaoshang/Miaoqu.kt
@@ -21,7 +21,7 @@ class Miaoqu : MCCMS(
 
     override val id = 589887691505478724
 
-    private class MiaoshangMCCMSConfig : MCCMSConfig(
+    private class MiaoquMCCMSConfig : MCCMSConfig(
         textSearchOnlyPageOne = true,
         lazyLoadImageAttr = "data-src",
     ) {

--- a/src/zh/miaoshang/src/eu/kanade/tachiyomi/extension/zh/miaoshang/Miaoqu.kt
+++ b/src/zh/miaoshang/src/eu/kanade/tachiyomi/extension/zh/miaoshang/Miaoqu.kt
@@ -9,7 +9,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Response
 import org.jsoup.Jsoup
 
-class Miaoshang : MCCMS(
+class Miaoqu : MCCMS(
     "喵趣漫画",
     "https://www.miaoqumh.com",
     "zh",


### PR DESCRIPTION
closes #2682 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension