### PR TITLE
CosmicScansID: Fix page selector

### DIFF
--- a/src/id/cosmicscansid/build.gradle
+++ b/src/id/cosmicscansid/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.CosmicScansID'
     themePkg = 'mangathemesia'
     baseUrl = 'https://cosmic345.co'
-    overrideVersionCode = 6
+    overrideVersionCode = 7
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/CosmicScansID.kt
+++ b/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/CosmicScansID.kt
@@ -42,5 +42,5 @@ class CosmicScansID : MangaThemesia(
     override fun Elements.imgAttr(): String = this.first()?.imgAttr() ?: ""
 
     // pages
-    override val pageSelector = "div#readerarea img:not(noscript img)"
+    override val pageSelector = "div#readerarea img:not(noscript img):not([alt=''])"
 }


### PR DESCRIPTION
Closes  #6060

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
