### PR TITLE
GalleryAdult: Add w for webp

### DIFF
--- a/lib-multisrc/galleryadults/build.gradle.kts
+++ b/lib-multisrc/galleryadults/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 2
+baseVersionCode = 3

--- a/lib-multisrc/galleryadults/src/eu/kanade/tachiyomi/multisrc/galleryadults/GalleryAdults.kt
+++ b/lib-multisrc/galleryadults/src/eu/kanade/tachiyomi/multisrc/galleryadults/GalleryAdults.kt
@@ -647,6 +647,7 @@ abstract class GalleryAdults(
                         "p" -> "png"
                         "b" -> "bmp"
                         "g" -> "gif"
+                        "w" -> "webp"
                         else -> "jpg"
                     }
                     val idx = image.key.toInt()


### PR DESCRIPTION
Closes #5915

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
