### PR TITLE
Cartoon18: fix page selector

### DIFF
--- a/src/zh/cartoon18/build.gradle
+++ b/src/zh/cartoon18/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Cartoon18'
     extClass = '.Cartoon18'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/zh/cartoon18/src/eu/kanade/tachiyomi/extension/zh/cartoon18/Cartoon18.kt
+++ b/src/zh/cartoon18/src/eu/kanade/tachiyomi/extension/zh/cartoon18/Cartoon18.kt
@@ -114,7 +114,7 @@ class Cartoon18 : HttpSource(), ConfigurableSource {
 
     override fun pageListParse(response: Response): List<Page> {
         val document = response.asJsoup()
-        val images = document.select("div#lightgallery a img")
+        val images = document.select("div#app > div > a img")
         return images.mapIndexed { index, image ->
             Page(index, imageUrl = image.attr("src"))
         }


### PR DESCRIPTION
Closes #5048

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
