### PR TITLE
ngkomik: update domain

### DIFF
--- a/src/id/ngomik/build.gradle
+++ b/src/id/ngomik/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Ngomik'
     extClass = '.Ngomik'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://ngomik.net'
-    overrideVersionCode = 2
+    baseUrl = 'https://ngomik.mom'
+    overrideVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/ngomik/src/eu/kanade/tachiyomi/extension/id/ngomik/Ngomik.kt
+++ b/src/id/ngomik/src/eu/kanade/tachiyomi/extension/id/ngomik/Ngomik.kt
@@ -8,7 +8,7 @@ import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 
-class Ngomik : MangaThemesia("Ngomik", "https://ngomik.net", "id", "/manga") {
+class Ngomik : MangaThemesia("Ngomik", "https://ngomik.mom", "id", "/manga") {
 
     private val userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.163 Safari/537.36"
 


### PR DESCRIPTION
closes  #4338

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
