### PR TITLE
Tecno Scans: update domain, add override URL setting

### DIFF
--- a/src/en/tecnoscans/build.gradle
+++ b/src/en/tecnoscans/build.gradle
@@ -2,8 +2,9 @@ ext {
     extName = 'Tecno Scans'
     extClass = '.TecnoScans'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://olyscans.xyz'
-    overrideVersionCode = 1
+    baseUrl = 'https://oliosscans.xyz'
+    overrideVersionCode = 2
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/tecnoscans/src/eu/kanade/tachiyomi/extension/en/tecnoscans/TecnoScans.kt
+++ b/src/en/tecnoscans/src/eu/kanade/tachiyomi/extension/en/tecnoscans/TecnoScans.kt
@@ -1,14 +1,67 @@
 package eu.kanade.tachiyomi.extension.en.tecnoscans
 
+import android.app.Application
+import android.content.SharedPreferences
+import android.widget.Toast
+import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.source.ConfigurableSource
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
-class TecnoScans : MangaThemesia(
-    "Tecno Scans",
-    "https://olyscans.xyz",
-    "en",
-) {
+class TecnoScans :
+    MangaThemesia(
+        "Tecno Scans",
+        "https://oliosscans.xyz",
+        "en",
+    ),
+    ConfigurableSource {
     override val client = super.client.newBuilder()
         .rateLimit(3)
         .build()
+
+    private val preferences: SharedPreferences =
+        Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
+
+    init {
+        preferences.getString(DEFAULT_BASE_URL_PREF, null).let { prefDefaultBaseUrl ->
+            if (prefDefaultBaseUrl != super.baseUrl) {
+                preferences.edit()
+                    .putString(BASE_URL_PREF, super.baseUrl)
+                    .putString(DEFAULT_BASE_URL_PREF, super.baseUrl)
+                    .apply()
+            }
+        }
+    }
+
+    override val baseUrl by lazy { getPrefBaseUrl() }
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        val baseUrlPref = androidx.preference.EditTextPreference(screen.context).apply {
+            key = BASE_URL_PREF
+            title = BASE_URL_PREF_TITLE
+            summary = BASE_URL_PREF_SUMMARY
+            setDefaultValue(super.baseUrl)
+            dialogTitle = BASE_URL_PREF_TITLE
+            dialogMessage = "Default: ${super.baseUrl}"
+
+            setOnPreferenceChangeListener { _, _ ->
+                Toast.makeText(screen.context, RESTART_APP, Toast.LENGTH_LONG).show()
+                true
+            }
+        }
+        screen.addPreference(baseUrlPref)
+    }
+
+    private fun getPrefBaseUrl(): String = preferences.getString(BASE_URL_PREF, super.baseUrl)!!
+
+    companion object {
+        private const val DEFAULT_BASE_URL_PREF = "defaultBaseUrl"
+        private const val RESTART_APP = "Restart app to apply new setting."
+        private const val BASE_URL_PREF_TITLE = "Override BaseUrl"
+        private const val BASE_URL_PREF = "overrideBaseUrl"
+        private const val BASE_URL_PREF_SUMMARY =
+            "For temporary uses. Updating the extension will erase this setting."
+    }
 }


### PR DESCRIPTION
Closes #5019

Adding ConfigurableSource since the URL was already updated since the issue was created 2 days ago. 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
