### PR TITLE
HentaiVN.plus: update domain, add override URL setting

### DIFF
--- a/src/vi/hentaivnplus/build.gradle
+++ b/src/vi/hentaivnplus/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'HentaiVN.plus'
     extClass = '.HentaiVNPlus'
     themePkg = 'madara'
-    baseUrl = 'https://hentaivn.cafe'
-    overrideVersionCode = 1
+    baseUrl = 'https://hentaivn.fit'
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/vi/hentaivnplus/src/eu/kanade/tachiyomi/extension/vi/hentaivnplus/HentaiVNPlus.kt
+++ b/src/vi/hentaivnplus/src/eu/kanade/tachiyomi/extension/vi/hentaivnplus/HentaiVNPlus.kt
@@ -1,17 +1,70 @@
 package eu.kanade.tachiyomi.extension.vi.hentaivnplus
 
+import android.app.Application
+import android.content.SharedPreferences
+import android.widget.Toast
+import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.source.ConfigurableSource
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class HentaiVNPlus : Madara(
-    "HentaiVN.plus",
-    "https://hentaivn.cafe",
-    "vi",
-    dateFormat = SimpleDateFormat("MM/dd/yyyy", Locale.ROOT),
-) {
+class HentaiVNPlus :
+    Madara(
+        "HentaiVN.plus",
+        "https://hentaivn.fit",
+        "vi",
+        dateFormat = SimpleDateFormat("MM/dd/yyyy", Locale.ROOT),
+    ),
+    ConfigurableSource {
     override val useLoadMoreRequest = LoadMoreStrategy.Never
     override val useNewChapterEndpoint = false
 
     override val mangaSubString = "truyen-hentai"
+
+    private val preferences: SharedPreferences =
+        Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
+
+    init {
+        preferences.getString(DEFAULT_BASE_URL_PREF, null).let { prefDefaultBaseUrl ->
+            if (prefDefaultBaseUrl != super.baseUrl) {
+                preferences.edit()
+                    .putString(BASE_URL_PREF, super.baseUrl)
+                    .putString(DEFAULT_BASE_URL_PREF, super.baseUrl)
+                    .apply()
+            }
+        }
+    }
+
+    override val baseUrl by lazy { getPrefBaseUrl() }
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        val baseUrlPref = androidx.preference.EditTextPreference(screen.context).apply {
+            key = BASE_URL_PREF
+            title = BASE_URL_PREF_TITLE
+            summary = BASE_URL_PREF_SUMMARY
+            setDefaultValue(super.baseUrl)
+            dialogTitle = BASE_URL_PREF_TITLE
+            dialogMessage = "Default: ${super.baseUrl}"
+
+            setOnPreferenceChangeListener { _, _ ->
+                Toast.makeText(screen.context, RESTART_APP, Toast.LENGTH_LONG).show()
+                true
+            }
+        }
+        screen.addPreference(baseUrlPref)
+    }
+
+    private fun getPrefBaseUrl(): String = preferences.getString(BASE_URL_PREF, super.baseUrl)!!
+
+    companion object {
+        private const val DEFAULT_BASE_URL_PREF = "defaultBaseUrl"
+        private const val RESTART_APP = "Khởi chạy lại ứng dụng để áp dụng thay đổi."
+        private const val BASE_URL_PREF_TITLE = "Ghi đè URL cơ sở"
+        private const val BASE_URL_PREF = "overrideBaseUrl"
+        private const val BASE_URL_PREF_SUMMARY =
+            "Dành cho sử dụng tạm thời, cập nhật tiện ích sẽ xóa cài đặt."
+    }
 }


### PR DESCRIPTION
The Vietnamese in preferences is MTL, seems fine when put through Google Translate back to English.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
