### PR TITLE
Jiangzaitoon: update chapter URL selector

### DIFF
--- a/src/tr/jiangzaitoon/build.gradle
+++ b/src/tr/jiangzaitoon/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Jiangzaitoon'
     themePkg = 'madara'
     baseUrl = 'https://jiangzaitoon.pro'
-    overrideVersionCode = 6
+    overrideVersionCode = 7
     isNsfw = true
 }
 

--- a/src/tr/jiangzaitoon/src/eu/kanade/tachiyomi/extension/tr/jiangzaitoon/Jiangzaitoon.kt
+++ b/src/tr/jiangzaitoon/src/eu/kanade/tachiyomi/extension/tr/jiangzaitoon/Jiangzaitoon.kt
@@ -21,4 +21,6 @@ class Jiangzaitoon : Madara(
             .readTimeout(3, TimeUnit.MINUTES) // aka shit source
             .build()
     }
+
+    override val chapterUrlSelector = "> a"
 }


### PR DESCRIPTION
Closes #4867 
Closes #4937

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
