### PR TITLE
Weeb Central: use correct chapter URL for WebView

### DIFF
--- a/src/en/weebcentral/build.gradle
+++ b/src/en/weebcentral/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Weeb Central'
     extClass = '.WeebCentral'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = true
 }
 

--- a/src/en/weebcentral/src/eu/kanade/tachiyomi/extension/en/weebcentral/WeebCentral.kt
+++ b/src/en/weebcentral/src/eu/kanade/tachiyomi/extension/en/weebcentral/WeebCentral.kt
@@ -164,6 +164,10 @@ class WeebCentral : ParsedHttpSource() {
         return GET(newUrl, headers)
     }
 
+    override fun getChapterUrl(chapter: SChapter): String {
+        return baseUrl + chapter.url
+    }
+
     override fun pageListParse(document: Document): List<Page> {
         return document.select("section[x-data~=scroll] > img").mapIndexed { index, element ->
             Page(index, imageUrl = element.attr("abs:src"))


### PR DESCRIPTION
Closes #6275

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
