### PR TITLE
DocTruyen5s: Update domain

### DIFF
--- a/src/vi/doctruyen5s/build.gradle
+++ b/src/vi/doctruyen5s/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'DocTruyen5s'
     extClass = '.DocTruyen5s'
     themePkg = 'liliana'
-    baseUrl = 'https://manga.io.vn'
-    overrideVersionCode = 2
+    baseUrl = 'https://dongmoe.com'
+    overrideVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/vi/doctruyen5s/src/eu/kanade/tachiyomi/extension/vi/doctruyen5s/DocTruyen5s.kt
+++ b/src/vi/doctruyen5s/src/eu/kanade/tachiyomi/extension/vi/doctruyen5s/DocTruyen5s.kt
@@ -2,4 +2,4 @@ package eu.kanade.tachiyomi.extension.vi.doctruyen5s
 
 import eu.kanade.tachiyomi.multisrc.liliana.Liliana
 
-class DocTruyen5s : Liliana("DocTruyen5s", "https://manga.io.vn", "vi")
+class DocTruyen5s : Liliana("DocTruyen5s", "https://dongmoe.com", "vi")


### PR DESCRIPTION
Closes #5110

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
