### PR TITLE
ColoredManga | Increase extVersionCode to match for older versions

### DIFF
--- a/src/en/coloredmanga/build.gradle
+++ b/src/en/coloredmanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ColoredManga'
     extClass = '.ColoredManga'
-    extVersionCode = 3
+    extVersionCode = 35
     isNsfw = true
 }
 


### PR DESCRIPTION
Checklist:
- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
