### PR TITLE
DiskusScan: Fix headers

### DIFF
--- a/src/pt/diskusscan/build.gradle
+++ b/src/pt/diskusscan/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.DiskusScan'
     themePkg = 'mangathemesia'
     baseUrl = 'https://diskusscan.com'
-    overrideVersionCode = 9
+    overrideVersionCode = 10
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/diskusscan/src/eu/kanade/tachiyomi/extension/pt/diskusscan/DiskusScan.kt
+++ b/src/pt/diskusscan/src/eu/kanade/tachiyomi/extension/pt/diskusscan/DiskusScan.kt
@@ -25,7 +25,8 @@ class DiskusScan : MangaThemesia(
         .build()
 
     override fun headersBuilder() = super.headersBuilder()
-        .set("Dnt", "1")
+        .set("Accept-Language", "pt-BR,en-US;q=0.7,en;q=0.3")
+        .set("Alt-Used", baseUrl.substringAfterLast("/"))
         .set("Sec-Fetch-Dest", "document")
         .set("Sec-Fetch-Mode", "navigate")
         .set("Sec-Fetch-Site", "same-origin")


### PR DESCRIPTION
Closes #4515

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
