### PR TITLE
MeituaTop: Fix chapter not found for Suwayomi users

### DIFF
--- a/src/all/meituatop/build.gradle
+++ b/src/all/meituatop/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Meitua.top'
     extClass = '.MeituaTop'
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = true
 }
 

--- a/src/all/meituatop/src/eu/kanade/tachiyomi/extension/all/meituatop/MeituaTop.kt
+++ b/src/all/meituatop/src/eu/kanade/tachiyomi/extension/all/meituatop/MeituaTop.kt
@@ -76,11 +76,15 @@ class MeituaTop : HttpSource() {
         val chapter = SChapter.create().apply {
             url = manga.url
             name = "Gallery"
-            date_upload = dateFormat.parse(manga.description!!)!!.time
+            date_upload = parseDate(manga.description!!)
             chapter_number = -2f
         }
         return Observable.just(listOf(chapter))
     }
+
+    private fun parseDate(date: String): Long = runCatching {
+        dateFormat.parse(date)?.time
+    }.getOrNull() ?: 0L
 
     override fun chapterListParse(response: Response) = throw UnsupportedOperationException()
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
