### PR TITLE
YuraManga: exclude alternating broken images

### DIFF
--- a/src/id/yuramanga/build.gradle
+++ b/src/id/yuramanga/build.gradle
@@ -3,7 +3,8 @@ ext {
     extClass = '.YuraManga'
     themePkg = 'zmanga'
     baseUrl = 'https://www.yuramanga.my.id'
-    overrideVersionCode = 37
+    overrideVersionCode = 38
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/yuramanga/src/eu/kanade/tachiyomi/extension/id/yuramanga/YuraManga.kt
+++ b/src/id/yuramanga/src/eu/kanade/tachiyomi/extension/id/yuramanga/YuraManga.kt
@@ -1,6 +1,8 @@
 package eu.kanade.tachiyomi.extension.id.yuramanga
 
 import eu.kanade.tachiyomi.multisrc.zmanga.ZManga
+import eu.kanade.tachiyomi.source.model.Page
+import org.jsoup.nodes.Document
 import java.io.IOException
 import java.text.SimpleDateFormat
 
@@ -22,4 +24,10 @@ class YuraManga : ZManga(
             response
         }
         .build()
+
+    override fun pageListParse(document: Document): List<Page> {
+        return document.select("div.reader-area img.lazyload").mapIndexed { i, img ->
+            Page(i, "", img.attr("abs:data-src"))
+        }
+    }
 }

--- a/src/id/yuramanga/src/eu/kanade/tachiyomi/extension/id/yuramanga/YuraManga.kt
+++ b/src/id/yuramanga/src/eu/kanade/tachiyomi/extension/id/yuramanga/YuraManga.kt
@@ -5,12 +5,13 @@ import eu.kanade.tachiyomi.source.model.Page
 import org.jsoup.nodes.Document
 import java.io.IOException
 import java.text.SimpleDateFormat
+import java.util.Locale
 
 class YuraManga : ZManga(
     "YuraManga",
     "https://www.yuramanga.my.id",
     "id",
-    SimpleDateFormat("dd/MM/yyyy"),
+    SimpleDateFormat("dd/MM/yyyy", Locale.ROOT),
 ) {
     // Moved from Madara to ZManga
     override val versionId = 3


### PR DESCRIPTION
Closes #6229

Made minimal changes to `pageListParse()` when compared to super function.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
