### PR TITLE
SlimeRead: fix crash

### DIFF
--- a/src/pt/slimeread/build.gradle
+++ b/src/pt/slimeread/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'SlimeRead'
     extClass = '.SlimeRead'
-    extVersionCode = 13
+    extVersionCode = 14
     isNsfw = true
 }
 

--- a/src/pt/slimeread/src/eu/kanade/tachiyomi/extension/pt/slimeread/SlimeRead.kt
+++ b/src/pt/slimeread/src/eu/kanade/tachiyomi/extension/pt/slimeread/SlimeRead.kt
@@ -110,12 +110,12 @@ class SlimeRead : HttpSource() {
         // Handling a large manga list
         return Observable.just(popularMangeCache!!)
             .map { mangaPage ->
-                val (mangas) = mangaPage
+                val mangas = mangaPage.mangas
                 val pageSize = 15
 
                 currentSlice = (page - 1) * pageSize
 
-                val startIndex = min(mangas.size, currentSlice)
+                val startIndex = min(mangas.size - 1, currentSlice)
                 val endIndex = min(mangas.size, currentSlice + pageSize)
 
                 val slice = mangas.subList(startIndex, endIndex)


### PR DESCRIPTION
Crash log:
```
          Fatal Exception: java.lang.NoSuchMethodError: No virtual method component1()Ljava/util/List; in class Leu/kanade/tachiyomi/source/model/MangasPage; or its super classes (declaration of 'eu.kanade.tachiyomi.source.model.MangasPage' appears in /data/app/~~-vkyf7JztvyghcOvoXWwOg==/app.komikku.beta-uc8a0Y0vxRWHYDzMRTPELg==/base.apk!classes3.dex)
       at eu.kanade.tachiyomi.extension.pt.slimeread.SlimeRead$fetchPopularManga$1.invoke(SlimeRead.kt:113)
       at eu.kanade.tachiyomi.extension.pt.slimeread.SlimeRead$fetchPopularManga$1.invoke(SlimeRead.kt:112)
       at eu.kanade.tachiyomi.extension.pt.slimeread.SlimeRead.fetchPopularManga$lambda$4(SlimeRead.kt:112)
       at eu.kanade.tachiyomi.extension.pt.slimeread.SlimeRead.$r8$lambda$GNPRWUeMlo-5q_jdFCFrZtDNBqo()
       at eu.kanade.tachiyomi.extension.pt.slimeread.SlimeRead$$ExternalSyntheticLambda1.call(D8$$SyntheticClass)
       at rx.internal.operators.OnSubscribeMap$MapSubscriber.onNext(OnSubscribeMap.java:69)
       at rx.internal.util.ScalarSynchronousObservable$WeakSingleProducer.request(ScalarSynchronousObservable.java:276)
       at rx.Subscriber.setProducer(Subscriber.java:211)
       at rx.internal.operators.OnSubscribeMap$MapSubscriber.setProducer(OnSubscribeMap.java:102)
       at rx.internal.util.ScalarSynchronousObservable$JustOnSubscribe.call(ScalarSynchronousObservable.java:138)
       at rx.internal.util.ScalarSynchronousObservable$JustOnSubscribe.call(ScalarSynchronousObservable.java:129)
       at rx.Observable.unsafeSubscribe(Observable.java:10327)
       at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:48)
       at rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:33)
       at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:48)
       at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:30)
       at rx.Observable.subscribe(Observable.java:10423)
       at rx.Observable.subscribe(Observable.java:10390)
       at tachiyomi.core.common.util.lang.RxCoroutineBridgeKt.awaitOne(RxCoroutineBridge.kt:29)
       at tachiyomi.core.common.util.lang.RxCoroutineBridgeKt.awaitSingle(RxCoroutineBridge.kt:24)
       at eu.kanade.tachiyomi.source.online.HttpSource.getPopularManga$suspendImpl(HttpSource.kt:153)
       at eu.kanade.tachiyomi.source.online.HttpSource.getPopularManga(HttpSource.kt:4)
       at eu.kanade.tachiyomi.ui.browse.source.feed.SourceFeedScreenModel$getFeed$1$1$1$page$1.invokeSuspend(SourceFeedScreenModel.kt:213)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:101)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
       at java.lang.Thread.run(Thread.java:1012)
```

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [X] Have removed `web_hi_res_512.png` when adding a new extension
