### PR TITLE
Flame Comics: fix double slash in manga/chapter URL

### DIFF
--- a/src/en/flamecomics/build.gradle
+++ b/src/en/flamecomics/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Flame Comics'
     extClass = '.FlameComics'
-    extVersionCode = 35
+    extVersionCode = 36
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComics.kt
+++ b/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComics.kt
@@ -175,7 +175,7 @@ class FlameComics : HttpSource() {
     override fun mangaDetailsRequest(manga: SManga): Request = GET(
         dataApiReqBuilder().apply {
             val seriesID =
-                ("$baseUrl/${manga.url}").toHttpUrl().pathSegments.last()
+                ("$baseUrl${manga.url}").toHttpUrl().pathSegments.last()
             addPathSegment("series")
             addPathSegment("$seriesID.json")
             addQueryParameter("id", seriesID)
@@ -185,7 +185,7 @@ class FlameComics : HttpSource() {
 
     override fun chapterListRequest(manga: SManga): Request = mangaDetailsRequest(manga)
 
-    override fun getMangaUrl(manga: SManga): String = "$baseUrl/${manga.url}"
+    override fun getMangaUrl(manga: SManga): String = "$baseUrl${manga.url}"
 
     override fun mangaDetailsParse(response: Response): SManga = SManga.create().apply {
         val seriesData =
@@ -232,8 +232,8 @@ class FlameComics : HttpSource() {
 
     override fun pageListRequest(chapter: SChapter): Request = GET(
         dataApiReqBuilder().apply {
-            val seriesID = ("$baseUrl/${chapter.url}").toHttpUrl().pathSegments[2]
-            val token = ("$baseUrl/${chapter.url}").toHttpUrl().pathSegments[3]
+            val seriesID = ("$baseUrl${chapter.url}").toHttpUrl().pathSegments[1]
+            val token = ("$baseUrl${chapter.url}").toHttpUrl().pathSegments[2]
             addPathSegment("series")
             addPathSegment(seriesID)
             addPathSegment("$token.json")
@@ -243,7 +243,7 @@ class FlameComics : HttpSource() {
         headers,
     )
 
-    override fun getChapterUrl(chapter: SChapter): String = "$baseUrl/${chapter.url}"
+    override fun getChapterUrl(chapter: SChapter): String = "$baseUrl${chapter.url}"
 
     override fun pageListParse(response: Response): List<Page> {
         val chapter =


### PR DESCRIPTION
Issue was mentioned in Discord.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
