### PR TITLE
Diskus - Fix - 510 Not Extend

### DIFF
--- a/src/pt/diskusscan/build.gradle
+++ b/src/pt/diskusscan/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.DiskusScan'
     themePkg = 'mangathemesia'
     baseUrl = 'https://diskusscan.com'
-    overrideVersionCode = 10
+    overrideVersionCode = 11
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/diskusscan/src/eu/kanade/tachiyomi/extension/pt/diskusscan/DiskusScan.kt
+++ b/src/pt/diskusscan/src/eu/kanade/tachiyomi/extension/pt/diskusscan/DiskusScan.kt
@@ -21,6 +21,13 @@ class DiskusScan : MangaThemesia(
     override val versionId = 2
 
     override val client = super.client.newBuilder()
+        .addInterceptor { chain ->
+            val request = chain.request()
+            val headers = request.headers.newBuilder()
+                .set("Accept-Encoding", "")
+                .build()
+            chain.proceed(request.newBuilder().headers(headers).build())
+        }
         .rateLimit(2, 1, TimeUnit.SECONDS)
         .build()
 


### PR DESCRIPTION
Closes #4579

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
