### PR TITLE
Kiryuu: update domain

### DIFF
--- a/src/id/kiryuu/build.gradle
+++ b/src/id/kiryuu/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Kiryuu'
     extClass = '.Kiryuu'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://kiryuu.org'
-    overrideVersionCode = 8
+    baseUrl = 'https://kiryuu.one'
+    overrideVersionCode = 9
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/kiryuu/src/eu/kanade/tachiyomi/extension/id/kiryuu/Kiryuu.kt
+++ b/src/id/kiryuu/src/eu/kanade/tachiyomi/extension/id/kiryuu/Kiryuu.kt
@@ -9,7 +9,7 @@ import org.jsoup.nodes.Document
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class Kiryuu : MangaThemesia("Kiryuu", "https://kiryuu.org", "id", dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("id"))) {
+class Kiryuu : MangaThemesia("Kiryuu", "https://kiryuu.one", "id", dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("id"))) {
     // Formerly "Kiryuu (WP Manga Stream)"
     override val id = 3639673976007021338
 


### PR DESCRIPTION
Closes  #6247

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
