### PR TITLE
RCO: fix the image couldn't be loaded

### DIFF
--- a/src/en/readcomiconline/build.gradle
+++ b/src/en/readcomiconline/build.gradle
@@ -5,3 +5,7 @@ ext {
 }
 
 apply from: "$rootDir/common.gradle"
+
+dependencies {
+    implementation project(':lib:randomua')
+}

--- a/src/en/readcomiconline/build.gradle
+++ b/src/en/readcomiconline/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ReadComicOnline'
     extClass = '.Readcomiconline'
-    extVersionCode = 26
+    extVersionCode = 28
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
@@ -11,6 +11,8 @@ import android.webkit.ConsoleMessage
 import android.webkit.WebChromeClient
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import eu.kanade.tachiyomi.lib.randomua.UserAgentType
+import eu.kanade.tachiyomi.lib.randomua.setRandomUserAgent
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.asObservableSuccess
 import eu.kanade.tachiyomi.source.ConfigurableSource
@@ -22,7 +24,6 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
-import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
@@ -52,6 +53,9 @@ class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
     private val json: Json by injectLazy()
 
     override val client: OkHttpClient = network.cloudflareClient.newBuilder()
+        .setRandomUserAgent(
+            userAgentType = UserAgentType.DESKTOP,
+        )
         .addNetworkInterceptor(::captchaInterceptor)
         .build()
 
@@ -69,10 +73,6 @@ class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
     }
 
     private var captchaUrl: String? = null
-
-    override fun headersBuilder() = Headers.Builder().apply {
-        add("User-Agent", "Mozilla/5.0 (Windows NT 6.3; WOW64)")
-    }
 
     private val preferences: SharedPreferences by lazy {
         Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
@@ -38,7 +38,6 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import kotlin.random.Random
 
 class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
 
@@ -235,6 +234,9 @@ class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
         var webView: WebView? = null
         var images: List<String> = emptyList()
 
+        val match = KEY_REGEX.find(document.outerHtml())
+        val key1 = match?.groups?.get(1)?.value ?: throw Exception("Fail to get image links.")
+        val key2 = match?.groups?.get(2)?.value ?: throw Exception("Fail to get image links.")
         handler.post {
             val innerWv = WebView(Injekt.get<Application>())
 
@@ -247,15 +249,9 @@ class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
 
             innerWv.webViewClient = object : WebViewClient() {
                 override fun onLoadResource(view: WebView?, url: String?) {
-                    val i = Random.nextInt(0, Int.MAX_VALUE)
                     view?.evaluateJavascript(
                         """
-                        const variable$i = Object.keys(window).find(key => {
-                          const value = window[key];
-                          return Array.isArray(value) && value.every(item => typeof item === 'string' && (item.includes('blogspot') || item.includes('whatsnew247')));
-                        });
-
-                        window[variable$i];
+                        window['$key2'].map(i => $key1(i));
                         """.trimIndent(),
                     ) {
                         try {
@@ -447,5 +443,6 @@ class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
         private const val QUALITY_PREF = "qualitypref"
         private const val SERVER_PREF_TITLE = "Server Preference"
         private const val SERVER_PREF = "serverpref"
+        private val KEY_REGEX = """\.attr\('src',\s*([^\(]+)\(([^\[]+)\[currImage\]\)""".toRegex()
     }
 }

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
@@ -55,6 +55,7 @@ class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
     override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .setRandomUserAgent(
             userAgentType = UserAgentType.DESKTOP,
+            filterInclude = listOf("chrome"),
         )
         .addNetworkInterceptor(::captchaInterceptor)
         .build()


### PR DESCRIPTION
Close: https://github.com/keiyoushi/extensions-source/issues/4115

Hope they won't break the extension soon.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
