### PR TITLE
Update domain for 3 extensions

### DIFF
--- a/src/en/mangagalaxy/build.gradle
+++ b/src/en/mangagalaxy/build.gradle
@@ -2,8 +2,9 @@ ext {
     extName = 'Manga Galaxy'
     extClass = '.MangaGalaxy'
     themePkg = 'iken'
-    baseUrl = 'https://mangagalaxy.org'
-    overrideVersionCode = 39
+    baseUrl = 'https://mangagalaxy.net'
+    overrideVersionCode = 40
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/mangagalaxy/src/eu/kanade/tachiyomi/extension/en/mangagalaxy/MangaGalaxy.kt
+++ b/src/en/mangagalaxy/src/eu/kanade/tachiyomi/extension/en/mangagalaxy/MangaGalaxy.kt
@@ -5,7 +5,7 @@ import eu.kanade.tachiyomi.multisrc.iken.Iken
 class MangaGalaxy : Iken(
     "Manga Galaxy",
     "en",
-    "https://mangagalaxy.org",
+    "https://mangagalaxy.net",
 ) {
     // moved from Madara to MangaThemesia to Iken
     override val versionId = 3

--- a/src/th/manga168/build.gradle
+++ b/src/th/manga168/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Manga168'
     extClass = '.Manga168'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://manga168.com'
-    overrideVersionCode = 0
+    baseUrl = 'https://manga168.net'
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/th/manga168/src/eu/kanade/tachiyomi/extension/th/manga168/Manga168.kt
+++ b/src/th/manga168/src/eu/kanade/tachiyomi/extension/th/manga168/Manga168.kt
@@ -9,7 +9,7 @@ import java.util.TimeZone
 
 class Manga168 : MangaThemesia(
     "Manga168",
-    "https://manga168.com",
+    "https://manga168.net",
     "th",
     dateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("th")).apply {
         timeZone = TimeZone.getTimeZone("Asia/Bangkok")

--- a/src/tr/mangadenizi/build.gradle
+++ b/src/tr/mangadenizi/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'MangaDenizi'
     extClass = '.MangaDenizi'
-    extVersionCode = 4
+    extVersionCode = 5
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/tr/mangadenizi/src/eu/kanade/tachiyomi/extension/tr/mangadenizi/MangaDenizi.kt
+++ b/src/tr/mangadenizi/src/eu/kanade/tachiyomi/extension/tr/mangadenizi/MangaDenizi.kt
@@ -20,7 +20,7 @@ import java.util.Locale
 class MangaDenizi : ParsedHttpSource() {
     override val name = "MangaDenizi"
 
-    override val baseUrl = "https://mangadenizi.com"
+    override val baseUrl = "https://www.mangadenizi.net"
 
     override val lang = "tr"
 


### PR DESCRIPTION
- Manga168
- MangaDenizi
- Manga Galaxy (Closes #5229)

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
