### PR TITLE
Upgrade some extensions from HTTP to HTTPS

### DIFF
--- a/src/en/lemonfont/build.gradle
+++ b/src/en/lemonfont/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'LemonFont'
     extClass = '.LemonFont'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/en/lemonfont/src/eu/kanade/tachiyomi/extension/en/lemonfont/LemonFont.kt
+++ b/src/en/lemonfont/src/eu/kanade/tachiyomi/extension/en/lemonfont/LemonFont.kt
@@ -16,7 +16,7 @@ import rx.Observable
 class LemonFont : ParsedHttpSource() {
     override val name = "LemonFont"
 
-    override val baseUrl = "http://lemonfontcomics.com"
+    override val baseUrl = "https://lemonfontcomics.com"
 
     override val lang = "en"
 

--- a/src/id/komikindoinfo/build.gradle
+++ b/src/id/komikindoinfo/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'KomikIndo.info'
     extClass = '.KomikIndoInfo'
     themePkg = 'zmanga'
-    baseUrl = 'http://komikindo.info'
-    overrideVersionCode = 0
+    baseUrl = 'https://komikindo.info'
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/id/komikindoinfo/src/eu/kanade/tachiyomi/extension/id/komikindoinfo/KomikIndoInfo.kt
+++ b/src/id/komikindoinfo/src/eu/kanade/tachiyomi/extension/id/komikindoinfo/KomikIndoInfo.kt
@@ -4,7 +4,7 @@ import eu.kanade.tachiyomi.multisrc.zmanga.ZManga
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class KomikIndoInfo : ZManga("KomikIndo.info", "http://komikindo.info", "id", dateFormat = SimpleDateFormat("MMM d, yyyy", Locale("id"))) {
+class KomikIndoInfo : ZManga("KomikIndo.info", "https://komikindo.info", "id", dateFormat = SimpleDateFormat("MMM d, yyyy", Locale("id"))) {
 
     override val hasProjectPage = true
 }

--- a/src/it/nifteam/build.gradle
+++ b/src/it/nifteam/build.gradle
@@ -2,8 +2,9 @@ ext {
     extName = 'NIFTeam'
     extClass = '.NIFTeam'
     themePkg = 'foolslide'
-    baseUrl = 'http://read-nifteam.info'
-    overrideVersionCode = 0
+    baseUrl = 'https://read-nifteam.info'
+    overrideVersionCode = 1
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/it/nifteam/src/eu/kanade/tachiyomi/extension/it/nifteam/NIFTeam.kt
+++ b/src/it/nifteam/src/eu/kanade/tachiyomi/extension/it/nifteam/NIFTeam.kt
@@ -2,4 +2,4 @@ package eu.kanade.tachiyomi.extension.it.nifteam
 
 import eu.kanade.tachiyomi.multisrc.foolslide.FoolSlide
 
-class NIFTeam : FoolSlide("NIFTeam", "http://read-nifteam.info", "it", "/slide")
+class NIFTeam : FoolSlide("NIFTeam", "https://read-nifteam.info", "it", "/slide")

--- a/src/it/tuttoanimemanga/build.gradle
+++ b/src/it/tuttoanimemanga/build.gradle
@@ -3,7 +3,8 @@ ext {
     extClass = '.TuttoAnimeManga'
     themePkg = 'pizzareader'
     baseUrl = 'https://tuttoanimemanga.net'
-    overrideVersionCode = 4
+    overrideVersionCode = 5
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/it/tuttoanimemanga/src/eu/kanade/tachiyomi/extension/it/tuttoanimemanga/TuttoAnimeManga.kt
+++ b/src/it/tuttoanimemanga/src/eu/kanade/tachiyomi/extension/it/tuttoanimemanga/TuttoAnimeManga.kt
@@ -3,7 +3,7 @@ package eu.kanade.tachiyomi.extension.it.tuttoanimemanga
 import eu.kanade.tachiyomi.multisrc.pizzareader.PizzaReader
 import kotlinx.serialization.json.Json
 
-class TuttoAnimeManga : PizzaReader("TuttoAnimeManga", "http://tuttoanimemanga.net", "it") {
+class TuttoAnimeManga : PizzaReader("TuttoAnimeManga", "https://tuttoanimemanga.net", "it") {
     override val json = Json {
         ignoreUnknownKeys = true
         coerceInputValues = true

--- a/src/pt/cafecomyaoi/build.gradle
+++ b/src/pt/cafecomyaoi/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Café com Yaoi'
     extClass = '.CafeComYaoi'
     themePkg = 'madara'
-    baseUrl = 'http://cafecomyaoi.com.br'
-    overrideVersionCode = 1
+    baseUrl = 'https://cafecomyaoi.com.br'
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/pt/cafecomyaoi/src/eu/kanade/tachiyomi/extension/pt/cafecomyaoi/CafeComYaoi.kt
+++ b/src/pt/cafecomyaoi/src/eu/kanade/tachiyomi/extension/pt/cafecomyaoi/CafeComYaoi.kt
@@ -9,10 +9,11 @@ import java.util.concurrent.TimeUnit
 
 class CafeComYaoi : Madara(
     "Café com Yaoi",
-    "http://cafecomyaoi.com.br",
+    "https://cafecomyaoi.com.br",
     "pt-BR",
     SimpleDateFormat("dd/MM/yyyy", Locale("pt", "BR")),
 ) {
+    override val useNewChapterEndpoint = true
 
     override val client: OkHttpClient = super.client.newBuilder()
         .rateLimit(1, 2, TimeUnit.SECONDS)

--- a/src/th/sodsaime/build.gradle
+++ b/src/th/sodsaime/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Sodsaime'
     themePkg = 'mangathemesia'
     baseUrl = 'https://www.xn--l3c0azab5a2gta.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/th/sodsaime/src/eu/kanade/tachiyomi/extension/th/sodsaime/Sodsaime.kt
+++ b/src/th/sodsaime/src/eu/kanade/tachiyomi/extension/th/sodsaime/Sodsaime.kt
@@ -4,4 +4,4 @@ import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class Sodsaime : MangaThemesia("สดใสเมะ", "http://www.xn--l3c0azab5a2gta.com", "th", dateFormat = SimpleDateFormat("MMMMM dd, yyyy", Locale("th")))
+class Sodsaime : MangaThemesia("สดใสเมะ", "https://www.xn--l3c0azab5a2gta.com", "th", dateFormat = SimpleDateFormat("MMMMM dd, yyyy", Locale("th")))


### PR DESCRIPTION
This skips some redirects as well.

Marked TuttoAnimeManga as not NSFW. The site has Berserk, To Love Ru, etc., but not sure if we want to consider the whole extension NSFW because of that.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
