### PR TITLE
Comick: Fix permanently cached First Cover URLs and Score on Description

### DIFF
--- a/src/all/comickfun/build.gradle
+++ b/src/all/comickfun/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comick'
     extClass = '.ComickFactory'
-    extVersionCode = 47
+    extVersionCode = 48
     isNsfw = true
 }
 

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
@@ -498,12 +498,12 @@ abstract class Comick(
         private val SPACE_AND_SLASH_REGEX = Regex("[ /]")
         private const val IGNORED_GROUPS_PREF = "IgnoredGroups"
         private const val INCLUDE_MU_TAGS_PREF = "IncludeMangaUpdatesTags"
-        private const val INCLUDE_MU_TAGS_DEFAULT = false
+        const val INCLUDE_MU_TAGS_DEFAULT = false
         private const val MIGRATED_IGNORED_GROUPS = "MigratedIgnoredGroups"
         private const val FIRST_COVER_PREF = "DefaultCover"
         private const val FIRST_COVER_DEFAULT = true
         private const val SCORE_POSITION_PREF = "ScorePosition"
-        private const val SCORE_POSITION_DEFAULT = "top"
+        const val SCORE_POSITION_DEFAULT = "top"
         private const val LIMIT = 20
         private const val CHAPTERS_LIMIT = 99999
     }

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
@@ -329,7 +329,11 @@ abstract class Comick(
                     is TagFilter -> {
                         if (it.state.isNotEmpty()) {
                             it.state.split(",").forEach {
-                                addQueryParameter("tags", it.trim().lowercase().replace(SPACE_AND_SLASH_REGEX, "-").replace("'-", "-and-039-").replace("'", "-and-039-"))
+                                addQueryParameter(
+                                    "tags",
+                                    it.trim().lowercase().replace(SPACE_AND_SLASH_REGEX, "-")
+                                        .replace("'-", "-and-039-").replace("'", "-and-039-"),
+                                )
                             }
                         }
                     }

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
@@ -378,10 +378,14 @@ abstract class Comick(
                 .parseAs<Covers>().mdCovers.reversed()
             return mangaData.toSManga(
                 includeMuTags = preferences.includeMuTags,
-                covers = if (covers.any { it.vol == "1" }) covers.filter { it.vol == "1" } else covers,
+                scorePosition = preferences.scorePosition,
+                covers = covers,
             )
         }
-        return mangaData.toSManga(includeMuTags = preferences.includeMuTags)
+        return mangaData.toSManga(
+            includeMuTags = preferences.includeMuTags,
+            scorePosition = preferences.scorePosition,
+        )
     }
 
     override fun getMangaUrl(manga: SManga): String {

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
@@ -381,9 +381,11 @@ abstract class Comick(
             val covers = client.newCall(GET(coversUrl)).execute()
                 .parseAs<Covers>().mdCovers.reversed().toMutableList()
             if (covers.any { it.vol == "1" }) covers.retainAll { it.vol == "1" }
-            if (covers.any {
-                    it.locale == comickLang.split('-').first()
-                }) covers.retainAll { it.locale == comickLang.split('-').first() }
+            if (
+                covers.any { it.locale == comickLang.split('-').first() }
+            ) {
+                covers.retainAll { it.locale == comickLang.split('-').first() }
+            }
             return mangaData.toSManga(
                 includeMuTags = preferences.includeMuTags,
                 scorePosition = preferences.scorePosition,

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
@@ -372,19 +372,6 @@ abstract class Comick(
     private fun mangaDetailsParse(response: Response, manga: SManga): SManga {
         val mangaData = response.parseAs<Manga>()
         if (!preferences.updateCover && manga.thumbnail_url != mangaData.comic.cover) {
-            if (manga.thumbnail_url.toString().endsWith("#1")) {
-                return mangaData.toSManga(
-                    includeMuTags = preferences.includeMuTags,
-                    scorePosition = preferences.scorePosition,
-                    covers = listOf(
-                        MDcovers(
-                            b2key = manga.thumbnail_url?.substringBeforeLast("#")
-                                ?.substringAfterLast("/"),
-                            vol = "1",
-                        ),
-                    ),
-                )
-            }
             val coversUrl =
                 "$apiUrl/comic/${mangaData.comic.slug ?: mangaData.comic.hid}/covers?tachiyomi=true"
             val covers = client.newCall(GET(coversUrl)).execute()

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
@@ -381,7 +381,9 @@ abstract class Comick(
             val covers = client.newCall(GET(coversUrl)).execute()
                 .parseAs<Covers>().mdCovers.reversed().toMutableList()
             if (covers.any { it.vol == "1" }) covers.retainAll { it.vol == "1" }
-            if (covers.any { it.locale == comickLang }) covers.retainAll { it.locale == comickLang }
+            if (covers.any {
+                    it.locale == comickLang.split('-').first()
+                }) covers.retainAll { it.locale == comickLang.split('-').first() }
             return mangaData.toSManga(
                 includeMuTags = preferences.includeMuTags,
                 scorePosition = preferences.scorePosition,

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
@@ -375,7 +375,9 @@ abstract class Comick(
             val coversUrl =
                 "$apiUrl/comic/${mangaData.comic.slug ?: mangaData.comic.hid}/covers?tachiyomi=true"
             val covers = client.newCall(GET(coversUrl)).execute()
-                .parseAs<Covers>().mdCovers.reversed()
+                .parseAs<Covers>().mdCovers.reversed().toMutableList()
+            if (covers.any { it.vol == "1" }) covers.retainAll { it.vol == "1" }
+            if (covers.any { it.locale == comickLang }) covers.retainAll { it.locale == comickLang }
             return mangaData.toSManga(
                 includeMuTags = preferences.includeMuTags,
                 scorePosition = preferences.scorePosition,

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Dto.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Dto.kt
@@ -150,7 +150,7 @@ class Covers(
 class MDcovers(
     val b2key: String?,
     val vol: String? = null,
-    val locale: String? = "ja",
+    val locale: String? = null,
 )
 
 @Serializable

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Dto.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Dto.kt
@@ -1,5 +1,7 @@
 package eu.kanade.tachiyomi.extension.all.comickfun
 
+import eu.kanade.tachiyomi.extension.all.comickfun.Comick.Companion.INCLUDE_MU_TAGS_DEFAULT
+import eu.kanade.tachiyomi.extension.all.comickfun.Comick.Companion.SCORE_POSITION_DEFAULT
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import kotlinx.serialization.SerialName
@@ -31,8 +33,8 @@ class Manga(
     private val demographic: String? = null,
 ) {
     fun toSManga(
-        includeMuTags: Boolean = false,
-        scorePosition: String = "",
+        includeMuTags: Boolean = INCLUDE_MU_TAGS_DEFAULT,
+        scorePosition: String = SCORE_POSITION_DEFAULT,
         covers: List<MDcovers>? = null,
     ) =
         SManga.create().apply {

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Dto.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Dto.kt
@@ -150,6 +150,7 @@ class Covers(
 class MDcovers(
     val b2key: String?,
     val vol: String? = null,
+    val locale: String? = "ja",
 )
 
 @Serializable


### PR DESCRIPTION
After loading a backup on https://backup.mihon.tools I realized a lot of covers were broken due to me using the Prefer First Cover preference and its permanent cache (skipping rechecks) of the first cover URL on my original assumption it would never change (I was wrong).

Other changes as described on commit messages

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
