### PR TITLE
Happymh: Fix Content-Type of images

### DIFF
--- a/src/zh/happymh/build.gradle
+++ b/src/zh/happymh/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Happymh'
     extClass = '.Happymh'
-    extVersionCode = 11
+    extVersionCode = 12
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/zh/happymh/src/eu/kanade/tachiyomi/extension/zh/happymh/Happymh.kt
+++ b/src/zh/happymh/src/eu/kanade/tachiyomi/extension/zh/happymh/Happymh.kt
@@ -22,9 +22,12 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 import okhttp3.FormBody
 import okhttp3.Headers
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
+import okhttp3.ResponseBody.Companion.asResponseBody
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
@@ -36,7 +39,6 @@ class Happymh : HttpSource(), ConfigurableSource {
     override val lang: String = "zh"
     override val supportsLatest: Boolean = true
     override val baseUrl: String = "https://m.happymh.com"
-    override val client: OkHttpClient = network.cloudflareClient
     private val json: Json by injectLazy()
 
     private val preferences = Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
@@ -49,6 +51,23 @@ class Happymh : HttpSource(), ConfigurableSource {
             editor.apply()
         }
     }
+
+    private val rewriteOctetStream: Interceptor = Interceptor { chain ->
+        val originalResponse: Response = chain.proceed(chain.request())
+        if (originalResponse.headers("Content-Type").contains("application/octet-stream") && originalResponse.request.url.toString().contains(".jpg")) {
+            val orgBody = originalResponse.body.source()
+            val newBody = orgBody.asResponseBody("image/jpeg".toMediaType())
+            originalResponse.newBuilder()
+                .body(newBody)
+                .build()
+        } else {
+            originalResponse
+        }
+    }
+
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
+        .addInterceptor(rewriteOctetStream)
+        .build()
 
     override fun headersBuilder(): Headers.Builder {
         val builder = super.headersBuilder()


### PR DESCRIPTION
No related issue. User report unable to read downloaded chapters.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
