### PR TITLE
LimitedTimeProject: Fix mangaSubString

### DIFF
--- a/src/pt/limitedtimeproject/build.gradle
+++ b/src/pt/limitedtimeproject/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.LimitedTimeProject'
     themePkg = 'madara'
     baseUrl = 'https://limitedtimeproject.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/pt/limitedtimeproject/src/eu/kanade/tachiyomi/extension/pt/limitedtimeproject/LimitedTimeProject.kt
+++ b/src/pt/limitedtimeproject/src/eu/kanade/tachiyomi/extension/pt/limitedtimeproject/LimitedTimeProject.kt
@@ -9,13 +9,13 @@ class LimitedTimeProject : Madara(
     "Limited Time Project",
     "https://limitedtimeproject.com",
     "pt-BR",
-    SimpleDateFormat("dd 'de' MMM 'de' yyyy", Locale("pt", "BR")),
+    SimpleDateFormat("dd/MM/yyyy", Locale.ROOT),
 ) {
     override val client = super.client.newBuilder()
         .rateLimit(3)
         .build()
 
-    override val mangaSubString = "manhwa"
+    override val mangaSubString = "manhwas"
 
     override val useLoadMoreRequest = LoadMoreStrategy.Never
 


### PR DESCRIPTION
Closes #5912

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
