### PR TITLE
Updated Contrib to match current repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -839,6 +839,15 @@ of `mitmweb`.
 APKs can be created in Android Studio via `Build > Build Bundle(s) / APK(s) > Build APK(s)` or 
 `Build > Generate Signed Bundle / APK`.
 
+If for some reason you decide to build the APK from the command line, you can use the following
+command (because you're doing things differently than expected, I assume you have some
+knowledge of gradlew and your OS):
+
+```console
+// Assuming that you have ./signingkey.jks in the root of the project
+$ KEY_STORE_PASSWORD="your_keystore_password" ALIAS="your_certificate_alias" KEY_PASSWORD="your_certificate_password" ./gradlew build
+```
+
 ## Submitting the changes
 
 When you feel confident about your changes, submit a new Pull Request so your code can be reviewed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,12 +86,11 @@ small, just do a normal full clone instead.**
     ```bash
     git sparse-checkout set --cone --sparse-index
     # add project folders
-    git sparse-checkout add .run buildSrc core gradle lib multisrc/src/main/java/generator
+    git sparse-checkout add buildSrc core gradle lib
     # add a single source
     git sparse-checkout add src/<lang>/<source>
     # add a multisrc theme
-    git sparse-checkout add multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/<source>
-    git sparse-checkout add multisrc/overrides/<source>
+    git sparse-checkout add lib-multisrc/<source>
     ```
 
     To remove a source, open `.git/info/sparse-checkout` and delete the exact
@@ -112,13 +111,11 @@ small, just do a normal full clone instead.**
     ```bash
     /*
     !/src/*
-    !/multisrc/overrides/*
-    !/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/*
+    !/multisrc-lib/*
     # allow a single source
     /src/<lang>/<source>
     # allow a multisrc theme
-    /multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/<source>
-    /multisrc/overrides/<source>
+    /lib-multisrc/<source>
     # or type the source name directly
     <source>
     ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -844,8 +844,8 @@ command (because you're doing things differently than expected, I assume you hav
 knowledge of gradlew and your OS):
 
 ```console
-// Assuming that you have ./signingkey.jks in the root of the project
-$ KEY_STORE_PASSWORD="your_keystore_password" ALIAS="your_certificate_alias" KEY_PASSWORD="your_certificate_password" ./gradlew build
+// For a single apk, use this command
+$ ./gradlew src:<lang>:<source>:assembleDebug
 ```
 
 ## Submitting the changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,11 +86,9 @@ small, just do a normal full clone instead.**
     ```bash
     git sparse-checkout set --cone --sparse-index
     # add project folders
-    git sparse-checkout add buildSrc core gradle lib
+    git sparse-checkout add buildSrc core gradle lib lib-multisrc
     # add a single source
     git sparse-checkout add src/<lang>/<source>
-    # add a multisrc theme
-    git sparse-checkout add lib-multisrc/<source>
     ```
 
     To remove a source, open `.git/info/sparse-checkout` and delete the exact


### PR DESCRIPTION
Removed non-existing folder of sparse-checkout commands. 

Also added a note for people who want to build from CLI (this commit can be dropped if wanted)

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
