### PR TITLE
MangaPro: deproxify images

### DIFF
--- a/src/ar/mangapro/build.gradle
+++ b/src/ar/mangapro/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaPro'
     themePkg = 'mangathemesia'
     baseUrl = 'https://promanga.pro'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/mangapro/src/eu/kanade/tachiyomi/extension/ar/mangapro/MangaPro.kt
+++ b/src/ar/mangapro/src/eu/kanade/tachiyomi/extension/ar/mangapro/MangaPro.kt
@@ -1,6 +1,10 @@
 package eu.kanade.tachiyomi.extension.ar.mangapro
 
+import android.util.Log
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import eu.kanade.tachiyomi.source.model.Page
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.jsoup.nodes.Document
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -11,4 +15,32 @@ class MangaPro : MangaThemesia(
     dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("ar")),
 ) {
     override val versionId = 3
+
+    override fun pageListParse(document: Document): List<Page> {
+        return super.pageListParse(document).onEach {
+            Log.d(name, it.imageUrl.toString())
+            val httpUrl = it.imageUrl!!.toHttpUrl()
+
+            if (wpImgRegex.containsMatchIn(httpUrl.host)) {
+                it.imageUrl = StringBuilder().apply {
+                    val ssl = httpUrl.queryParameter("ssl")
+                    when (ssl) {
+                        null -> append(httpUrl.scheme)
+                        "0" -> append("http")
+                        else -> append("https")
+                    }
+                    append("://")
+                    append(httpUrl.pathSegments.joinToString("/"))
+                    val search = httpUrl.queryParameter("q")
+                    if (search != null) {
+                        append("?q=")
+                        append(search)
+                    }
+                }.toString()
+            }
+            Log.d(name, it.imageUrl.toString())
+        }
+    }
 }
+
+private val wpImgRegex = Regex("""i\d+\.wp\.com""")

--- a/src/ar/mangapro/src/eu/kanade/tachiyomi/extension/ar/mangapro/MangaPro.kt
+++ b/src/ar/mangapro/src/eu/kanade/tachiyomi/extension/ar/mangapro/MangaPro.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.extension.ar.mangapro
 
-import android.util.Log
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import eu.kanade.tachiyomi.source.model.Page
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -18,7 +17,6 @@ class MangaPro : MangaThemesia(
 
     override fun pageListParse(document: Document): List<Page> {
         return super.pageListParse(document).onEach {
-            Log.d(name, it.imageUrl.toString())
             val httpUrl = it.imageUrl!!.toHttpUrl()
 
             if (wpImgRegex.containsMatchIn(httpUrl.host)) {
@@ -38,7 +36,6 @@ class MangaPro : MangaThemesia(
                     }
                 }.toString()
             }
-            Log.d(name, it.imageUrl.toString())
         }
     }
 }


### PR DESCRIPTION
closes #4517

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
