### PR TITLE
Reset Scans: fix chapter names

### DIFF
--- a/src/en/resetscans/build.gradle
+++ b/src/en/resetscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ResetScans'
     themePkg = 'madara'
     baseUrl = 'https://reset-scans.co'
-    overrideVersionCode = 4
+    overrideVersionCode = 5
     isNsfw = false
 }
 

--- a/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
+++ b/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
@@ -13,4 +13,5 @@ class ResetScans : Madara(
     override val useLoadMoreRequest = LoadMoreStrategy.Always
     override val useNewChapterEndpoint = true
     override fun chapterListSelector(): String = "li.wp-manga-chapter.free-chap"
+    override val chapterUrlSelector = "div > a"
 }


### PR DESCRIPTION
Closes #4879 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
