### PR TITLE
Improve build times for local builds

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,14 @@
 # Editor configuration, see https://editorconfig.org
 root = true
 
+[*]
+insert_final_newline = true
+end_of_line = lf
+
 [*.kt]
 charset = utf-8
-end_of_line = lf
 indent_size = 4
 indent_style = space
-insert_final_newline = true
 trim_trailing_whitespace = true
 ij_kotlin_allow_trailing_comma = true
 ij_kotlin_allow_trailing_comma_on_call_site = true
@@ -15,5 +17,3 @@ ij_kotlin_name_count_to_use_star_import_for_members = 2147483647
 
 [*.properties]
 charset = utf-8
-end_of_line = lf
-insert_final_newline = true

--- a/common.gradle
+++ b/common.gradle
@@ -9,6 +9,7 @@ assert !ext.has("libVersion")
 assert extName.chars().max().asInt < 0x180 : "Extension name should be romanized"
 
 Project theme = ext.has("themePkg") ? project(":lib-multisrc:$themePkg") : null
+if (theme != null) evaluationDependsOn(theme.path)
 
 android {
     compileSdk AndroidConfig.compileSdk

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,3 +25,5 @@ android.useAndroidX=true
 android.enableBuildConfigAsBytecode=true
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
+
+org.gradle.configureondemand=true


### PR DESCRIPTION
- don't import the whole project when building a single extension
  - tried with android studio, didn't face any problem with this configuration
  - mostly useful for command line builds 
- add new line at the end with linter