### PR TITLE
Shinigami: Update domain

### DIFF
--- a/src/id/shinigami/build.gradle
+++ b/src/id/shinigami/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Shinigami'
     extClass = '.Shinigami'
     themePkg = 'madara'
-    baseUrl = 'https://shinigami03.com'
-    overrideVersionCode = 25
+    baseUrl = 'https://shinigami05.com'
+    overrideVersionCode = 26
     isNsfw = false
 }
 

--- a/src/id/shinigami/src/eu/kanade/tachiyomi/extension/id/shinigami/Shinigami.kt
+++ b/src/id/shinigami/src/eu/kanade/tachiyomi/extension/id/shinigami/Shinigami.kt
@@ -19,11 +19,17 @@ import org.jsoup.nodes.Element
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
-class Shinigami : Madara("Shinigami", "https://shinigami03.com", "id"), ConfigurableSource {
+class Shinigami : Madara("Shinigami", "https://shinigami05.com", "id"), ConfigurableSource {
     // moved from Reaper Scans (id) to Shinigami (id)
     override val id = 3411809758861089969
 
     override val baseUrl by lazy { getPrefBaseUrl() }
+
+    override val mangaSubString = "semua-series"
+
+    override val useLoadMoreRequest = LoadMoreStrategy.Never
+
+    override val useNewChapterEndpoint = false
 
     private val preferences: SharedPreferences by lazy {
         Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
@@ -59,9 +65,6 @@ class Shinigami : Madara("Shinigami", "https://shinigami03.com", "id"), Configur
         }
     }
 
-    override val useLoadMoreRequest = LoadMoreStrategy.Never
-    override val useNewChapterEndpoint = false
-
     override fun headersBuilder() = super.headersBuilder().apply {
         add("Sec-Fetch-Dest", "document")
         add("Sec-Fetch-Mode", "navigate")
@@ -81,8 +84,6 @@ class Shinigami : Madara("Shinigami", "https://shinigami03.com", "id"), Configur
         }
         .rateLimit(3)
         .build()
-
-    override val mangaSubString = "semua-series"
 
     // Tags are useless as they are just SEO keywords.
     override val mangaDetailsSelectorTag = ""


### PR DESCRIPTION
Closes #5088

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
