### PR TITLE
LikeManga: fix url

### DIFF
--- a/src/en/likemanga/build.gradle
+++ b/src/en/likemanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'LikeManga'
     extClass = '.LikeManga'
-    extVersionCode = 4
+    extVersionCode = 5
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/likemanga/src/eu/kanade/tachiyomi/extension/en/likemanga/LikeManga.kt
+++ b/src/en/likemanga/src/eu/kanade/tachiyomi/extension/en/likemanga/LikeManga.kt
@@ -30,7 +30,7 @@ import java.util.Locale
 class LikeManga : ParsedHttpSource() {
     override val name = "LikeManga"
 
-    override val baseUrl = "https://likemanga.io"
+    override val baseUrl = "https://likemanga.ink"
 
     override val lang = "en"
 


### PR DESCRIPTION
Closes #6163

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
