### PR TITLE
Dynasty scanlator

### DIFF
--- a/src/en/dynasty/build.gradle
+++ b/src/en/dynasty/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Dynasty'
     extClass = '.DynastyFactory'
-    extVersionCode = 24
+    extVersionCode = 25
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyFactory.kt
+++ b/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyFactory.kt
@@ -14,4 +14,5 @@ fun getAllDynasty() =
         DynastyDoujins(),
         DynastyIssues(),
         DynastySeries(),
+        DynastyScanlator(),
     )

--- a/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyScanlator.kt
+++ b/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyScanlator.kt
@@ -1,0 +1,44 @@
+package eu.kanade.tachiyomi.extension.en.dynasty
+
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import okhttp3.Request
+import okhttp3.Response
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+
+class DynastyScanlator : DynastyScans() {
+    override val name = "Dynasty-Scanlator"
+    override val searchPrefix = "scanlators"
+    override val categoryPrefix = "Scanlator"
+
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+        return GET(
+            "$baseUrl/search?q=$query&classes%5B%5D=$categoryPrefix&page=$page&sort=",
+            headers,
+        )
+    }
+
+    override fun popularMangaInitialUrl() = ""
+
+    override fun popularMangaFromElement(element: Element): SManga {
+        val manga = SManga.create()
+        manga.setUrlWithoutDomain(element.select("a").attr("href"))
+        manga.title = element.select("div.caption").text()
+        return manga
+    }
+
+    override fun mangaDetailsParse(document: Document): SManga {
+        val manga = SManga.create()
+        parseHeader(document, manga)
+        return manga
+    }
+
+    override fun chapterListSelector() = "dl.chapter-list > dd"
+
+    override fun chapterListParse(response: Response): List<SChapter> {
+        return super.chapterListParse(response).reversed()
+    }
+}


### PR DESCRIPTION
Closes #391

I tried to add also the Authors but I do not think that could be possible, there are an extra layer for each series to get all the chapters.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
