### PR TITLE
MangaHere: Remove no-cache header

### DIFF
--- a/src/en/mangahere/build.gradle
+++ b/src/en/mangahere/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Mangahere'
     extClass = '.Mangahere'
-    extVersionCode = 20
+    extVersionCode = 21
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/mangahere/src/eu/kanade/tachiyomi/extension/en/mangahere/Mangahere.kt
+++ b/src/en/mangahere/src/eu/kanade/tachiyomi/extension/en/mangahere/Mangahere.kt
@@ -36,7 +36,6 @@ class Mangahere : ParsedHttpSource() {
 
     override fun headersBuilder(): Headers.Builder = super.headersBuilder()
         .set("Referer", "$baseUrl/")
-        .set("Cache-Control", "no-cache")
 
     private val cookieInterceptor = CookieInterceptor(
         baseUrl.substringAfter("://"),
@@ -47,13 +46,6 @@ class Mangahere : ParsedHttpSource() {
 
     private val notRateLimitClient: OkHttpClient = network.cloudflareClient.newBuilder()
         .addNetworkInterceptor(cookieInterceptor)
-        .addNetworkInterceptor { chain ->
-            val newRequest = chain.request().newBuilder()
-                .header("Cache-Control", "no-cache")
-                .removeHeader("If-Modified-Since")
-                .build()
-            chain.proceed(newRequest)
-        }
         .build()
 
     override val client: OkHttpClient = notRateLimitClient.newBuilder()


### PR DESCRIPTION
Closes #5225

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
