### PR TITLE
fix parseChapterPage selector

### DIFF
--- a/src/all/ehentai/build.gradle
+++ b/src/all/ehentai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'E-Hentai'
     extClass = '.EHFactory'
-    extVersionCode = 20
+    extVersionCode = 21
     isNsfw = true
 }
 

--- a/src/all/ehentai/src/eu/kanade/tachiyomi/extension/all/ehentai/EHentai.kt
+++ b/src/all/ehentai/src/eu/kanade/tachiyomi/extension/all/ehentai/EHentai.kt
@@ -131,9 +131,9 @@ abstract class EHentai(
     }
 
     private fun parseChapterPage(response: Element) = with(response) {
-        select(".gdtm a").map {
-            Pair(it.child(0).attr("alt").toInt(), it.attr("href"))
-        }.sortedBy(Pair<Int, String>::first).map { it.second }
+        select("#gdt a").map {
+            it.attr("href")
+        }
     }
 
     private fun chapterPageCall(np: String) = client.newCall(chapterPageRequest(np)).asObservableSuccess()


### PR DESCRIPTION
closes #5745 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
