### PR TITLE
HentaiRead: Fix url selector

### DIFF
--- a/src/en/hentairead/build.gradle
+++ b/src/en/hentairead/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Hentairead'
     themePkg = 'madara'
     baseUrl = 'https://hentairead.com'
-    overrideVersionCode = 7
+    overrideVersionCode = 8
     isNsfw = true
 }
 

--- a/src/en/hentairead/src/eu/kanade/tachiyomi/extension/en/hentairead/Hentairead.kt
+++ b/src/en/hentairead/src/eu/kanade/tachiyomi/extension/en/hentairead/Hentairead.kt
@@ -94,7 +94,7 @@ class Hentairead : Madara("HentaiRead", "https://hentairead.com", "en", dateForm
     override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/$mangaSubString/${searchPage(page)}?sortby=views", headers)
     override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/$mangaSubString/${searchPage(page)}?sortby=new", headers)
     override fun popularMangaSelector() = ".manga-item"
-    override val popularMangaUrlSelector = ".manga-item__bottom a"
+    override val popularMangaUrlSelector = "a.manga-item__link"
 
     private fun getTagId(tag: String, type: String): Int? {
         val ajax = "$baseUrl/wp-admin/admin-ajax.php?action=search_manga_terms&search=$tag&taxonomy=$type".replace("artist", "manga_artist")


### PR DESCRIPTION
Closes #5600

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
