### PR TITLE
ReaperScans: Fix date format

### DIFF
--- a/src/en/reaperscans/build.gradle
+++ b/src/en/reaperscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ReaperScans'
     themePkg = 'heancms'
     baseUrl = 'https://reaperscans.com'
-    overrideVersionCode = 27
+    overrideVersionCode = 28
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/reaperscans/src/eu/kanade/tachiyomi/extension/en/reaperscans/ReaperScans.kt
+++ b/src/en/reaperscans/src/eu/kanade/tachiyomi/extension/en/reaperscans/ReaperScans.kt
@@ -8,6 +8,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import java.text.SimpleDateFormat
 import java.util.Locale
+import java.util.TimeZone
 
 class ReaperScans : HeanCms("Reaper Scans", "https://reaperscans.com", "en") {
 
@@ -20,7 +21,7 @@ class ReaperScans : HeanCms("Reaper Scans", "https://reaperscans.com", "en") {
     override val useNewChapterEndpoint = true
     override val useNewQueryEndpoint = true
     override val enableLogin = true
-    override val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+    override val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply { this.timeZone = TimeZone.getTimeZone("UTC") }
     override val cdnUrl = "https://media.reaperscans.com/file/4SRBHm"
 
     override fun latestUpdatesRequest(page: Int): Request {


### PR DESCRIPTION
This caused new chapters to be delayed based on your time zone.

UTC-8 would have chapters delayed by 8 hours.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
