### PR TITLE
BlogTruyen: update page list selector

### DIFF
--- a/lib-multisrc/blogtruyen/build.gradle.kts
+++ b/lib-multisrc/blogtruyen/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 1
+baseVersionCode = 2

--- a/lib-multisrc/blogtruyen/src/eu/kanade/tachiyomi/multisrc/blogtruyen/BlogTruyen.kt
+++ b/lib-multisrc/blogtruyen/src/eu/kanade/tachiyomi/multisrc/blogtruyen/BlogTruyen.kt
@@ -291,7 +291,7 @@ abstract class BlogTruyen(
     override fun pageListParse(document: Document): List<Page> {
         val pages = mutableListOf<Page>()
 
-        document.select("#content > img").forEachIndexed { i, e ->
+        document.select(".content > img, #content > img").forEachIndexed { i, e ->
             pages.add(Page(i, imageUrl = e.absUrl("src")))
         }
 


### PR DESCRIPTION
closes #3833

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
