### PR TITLE
MangaReader: Add support for Portuguese and Spanish

### DIFF
--- a/src/all/mangareaderto/build.gradle
+++ b/src/all/mangareaderto/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaReaderFactory'
     themePkg = 'mangareader'
     baseUrl = 'https://mangareader.to'
-    overrideVersionCode = 3
+    overrideVersionCode = 4
     isNsfw = true
 }
 

--- a/src/all/mangareaderto/src/eu/kanade/tachiyomi/extension/all/mangareaderto/MangaReader.kt
+++ b/src/all/mangareaderto/src/eu/kanade/tachiyomi/extension/all/mangareaderto/MangaReader.kt
@@ -22,8 +22,11 @@ import org.jsoup.select.Evaluator
 import rx.Observable
 
 open class MangaReader(
-    override val lang: String,
+    val language: Language,
 ) : MangaReader() {
+
+    override val lang = language.code
+
     override val name = "MangaReader"
 
     override val baseUrl = "https://mangareader.to"
@@ -33,10 +36,10 @@ open class MangaReader(
         .build()
 
     override fun latestUpdatesRequest(page: Int) =
-        GET("$baseUrl/filter?sort=latest-updated&language=$lang&page=$page", headers)
+        GET("$baseUrl/filter?sort=latest-updated&language=${language.infix}&page=$page", headers)
 
     override fun popularMangaRequest(page: Int) =
-        GET("$baseUrl/filter?sort=most-viewed&language=$lang&page=$page", headers)
+        GET("$baseUrl/filter?sort=most-viewed&language=${language.infix}&page=$page", headers)
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         val urlBuilder = baseUrl.toHttpUrl().newBuilder()
@@ -47,7 +50,7 @@ open class MangaReader(
             }
         } else {
             urlBuilder.addPathSegment("filter").apply {
-                addQueryParameter("language", lang)
+                addQueryParameter("language", language.infix)
                 addQueryParameter("page", page.toString())
                 filters.ifEmpty(::getFilterList).forEach { filter ->
                     when (filter) {
@@ -142,7 +145,7 @@ open class MangaReader(
     override fun parseChapterElements(response: Response, isVolume: Boolean): List<Element> {
         val container = response.parseHtmlProperty().run {
             val type = if (isVolume) "volumes" else "chapters"
-            selectFirst(Evaluator.Id("$lang-$type")) ?: return emptyList()
+            selectFirst(Evaluator.Id("${language.chapterInfix}-$type")) ?: return emptyList()
         }
         return container.children()
     }

--- a/src/all/mangareaderto/src/eu/kanade/tachiyomi/extension/all/mangareaderto/MangaReaderFactory.kt
+++ b/src/all/mangareaderto/src/eu/kanade/tachiyomi/extension/all/mangareaderto/MangaReaderFactory.kt
@@ -4,5 +4,19 @@ import eu.kanade.tachiyomi.source.SourceFactory
 
 class MangaReaderFactory : SourceFactory {
     override fun createSources() =
-        arrayOf("en", "fr", "ja", "ko", "zh").map(::MangaReader)
+        arrayOf(
+            Language("en"),
+            Language("es", chapterInfix = "es-mx"),
+            Language("fr"),
+            Language("ja"),
+            Language("ko"),
+            Language("pt-BR", infix = "pt"),
+            Language("zh"),
+        ).map(::MangaReader)
 }
+
+data class Language(
+    val code: String,
+    val infix: String = code,
+    val chapterInfix: String = code.lowercase(),
+)


### PR DESCRIPTION
Closes #5865

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
