### PR TITLE
VisorInari: update domain

### DIFF
--- a/src/es/inarimanga/build.gradle
+++ b/src/es/inarimanga/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Visor Inari'
     extClass = '.VisorInari'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://vrinari.org'
-    overrideVersionCode = 14
+    baseUrl = 'https://clubinari.org'
+    overrideVersionCode = 15
     isNsfw = true
 }
 

--- a/src/es/inarimanga/src/eu/kanade/tachiyomi/extension/es/inarimanga/VisorInari.kt
+++ b/src/es/inarimanga/src/eu/kanade/tachiyomi/extension/es/inarimanga/VisorInari.kt
@@ -8,7 +8,7 @@ import java.util.Locale
 
 class VisorInari : MangaThemesia(
     "Visor Inari",
-    "https://vrinari.org",
+    "https://clubinari.org",
     "es",
     dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("es")),
 ) {


### PR DESCRIPTION
Closes #6051

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
