### PR TITLE
NoIndexScan: Fix manga details selector

### DIFF
--- a/src/pt/noindexscan/build.gradle
+++ b/src/pt/noindexscan/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.NoIndexScan'
     themePkg = 'madara'
     baseUrl = 'https://noindexscan.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/pt/noindexscan/src/eu/kanade/tachiyomi/extension/pt/noindexscan/NoIndexScan.kt
+++ b/src/pt/noindexscan/src/eu/kanade/tachiyomi/extension/pt/noindexscan/NoIndexScan.kt
@@ -11,7 +11,7 @@ class NoIndexScan : Madara(
     "No Index Scan",
     "https://noindexscan.com",
     "pt-BR",
-    SimpleDateFormat("dd 'de' MMMMM 'de' yyyy", Locale("pt", "BR")),
+    SimpleDateFormat("dd/MM/yyyy", Locale.ROOT),
 ) {
     override val client: OkHttpClient = super.client.newBuilder()
         .rateLimit(1, 2, TimeUnit.SECONDS)

--- a/src/pt/noindexscan/src/eu/kanade/tachiyomi/extension/pt/noindexscan/NoIndexScan.kt
+++ b/src/pt/noindexscan/src/eu/kanade/tachiyomi/extension/pt/noindexscan/NoIndexScan.kt
@@ -18,4 +18,7 @@ class NoIndexScan : Madara(
         .build()
 
     override val useNewChapterEndpoint = true
+
+    override val mangaDetailsSelectorTitle = "div[class*='post-title'] h1"
+    override val mangaDetailsSelectorStatus = "div.summary-heading:has(h5:contains(Status)) + div.summary-content"
 }


### PR DESCRIPTION
Closes #4685

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
