### PR TITLE
MangasOriginesFr: Fix dateFormat

### DIFF
--- a/src/fr/mangasoriginesfr/build.gradle
+++ b/src/fr/mangasoriginesfr/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangasOriginesFr'
     themePkg = 'madara'
     baseUrl = 'https://mangas-origines.fr'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/mangasoriginesfr/src/eu/kanade/tachiyomi/extension/fr/mangasoriginesfr/MangasOriginesFr.kt
+++ b/src/fr/mangasoriginesfr/src/eu/kanade/tachiyomi/extension/fr/mangasoriginesfr/MangasOriginesFr.kt
@@ -4,7 +4,12 @@ import eu.kanade.tachiyomi.multisrc.madara.Madara
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class MangasOriginesFr : Madara("Mangas-Origines.fr", "https://mangas-origines.fr", "fr", SimpleDateFormat("dd/mm/yyyy", Locale("fr"))) {
+class MangasOriginesFr : Madara(
+    "Mangas-Origines.fr",
+    "https://mangas-origines.fr",
+    "fr",
+    SimpleDateFormat("dd/MM/yyyy", Locale("fr")),
+) {
     override val mangaSubString = "catalogues"
 
     // Manga Details Selectors


### PR DESCRIPTION
Closes #5658

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
