### PR TITLE
OppaiStream: Fix no chapters found and manga details

### DIFF
--- a/src/en/oppaistream/build.gradle
+++ b/src/en/oppaistream/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Oppai Stream'
     extClass = '.OppaiStream'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/en/oppaistream/src/eu/kanade/tachiyomi/extension/en/oppaistream/OppaiStream.kt
+++ b/src/en/oppaistream/src/eu/kanade/tachiyomi/extension/en/oppaistream/OppaiStream.kt
@@ -16,6 +16,7 @@ import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import rx.Observable
+import java.net.URLDecoder
 import java.util.Calendar
 
 class OppaiStream : ParsedHttpSource() {
@@ -115,7 +116,13 @@ class OppaiStream : ParsedHttpSource() {
         return SManga.create().apply {
             thumbnail_url = element.select("img.read-cover").attr("src")
             title = element.select("h3.man-title").text()
-            setUrlWithoutDomain(element.absUrl("href"))
+            val rawUrl = element.absUrl("href")
+            val url = if (rawUrl.contains("/fw?to=")) {
+                URLDecoder.decode(rawUrl.substringAfter("/fw?to="), "UTF-8")
+            } else {
+                rawUrl
+            }
+            setUrlWithoutDomain(url)
         }
     }
 


### PR DESCRIPTION
Closes #4826 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
