### PR TITLE
Add exception to Batoto when manga removed + regex update

### DIFF
--- a/src/all/batoto/build.gradle
+++ b/src/all/batoto/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Bato.to'
     extClass = '.BatoToFactory'
-    extVersionCode = 41
+    extVersionCode = 42
     isNsfw = true
 }
 

--- a/src/all/batoto/build.gradle
+++ b/src/all/batoto/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Bato.to'
     extClass = '.BatoToFactory'
-    extVersionCode = 42
+    extVersionCode = 41
     isNsfw = true
 }
 

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
@@ -393,9 +393,12 @@ open class BatoTo(
     }
 
     private fun checkChapterLists(document: Document): Boolean {
-        val alertWarningElement = document.select(".episode-list > .alert-warning").firstOrNull()
-        if (alertWarningElement != null && alertWarningElement.text().contains("This comic has been marked as deleted and the chapter list is not available.")) {
-            throw IOException("This comic was deleted.")
+        val chapterListElements = document.select(chapterListSelector())
+        if (chapterListElements.isEmpty()) {
+            val alertWarningElement = document.select(".episode-list > .alert-warning").firstOrNull()
+            if (alertWarningElement != null && alertWarningElement.text().contains("This comic has been marked as deleted and the chapter list is not available.")) {
+                throw IOException("This comic was deleted.")
+            }
         }
         return false
     }

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
@@ -323,7 +323,7 @@ open class BatoTo(
         return super.mangaDetailsRequest(manga)
     }
     private var titleRegex: Regex =
-        Regex("(?:\\([^()]*\\)|\\{[^{}]*\\}|\\[(?:(?!]).)*]|«[^»]*»|〘[^〙]*〙|「[^」]*」|『[^』]*』|≪[^≫]*≫|﹛[^﹜]*﹜|〖[^〖〗]*〗|𖤍.+?𖤍|/.+?|⌜.+?⌝)\\s*")
+        Regex("(?:\\([^()]*\\)|\\{[^{}]*\\}|\\[(?:(?!]).)*]|«[^»]*»|〘[^〙]*〙|「[^」]*」|『[^』]*』|≪[^≫]*≫|﹛[^﹜]*﹜|〖[^〖〗]*〗|𖤍.+?𖤍|《[^》]*》|/.+?|⌜.+?⌝)\\s*")
 
     override fun mangaDetailsParse(document: Document): SManga {
         val infoElement = document.select("div#mainer div.container-fluid")
@@ -392,14 +392,7 @@ open class BatoTo(
     }
 
     private fun checkChapterLists(document: Document): Boolean {
-        val chapterListElements = document.select(chapterListSelector())
-        if (chapterListElements.isEmpty()) {
-            val alertWarningElement = document.select(".episode-list > .alert-warning").firstOrNull()
-            if (alertWarningElement != null && alertWarningElement.text().contains("This comic has been marked as deleted and the chapter list is not available.")) {
-                throw Exception("This comic was deleted.")
-            }
-        }
-        return false
+        return document.select(".episode-list > .alert-warning").text().contains("This comic has been marked as deleted and the chapter list is not available.")
     }
 
     override fun chapterListRequest(manga: SManga): Request {

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
@@ -38,7 +38,6 @@ import rx.Observable
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
-import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
@@ -397,7 +396,7 @@ open class BatoTo(
         if (chapterListElements.isEmpty()) {
             val alertWarningElement = document.select(".episode-list > .alert-warning").firstOrNull()
             if (alertWarningElement != null && alertWarningElement.text().contains("This comic has been marked as deleted and the chapter list is not available.")) {
-                throw IOException("This comic was deleted.")
+                throw Exception("This comic was deleted.")
             }
         }
         return false

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
@@ -38,6 +38,7 @@ import rx.Observable
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
+import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
@@ -323,7 +324,7 @@ open class BatoTo(
         return super.mangaDetailsRequest(manga)
     }
     private var titleRegex: Regex =
-        Regex("(?:\\([^()]*\\)|\\{[^{}]*\\}|\\[(?:(?!]).)*]|«[^»]*»|〘[^〙]*〙|「[^」]*」|『[^』]*』|≪[^≫]*≫|﹛[^﹜]*﹜|〖[^〖〗]*〗|𖤍.+?𖤍|/.+?)\\s*|([|/~].*)|-.*-")
+        Regex("(?:\\([^()]*\\)|\\{[^{}]*\\}|\\[(?:(?!]).)*]|«[^»]*»|〘[^〙]*〙|「[^」]*」|『[^』]*』|≪[^≫]*≫|﹛[^﹜]*﹜|〖[^〖〗]*〗|𖤍.+?𖤍|/.+?|⌜.+?⌝)\\s*")
 
     override fun mangaDetailsParse(document: Document): SManga {
         val infoElement = document.select("div#mainer div.container-fluid")
@@ -392,7 +393,11 @@ open class BatoTo(
     }
 
     private fun checkChapterLists(document: Document): Boolean {
-        return document.select(".episode-list > .alert-warning").text().contains("This comic has been marked as deleted and the chapter list is not available.")
+        val alertWarningElement = document.select(".episode-list > .alert-warning").firstOrNull()
+        if (alertWarningElement != null && alertWarningElement.text().contains("This comic has been marked as deleted and the chapter list is not available.")) {
+            throw IOException("This comic was deleted.")
+        }
+        return false
     }
 
     override fun chapterListRequest(manga: SManga): Request {


### PR DESCRIPTION

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
