### PR TITLE
RawXZ: source change to .to

### DIFF
--- a/src/ja/rawxz/build.gradle
+++ b/src/ja/rawxz/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.RawXZ'
     themePkg = 'madara'
     baseUrl = 'https://rawxz.si'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/ja/rawxz/src/eu/kanade/tachiyomi/extension/ja/rawxz/RawXZ.kt
+++ b/src/ja/rawxz/src/eu/kanade/tachiyomi/extension/ja/rawxz/RawXZ.kt
@@ -6,7 +6,7 @@ import java.util.Locale
 
 class RawXZ : Madara(
     "RawXZ",
-    "https://rawxz.si",
+    "https://rawxz.to",
     "ja",
     dateFormat = SimpleDateFormat("M月 d, yyyy", Locale.ROOT),
 ) {


### PR DESCRIPTION
Closes #6148 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
