### PR TITLE
GenzToons: Fix wrong image url and increase timeouts

### DIFF
--- a/src/en/suryascans/build.gradle
+++ b/src/en/suryascans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.GenzToons'
     themePkg = 'keyoapp'
     baseUrl = 'https://genzupdates.com'
-    overrideVersionCode = 29
+    overrideVersionCode = 30
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/suryascans/src/eu/kanade/tachiyomi/extension/en/suryascans/GenzToons.kt
+++ b/src/en/suryascans/src/eu/kanade/tachiyomi/extension/en/suryascans/GenzToons.kt
@@ -13,6 +13,7 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.util.concurrent.TimeUnit
 
 class GenzToons :
     Keyoapp(
@@ -27,6 +28,9 @@ class GenzToons :
 
     override val client = super.client.newBuilder()
         .rateLimit(3)
+        .connectTimeout(90, TimeUnit.SECONDS)
+        .writeTimeout(90, TimeUnit.SECONDS)
+        .readTimeout(90, TimeUnit.SECONDS)
         .build()
 
     override fun chapterListSelector(): String {
@@ -70,6 +74,6 @@ class GenzToons :
     companion object {
         private const val SHOW_PAID_CHAPTERS_PREF = "pref_show_paid_chap"
         private const val SHOW_PAID_CHAPTERS_DEFAULT = false
-        private val CDN_URL_REGEX = """realUrl\s*=\s*`([^`]+)\$""".toRegex()
+        private val CDN_URL_REGEX = """realUrl\s*=\s*`([^`]+?)\$""".toRegex()
     }
 }


### PR DESCRIPTION
Closes #5619 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
