### PR TITLE
Nicovideo: Adding early access prefix to chapters

### DIFF
--- a/src/ja/nicovideoseiga/build.gradle
+++ b/src/ja/nicovideoseiga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Nicovideo Seiga'
     extClass = '.NicovideoSeiga'
-    extVersionCode = 4
+    extVersionCode = 5
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ja/nicovideoseiga/src/eu/kanade/tachiyomi/extension/ja/nicovideoseiga/NicovideoSeiga.kt
+++ b/src/ja/nicovideoseiga/src/eu/kanade/tachiyomi/extension/ja/nicovideoseiga/NicovideoSeiga.kt
@@ -114,8 +114,12 @@ class NicovideoSeiga : HttpSource() {
             .filter { it.ownership.sellStatus != "publication_finished" }
             .map { chapter ->
                 SChapter.create().apply {
-                    val isPaid = chapter.ownership.sellStatus == "selling"
-                    name = (if (isPaid) "\uD83D\uDCB4 " else "") + chapter.meta.title
+                    val prefix = when (chapter.ownership.sellStatus) {
+                        "selling" -> "\uD83D\uDCB4 "
+                        "pre_selling" -> "\u23F3\uD83D\uDCB4 "
+                        else -> ""
+                    }
+                    name = prefix + chapter.meta.title
                     // Timestamp is in seconds, convert to milliseconds
                     date_upload = chapter.meta.createdAt * 1000
                     // While chapters are properly sorted, authors often add promotional material as "chapters" which breaks trackers


### PR DESCRIPTION
Adding ⏳💴 as prefix for chapters that are early access, but will turn to free for limited time at a later date.
Previously early access chapters do not have any prefixes

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
