### PR TITLE
Colamanga: Fix thumbnail_url

### DIFF
--- a/lib-multisrc/colamanga/build.gradle.kts
+++ b/lib-multisrc/colamanga/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 4
+baseVersionCode = 5
 
 dependencies {
     api(project(":lib:synchrony"))

--- a/lib-multisrc/colamanga/src/eu/kanade/tachiyomi/multisrc/colamanga/ColaManga.kt
+++ b/lib-multisrc/colamanga/src/eu/kanade/tachiyomi/multisrc/colamanga/ColaManga.kt
@@ -153,7 +153,7 @@ abstract class ColaManga(
 
     override fun mangaDetailsParse(document: Document) = SManga.create().apply {
         title = document.selectFirst("h1.fed-part-eone")!!.text()
-        thumbnail_url = document.selectFirst("a.fed-list-pics")?.absUrl("data-orignal")
+        thumbnail_url = document.selectFirst("a.fed-list-pics")?.absUrl("data-original")
         author = document.selectFirst("span.fed-text-muted:contains($authorTitle) + a")?.text()
         genre = document.select("span.fed-text-muted:contains($genreTitle) ~ a").joinToString { it.text() }
         description = document


### PR DESCRIPTION
No related issue.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
