### PR TITLE
fix (GoDa multitheme): avoid the case when no search result is found

### DIFF
--- a/lib-multisrc/goda/build.gradle.kts
+++ b/lib-multisrc/goda/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 1
+baseVersionCode = 2

--- a/lib-multisrc/goda/src/eu/kanade/tachiyomi/multisrc/goda/GoDa.kt
+++ b/lib-multisrc/goda/src/eu/kanade/tachiyomi/multisrc/goda/GoDa.kt
@@ -39,7 +39,7 @@ open class GoDa(
 
     override fun popularMangaParse(response: Response): MangasPage {
         val document = response.asJsoup().also(::parseGenres)
-        val mangas = document.select(".cardlist .pb-2 a").map { element ->
+        val mangas = document.select(".container > .cardlist .pb-2 a").map { element ->
             SManga.create().apply {
                 val imgSrc = element.selectFirst("img")!!.attr("src")
                 url = getKey(element.attr("href"))


### PR DESCRIPTION
Issue: search for something which return no result
Actual: It always includes something like "You may like" which is not actual expected results.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [X] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
