### PR TITLE
Kiryuu: fix image mime

### DIFF
--- a/src/id/kiryuu/build.gradle
+++ b/src/id/kiryuu/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Kiryuu'
     themePkg = 'mangathemesia'
     baseUrl = 'https://kiryuu.org'
-    overrideVersionCode = 7
+    overrideVersionCode = 8
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/kiryuu/src/eu/kanade/tachiyomi/extension/id/kiryuu/Kiryuu.kt
+++ b/src/id/kiryuu/src/eu/kanade/tachiyomi/extension/id/kiryuu/Kiryuu.kt
@@ -2,7 +2,9 @@ package eu.kanade.tachiyomi.extension.id.kiryuu
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.jsoup.nodes.Document
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -12,6 +14,21 @@ class Kiryuu : MangaThemesia("Kiryuu", "https://kiryuu.org", "id", dateFormat = 
     override val id = 3639673976007021338
 
     override val client: OkHttpClient = super.client.newBuilder()
+        .addInterceptor { chain ->
+            val response = chain.proceed(chain.request())
+            val mime = response.headers["Content-Type"]
+            if (response.isSuccessful) {
+                if (mime != "application/octet-stream") {
+                    return@addInterceptor response
+                }
+                // Fix image content type
+                val type = IMG_CONTENT_TYPE.toMediaType()
+                val body = response.body.bytes().toResponseBody(type)
+                return@addInterceptor response.newBuilder().body(body)
+                    .header("Content-Type", IMG_CONTENT_TYPE).build()
+            }
+            response
+        }
         .rateLimit(4)
         .build()
 
@@ -22,3 +39,5 @@ class Kiryuu : MangaThemesia("Kiryuu", "https://kiryuu.org", "id", dateFormat = 
 
     override val hasProjectPage = true
 }
+
+private const val IMG_CONTENT_TYPE = "image/jpeg"


### PR DESCRIPTION
closes #3756

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
