### PR TITLE
ResetScan: change theme to Madara

### DIFF
--- a/src/en/resetscans/build.gradle
+++ b/src/en/resetscans/build.gradle
@@ -1,9 +1,9 @@
 ext {
     extName = 'Reset Scans'
     extClass = '.ResetScans'
-    themePkg = 'fuzzydoodle'
-    baseUrl = 'https://reset-scans.xyz'
-    overrideVersionCode = 43
+    themePkg = 'madara'
+    baseUrl = 'https://rspro.xyz'
+    overrideVersionCode = 8
     isNsfw = false
 }
 

--- a/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
+++ b/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
@@ -1,14 +1,30 @@
 package eu.kanade.tachiyomi.extension.en.resetscans
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.source.model.SChapter
+import org.jsoup.nodes.Element
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
 
 class ResetScans : Madara(
     "Reset Scans",
     "https://rspro.xyz",
     "en",
+    dateFormat = SimpleDateFormat("MMM dd yyyy", Locale.US),
 ) {
     // Moved from FuzzyDoodle to Madara
     override val versionId = 3
 
+    override val useNewChapterEndpoint = true
+
     override fun chapterListSelector() = "li.wp-manga-chapter>div:not(:has(a[href*=#]))"
+
+    override fun chapterFromElement(element: Element): SChapter {
+        // Year is not defined so just use the current one
+        return super.chapterFromElement(element).apply {
+            val currentYear = Calendar.getInstance().get(Calendar.YEAR)
+            date_upload = parseChapterDate("${element.selectFirst(chapterDateSelector())?.text()} $currentYear")
+        }
+    }
 }

--- a/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
+++ b/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
@@ -1,17 +1,14 @@
 package eu.kanade.tachiyomi.extension.en.resetscans
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
-import eu.kanade.tachiyomi.source.model.SChapter
-import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
-import java.util.Calendar
 import java.util.Locale
 
 class ResetScans : Madara(
     "Reset Scans",
     "https://rspro.xyz",
     "en",
-    dateFormat = SimpleDateFormat("MMM dd yyyy", Locale.US),
+    dateFormat = SimpleDateFormat("MMM dd", Locale.US),
 ) {
     // Moved from FuzzyDoodle to Madara
     override val versionId = 3
@@ -19,12 +16,4 @@ class ResetScans : Madara(
     override val useNewChapterEndpoint = true
 
     override fun chapterListSelector() = "li.wp-manga-chapter>div:not(:has(a[href*=#]))"
-
-    override fun chapterFromElement(element: Element): SChapter {
-        // Year is not defined so just use the current one
-        return super.chapterFromElement(element).apply {
-            val currentYear = Calendar.getInstance().get(Calendar.YEAR)
-            date_upload = parseChapterDate("${element.selectFirst(chapterDateSelector())?.text()} $currentYear")
-        }
-    }
 }

--- a/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
+++ b/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
@@ -1,13 +1,14 @@
 package eu.kanade.tachiyomi.extension.en.resetscans
-import eu.kanade.tachiyomi.multisrc.fuzzydoodle.FuzzyDoodle
 
-class ResetScans : FuzzyDoodle(
+import eu.kanade.tachiyomi.multisrc.madara.Madara
+
+class ResetScans : Madara(
     "Reset Scans",
-    "https://reset-scans.xyz",
+    "https://rspro.xyz",
     "en",
 ) {
-    override val latestFromHomePage = true
+    // Moved from FuzzyDoodle to Madara
+    override val versionId = 3
 
-    // Moved from Madara to FuzzyDoodle
-    override val versionId = 2
+    override fun chapterListSelector() = "li.wp-manga-chapter>div:not(:has(a[href*=#]))"
 }


### PR DESCRIPTION
Closes #5890

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
