### PR TITLE
Magcomi: fix popular manga css selector

### DIFF
--- a/src/ja/magcomi/build.gradle
+++ b/src/ja/magcomi/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MagComi'
     themePkg = 'gigaviewer'
     baseUrl = 'https://magcomi.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ja/magcomi/src/eu/kanade/tachiyomi/extension/ja/magcomi/MagComi.kt
+++ b/src/ja/magcomi/src/eu/kanade/tachiyomi/extension/ja/magcomi/MagComi.kt
@@ -20,11 +20,11 @@ class MagComi : GigaViewer(
 
     override val publisher: String = "マッグガーデン"
 
-    override fun popularMangaSelector(): String = "ul.magcomi-series-list li.series-item > a"
+    override fun popularMangaSelector(): String = "ul[class^=\"SeriesSection_series_list\"] > li > a"
 
     override fun popularMangaFromElement(element: Element): SManga = SManga.create().apply {
-        title = element.select("h3.series-title").text()
-        thumbnail_url = element.select("div.series-thumb img").attr("src")
+        title = element.select("h3").text()
+        thumbnail_url = element.select("div.jsx-series-thumb > span > noscript > img").attr("src")
         setUrlWithoutDomain(element.attr("href"))
     }
 


### PR DESCRIPTION
Closes #5432.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
