### PR TITLE
KemonoTheme: Fix chapter URL in Webview

### DIFF
--- a/lib-multisrc/kemono/build.gradle.kts
+++ b/lib-multisrc/kemono/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 13
+baseVersionCode = 14

--- a/lib-multisrc/kemono/src/eu/kanade/tachiyomi/multisrc/kemono/Kemono.kt
+++ b/lib-multisrc/kemono/src/eu/kanade/tachiyomi/multisrc/kemono/Kemono.kt
@@ -191,6 +191,8 @@ open class Kemono(
 
     override fun mangaDetailsParse(response: Response) = throw UnsupportedOperationException()
 
+    override fun getChapterUrl(chapter: SChapter) = "$baseUrl${chapter.url.replace("$apiPath/", "")}"
+
     override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> = Observable.fromCallable {
         KemonoPostDto.dateFormat.timeZone = when (manga.author) {
             "Pixiv Fanbox", "Fantia" -> TimeZone.getTimeZone("GMT+09:00")


### PR DESCRIPTION
Closes #5638

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
