### PR TITLE
Hiperdex: update status selector

### DIFF
--- a/src/en/hiperdex/build.gradle
+++ b/src/en/hiperdex/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Hiperdex'
     themePkg = 'madara'
     baseUrl = 'https://hipertoon.com'
-    overrideVersionCode = 15
+    overrideVersionCode = 16
     isNsfw = true
 }
 

--- a/src/en/hiperdex/src/eu/kanade/tachiyomi/extension/en/hiperdex/Hiperdex.kt
+++ b/src/en/hiperdex/src/eu/kanade/tachiyomi/extension/en/hiperdex/Hiperdex.kt
@@ -22,6 +22,8 @@ class Hiperdex :
     ),
     ConfigurableSource {
 
+    override val mangaDetailsSelectorStatus = "div.summary-heading:contains(Status) + div.summary-content"
+
     private val preferences =
         Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
 


### PR DESCRIPTION
Closes #6030

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
