### PR TITLE
Refactor out usage of `* -1`

### DIFF
--- a/lib-multisrc/fmreader/src/eu/kanade/tachiyomi/multisrc/fmreader/FMReader.kt
+++ b/lib-multisrc/fmreader/src/eu/kanade/tachiyomi/multisrc/fmreader/FMReader.kt
@@ -269,32 +269,32 @@ abstract class FMReader(
         // languages: en, vi, es, tr
         return when (dateWord) {
             "min", "minute", "phút", "minuto", "dakika" -> Calendar.getInstance().apply {
-                add(Calendar.MINUTE, value * -1)
+                add(Calendar.MINUTE, -value)
                 set(Calendar.SECOND, 0)
                 set(Calendar.MILLISECOND, 0)
             }.timeInMillis
             "hour", "giờ", "hora", "saat" -> Calendar.getInstance().apply {
-                add(Calendar.HOUR_OF_DAY, value * -1)
+                add(Calendar.HOUR_OF_DAY, -value)
                 set(Calendar.SECOND, 0)
                 set(Calendar.MILLISECOND, 0)
             }.timeInMillis
             "day", "ngày", "día", "gün" -> Calendar.getInstance().apply {
-                add(Calendar.DATE, value * -1)
+                add(Calendar.DATE, -value)
                 set(Calendar.SECOND, 0)
                 set(Calendar.MILLISECOND, 0)
             }.timeInMillis
             "week", "tuần", "semana", "hafta" -> Calendar.getInstance().apply {
-                add(Calendar.DATE, value * 7 * -1)
+                add(Calendar.DATE, -value * 7)
                 set(Calendar.SECOND, 0)
                 set(Calendar.MILLISECOND, 0)
             }.timeInMillis
             "month", "tháng", "mes", "ay" -> Calendar.getInstance().apply {
-                add(Calendar.MONTH, value * -1)
+                add(Calendar.MONTH, -value)
                 set(Calendar.SECOND, 0)
                 set(Calendar.MILLISECOND, 0)
             }.timeInMillis
             "year", "năm", "año", "yıl" -> Calendar.getInstance().apply {
-                add(Calendar.YEAR, value * -1)
+                add(Calendar.YEAR, -value)
                 set(Calendar.SECOND, 0)
                 set(Calendar.MILLISECOND, 0)
             }.timeInMillis

--- a/lib-multisrc/hentaihand/src/eu/kanade/tachiyomi/multisrc/hentaihand/HentaiHand.kt
+++ b/lib-multisrc/hentaihand/src/eu/kanade/tachiyomi/multisrc/hentaihand/HentaiHand.kt
@@ -232,7 +232,7 @@ abstract class HentaiHand(
                     val date = it.jsonObject["added_at"]!!.jsonPrimitive.content
                     date_upload = if (date.contains("day")) {
                         Calendar.getInstance().apply {
-                            add(Calendar.DATE, date.filter { it.isDigit() }.toInt() * -1)
+                            add(Calendar.DATE, -date.filter { it.isDigit() }.toInt())
                         }.timeInMillis
                     } else {
                         DATE_FORMAT.parse(it.jsonObject["added_at"]!!.jsonPrimitive.content)?.time ?: 0
@@ -248,7 +248,7 @@ abstract class HentaiHand(
                     val date = obj.jsonObject["uploaded_at"]!!.jsonPrimitive.content
                     date_upload = if (date.contains("day")) {
                         Calendar.getInstance().apply {
-                            add(Calendar.DATE, date.filter { it.isDigit() }.toInt() * -1)
+                            add(Calendar.DATE, -date.filter { it.isDigit() }.toInt())
                         }.timeInMillis
                     } else {
                         DATE_FORMAT.parse(obj.jsonObject["uploaded_at"]!!.jsonPrimitive.content)?.time ?: 0

--- a/lib-multisrc/mangabox/src/eu/kanade/tachiyomi/multisrc/mangabox/MangaBox.kt
+++ b/lib-multisrc/mangabox/src/eu/kanade/tachiyomi/multisrc/mangabox/MangaBox.kt
@@ -221,9 +221,9 @@ abstract class MangaBox(
             val value = date.split(' ')[0].toIntOrNull()
             val cal = Calendar.getInstance()
             when {
-                value != null && "min" in date -> cal.apply { add(Calendar.MINUTE, value * -1) }
-                value != null && "hour" in date -> cal.apply { add(Calendar.HOUR_OF_DAY, value * -1) }
-                value != null && "day" in date -> cal.apply { add(Calendar.DATE, value * -1) }
+                value != null && "min" in date -> cal.apply { add(Calendar.MINUTE, -value) }
+                value != null && "hour" in date -> cal.apply { add(Calendar.HOUR_OF_DAY, -value) }
+                value != null && "day" in date -> cal.apply { add(Calendar.DATE, -value) }
                 else -> null
             }?.timeInMillis
         } else {

--- a/lib-multisrc/zbulu/src/eu/kanade/tachiyomi/multisrc/zbulu/Zbulu.kt
+++ b/lib-multisrc/zbulu/src/eu/kanade/tachiyomi/multisrc/zbulu/Zbulu.kt
@@ -152,25 +152,25 @@ abstract class Zbulu(
             val value = date.split(' ')[0].toInt()
             when {
                 "second" in date -> Calendar.getInstance().apply {
-                    add(Calendar.SECOND, value * -1)
+                    add(Calendar.SECOND, -value)
                 }.timeInMillis
                 "minute" in date -> Calendar.getInstance().apply {
-                    add(Calendar.MINUTE, value * -1)
+                    add(Calendar.MINUTE, -value)
                 }.timeInMillis
                 "hour" in date -> Calendar.getInstance().apply {
-                    add(Calendar.HOUR_OF_DAY, value * -1)
+                    add(Calendar.HOUR_OF_DAY, -value)
                 }.timeInMillis
                 "day" in date -> Calendar.getInstance().apply {
-                    add(Calendar.DATE, value * -1)
+                    add(Calendar.DATE, -value)
                 }.timeInMillis
                 "week" in date -> Calendar.getInstance().apply {
-                    add(Calendar.DATE, value * 7 * -1)
+                    add(Calendar.DATE, -value * 7)
                 }.timeInMillis
                 "month" in date -> Calendar.getInstance().apply {
-                    add(Calendar.MONTH, value * -1)
+                    add(Calendar.MONTH, -value)
                 }.timeInMillis
                 "year" in date -> Calendar.getInstance().apply {
-                    add(Calendar.YEAR, value * -1)
+                    add(Calendar.YEAR, -value)
                 }.timeInMillis
                 else -> {
                     0L

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
@@ -428,46 +428,46 @@ open class BatoTo(
 
         return when {
             "secs" in date -> Calendar.getInstance().apply {
-                add(Calendar.SECOND, value * -1)
+                add(Calendar.SECOND, -value)
             }.timeInMillis
             "mins" in date -> Calendar.getInstance().apply {
-                add(Calendar.MINUTE, value * -1)
+                add(Calendar.MINUTE, -value)
             }.timeInMillis
             "hours" in date -> Calendar.getInstance().apply {
-                add(Calendar.HOUR_OF_DAY, value * -1)
+                add(Calendar.HOUR_OF_DAY, -value)
             }.timeInMillis
             "days" in date -> Calendar.getInstance().apply {
-                add(Calendar.DATE, value * -1)
+                add(Calendar.DATE, -value)
             }.timeInMillis
             "weeks" in date -> Calendar.getInstance().apply {
-                add(Calendar.DATE, value * 7 * -1)
+                add(Calendar.DATE, -value * 7)
             }.timeInMillis
             "months" in date -> Calendar.getInstance().apply {
-                add(Calendar.MONTH, value * -1)
+                add(Calendar.MONTH, -value)
             }.timeInMillis
             "years" in date -> Calendar.getInstance().apply {
-                add(Calendar.YEAR, value * -1)
+                add(Calendar.YEAR, -value)
             }.timeInMillis
             "sec" in date -> Calendar.getInstance().apply {
-                add(Calendar.SECOND, value * -1)
+                add(Calendar.SECOND, -value)
             }.timeInMillis
             "min" in date -> Calendar.getInstance().apply {
-                add(Calendar.MINUTE, value * -1)
+                add(Calendar.MINUTE, -value)
             }.timeInMillis
             "hour" in date -> Calendar.getInstance().apply {
-                add(Calendar.HOUR_OF_DAY, value * -1)
+                add(Calendar.HOUR_OF_DAY, -value)
             }.timeInMillis
             "day" in date -> Calendar.getInstance().apply {
-                add(Calendar.DATE, value * -1)
+                add(Calendar.DATE, -value)
             }.timeInMillis
             "week" in date -> Calendar.getInstance().apply {
-                add(Calendar.DATE, value * 7 * -1)
+                add(Calendar.DATE, -value * 7)
             }.timeInMillis
             "month" in date -> Calendar.getInstance().apply {
-                add(Calendar.MONTH, value * -1)
+                add(Calendar.MONTH, -value)
             }.timeInMillis
             "year" in date -> Calendar.getInstance().apply {
-                add(Calendar.YEAR, value * -1)
+                add(Calendar.YEAR, -value)
             }.timeInMillis
             else -> {
                 return 0

--- a/src/en/doujins/src/eu/kanade/tachiyomi/extension/en/doujins/Doujins.kt
+++ b/src/en/doujins/src/eu/kanade/tachiyomi/extension/en/doujins/Doujins.kt
@@ -85,12 +85,12 @@ class Doujins : HttpSource() {
             set(Calendar.MINUTE, 0)
             set(Calendar.SECOND, 0)
             set(Calendar.MILLISECOND, 0)
-            add(Calendar.DATE, -1 * PAGE_DAYS * (page - 1))
+            add(Calendar.DATE, -PAGE_DAYS * (page - 1))
         }
 
         val endDateSec = endDate.timeInMillis / 1000
         val startDateSec = endDate.apply {
-            add(Calendar.DATE, -1 * PAGE_DAYS)
+            add(Calendar.DATE, -PAGE_DAYS)
         }.timeInMillis / 1000
 
         return "$baseUrl/folders?start=$startDateSec&end=$endDateSec"

--- a/src/en/hentai2read/src/eu/kanade/tachiyomi/extension/en/hentai2read/Hentai2Read.kt
+++ b/src/en/hentai2read/src/eu/kanade/tachiyomi/extension/en/hentai2read/Hentai2Read.kt
@@ -222,25 +222,25 @@ class Hentai2Read : ParsedHttpSource() {
 
         return when {
             "second" in date -> Calendar.getInstance().apply {
-                add(Calendar.SECOND, value * -1)
+                add(Calendar.SECOND, -value)
             }.timeInMillis
             "minute" in date -> Calendar.getInstance().apply {
-                add(Calendar.MINUTE, value * -1)
+                add(Calendar.MINUTE, -value)
             }.timeInMillis
             "hour" in date -> Calendar.getInstance().apply {
-                add(Calendar.HOUR_OF_DAY, value * -1)
+                add(Calendar.HOUR_OF_DAY, -value)
             }.timeInMillis
             "day" in date -> Calendar.getInstance().apply {
-                add(Calendar.DATE, value * -1)
+                add(Calendar.DATE, -value)
             }.timeInMillis
             "week" in date -> Calendar.getInstance().apply {
-                add(Calendar.DATE, value * 7 * -1)
+                add(Calendar.DATE, -value * 7)
             }.timeInMillis
             "month" in date -> Calendar.getInstance().apply {
-                add(Calendar.MONTH, value * -1)
+                add(Calendar.MONTH, -value)
             }.timeInMillis
             "year" in date -> Calendar.getInstance().apply {
-                add(Calendar.YEAR, value * -1)
+                add(Calendar.YEAR, -value)
             }.timeInMillis
             else -> {
                 return 0

--- a/src/en/zeroscans/src/eu/kanade/tachiyomi/extension/en/zeroscans/ZeroScansHelper.kt
+++ b/src/en/zeroscans/src/eu/kanade/tachiyomi/extension/en/zeroscans/ZeroScansHelper.kt
@@ -62,25 +62,25 @@ class ZeroScansHelper {
 
         return when (date.split(' ')[1].removeSuffix("s")) {
             "sec" -> Calendar.getInstance().apply {
-                add(Calendar.SECOND, value * -1)
+                add(Calendar.SECOND, -value)
             }.timeInMillis
             "min" -> Calendar.getInstance().apply {
-                add(Calendar.MINUTE, value * -1)
+                add(Calendar.MINUTE, -value)
             }.timeInMillis
             "hour" -> Calendar.getInstance().apply {
-                add(Calendar.HOUR_OF_DAY, value * -1)
+                add(Calendar.HOUR_OF_DAY, -value)
             }.timeInMillis
             "day" -> Calendar.getInstance().apply {
-                add(Calendar.DATE, value * -1)
+                add(Calendar.DATE, -value)
             }.timeInMillis
             "week" -> Calendar.getInstance().apply {
-                add(Calendar.DATE, value * 7 * -1)
+                add(Calendar.DATE, -value * 7)
             }.timeInMillis
             "month" -> Calendar.getInstance().apply {
-                add(Calendar.MONTH, value * -1)
+                add(Calendar.MONTH, -value)
             }.timeInMillis
             "year" -> Calendar.getInstance().apply {
-                add(Calendar.YEAR, value * -1)
+                add(Calendar.YEAR, -value)
             }.timeInMillis
             else -> {
                 return 0

--- a/src/fr/furyosquad/src/eu/kanade/tachiyomi/extension/fr/furyosquad/FuryoSquad.kt
+++ b/src/fr/furyosquad/src/eu/kanade/tachiyomi/extension/fr/furyosquad/FuryoSquad.kt
@@ -192,32 +192,32 @@ class FuryoSquad : ParsedHttpSource() {
         return if (value != null) {
             when (date.split(" ")[4]) {
                 "minute", "minutes" -> Calendar.getInstance().apply {
-                    add(Calendar.MINUTE, value * -1)
+                    add(Calendar.MINUTE, -value)
                     set(Calendar.SECOND, 0)
                     set(Calendar.MILLISECOND, 0)
                 }.timeInMillis
                 "heure", "heures" -> Calendar.getInstance().apply {
-                    add(Calendar.HOUR_OF_DAY, value * -1)
+                    add(Calendar.HOUR_OF_DAY, -value)
                     set(Calendar.SECOND, 0)
                     set(Calendar.MILLISECOND, 0)
                 }.timeInMillis
                 "jour", "jours" -> Calendar.getInstance().apply {
-                    add(Calendar.DATE, value * -1)
+                    add(Calendar.DATE, -value)
                     set(Calendar.SECOND, 0)
                     set(Calendar.MILLISECOND, 0)
                 }.timeInMillis
                 "semaine", "semaines" -> Calendar.getInstance().apply {
-                    add(Calendar.DATE, value * 7 * -1)
+                    add(Calendar.DATE, -value * 7)
                     set(Calendar.SECOND, 0)
                     set(Calendar.MILLISECOND, 0)
                 }.timeInMillis
                 "mois" -> Calendar.getInstance().apply {
-                    add(Calendar.MONTH, value * -1)
+                    add(Calendar.MONTH, -value)
                     set(Calendar.SECOND, 0)
                     set(Calendar.MILLISECOND, 0)
                 }.timeInMillis
                 "an", "ans", "année", "années" -> Calendar.getInstance().apply {
-                    add(Calendar.YEAR, value * -1)
+                    add(Calendar.YEAR, -value)
                     set(Calendar.SECOND, 0)
                     set(Calendar.MILLISECOND, 0)
                 }.timeInMillis

--- a/src/id/bacakomik/src/eu/kanade/tachiyomi/extension/id/bacakomik/BacaKomik.kt
+++ b/src/id/bacakomik/src/eu/kanade/tachiyomi/extension/id/bacakomik/BacaKomik.kt
@@ -140,25 +140,25 @@ class BacaKomik : ParsedHttpSource() {
             val value = date.split(' ')[0].toInt()
             when {
                 "detik" in date -> Calendar.getInstance().apply {
-                    add(Calendar.SECOND, value * -1)
+                    add(Calendar.SECOND, -value)
                 }.timeInMillis
                 "menit" in date -> Calendar.getInstance().apply {
-                    add(Calendar.MINUTE, value * -1)
+                    add(Calendar.MINUTE, -value)
                 }.timeInMillis
                 "jam" in date -> Calendar.getInstance().apply {
-                    add(Calendar.HOUR_OF_DAY, value * -1)
+                    add(Calendar.HOUR_OF_DAY, -value)
                 }.timeInMillis
                 "hari" in date -> Calendar.getInstance().apply {
-                    add(Calendar.DATE, value * -1)
+                    add(Calendar.DATE, -value)
                 }.timeInMillis
                 "minggu" in date -> Calendar.getInstance().apply {
-                    add(Calendar.DATE, value * 7 * -1)
+                    add(Calendar.DATE, -value * 7)
                 }.timeInMillis
                 "bulan" in date -> Calendar.getInstance().apply {
-                    add(Calendar.MONTH, value * -1)
+                    add(Calendar.MONTH, -value)
                 }.timeInMillis
                 "tahun" in date -> Calendar.getInstance().apply {
-                    add(Calendar.YEAR, value * -1)
+                    add(Calendar.YEAR, -value)
                 }.timeInMillis
                 else -> {
                     0L

--- a/src/id/komikcast/src/eu/kanade/tachiyomi/extension/id/komikcast/KomikCast.kt
+++ b/src/id/komikcast/src/eu/kanade/tachiyomi/extension/id/komikcast/KomikCast.kt
@@ -107,22 +107,22 @@ class KomikCast : MangaThemesia("Komik Cast", "https://komikcast.cz", "id", "/da
             val value = date.split(' ')[0].toInt()
             when {
                 "min" in date -> Calendar.getInstance().apply {
-                    add(Calendar.MINUTE, value * -1)
+                    add(Calendar.MINUTE, -value)
                 }.timeInMillis
                 "hour" in date -> Calendar.getInstance().apply {
-                    add(Calendar.HOUR_OF_DAY, value * -1)
+                    add(Calendar.HOUR_OF_DAY, -value)
                 }.timeInMillis
                 "day" in date -> Calendar.getInstance().apply {
-                    add(Calendar.DATE, value * -1)
+                    add(Calendar.DATE, -value)
                 }.timeInMillis
                 "week" in date -> Calendar.getInstance().apply {
-                    add(Calendar.DATE, value * 7 * -1)
+                    add(Calendar.DATE, -value * 7)
                 }.timeInMillis
                 "month" in date -> Calendar.getInstance().apply {
-                    add(Calendar.MONTH, value * -1)
+                    add(Calendar.MONTH, -value)
                 }.timeInMillis
                 "year" in date -> Calendar.getInstance().apply {
-                    add(Calendar.YEAR, value * -1)
+                    add(Calendar.YEAR, -value)
                 }.timeInMillis
                 else -> {
                     0L

--- a/src/id/komikindoid/src/eu/kanade/tachiyomi/extension/id/komikindoid/KomikIndoID.kt
+++ b/src/id/komikindoid/src/eu/kanade/tachiyomi/extension/id/komikindoid/KomikIndoID.kt
@@ -170,25 +170,25 @@ class KomikIndoID : ParsedHttpSource() {
             val value = date.split(' ')[0].toInt()
             when {
                 "detik" in date -> Calendar.getInstance().apply {
-                    add(Calendar.SECOND, value * -1)
+                    add(Calendar.SECOND, -value)
                 }.timeInMillis
                 "menit" in date -> Calendar.getInstance().apply {
-                    add(Calendar.MINUTE, value * -1)
+                    add(Calendar.MINUTE, -value)
                 }.timeInMillis
                 "jam" in date -> Calendar.getInstance().apply {
-                    add(Calendar.HOUR_OF_DAY, value * -1)
+                    add(Calendar.HOUR_OF_DAY, -value)
                 }.timeInMillis
                 "hari" in date -> Calendar.getInstance().apply {
-                    add(Calendar.DATE, value * -1)
+                    add(Calendar.DATE, -value)
                 }.timeInMillis
                 "minggu" in date -> Calendar.getInstance().apply {
-                    add(Calendar.DATE, value * 7 * -1)
+                    add(Calendar.DATE, -value * 7)
                 }.timeInMillis
                 "bulan" in date -> Calendar.getInstance().apply {
-                    add(Calendar.MONTH, value * -1)
+                    add(Calendar.MONTH, -value)
                 }.timeInMillis
                 "tahun" in date -> Calendar.getInstance().apply {
-                    add(Calendar.YEAR, value * -1)
+                    add(Calendar.YEAR, -value)
                 }.timeInMillis
                 else -> {
                     0L

--- a/src/ja/kisslove/src/eu/kanade/tachiyomi/extension/ja/kisslove/KissLove.kt
+++ b/src/ja/kisslove/src/eu/kanade/tachiyomi/extension/ja/kisslove/KissLove.kt
@@ -49,12 +49,12 @@ class KissLove : FMReader("KissLove", "https://klz9.com", "ja") {
         }
 
         when (date.split(' ')[dateWordIndex]) {
-            "mins", "minutes" -> chapterDate.add(Calendar.MINUTE, value * -1)
-            "hours" -> chapterDate.add(Calendar.HOUR_OF_DAY, value * -1)
-            "days" -> chapterDate.add(Calendar.DATE, value * -1)
-            "weeks" -> chapterDate.add(Calendar.DATE, value * 7 * -1)
-            "months" -> chapterDate.add(Calendar.MONTH, value * -1)
-            "years" -> chapterDate.add(Calendar.YEAR, value * -1)
+            "mins", "minutes" -> chapterDate.add(Calendar.MINUTE, -value)
+            "hours" -> chapterDate.add(Calendar.HOUR_OF_DAY, -value)
+            "days" -> chapterDate.add(Calendar.DATE, -value)
+            "weeks" -> chapterDate.add(Calendar.DATE, -value * 7)
+            "months" -> chapterDate.add(Calendar.MONTH, -value)
+            "years" -> chapterDate.add(Calendar.YEAR, -value)
             else -> return 0
         }
 

--- a/src/ja/mangagun/src/eu/kanade/tachiyomi/extension/ja/mangagun/MangaGun.kt
+++ b/src/ja/mangagun/src/eu/kanade/tachiyomi/extension/ja/mangagun/MangaGun.kt
@@ -60,12 +60,12 @@ class MangaGun : FMReader("MangaGun", "https://$DOMAIN", "ja") {
         }
 
         when (date.split(' ')[dateWordIndex]) {
-            "mins", "minutes" -> chapterDate.add(Calendar.MINUTE, value * -1)
-            "hours" -> chapterDate.add(Calendar.HOUR_OF_DAY, value * -1)
-            "days" -> chapterDate.add(Calendar.DATE, value * -1)
-            "weeks" -> chapterDate.add(Calendar.DATE, value * 7 * -1)
-            "months" -> chapterDate.add(Calendar.MONTH, value * -1)
-            "years" -> chapterDate.add(Calendar.YEAR, value * -1)
+            "mins", "minutes" -> chapterDate.add(Calendar.MINUTE, -value)
+            "hours" -> chapterDate.add(Calendar.HOUR_OF_DAY, -value)
+            "days" -> chapterDate.add(Calendar.DATE, -value)
+            "weeks" -> chapterDate.add(Calendar.DATE, -value * 7)
+            "months" -> chapterDate.add(Calendar.MONTH, -value)
+            "years" -> chapterDate.add(Calendar.YEAR, -value)
             else -> return 0
         }
 

--- a/src/ja/welovemangaone/src/eu/kanade/tachiyomi/extension/ja/welovemangaone/WeLoveMangaOne.kt
+++ b/src/ja/welovemangaone/src/eu/kanade/tachiyomi/extension/ja/welovemangaone/WeLoveMangaOne.kt
@@ -46,12 +46,12 @@ class WeLoveMangaOne : FMReader("WeLoveMangaOne", "https://welovemanga.one", "ja
         }
 
         when (date.split(' ')[dateWordIndex]) {
-            "mins", "minutes" -> chapterDate.add(Calendar.MINUTE, value * -1)
-            "hours" -> chapterDate.add(Calendar.HOUR_OF_DAY, value * -1)
-            "days" -> chapterDate.add(Calendar.DATE, value * -1)
-            "weeks" -> chapterDate.add(Calendar.DATE, value * 7 * -1)
-            "months" -> chapterDate.add(Calendar.MONTH, value * -1)
-            "years" -> chapterDate.add(Calendar.YEAR, value * -1)
+            "mins", "minutes" -> chapterDate.add(Calendar.MINUTE, -value)
+            "hours" -> chapterDate.add(Calendar.HOUR_OF_DAY, -value)
+            "days" -> chapterDate.add(Calendar.DATE, -value)
+            "weeks" -> chapterDate.add(Calendar.DATE, -value * 7)
+            "months" -> chapterDate.add(Calendar.MONTH, -value)
+            "years" -> chapterDate.add(Calendar.YEAR, -value)
             else -> return 0
         }
 


### PR DESCRIPTION
These expressions are functionally equivalent and highly unlikely to cause issues, so versions have not been bumped. Removing `* -1` is in my opinion easier to read.

Build succeeds with `./gradlew -p src assembleDebug`, not sure what the equivalent is in Android Studio.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
