### PR TITLE
EnryuManga: update domain

### DIFF
--- a/src/en/enryumanga/build.gradle
+++ b/src/en/enryumanga/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'EnryuManga'
     extClass = '.EnryuManga'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://enryumanga.com'
-    overrideVersionCode = 0
+    baseUrl = 'https://enryumanga.net'
+    overrideVersionCode = 1
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/enryumanga/src/eu/kanade/tachiyomi/extension/en/enryumanga/EnryuManga.kt
+++ b/src/en/enryumanga/src/eu/kanade/tachiyomi/extension/en/enryumanga/EnryuManga.kt
@@ -2,4 +2,4 @@ package eu.kanade.tachiyomi.extension.en.enryumanga
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 
-class EnryuManga : MangaThemesia("EnryuManga", "https://enryumanga.com", "en")
+class EnryuManga : MangaThemesia("EnryuManga", "https://enryumanga.net", "en")


### PR DESCRIPTION
closes #1877

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
