### PR TITLE
Pixiv: fix search repeats itself

### DIFF
--- a/src/all/pixiv/build.gradle
+++ b/src/all/pixiv/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Pixiv'
     extClass = '.PixivFactory'
-    extVersionCode = 8
+    extVersionCode = 9
     isNsfw = true
 }
 

--- a/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/Pixiv.kt
+++ b/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/Pixiv.kt
@@ -86,7 +86,7 @@ class Pixiv(override val lang: String) : HttpSource() {
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
         val filters = filters.list as PixivFilters
-        val hash = Pair(query, filters).hashCode()
+        val hash = Pair(query, filters.toList()).hashCode()
 
         if (hash != searchHash || page == 1) {
             searchHash = hash


### PR DESCRIPTION
Close https://github.com/keiyoushi/extensions-source/issues/4923

PixivFilters is a delegation that acts as a proxy to MutableList. However, the hashcode is not proxied to MutableList. ref: https://youtrack.jetbrains.com/issue/KT-15445

Therefore, the hashcode of filters here is not the hashcode of the list, even if two filters have the same content.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
