### PR TITLE
LXHentai: Update domain and selectors

### DIFF
--- a/src/vi/lxhentai/AndroidManifest.xml
+++ b/src/vi/lxhentai/AndroidManifest.xml
@@ -14,7 +14,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:host="lxmanga.click"
+                    android:host="lxmanga.online"
                     android:pathPattern="/truyen/..*"
                     android:scheme="https" />
             </intent-filter>

--- a/src/vi/lxhentai/build.gradle
+++ b/src/vi/lxhentai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'LXHentai'
     extClass = '.LxHentai'
-    extVersionCode = 8
+    extVersionCode = 9
     isNsfw = true
 }
 

--- a/src/vi/lxhentai/src/eu/kanade/tachiyomi/extension/vi/lxhentai/LxHentai.kt
+++ b/src/vi/lxhentai/src/eu/kanade/tachiyomi/extension/vi/lxhentai/LxHentai.kt
@@ -30,7 +30,7 @@ class LxHentai : ParsedHttpSource(), ConfigurableSource {
 
     override val name = "LXHentai"
 
-    private val defaultBaseUrl = "https://lxmanga.click"
+    private val defaultBaseUrl = "https://lxmanga.online"
 
     override val baseUrl by lazy { getPrefBaseUrl() }
 
@@ -118,11 +118,7 @@ class LxHentai : ParsedHttpSource(), ConfigurableSource {
     override fun searchMangaFromElement(element: Element) = SManga.create().apply {
         setUrlWithoutDomain(element.select("div.p-2.truncate a").first()!!.attr("href"))
         title = element.select("div.p-2.truncate a").first()!!.text()
-        thumbnail_url = element.select("div.cover")
-            .first()!!
-            .attr("style")
-            .substringAfter("url('")
-            .substringBefore("')")
+        thumbnail_url = element.selectFirst("div.cover")?.absUrl("data-bg")
     }
 
     override fun searchMangaNextPageSelector() = "li:contains(Cuối)"
@@ -151,11 +147,9 @@ class LxHentai : ParsedHttpSource(), ConfigurableSource {
             }
         }.trim()
 
-        thumbnail_url = document.select(".cover")
-            .first()!!
-            .attr("style")
-            .substringAfter("url('")
-            .substringBefore("')")
+        thumbnail_url = document.selectFirst(".cover")?.attr("style")?.let {
+            IMAGE_REGEX.find(it)?.groups?.get("img")?.value
+        }
 
         val statusString = document.select("div.grow div.mt-2:contains(Tình trạng) a").first()!!.text()
         status = when (statusString) {
@@ -167,7 +161,7 @@ class LxHentai : ParsedHttpSource(), ConfigurableSource {
         setUrlWithoutDomain(document.location())
     }
 
-    override fun chapterListSelector(): String = "ul.overflow-y-auto.overflow-x-hidden a"
+    override fun chapterListSelector(): String = "ul.overflow-y-auto.overflow-x-hidden > a"
 
     override fun chapterFromElement(element: Element) = SChapter.create().apply {
         setUrlWithoutDomain(element.attr("href"))
@@ -340,6 +334,7 @@ class LxHentai : ParsedHttpSource(), ConfigurableSource {
         const val PREFIX_ID_SEARCH = "id:"
 
         val CHAPTER_NUMBER_REGEX = Regex("""[+\-]?([0-9]*[.])?[0-9]+""", RegexOption.IGNORE_CASE)
+        val IMAGE_REGEX = """url\('(?<img>[^']+)""".toRegex()
 
         private const val DEFAULT_BASE_URL_PREF = "defaultBaseUrl"
         private const val RESTART_APP = "Khởi chạy lại ứng dụng để áp dụng thay đổi."


### PR DESCRIPTION
Closes #5690
Closes #5385

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
