### PR TITLE
Lua Scans: exclude paid chapters

### DIFF
--- a/src/en/luascans/build.gradle
+++ b/src/en/luascans/build.gradle
@@ -3,7 +3,8 @@ ext {
     extClass = '.LuaScans'
     themePkg = 'keyoapp'
     baseUrl = 'https://luacomic.net'
-    overrideVersionCode = 29
+    overrideVersionCode = 30
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/luascans/src/eu/kanade/tachiyomi/extension/en/luascans/LuaScans.kt
+++ b/src/en/luascans/src/eu/kanade/tachiyomi/extension/en/luascans/LuaScans.kt
@@ -9,4 +9,6 @@ class LuaScans : Keyoapp(
 ) {
     // migrated from MangaThemesia to Keyoapp
     override val versionId = 2
+
+    override fun chapterListSelector() = "${super.chapterListSelector()}:not(:has(img[src^='/assets/images/Coin.svg']))"
 }


### PR DESCRIPTION
Closes  #5093

Have not tested with an account with bought chapters. If it becomes an issue people will probably complain and it can be fixed then.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
