### PR TITLE
NhatTruyen: update search path

### DIFF
--- a/src/vi/nhattruyen/build.gradle
+++ b/src/vi/nhattruyen/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.NhatTruyen'
     themePkg = 'wpcomics'
     baseUrl = 'https://nhattruyenvn.com'
-    overrideVersionCode = 18
+    overrideVersionCode = 19
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/vi/nhattruyen/src/eu/kanade/tachiyomi/extension/vi/nhattruyen/NhatTruyen.kt
+++ b/src/vi/nhattruyen/src/eu/kanade/tachiyomi/extension/vi/nhattruyen/NhatTruyen.kt
@@ -20,7 +20,7 @@ class NhatTruyen : WPComics(
     dateFormat = SimpleDateFormat("dd/MM/yy", Locale.getDefault()),
     gmtOffset = null,
 ) {
-    override val searchPath = "the-loai"
+    override val searchPath = "tim-truyen"
 
     /**
      * NetTruyen/NhatTruyen redirect back to catalog page if searching query is not found.


### PR DESCRIPTION
NhatTruyen changed their search path, which makes the app unable to search and migrate manga. 
This pull request updates the search path, and I tested on my device.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
