### PR TITLE
Fix HotComics only showing one chapter

### DIFF
--- a/lib-multisrc/hotcomics/build.gradle.kts
+++ b/lib-multisrc/hotcomics/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 1
+baseVersionCode = 2
 
 dependencies {
     api(project(":lib:cookieinterceptor"))

--- a/lib-multisrc/hotcomics/src/eu/kanade/tachiyomi/multisrc/hotcomics/HotComics.kt
+++ b/lib-multisrc/hotcomics/src/eu/kanade/tachiyomi/multisrc/hotcomics/HotComics.kt
@@ -120,7 +120,7 @@ abstract class HotComics(
     override fun chapterListParse(response: Response): List<SChapter> {
         return response.asJsoup().select("#tab-chapter a").map { element ->
             SChapter.create().apply {
-                setUrlWithoutDomain(element.absUrl("href"))
+                setUrlWithoutDomain(element.attr("onclick").substringAfter("popupLogin('").substringBefore("'"))
                 name = element.selectFirst(".cell-num")!!.text()
                 date_upload = parseDate(element.selectFirst(".cell-time")?.text())
             }


### PR DESCRIPTION
Closes #5370
Closes #5328 

Tested with HotComics and DayComics, the other 3 are down

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
