### PR TITLE
MangasNoSekai: Fix popular and latest

### DIFF
--- a/src/es/mangasnosekai/build.gradle
+++ b/src/es/mangasnosekai/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangasNoSekai'
     themePkg = 'madara'
     baseUrl = 'https://mangasnosekai.com'
-    overrideVersionCode = 15
+    overrideVersionCode = 16
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/mangasnosekai/src/eu/kanade/tachiyomi/extension/es/mangasnosekai/MangasNoSekai.kt
+++ b/src/es/mangasnosekai/src/eu/kanade/tachiyomi/extension/es/mangasnosekai/MangasNoSekai.kt
@@ -5,7 +5,6 @@ import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
-import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.util.asJsoup
@@ -34,52 +33,6 @@ class MangasNoSekai : Madara(
         .build()
 
     override val useNewChapterEndpoint = true
-
-    private var libraryPath = ""
-
-    private fun getLibraryPath() {
-        libraryPath = try {
-            val document = client.newCall(GET(baseUrl, headers)).execute().asJsoup()
-            val libraryUrl = document.selectFirst("ul > li[id^=menu-item] > a[href]")
-
-            libraryUrl?.attr("href")?.removeSuffix("/")?.substringAfterLast("/")
-                ?: "manganews3"
-        } catch (e: Exception) {
-            "manganews3"
-        }
-    }
-
-    override fun popularMangaRequest(page: Int): Request {
-        if (libraryPath.isBlank()) getLibraryPath()
-        return GET("$baseUrl/$libraryPath/#$page", headers)
-    }
-
-    override fun popularMangaParse(response: Response): MangasPage {
-        val page = response.request.url.fragment?.toIntOrNull() ?: 1
-        val document = response.asJsoup()
-        val orderValue = document.selectFirst("select#order_select > option:eq(5)")
-            ?.attr("value")
-            ?: "views2"
-        val url = "$baseUrl/$libraryPath/${searchPage(page)}?m_orderby=$orderValue"
-        val newResponse = client.newCall(GET(url, headers)).execute()
-        return super.popularMangaParse(newResponse)
-    }
-
-    override fun latestUpdatesRequest(page: Int): Request {
-        if (libraryPath.isBlank()) getLibraryPath()
-        return GET("$baseUrl/$libraryPath/#$page", headers)
-    }
-
-    override fun latestUpdatesParse(response: Response): MangasPage {
-        val page = response.request.url.fragment?.toIntOrNull() ?: 1
-        val document = response.asJsoup()
-        val orderValue = document.selectFirst("select#order_select > option:eq(1)")
-            ?.attr("value")
-            ?: "latest2"
-        val url = "$baseUrl/$libraryPath/${searchPage(page)}?m_orderby=$orderValue"
-        val newResponse = client.newCall(GET(url, headers)).execute()
-        return super.popularMangaParse(newResponse)
-    }
 
     override fun popularMangaSelector() = "div.page-listing-item > div.row > div"
 
@@ -173,11 +126,11 @@ class MangasNoSekai : Madara(
 
     override val orderByFilterOptions: Map<String, String> = mapOf(
         intl["order_by_filter_relevance"] to "",
-        intl["order_by_filter_latest"] to "latest2",
+        intl["order_by_filter_latest"] to "latest3",
         intl["order_by_filter_az"] to "alphabet",
         intl["order_by_filter_rating"] to "rating",
         intl["order_by_filter_trending"] to "trending",
-        intl["order_by_filter_views"] to "views2",
+        intl["order_by_filter_views"] to "views3",
         intl["order_by_filter_new"] to "new-manga",
     )
 
@@ -199,31 +152,26 @@ class MangasNoSekai : Madara(
         val document = response.asJsoup()
         launchIO { countViews(document) }
 
-        val txtUrl = "https://raw.githubusercontent.com/bapeey/extensions-tools/main/keiyoushi/mns/values.txt"
-        val values = client.newCall(GET(txtUrl)).execute().body.string().split("\n")
-
         val mangaSlug = response.request.url.toString().substringAfter(baseUrl).removeSuffix("/")
-        val coreScript = document.selectFirst(values[0])!!.attr("abs:src")
+        val coreScript = document.selectFirst("script#wp-manga-js")!!.attr("abs:src")
         val coreScriptBody = Deobfuscator.deobfuscateScript(client.newCall(GET(coreScript, headers)).execute().body.string())
             ?: throw Exception("No se pudo deobfuscar el script")
 
-        val url = values[5].toRegex().find(coreScriptBody)?.groupValues?.get(1)
-            ?: throw Exception("No se pudo obtener la url del capítulo")
+        val regexCapture = ACTION_REGEX.find(coreScriptBody)?.groupValues
+        val url = regexCapture?.get(1) ?: throw Exception("No se pudo obtener la url del capítulo")
+        val data = regexCapture.getOrNull(2)?.trim() ?: throw Exception("No se pudo obtener la data del capítulo")
 
-        val data = values[5].toRegex().find(coreScriptBody)?.groupValues?.get(2)?.trim()
-            ?: throw Exception("No se pudo obtener la data del capítulo")
-
-        val objects = values[6].toRegex().findAll(data)
+        val objects = OBJECTS_REGEX.findAll(data)
             .mapNotNull { matchResult ->
                 val key = matchResult.groupValues[1]
                 val value = matchResult.groupValues.getOrNull(2)
                 if (!value.isNullOrEmpty()) key to value else null
             }.toList()
 
-        val mangaId = document.selectFirst(values[1])?.data()
-            ?.let { values[7].toRegex().find(it)?.groupValues?.get(1) }
-            ?: document.selectFirst(values[2])?.data()
-                ?.let { values[8].toRegex().find(it)?.groupValues?.get(1) }
+        val mangaId = document.selectFirst("script#wp-manga-js-extra")?.data()
+            ?.let { MANGA_ID_REGEX.find(it)?.groupValues?.get(1) }
+            ?: document.selectFirst("script#manga_disqus_embed-js-extra")?.data()
+                ?.let { ALT_MANGA_ID_REGEX.find(it)?.groupValues?.get(1) }
             ?: throw Exception("No se pudo obtener el id del manga")
 
         val chapterElements = mutableListOf<Element>()
@@ -257,5 +205,12 @@ class MangasNoSekai : Madara(
     private fun chaptersFromJson(jsonString: String, mangaSlug: String): List<SChapter> {
         val result = json.decodeFromString<PayloadDto>(jsonString)
         return result.manga.first().chapters.map { it.toSChapter(mangaSlug) }
+    }
+
+    companion object {
+        val ACTION_REGEX = """function\s+.*?[\s\S]*?\.ajax;?[\s\S]*?(?:'?url'?:\s*'([^']*)')(?:[\s\S]*?'?data'?:\s*\{([^}]*)\})?""".toRegex()
+        val OBJECTS_REGEX = """\s*'?(\w+)'?\s*:\s*(?:(?:'([^']*)'|([^,\r\n]+))\s*,?\s*)""".toRegex()
+        val MANGA_ID_REGEX = """\"manga_id"\s*:\s*"(.*)\"""".toRegex()
+        val ALT_MANGA_ID_REGEX = """\"postId"\s*:\s*"(.*)\"""".toRegex()
     }
 }

--- a/src/es/mangasnosekai/src/eu/kanade/tachiyomi/extension/es/mangasnosekai/MangasNoSekai.kt
+++ b/src/es/mangasnosekai/src/eu/kanade/tachiyomi/extension/es/mangasnosekai/MangasNoSekai.kt
@@ -34,6 +34,10 @@ class MangasNoSekai : Madara(
 
     override val useNewChapterEndpoint = true
 
+    override fun popularMangaRequest(page: Int): Request {
+        return GET("$baseUrl/biblioteca/${searchPage(page)}?m_orderby=views", headers)
+    }
+
     override fun popularMangaSelector() = "div.page-listing-item > div.row > div"
 
     override fun popularMangaNextPageSelector() = "a.next.page-numbers"
@@ -58,6 +62,10 @@ class MangasNoSekai : Madara(
         }
 
         return manga
+    }
+
+    override fun latestUpdatesRequest(page: Int): Request {
+        return GET("$baseUrl/biblioteca/${searchPage(page)}?m_orderby=latest", headers)
     }
 
     override fun searchMangaNextPageSelector() = "nav.navigation a.next"


### PR DESCRIPTION
Its actually a site issue.
Since they haven't tried to break the extension in months, I'm stopping the fetching of selectors from my repo. I'll revert if they start breaking the extension again

Closes #5008

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
