### PR TITLE
HentaiWebtoon: fix chapter list & search

### DIFF
--- a/src/en/hentaiwebtoon/build.gradle
+++ b/src/en/hentaiwebtoon/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.HentaiWebtoon'
     themePkg = 'madara'
     baseUrl = 'https://hentaiwebtoon.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/en/hentaiwebtoon/src/eu/kanade/tachiyomi/extension/en/hentaiwebtoon/HentaiWebtoon.kt
+++ b/src/en/hentaiwebtoon/src/eu/kanade/tachiyomi/extension/en/hentaiwebtoon/HentaiWebtoon.kt
@@ -1,9 +1,43 @@
 package eu.kanade.tachiyomi.extension.en.hentaiwebtoon
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.source.model.SManga
+import okhttp3.FormBody
+import okhttp3.Request
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
 
 class HentaiWebtoon : Madara("HentaiWebtoon", "https://hentaiwebtoon.com", "en") {
 
     // The website does not flag the content.
     override val filterNonMangaItems = false
+    override val useNewChapterEndpoint = false
+    override val sendViewCount = false
+    override val fetchGenres = false
+    override val useLoadMoreRequest = LoadMoreStrategy.Never
+
+    override fun popularMangaNextPageSelector() = "a.next"
+    override fun searchMangaSelector() = "li.movie-item > a"
+    override fun searchMangaNextPageSelector() = "a.next"
+
+    override fun searchMangaFromElement(element: Element): SManga {
+        return SManga.create().apply {
+            setUrlWithoutDomain(element.absUrl("href"))
+            title = element.attr("title")
+        }
+    }
+
+    override fun oldXhrChaptersRequest(mangaId: String): Request {
+        val form = FormBody.Builder()
+            .add("action", "ajax_chap")
+            .add("post_id", mangaId)
+            .build()
+
+        return POST("$baseUrl/wp-admin/admin-ajax.php", xhrHeaders, form)
+    }
+
+    override fun pageListParse(document: Document) = super.pageListParse(document).onEach {
+        it.imageUrl = it.imageUrl?.replace("http://", "https://")
+    }
 }


### PR DESCRIPTION
closes #4558

I am starting to see a pattern here...

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
