### PR TITLE
HentaiDex: fix global searching

### DIFF
--- a/src/en/hentaidex/build.gradle
+++ b/src/en/hentaidex/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.HentaiDex'
     themePkg = 'mangathemesia'
     baseUrl = 'https://dexhentai.com'
-    overrideVersionCode  = 0
+    overrideVersionCode  = 1
     isNsfw = true
 }
 

--- a/src/en/hentaidex/src/eu/kanade/tachiyomi/extension/en/hentaidex/HentaiDex.kt
+++ b/src/en/hentaidex/src/eu/kanade/tachiyomi/extension/en/hentaidex/HentaiDex.kt
@@ -63,11 +63,14 @@ class HentaiDex : MangaThemesia(
 
                 is GenreListFilter -> {
                     filter.state
-                        .filter { it.state != Filter.TriState.STATE_IGNORE }
+                        .filterNot { it.state == Filter.TriState.STATE_IGNORE }
                         .forEach {
-                            val value =
-                                if (it.state == Filter.TriState.STATE_EXCLUDE) "-${it.value}" else it.value
-                            url.addQueryParameter("genre[]", value)
+                            val genre = when (it.state) {
+                                Filter.TriState.STATE_EXCLUDE -> "-${it.value}"
+                                else -> it.value
+                            }
+
+                            url.addQueryParameter("genre[]", genre)
                         }
                 }
                 // if site has project page, default value "hasProjectPage" = false

--- a/src/en/hentaidex/src/eu/kanade/tachiyomi/extension/en/hentaidex/HentaiDex.kt
+++ b/src/en/hentaidex/src/eu/kanade/tachiyomi/extension/en/hentaidex/HentaiDex.kt
@@ -1,7 +1,12 @@
 package eu.kanade.tachiyomi.extension.en.hentaidex
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.source.model.Filter
+import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.SChapter
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
@@ -12,8 +17,10 @@ class HentaiDex : MangaThemesia(
     "https://dexhentai.com",
     "en",
     dateFormat = SimpleDateFormat("MMMM d, yyyy", Locale.US),
+    mangaUrlDirectory = "/title",
 ) {
-    override fun chapterListParse(response: Response): List<SChapter> = super.chapterListParse(response).sortedByDescending { it.chapter_number }
+    override fun chapterListParse(response: Response): List<SChapter> =
+        super.chapterListParse(response).sortedByDescending { it.chapter_number }
 
     override fun chapterFromElement(element: Element) = SChapter.create().apply {
         val urlElements = element.select("a")
@@ -21,5 +28,96 @@ class HentaiDex : MangaThemesia(
         name = element.select(".chapternum").text().ifBlank { urlElements.first()!!.text() }
         chapter_number = element.attr("data-num").toFloat()
         date_upload = element.selectFirst(".chapterdate")?.text().parseChapterDate()
+    }
+
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+        val url = baseUrl.toHttpUrl().newBuilder()
+
+        // Can't use filter if is a global search
+        if (query.isNotEmpty()) {
+            url.addQueryParameter("s", query)
+            return GET(url.build(), headers)
+        }
+
+        filters.forEach { filter ->
+            when (filter) {
+                is AuthorFilter -> {
+                    url.addQueryParameter("author", filter.state)
+                }
+
+                is YearFilter -> {
+                    url.addQueryParameter("yearx", filter.state)
+                }
+
+                is StatusFilter -> {
+                    url.addQueryParameter("status", filter.selectedValue())
+                }
+
+                is TypeFilter -> {
+                    url.addQueryParameter("type", filter.selectedValue())
+                }
+
+                is OrderByFilter -> {
+                    url.addQueryParameter("order", filter.selectedValue())
+                }
+
+                is GenreListFilter -> {
+                    filter.state
+                        .filter { it.state != Filter.TriState.STATE_IGNORE }
+                        .forEach {
+                            val value =
+                                if (it.state == Filter.TriState.STATE_EXCLUDE) "-${it.value}" else it.value
+                            url.addQueryParameter("genre[]", value)
+                        }
+                }
+                // if site has project page, default value "hasProjectPage" = false
+                is ProjectFilter -> {
+                    if (filter.selectedValue() == "project-filter-on") {
+                        url.setPathSegment(0, projectPageString.substring(1))
+                    }
+                }
+
+                else -> { /* Do Nothing */
+                }
+            }
+        }
+        url.addPathSegment(mangaUrlDirectory.substring(1))
+            .addQueryParameter("page", page.toString())
+        return GET(url.build(), headers)
+    }
+
+    override fun getFilterList(): FilterList {
+        val filters = mutableListOf<Filter<*>>(
+            Filter.Header("Text search ignores filters"),
+            Filter.Separator(),
+            AuthorFilter(intl["author_filter_title"]),
+            YearFilter(intl["year_filter_title"]),
+            StatusFilter(intl["status_filter_title"], statusOptions),
+            TypeFilter(intl["type_filter_title"], typeFilterOptions),
+            OrderByFilter(intl["order_by_filter_title"], orderByFilterOptions),
+        )
+        if (!genrelist.isNullOrEmpty()) {
+            filters.addAll(
+                listOf(
+                    Filter.Header(intl["genre_exclusion_warning"]),
+                    GenreListFilter(intl["genre_filter_title"], getGenreList()),
+                ),
+            )
+        } else {
+            filters.add(
+                Filter.Header(intl["genre_missing_warning"]),
+            )
+        }
+        if (hasProjectPage) {
+            filters.addAll(
+                mutableListOf<Filter<*>>(
+                    Filter.Separator(),
+                    Filter.Header(intl["project_filter_warning"]),
+                    Filter.Header(intl.format("project_filter_name", name)),
+                    ProjectFilter(intl["project_filter_title"], projectFilterOptions),
+                ),
+            )
+        }
+        return FilterList(filters)
     }
 }


### PR DESCRIPTION
Closes #6110

Override getFilterList() but just to add new header, explaining that you can not do both search and filter

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
