### PR TITLE
Nicovideo Seiga: Fix image intercept

### DIFF
--- a/src/ja/nicovideoseiga/build.gradle
+++ b/src/ja/nicovideoseiga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Nicovideo Seiga'
     extClass = '.NicovideoSeiga'
-    extVersionCode = 5
+    extVersionCode = 6
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ja/nicovideoseiga/src/eu/kanade/tachiyomi/extension/ja/nicovideoseiga/NicovideoSeiga.kt
+++ b/src/ja/nicovideoseiga/src/eu/kanade/tachiyomi/extension/ja/nicovideoseiga/NicovideoSeiga.kt
@@ -220,7 +220,7 @@ class NicovideoSeiga : HttpSource() {
         // drm.cdn.nicomanga.jp -> Paid manga (Encrypted)
         // deliver.cdn.nicomanga.jp -> Free manga (Unencrypted)
         val imageRegex =
-            Regex("https://drm.cdn.nicomanga.jp/image/([a-f0-9]+)_\\d{4}/\\d+p(\\.[a-z]+)?(\\?\\d+)?")
+            Regex("https://drm.cdn.nicomanga.jp/image/([a-f0-9]+)_\\d+/\\d+p(\\.[a-z]+)?(\\?\\d+)?")
         val match = imageRegex.find(chain.request().url.toUrl().toString())
             ?: return chain.proceed(chain.request())
 


### PR DESCRIPTION
Latest chapters are not able to decrypt due to the regex for the intercept being too strict.

Users will need to invalidate their download index, and in worse cases, clear mihon's cache entirely from system settings.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
