### PR TITLE
[Akuma] fix language filter & add a preference for show short title

### DIFF
--- a/src/all/akuma/build.gradle
+++ b/src/all/akuma/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Akuma'
     extClass = '.AkumaFactory'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
+++ b/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
@@ -116,7 +116,7 @@ class Akuma(
         Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
     }
 
-    private var displayFullTitle: Boolean = preferences.getBoolean(PREF_TITLE, true)
+    private var displayFullTitle: Boolean get() = preferences.getBoolean(PREF_TITLE, false)
 
     private val shortenTitleRegex = Regex("""(\[[^]]*]|[({][^)}]*[)}])""")
     private fun String.shortenTitle() = this.replace(shortenTitleRegex, "").trim()
@@ -125,12 +125,6 @@ class Akuma(
         SwitchPreferenceCompat(screen.context).apply {
             key = PREF_TITLE
             title = "Display manga title as full title"
-            setDefaultValue(true)
-
-            setOnPreferenceChangeListener { _, newValue ->
-                displayFullTitle = newValue == true
-                true
-            }
         }.also(screen::addPreference)
     }
 

--- a/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
+++ b/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
@@ -246,7 +246,9 @@ class Akuma(
 
     override fun mangaDetailsParse(document: Document) = with(document) {
         SManga.create().apply {
-            title = select(".entry-title").text()
+            title = select(".entry-title").text().replace("\"", "").let {
+                if (displayFullTitle) it.trim() else it.shortenTitle()
+            }
             thumbnail_url = select(".img-thumbnail").attr("abs:src")
 
             author = select(".group~.value").eachText().joinToString()

--- a/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
+++ b/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
@@ -116,7 +116,7 @@ class Akuma(
         Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
     }
 
-    private var displayFullTitle: Boolean get() = preferences.getBoolean(PREF_TITLE, false)
+    private val displayFullTitle: Boolean get() = preferences.getBoolean(PREF_TITLE, false)
 
     private val shortenTitleRegex = Regex("""(\[[^]]*]|[({][^)}]*[)}])""")
     private fun String.shortenTitle() = this.replace(shortenTitleRegex, "").trim()

--- a/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
+++ b/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
@@ -125,6 +125,7 @@ class Akuma(
         SwitchPreferenceCompat(screen.context).apply {
             key = PREF_TITLE
             title = "Display manga title as full title"
+            setDefaultValue(false)
         }.also(screen::addPreference)
     }
 

--- a/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
+++ b/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
@@ -121,7 +121,7 @@ class Akuma(
     private fun String.shortenTitle() = this.replace(shortenTitleRegex, "").trim()
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        SwitchPreference(screen.context).apply {
+        SwitchPreferenceCompat(screen.context).apply {
             key = PREF_TITLE
             title = "Display manga title as full title"
             setDefaultValue(true)

--- a/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
+++ b/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
@@ -7,6 +7,7 @@ import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
@@ -35,7 +36,7 @@ import java.util.TimeZone
 class Akuma(
     override val lang: String,
     private val akumaLang: String,
-) : ParsedHttpSource() {
+) : ConfigurableSource, ParsedHttpSource() {
 
     override val name = "Akuma"
 

--- a/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
+++ b/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
@@ -128,7 +128,7 @@ class Akuma(
             setDefaultValue(true)
 
             setOnPreferenceChangeListener { _, newValue ->
-                displayFullTitle = newValue
+                displayFullTitle = newValue == true
                 true
             }
         }.also(screen::addPreference)

--- a/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
+++ b/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
@@ -1,8 +1,8 @@
 package eu.kanade.tachiyomi.extension.all.akuma
 
 import android.app.Application
-import androidx.preference.PreferenceScreen
 import android.content.SharedPreferences
+import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST

--- a/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
+++ b/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
@@ -128,6 +128,7 @@ class Akuma(
 
             setOnPreferenceChangeListener { _, newValue ->
                 displayFullTitle = newValue
+                true
             }
         }.also(screen::addPreference)
     }

--- a/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
+++ b/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
@@ -176,7 +176,7 @@ class Akuma(
         val finalQuery: MutableList<String> = mutableListOf(query)
 
         if (lang != "all") {
-            finalQuery.add("language: $akumaLang$")
+            finalQuery.add("language:$akumaLang$")
         }
         filters.forEach { filter ->
             when (filter) {


### PR DESCRIPTION
the syntax  (e.g.) `language: english$` is an error. that is mean "title is exactly english language tag contains  ", which can be find in the website when typed this in.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
