### PR TITLE
Update domain for 7 extensions

### DIFF
--- a/src/en/erosscans/build.gradle
+++ b/src/en/erosscans/build.gradle
@@ -2,8 +2,9 @@ ext {
     extName = 'Eros Scans'
     extClass = '.ErosScans'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://erosscans.xyz'
-    overrideVersionCode = 0
+    baseUrl = 'https://tercoscans.xyz'
+    overrideVersionCode = 1
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/erosscans/src/eu/kanade/tachiyomi/extension/en/erosscans/ErosScans.kt
+++ b/src/en/erosscans/src/eu/kanade/tachiyomi/extension/en/erosscans/ErosScans.kt
@@ -5,7 +5,7 @@ import eu.kanade.tachiyomi.network.interceptor.rateLimit
 
 class ErosScans : MangaThemesia(
     "Eros Scans",
-    "https://erosscans.xyz",
+    "https://tercoscans.xyz",
     "en",
 ) {
     override val client = super.client.newBuilder()

--- a/src/en/mangabtt/build.gradle
+++ b/src/en/mangabtt/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaBTT'
     extClass = '.MangaBTT'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/en/mangabtt/src/eu/kanade/tachiyomi/extension/en/mangabtt/MangaBTT.kt
+++ b/src/en/mangabtt/src/eu/kanade/tachiyomi/extension/en/mangabtt/MangaBTT.kt
@@ -20,7 +20,7 @@ class MangaBTT : ParsedHttpSource() {
 
     override val name = "MangaBTT"
 
-    override val baseUrl = "https://manhwalampo.com"
+    override val baseUrl = "https://manhwabtt.cc"
 
     override val lang = "en"
 

--- a/src/en/tecnoscans/build.gradle
+++ b/src/en/tecnoscans/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Tecno Scans'
     extClass = '.TecnoScans'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://oliosscans.xyz'
-    overrideVersionCode = 2
+    baseUrl = 'https://tecolyscans.xyz'
+    overrideVersionCode = 3
     isNsfw = false
 }
 

--- a/src/en/tecnoscans/src/eu/kanade/tachiyomi/extension/en/tecnoscans/TecnoScans.kt
+++ b/src/en/tecnoscans/src/eu/kanade/tachiyomi/extension/en/tecnoscans/TecnoScans.kt
@@ -13,7 +13,7 @@ import uy.kohesive.injekt.api.get
 class TecnoScans :
     MangaThemesia(
         "Tecno Scans",
-        "https://oliosscans.xyz",
+        "https://tecolyscans.xyz",
         "en",
     ),
     ConfigurableSource {

--- a/src/es/knightnoscanlation/build.gradle
+++ b/src/es/knightnoscanlation/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Knight No Scanlation'
     extClass = '.KnightNoScanlation'
     themePkg = 'madara'
-    baseUrl = 'https://lectorkns.com'
-    overrideVersionCode = 1
+    baseUrl = 'https://lectorkns.eyudud.net'
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/es/knightnoscanlation/src/eu/kanade/tachiyomi/extension/es/knightnoscanlation/KnightNoScanlation.kt
+++ b/src/es/knightnoscanlation/src/eu/kanade/tachiyomi/extension/es/knightnoscanlation/KnightNoScanlation.kt
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit
 
 class KnightNoScanlation : Madara(
     "Knight No Scanlation",
-    "https://lectorkns.com",
+    "https://lectorkns.eyudud.net",
     "es",
     SimpleDateFormat("MMMM dd, yyyy", Locale("es")),
 ) {
@@ -19,6 +19,10 @@ class KnightNoScanlation : Madara(
         .build()
 
     override val mangaSubString = "sr"
+
+    override val useLoadMoreRequest = LoadMoreStrategy.Always
+
+    override val useNewChapterEndpoint = true
 
     override val mangaDetailsSelectorStatus = "div.post-content_item:contains(Status) div.summary-content"
 }

--- a/src/tr/summertoon/build.gradle
+++ b/src/tr/summertoon/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'SummerToon'
     extClass = '.SummerToon'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://summertoon.biz'
-    overrideVersionCode = 3
+    baseUrl = 'https://summertoon.co'
+    overrideVersionCode = 4
     isNsfw = false
 }
 

--- a/src/tr/summertoon/src/eu/kanade/tachiyomi/extension/tr/summertoon/SummerToon.kt
+++ b/src/tr/summertoon/src/eu/kanade/tachiyomi/extension/tr/summertoon/SummerToon.kt
@@ -7,7 +7,7 @@ import java.util.Locale
 
 class SummerToon : MangaThemesia(
     "SummerToon",
-    "https://summertoon.biz",
+    "https://summertoon.co",
     "tr",
     dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("tr")),
 ) {

--- a/src/vi/nettruyenco/build.gradle
+++ b/src/vi/nettruyenco/build.gradle
@@ -2,8 +2,9 @@ ext {
     extName = 'NetTruyenCO (unoriginal)'
     extClass = '.NetTruyenCO'
     themePkg = 'wpcomics'
-    baseUrl = 'https://nettruyenaa.com'
-    overrideVersionCode = 2
+    baseUrl = 'https://nettruyenww.com'
+    overrideVersionCode = 3
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/vi/nettruyenco/src/eu/kanade/tachiyomi/extension/vi/nettruyenco/NetTruyenCO.kt
+++ b/src/vi/nettruyenco/src/eu/kanade/tachiyomi/extension/vi/nettruyenco/NetTruyenCO.kt
@@ -8,7 +8,7 @@ import java.util.Locale
 
 class NetTruyenCO : WPComics(
     "NetTruyenCO (unoriginal)",
-    "https://nettruyenaa.com",
+    "https://nettruyenww.com",
     "vi",
     dateFormat = SimpleDateFormat("dd/MM/yy", Locale.getDefault()),
     gmtOffset = null,

--- a/src/vi/truyenvn/build.gradle
+++ b/src/vi/truyenvn/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'TruyenVN'
     extClass = '.TruyenVN'
     themePkg = 'madara'
-    baseUrl = 'https://truyenvn.mobi'
-    overrideVersionCode = 4
+    baseUrl = 'https://truyenvn.blog'
+    overrideVersionCode = 5
     isNsfw = true
 }
 

--- a/src/vi/truyenvn/src/eu/kanade/tachiyomi/extension/vi/truyenvn/TruyenVN.kt
+++ b/src/vi/truyenvn/src/eu/kanade/tachiyomi/extension/vi/truyenvn/TruyenVN.kt
@@ -6,7 +6,7 @@ import java.util.Locale
 
 class TruyenVN : Madara(
     "TruyenVN",
-    "https://truyenvn.mobi",
+    "https://truyenvn.blog",
     "vi",
     dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.ROOT),
 ) {


### PR DESCRIPTION
- Knight No Scanlation
- SummerToon
- TruyenVN (Closes #5392)
- Eros Scans
- Tecno Scans
- MangaBTT
- NetTruyenCO (unoriginal) (Closes #5484)


Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
