### PR TITLE
SirenKomik: Fix nullpointer

### DIFF
--- a/src/id/mangkomik/build.gradle
+++ b/src/id/mangkomik/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.SirenKomik'
     themePkg = 'mangathemesia'
     baseUrl = 'https://sirenkomik.my.id'
-    overrideVersionCode = 3
+    overrideVersionCode = 4
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/mangkomik/src/eu/kanade/tachiyomi/extension/id/mangkomik/SirenKomik.kt
+++ b/src/id/mangkomik/src/eu/kanade/tachiyomi/extension/id/mangkomik/SirenKomik.kt
@@ -25,11 +25,12 @@ class SirenKomik : MangaThemesia(
     override val seriesAuthorSelector = ".keterangan-komik:contains(author) span"
     override val seriesArtistSelector = ".keterangan-komik:contains(artist) span"
 
+    override fun chapterListSelector() = ".list-chapter a"
+
     override fun chapterFromElement(element: Element) = SChapter.create().apply {
-        val urlElements = element.select("a")
-        setUrlWithoutDomain(urlElements.attr("href"))
-        name = element.select(".nomer-chapter").text().ifBlank { urlElements.first()!!.text() }
+        name = element.selectFirst(".nomer-chapter")!!.text()
         date_upload = element.selectFirst(".tgl-chapter")?.text().parseChapterDate()
+        setUrlWithoutDomain(element.absUrl("href"))
     }
 
     override fun pageListParse(document: Document): List<Page> {


### PR DESCRIPTION
Closes #5824

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
