### PR TITLE
CatharsisWorld: Add SSL ignore

### DIFF
--- a/src/es/catharsisworld/build.gradle
+++ b/src/es/catharsisworld/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.CatharsisWorld'
     themePkg = 'mangathemesia'
     baseUrl = 'https://catharsisworld.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/es/catharsisworld/src/eu/kanade/tachiyomi/extension/es/catharsisworld/CatharsisWorld.kt
+++ b/src/es/catharsisworld/src/eu/kanade/tachiyomi/extension/es/catharsisworld/CatharsisWorld.kt
@@ -1,7 +1,14 @@
 package eu.kanade.tachiyomi.extension.es.catharsisworld
 
+import android.annotation.SuppressLint
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import okhttp3.OkHttpClient
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
 
 class CatharsisWorld : MangaThemesia(
     "Catharsis World",
@@ -10,5 +17,24 @@ class CatharsisWorld : MangaThemesia(
 ) {
     override val client = super.client.newBuilder()
         .rateLimit(3)
+        .ignoreAllSSLErrors()
         .build()
+
+    private fun OkHttpClient.Builder.ignoreAllSSLErrors(): OkHttpClient.Builder {
+        val naiveTrustManager = @SuppressLint("CustomX509TrustManager")
+        object : X509TrustManager {
+            override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+            override fun checkClientTrusted(certs: Array<X509Certificate>, authType: String) = Unit
+            override fun checkServerTrusted(certs: Array<X509Certificate>, authType: String) = Unit
+        }
+
+        val insecureSocketFactory = SSLContext.getInstance("TLSv1.2").apply {
+            val trustAllCerts = arrayOf<TrustManager>(naiveTrustManager)
+            init(null, trustAllCerts, SecureRandom())
+        }.socketFactory
+
+        sslSocketFactory(insecureSocketFactory, naiveTrustManager)
+        hostnameVerifier { _, _ -> true }
+        return this
+    }
 }


### PR DESCRIPTION
Closes  #5354

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
