### PR TITLE
WebDexScans: update manga url directory

### DIFF
--- a/src/en/webdexscans/build.gradle
+++ b/src/en/webdexscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.WebdexScans'
     themePkg = 'madara'
     baseUrl = 'https://webdexscans.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/webdexscans/src/eu/kanade/tachiyomi/extension/en/webdexscans/WebdexScans.kt
+++ b/src/en/webdexscans/src/eu/kanade/tachiyomi/extension/en/webdexscans/WebdexScans.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.extension.en.webdexscans
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 
 class WebdexScans : Madara("Webdex Scans", "https://webdexscans.com", "en") {
+    override val mangaSubString = "series"
     override val useNewChapterEndpoint = true
     override val mangaDetailsSelectorStatus = "div.summary-heading:contains(Status) + div.summary-content"
 }


### PR DESCRIPTION
closes  #1817

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
