### PR TITLE
Photos18: Fix blank chapter name

### DIFF
--- a/src/all/photos18/build.gradle
+++ b/src/all/photos18/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Photos18'
     extClass = '.Photos18'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/all/photos18/src/eu/kanade/tachiyomi/extension/all/photos18/Photos18.kt
+++ b/src/all/photos18/src/eu/kanade/tachiyomi/extension/all/photos18/Photos18.kt
@@ -20,7 +20,6 @@ import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.select.Evaluator
-import rx.Observable
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -81,17 +80,15 @@ class Photos18 : HttpSource(), ConfigurableSource {
 
     override fun searchMangaParse(response: Response) = popularMangaParse(response)
 
-    override fun fetchMangaDetails(manga: SManga): Observable<SManga> = Observable.just(manga)
-
     override fun mangaDetailsParse(response: Response) = throw UnsupportedOperationException()
 
-    override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> {
+    override suspend fun getChapterList(manga: SManga): List<SChapter> {
         val chapter = SChapter.create().apply {
             url = manga.url
-            name = manga.title
-            chapter_number = -2f
+            name = "Gallery"
+            chapter_number = 0f
         }
-        return Observable.just(listOf(chapter))
+        return listOf(chapter)
     }
 
     override fun chapterListParse(response: Response) = throw UnsupportedOperationException()

--- a/src/all/photos18/src/eu/kanade/tachiyomi/extension/all/photos18/Photos18.kt
+++ b/src/all/photos18/src/eu/kanade/tachiyomi/extension/all/photos18/Photos18.kt
@@ -20,6 +20,7 @@ import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.select.Evaluator
+import rx.Observable
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -80,15 +81,17 @@ class Photos18 : HttpSource(), ConfigurableSource {
 
     override fun searchMangaParse(response: Response) = popularMangaParse(response)
 
+    override fun fetchMangaDetails(manga: SManga): Observable<SManga> = Observable.just(manga)
+
     override fun mangaDetailsParse(response: Response) = throw UnsupportedOperationException()
 
-    override suspend fun getChapterList(manga: SManga): List<SChapter> {
+    override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> {
         val chapter = SChapter.create().apply {
             url = manga.url
             name = "Gallery"
             chapter_number = 0f
         }
-        return listOf(chapter)
+        return Observable.just(listOf(chapter))
     }
 
     override fun chapterListParse(response: Response) = throw UnsupportedOperationException()


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
