### PR TITLE
Weeb Central: Fix no pages found for Suwayomi users

### DIFF
--- a/src/en/weebcentral/build.gradle
+++ b/src/en/weebcentral/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Weeb Central'
     extClass = '.WeebCentral'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/en/weebcentral/src/eu/kanade/tachiyomi/extension/en/weebcentral/WeebCentral.kt
+++ b/src/en/weebcentral/src/eu/kanade/tachiyomi/extension/en/weebcentral/WeebCentral.kt
@@ -160,10 +160,8 @@ class WeebCentral : ParsedHttpSource() {
             ?.addQueryParameter("reading_style", "long_strip")
             ?.build()
             ?.toString()
-            ?: chapter.url
-
-        chapter.setUrlWithoutDomain(newUrl)
-        return super.pageListRequest(chapter)
+            ?: (baseUrl + chapter.url)
+        return GET(newUrl, headers)
     }
 
     override fun pageListParse(document: Document): List<Page> {


### PR DESCRIPTION
Closes #6139
Closes #6180

Suwayomi uses the same object to pre-fetch the realUrl and save to the database. However, getChapterUrl will invoke pageListRequest, which will modify the chapter.url, resulting in the modified URL being stored in the database. When loading pages subsequently, pageListRequest is called again, causing the "images" path segment to be concatenated repeatedly, leading to 'no pages found'.

https://github.com/Suwayomi/Suwayomi-Server/blob/fb51834153b33060779e93d3c460f55878a712cb/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt#L197

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
