### PR TITLE
Lava Scans: update domain

### DIFF
--- a/src/all/thunderscans/build.gradle
+++ b/src/all/thunderscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ThunderScansFactory'
     themePkg = 'mangathemesia'
     baseUrl = 'https://en-thunderscans.com'
-    overrideVersionCode = 5
+    overrideVersionCode = 6
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/thunderscans/src/eu/kanade/tachiyomi/extension/all/thunderscans/ThunderScansFactory.kt
+++ b/src/all/thunderscans/src/eu/kanade/tachiyomi/extension/all/thunderscans/ThunderScansFactory.kt
@@ -7,19 +7,21 @@ import java.util.Locale
 
 class ThunderScansFactory : SourceFactory {
     override fun createSources() = listOf(
-        ThunderScansAR(),
-        ThunderScansEN(),
+        LavaScans(),
+        ThunderScans(),
     )
 }
 
-class ThunderScansAR : MangaThemesiaAlt(
-    "Thunder Scans",
-    "https://ar-thunderepic.com",
+class LavaScans : MangaThemesiaAlt(
+    "Lava Scans",
+    "https://lavascans.com",
     "ar",
     dateFormat = SimpleDateFormat("MMM d, yyy", Locale("ar")),
-)
+) {
+    override val id = 3209001028102012989
+}
 
-class ThunderScansEN : MangaThemesiaAlt(
+class ThunderScans : MangaThemesiaAlt(
     "Thunder Scans",
     "https://en-thunderscans.com",
     "en",


### PR DESCRIPTION
Closes #5356

Keeping as a factory to avoid forced migration for both AR and EN users. Since there was no technical reason for combining them into a factory in the first place I assume it was because they are related. They are most likely still related, since the old domain redirects to the new domain.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
