### PR TITLE
fix(flamecomics): Avoid downloading unloadable image

### DIFF
--- a/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComics.kt
+++ b/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComics.kt
@@ -45,7 +45,8 @@ class FlameComics : MangaThemesia(
         return document.select("#readerarea p:has(img), $composedSelector").toList()
             .filter {
                 it.select("img").all { imgEl ->
-                    imgEl.attr("abs:src").isNullOrEmpty().not()
+                    val imgUrl = imgEl.attr("abs:src")
+                    imgUrl.isNullOrEmpty().not() && imgUrl.endsWith("readonflamescans.jpg").not()
                 }
             }
             .mapIndexed { i, el ->


### PR DESCRIPTION
And it contains wrong information since their website changed.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
