### PR TITLE
HentaiVN.plus: update domain

### DIFF
--- a/src/vi/hentaivnplus/build.gradle
+++ b/src/vi/hentaivnplus/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'HentaiVN.plus'
     extClass = '.HentaiVNPlus'
     themePkg = 'madara'
-    baseUrl = 'https://hentaivn.fit'
-    overrideVersionCode = 2
+    baseUrl = 'https://hentaivn.vin'
+    overrideVersionCode = 3
     isNsfw = true
 }
 

--- a/src/vi/hentaivnplus/src/eu/kanade/tachiyomi/extension/vi/hentaivnplus/HentaiVNPlus.kt
+++ b/src/vi/hentaivnplus/src/eu/kanade/tachiyomi/extension/vi/hentaivnplus/HentaiVNPlus.kt
@@ -14,7 +14,7 @@ import java.util.Locale
 class HentaiVNPlus :
     Madara(
         "HentaiVN.plus",
-        "https://hentaivn.fit",
+        "https://hentaivn.vin",
         "vi",
         dateFormat = SimpleDateFormat("MM/dd/yyyy", Locale.ROOT),
     ),


### PR DESCRIPTION
Skips some redirect.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
