### PR TITLE
ManhwaIndo: update domain & deduplicate images

### DIFF
--- a/src/id/manhwaindo/build.gradle
+++ b/src/id/manhwaindo/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'ManhwaIndo'
     extClass = '.ManhwaIndo'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://manhwaindo.id'
-    overrideVersionCode = 4
+    baseUrl = 'https://manhwaindo.net'
+    overrideVersionCode = 5
     isNsfw = true
 }
 

--- a/src/id/manhwaindo/src/eu/kanade/tachiyomi/extension/id/manhwaindo/ManhwaIndo.kt
+++ b/src/id/manhwaindo/src/eu/kanade/tachiyomi/extension/id/manhwaindo/ManhwaIndo.kt
@@ -1,17 +1,21 @@
 package eu.kanade.tachiyomi.extension.id.manhwaindo
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import okhttp3.Response
 import java.text.SimpleDateFormat
 import java.util.Locale
 
 class ManhwaIndo : MangaThemesia(
     "Manhwa Indo",
-    "https://manhwaindo.id",
+    "https://manhwaindo.net",
     "id",
     "/series",
     SimpleDateFormat("MMMM dd, yyyy", Locale.US),
 ) {
-    override val seriesTitleSelector = ".ts-breadcrumb li:last-child span"
-
     override val hasProjectPage = true
+
+    override fun pageListParse(response: Response) =
+        super.pageListParse(response).distinctBy {
+            it.imageUrl!!
+        }
 }


### PR DESCRIPTION
closes #1814

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
