### PR TITLE
Luminousscans -> RadiantScans: update domain

### DIFF
--- a/src/en/luminousscans/build.gradle
+++ b/src/en/luminousscans/build.gradle
@@ -1,9 +1,9 @@
 ext {
-    extName = 'Luminous Scans'
-    extClass = '.LuminousScans'
+    extName = 'Radiant Scans'
+    extClass = '.RadiantScans'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://luminous-scans.com'
-    overrideVersionCode = 8
+    baseUrl = 'https://radiantscans.com'
+    overrideVersionCode = 9
     isNsfw = false
 }
 

--- a/src/en/luminousscans/src/eu/kanade/tachiyomi/extension/en/luminousscans/RadiantScans.kt
+++ b/src/en/luminousscans/src/eu/kanade/tachiyomi/extension/en/luminousscans/RadiantScans.kt
@@ -5,13 +5,16 @@ import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.source.model.FilterList
 import okhttp3.Request
 
-class LuminousScans : MangaThemesiaAlt(
-    "Luminous Scans",
-    "https://luminous-scans.com",
+class RadiantScans : MangaThemesiaAlt(
+    "Radiant Scans",
+    "https://radiantscans.com",
     "en",
     mangaUrlDirectory = "/series",
     randomUrlPrefKey = "pref_permanent_manga_url_2_en",
 ) {
+    // Luminous Scans -> Radiant Scans
+    override val id = 1019556752273106311
+
     init {
         // remove legacy preferences
         preferences.run {


### PR DESCRIPTION
closes #4717

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
