### PR TITLE
YugenMangas: Update domains

### DIFF
--- a/src/pt/yugenmangas/build.gradle
+++ b/src/pt/yugenmangas/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Yugen Mangás'
     extClass = '.YugenMangas'
-    extVersionCode = 40
+    extVersionCode = 41
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/yugenmangas/src/eu/kanade/tachiyomi/extension/pt/yugenmangas/YugenMangas.kt
+++ b/src/pt/yugenmangas/src/eu/kanade/tachiyomi/extension/pt/yugenmangas/YugenMangas.kt
@@ -40,6 +40,8 @@ class YugenMangas : HttpSource() {
         .rateLimit(1, 2, TimeUnit.SECONDS)
         .build()
 
+    override val versionId = 2
+
     private val json: Json by injectLazy()
 
     override fun headersBuilder(): Headers.Builder = Headers.Builder()

--- a/src/pt/yugenmangas/src/eu/kanade/tachiyomi/extension/pt/yugenmangas/YugenMangas.kt
+++ b/src/pt/yugenmangas/src/eu/kanade/tachiyomi/extension/pt/yugenmangas/YugenMangas.kt
@@ -22,13 +22,15 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import okio.Buffer
 import uy.kohesive.injekt.injectLazy
+import java.text.SimpleDateFormat
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 class YugenMangas : HttpSource() {
 
     override val name = "Yugen Mangás"
 
-    override val baseUrl = "https://yugenapp.lat"
+    override val baseUrl = "https://yugenweb.com"
 
     override val lang = "pt-BR"
 
@@ -49,80 +51,79 @@ class YugenMangas : HttpSource() {
         .add("Accept", "application/json, text/plain, */*")
         .add("Origin", baseUrl)
         .add("Sec-Fetch-Dest", "empty")
-        .add("Sec-Fetch-Mode", "cors")
+        .add("Sec-Fetch-Mode", "no-cors")
         .add("Sec-Fetch-Site", "same-site")
 
     override fun popularMangaRequest(page: Int): Request {
-        return GET("$API_BASE_URL/top_series_all/", apiHeaders)
+        val url = "$BASE_API/widgets/sort_and_filter/".toHttpUrl().newBuilder()
+            .addQueryParameter("page", "$page")
+            .addQueryParameter("sort", "views")
+            .addQueryParameter("order", "desc")
+            .build()
+
+        return GET(url, apiHeaders)
     }
 
     override fun popularMangaParse(response: Response): MangasPage {
-        val result = response.parseAs<List<YugenMangaDto>>()
-        val mangaList = result.map { it.toSManga(API_HOST) }
-        return MangasPage(mangaList, hasNextPage = false)
+        val dto = response.parseAs<PageDto<MangaDto>>()
+        val mangaList = dto.results.map { it.toSManga() }
+        return MangasPage(mangaList, hasNextPage = dto.hasNext())
     }
 
     override fun latestUpdatesRequest(page: Int): Request {
-        return GET("$API_BASE_URL/latest_updates/", apiHeaders)
+        return GET("$BASE_API/widgets/home/updates/", apiHeaders)
     }
 
-    override fun latestUpdatesParse(response: Response) = popularMangaParse(response)
+    override fun latestUpdatesParse(response: Response): MangasPage {
+        val dto = response.parseAs<LatestUpdatesDto>()
+        val mangaList = dto.series.map { it.toSManga() }
+        return MangasPage(mangaList, hasNextPage = false)
+    }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        val apiUrl = "$API_BASE_URL/series".toHttpUrl().newBuilder()
-            .addQueryParameter("search", query)
-            .build()
-
-        return GET(apiUrl, apiHeaders)
+        val payload = json.encodeToString(SearchDto(query)).toRequestBody(JSON_MEDIA_TYPE)
+        return POST("$BASE_API/widgets/search/", apiHeaders, payload)
     }
 
-    override fun searchMangaParse(response: Response) = popularMangaParse(response)
+    override fun searchMangaParse(response: Response) = latestUpdatesParse(response)
 
     override fun mangaDetailsRequest(manga: SManga): Request {
-        val slug = manga.url.removePrefix("/series/")
-        return POST("$API_BASE_URL/serie/serie_details/$slug", apiHeaders)
+        val code = manga.url.substringAfterLast("/")
+        val payload = json.encodeToString(SeriesDto(code)).toRequestBody(JSON_MEDIA_TYPE)
+        return POST("$BASE_API/series/detail/series/", apiHeaders, payload)
     }
 
     override fun getMangaUrl(manga: SManga) = baseUrl + manga.url
 
     override fun mangaDetailsParse(response: Response): SManga {
-        return response.parseAs<YugenMangaDto>().toSManga(API_BASE_URL)
+        return response.parseAs<MangaDetailsDto>().toSManga()
     }
 
     override fun chapterListRequest(manga: SManga): Request {
-        val slug = manga.url.removePrefix("/series/")
-        val body = YugenGetChaptersBySeriesDto(slug)
-        val payload = json.encodeToString(body).toRequestBody(JSON_MEDIA_TYPE)
-
-        val newHeaders = apiHeadersBuilder()
-            .set("Content-Length", payload.contentLength().toString())
-            .set("Content-Type", payload.contentType().toString())
-            .build()
-
-        return POST("$API_BASE_URL/chapters/get_chapters_by_serie/", newHeaders, payload)
+        val code = manga.url.substringAfterLast("/")
+        val payload = json.encodeToString(SeriesDto(code)).toRequestBody(JSON_MEDIA_TYPE)
+        return POST("$BASE_API/series/chapters/get-series-chapters/", apiHeaders, payload)
     }
 
     override fun pageListRequest(chapter: SChapter): Request {
-        val slug = chapter.url.removePrefix("/series/").substringBefore("/")
-        val chapterSlug = chapter.url.substringAfterLast("/")
-
-        return POST("$API_BASE_URL/serie/$slug/chapter/$chapterSlug/images/imgs/get/", apiHeaders)
+        val code = chapter.url.substringAfterLast("/")
+        val payload = json.encodeToString(SeriesDto(code)).toRequestBody(JSON_MEDIA_TYPE)
+        return POST("$BASE_API/chapters/chapter-info/", apiHeaders, payload)
     }
 
     override fun chapterListParse(response: Response): List<SChapter> {
-        val (seriesSlug) = response.request.body!!.parseAs<YugenGetChaptersBySeriesDto>()
-
-        return response.parseAs<YugenChapterListDto>().chapters
-            .map { it.toSChapter(seriesSlug) }
-            .sortedByDescending(SChapter::chapter_number)
+        val series = response.request.body!!.parseAs<SeriesDto>()
+        return response.parseAs<List<ChapterDto>>()
+            .map { it.toSChapter(series.code) }
+            .reversed()
     }
 
     override fun getChapterUrl(chapter: SChapter) = baseUrl + chapter.url
 
     override fun pageListParse(response: Response): List<Page> {
-        val result = response.parseAs<YugenPageList>()
-
-        return result.chapterImages.mapIndexed { index, url -> Page(index, baseUrl, "$API_HOST/$url") }
+        return response.parseAs<PageListDto>().images.mapIndexed { index, imageUrl ->
+            Page(index, baseUrl, "$BASE_MEDIA/$imageUrl")
+        }
     }
 
     override fun imageUrlParse(response: Response) = ""
@@ -145,8 +146,9 @@ class YugenMangas : HttpSource() {
     }
 
     companion object {
-        private const val API_HOST = "https://api.yugenapp.lat"
-        private const val API_BASE_URL = "$API_HOST/api"
+        private const val BASE_API = "https://api.yugenweb.com/api"
+        private const val BASE_MEDIA = "https://media.yugenweb.com"
         private val JSON_MEDIA_TYPE = "application/json".toMediaType()
+        val DATE_FORMAT = SimpleDateFormat("dd/MM/yyyy", Locale.ROOT)
     }
 }


### PR DESCRIPTION
Note
- Old API works, but may be closed;
- Manga slugs have also been changed;
- I couldn't identify the date format, so I kept the previous one

Closes #4689

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
