### PR TITLE
ResetScans: Migrate theme

### DIFF
--- a/src/en/resetscans/build.gradle
+++ b/src/en/resetscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ResetScans'
     themePkg = 'fuzzydoodle'
     baseUrl = 'https://reset-scans.xyz'
-    overrideVersionCode = 42
+    overrideVersionCode = 43
     isNsfw = false
 }
 

--- a/src/en/resetscans/build.gradle
+++ b/src/en/resetscans/build.gradle
@@ -1,9 +1,9 @@
 ext {
     extName = 'Reset Scans'
     extClass = '.ResetScans'
-    themePkg = 'madara'
-    baseUrl = 'https://rspro.xyz'
-    overrideVersionCode = 6
+    themePkg = 'fuzzydoodle'
+    baseUrl = 'https://reset-scans.xyz'
+    overrideVersionCode = 42
     isNsfw = false
 }
 

--- a/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
+++ b/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
@@ -6,7 +6,7 @@ class ResetScans : FuzzyDoodle(
     "https://reset-scans.xyz",
     "en",
 ) {
-    override val supportsLatest = false
+    override val latestFromHomePage = true
 
     // Moved from Madara to FuzzyDoodle
     override val versionId = 2

--- a/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
+++ b/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
@@ -1,17 +1,13 @@
 package eu.kanade.tachiyomi.extension.en.resetscans
-import eu.kanade.tachiyomi.multisrc.madara.Madara
-import java.text.SimpleDateFormat
-import java.util.Locale
+import eu.kanade.tachiyomi.multisrc.fuzzydoodle.FuzzyDoodle
 
-class ResetScans : Madara(
+class ResetScans : FuzzyDoodle(
     "Reset Scans",
-    "https://rspro.xyz",
+    "https://reset-scans.xyz",
     "en",
-    dateFormat = SimpleDateFormat("MMM dd", Locale("en")),
 ) {
+    override val supportsLatest = false
 
-    override val useLoadMoreRequest = LoadMoreStrategy.Always
-    override val useNewChapterEndpoint = true
-    override fun chapterListSelector(): String = "li.wp-manga-chapter.free-chap"
-    override val chapterUrlSelector = "div > a"
+    // Moved from Madara to FuzzyDoodle
+    override val versionId = 2
 }


### PR DESCRIPTION
Closes #5340

Bump versionID because slugs aren't the same.
Wayback machine: https://web.archive.org/web/20240815200953/http://resetscan.com/

Example:
 - https://reset-scans.xyz/manga/the-scholarly-reincarnation (The Scholarly Reincarnation )
 - https://resetscan.com/manga/scholar-return/ (The Scholarly Reincarnation)


Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
