### PR TITLE
ShijieScans: Fix mangaUrlDirectory

### DIFF
--- a/src/tr/shijiescans/build.gradle
+++ b/src/tr/shijiescans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ShijieScans'
     themePkg = 'mangathemesia'
     baseUrl = 'https://shijiescans.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/tr/shijiescans/src/eu/kanade/tachiyomi/extension/tr/shijiescans/ShijieScans.kt
+++ b/src/tr/shijiescans/src/eu/kanade/tachiyomi/extension/tr/shijiescans/ShijieScans.kt
@@ -8,5 +8,6 @@ class ShijieScans : MangaThemesia(
     "Shijie Scans",
     "https://shijiescans.com",
     "tr",
-    dateFormat = SimpleDateFormat("MMM d, yyy", Locale("tr")),
+    "/seri",
+    SimpleDateFormat("MMM d, yyy", Locale("tr")),
 )


### PR DESCRIPTION
Closes  #5074

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
