### PR TITLE
MangaDemon: Fix bad url in some entries

### DIFF
--- a/src/en/mangademon/build.gradle
+++ b/src/en/mangademon/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Manga Demon'
     extClass = '.MangaDemon'
-    extVersionCode = 13
+    extVersionCode = 14
     isNsfw = false
 }
 

--- a/src/en/mangademon/src/eu/kanade/tachiyomi/extension/en/mangademon/MangaDemon.kt
+++ b/src/en/mangademon/src/eu/kanade/tachiyomi/extension/en/mangademon/MangaDemon.kt
@@ -161,7 +161,7 @@ class MangaDemon : ParsedHttpSource() {
         }
     }
 
-    private fun Element.encodedAttr(attr: String) = URLEncoder.encode(attr(attr), "UTF-8")
+    private fun Element.encodedAttr(attribute: String) = URLEncoder.encode(attr(attribute), "UTF-8")
 
     override fun imageUrlParse(document: Document): String = throw UnsupportedOperationException()
 

--- a/src/en/mangademon/src/eu/kanade/tachiyomi/extension/en/mangademon/MangaDemon.kt
+++ b/src/en/mangademon/src/eu/kanade/tachiyomi/extension/en/mangademon/MangaDemon.kt
@@ -15,6 +15,7 @@ import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import rx.Observable
+import java.net.URLEncoder
 import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -44,7 +45,7 @@ class MangaDemon : ParsedHttpSource() {
     override fun popularMangaSelector() = "div#advanced-content > div.advanced-element"
 
     override fun popularMangaFromElement(element: Element) = SManga.create().apply {
-        setUrlWithoutDomain(element.selectFirst("a")!!.attr("abs:href"))
+        setUrlWithoutDomain(element.selectFirst("a")!!.encodedAttr("href"))
         title = element.selectFirst("h1")!!.ownText()
         thumbnail_url = element.selectFirst("img")?.attr("abs:src")
     }
@@ -59,7 +60,7 @@ class MangaDemon : ParsedHttpSource() {
 
     override fun latestUpdatesFromElement(element: Element) = SManga.create().apply {
         with(element.selectFirst("div.updates-element-info")!!) {
-            setUrlWithoutDomain(selectFirst("a")!!.attr("abs:href"))
+            setUrlWithoutDomain(selectFirst("a")!!.encodedAttr("href"))
             title = selectFirst("a")!!.ownText()
         }
         thumbnail_url = element.selectFirst("div.thumb img")!!.attr("abs:src")
@@ -87,7 +88,7 @@ class MangaDemon : ParsedHttpSource() {
     override fun searchMangaNextPageSelector() = null
 
     override fun searchMangaFromElement(element: Element) = SManga.create().apply {
-        setUrlWithoutDomain(element.attr("abs:href"))
+        setUrlWithoutDomain(element.encodedAttr("href"))
         title = element.selectFirst("div.seach-right > div")!!.ownText()
         thumbnail_url = element.selectFirst("img")!!.attr("abs:src")
     }
@@ -141,7 +142,7 @@ class MangaDemon : ParsedHttpSource() {
     override fun chapterListSelector() = "div#chapters-list a.chplinks"
 
     override fun chapterFromElement(element: Element) = SChapter.create().apply {
-        setUrlWithoutDomain(element.attr("abs:href"))
+        setUrlWithoutDomain(element.encodedAttr("href"))
         name = element.ownText()
         date_upload = parseDate(element.selectFirst("span")?.ownText())
     }
@@ -159,6 +160,8 @@ class MangaDemon : ParsedHttpSource() {
             Page(i, "", element.attr("abs:src"))
         }
     }
+
+    private fun Element.encodedAttr(attr: String) = URLEncoder.encode(attr(attr), "UTF-8")
 
     override fun imageUrlParse(document: Document): String = throw UnsupportedOperationException()
 


### PR DESCRIPTION
Closes #4860

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
