### PR TITLE
Flame Comics: Fix page selector

### DIFF
--- a/src/en/flamecomics/build.gradle
+++ b/src/en/flamecomics/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.FlameComics'
     themePkg = 'mangathemesia'
     baseUrl = 'https://flamecomics.me'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComics.kt
+++ b/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComics.kt
@@ -30,6 +30,8 @@ class FlameComics : MangaThemesia(
         .addInterceptor(::composedImageIntercept)
         .build()
 
+    override val pageSelector = "div#readerarea img:not(noscript img)[class*=wp-image]"
+
     // Split Image Fixer Start
     private val composedSelector: String = "#readerarea div.figure_container div.composed_figure"
 


### PR DESCRIPTION
I couldn't find any chapter with composed selector to test
Closes #4870 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
