### PR TITLE
Mangatale: update domain, change selector, tweak rate limit

### DIFF
--- a/src/id/mangatale/build.gradle
+++ b/src/id/mangatale/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'MangaTale'
     extClass = '.MangaTale'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://mangatale.co'
-    overrideVersionCode = 3
+    baseUrl = 'https://mangatale.id'
+    overrideVersionCode = 4
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/mangatale/src/eu/kanade/tachiyomi/extension/id/mangatale/MangaTale.kt
+++ b/src/id/mangatale/src/eu/kanade/tachiyomi/extension/id/mangatale/MangaTale.kt
@@ -7,10 +7,10 @@ import okhttp3.OkHttpClient
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.jsoup.nodes.Document
 
-class MangaTale : MangaThemesia("MangaTale", "https://mangatale.co", "id") {
+class MangaTale : MangaThemesia("MangaTale", "https://mangatale.id", "id") {
 
     override val client: OkHttpClient = super.client.newBuilder()
-        .rateLimit(20, 5)
+        .rateLimit(12, 3)
         .addInterceptor { chain ->
             val response = chain.proceed(chain.request())
             val mime = response.headers["Content-Type"]
@@ -28,7 +28,7 @@ class MangaTale : MangaThemesia("MangaTale", "https://mangatale.co", "id") {
         }
         .build()
 
-    override val seriesTitleSelector = ".ts-breadcrumb li:last-child span"
+    override val seriesTitleSelector = ".ts-breadcrumb span:last-child span"
 
     override fun mangaDetailsParse(document: Document) = super.mangaDetailsParse(document).apply {
         thumbnail_url = document.selectFirst(seriesThumbnailSelector)?.imgAttr()


### PR DESCRIPTION
closes #4986

- update domain
- change title selector
- tweak rate limit

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
