### PR TITLE
Weeb Central: fix broken chapter link

### DIFF
--- a/src/en/weebcentral/build.gradle
+++ b/src/en/weebcentral/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Weeb Central'
     extClass = '.WeebCentral'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/en/weebcentral/src/eu/kanade/tachiyomi/extension/en/weebcentral/WeebCentral.kt
+++ b/src/en/weebcentral/src/eu/kanade/tachiyomi/extension/en/weebcentral/WeebCentral.kt
@@ -8,6 +8,7 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Request
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
@@ -149,6 +150,21 @@ class WeebCentral : ParsedHttpSource() {
         }
     }
     // =============================== Pages ================================
+
+    override fun pageListRequest(chapter: SChapter): Request {
+        val newUrl = (baseUrl + chapter.url)
+            .toHttpUrlOrNull()
+            ?.newBuilder()
+            ?.addPathSegment("images")
+            ?.addQueryParameter("is_prev", "False")
+            ?.addQueryParameter("reading_style", "long_strip")
+            ?.build()
+            ?.toString()
+            ?: chapter.url
+
+        chapter.setUrlWithoutDomain(newUrl)
+        return super.pageListRequest(chapter)
+    }
 
     override fun pageListParse(document: Document): List<Page> {
         return document.select("section[x-data~=scroll] > img").mapIndexed { index, element ->


### PR DESCRIPTION
Closes #5928

Using `pageListRequest()` so users don't have to refresh their chapter list.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
 