### PR TITLE
HentaiManga: fix chapter list & search

### DIFF
--- a/src/en/hentaimanga/build.gradle
+++ b/src/en/hentaimanga/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.HentaiManga'
     themePkg = 'madara'
     baseUrl = 'https://hentaimanga.me'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/en/hentaimanga/src/eu/kanade/tachiyomi/extension/en/hentaimanga/HentaiManga.kt
+++ b/src/en/hentaimanga/src/eu/kanade/tachiyomi/extension/en/hentaimanga/HentaiManga.kt
@@ -1,6 +1,11 @@
 package eu.kanade.tachiyomi.extension.en.hentaimanga
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.source.model.SManga
+import okhttp3.FormBody
+import okhttp3.Request
+import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -13,4 +18,28 @@ class HentaiManga : Madara(
 
     // The website does not flag the content.
     override val filterNonMangaItems = false
+    override val useNewChapterEndpoint = false
+    override val sendViewCount = false
+    override val fetchGenres = false
+    override val useLoadMoreRequest = LoadMoreStrategy.Never
+
+    override fun popularMangaNextPageSelector() = "a.next"
+    override fun searchMangaSelector() = "li.movie-item > a"
+    override fun searchMangaNextPageSelector() = "a.next"
+
+    override fun searchMangaFromElement(element: Element): SManga {
+        return SManga.create().apply {
+            setUrlWithoutDomain(element.absUrl("href"))
+            title = element.attr("title")
+        }
+    }
+
+    override fun oldXhrChaptersRequest(mangaId: String): Request {
+        val form = FormBody.Builder()
+            .add("action", "ajax_chap")
+            .add("post_id", mangaId)
+            .build()
+
+        return POST("$baseUrl/wp-admin/admin-ajax.php", xhrHeaders, form)
+    }
 }


### PR DESCRIPTION
closes #4522

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
