### PR TITLE
AsuraScans: Prevent slug map break

### DIFF
--- a/src/en/asurascans/build.gradle
+++ b/src/en/asurascans/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Asura Scans'
     extClass = '.AsuraScans'
-    extVersionCode = 40
+    extVersionCode = 41
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScans.kt
+++ b/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScans.kt
@@ -192,9 +192,11 @@ class AsuraScans : ParsedHttpSource(), ConfigurableSource {
     override fun mangaDetailsParse(response: Response): SManga {
         if (preferences.dynamicUrl()) {
             val url = response.request.url.toString()
-            val newSlug = url.substringAfter("/series/").substringBefore("/")
-            val absSlug = newSlug.substringBeforeLast("-")
-            preferences.slugMap = preferences.slugMap.apply { put(absSlug, newSlug) }
+            val newSlug = url.substringAfter("/series/", "").substringBefore("/")
+            if (newSlug.isNotEmpty()) {
+                val absSlug = newSlug.substringBeforeLast("-")
+                preferences.slugMap = preferences.slugMap.apply { put(absSlug, newSlug) }
+            }
         }
         return super.mangaDetailsParse(response)
     }
@@ -225,9 +227,11 @@ class AsuraScans : ParsedHttpSource(), ConfigurableSource {
     override fun chapterListParse(response: Response): List<SChapter> {
         if (preferences.dynamicUrl()) {
             val url = response.request.url.toString()
-            val newSlug = url.substringAfter("/series/").substringBefore("/")
-            val absSlug = newSlug.substringBeforeLast("-")
-            preferences.slugMap = preferences.slugMap.apply { put(absSlug, newSlug) }
+            val newSlug = url.substringAfter("/series/", "").substringBefore("/")
+            if (newSlug.isNotEmpty()) {
+                val absSlug = newSlug.substringBeforeLast("-")
+                preferences.slugMap = preferences.slugMap.apply { put(absSlug, newSlug) }
+            }
         }
         return super.chapterListParse(response)
     }

--- a/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScans.kt
+++ b/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScans.kt
@@ -57,6 +57,9 @@ class AsuraScans : ParsedHttpSource(), ConfigurableSource {
             if (contains("pref_permanent_manga_url_2_en")) {
                 edit().remove("pref_permanent_manga_url_2_en").apply()
             }
+            if (contains("pref_slug_map")) {
+                edit().remove("pref_slug_map").apply()
+            }
         }
     }
 
@@ -312,7 +315,7 @@ class AsuraScans : ParsedHttpSource(), ConfigurableSource {
         private val CLEAN_DATE_REGEX = """(\d+)(st|nd|rd|th)""".toRegex()
         private val OLD_FORMAT_MANGA_REGEX = """^/manga/(\d+-)?([^/]+)/?$""".toRegex()
         private val OLD_FORMAT_CHAPTER_REGEX = """^/(\d+-)?[^/]*-chapter-\d+(-\d+)*/?$""".toRegex()
-        private const val PREF_SLUG_MAP = "pref_slug_map"
+        private const val PREF_SLUG_MAP = "pref_slug_map_2"
         private const val PREF_DYNAMIC_URL = "pref_dynamic_url"
     }
 }


### PR DESCRIPTION
I'm recreating the slug map too

Maybe it's better to remove it? I don't know if it's really useful.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
