### PR TITLE
Fixed Kemono MultiSrc

### DIFF
--- a/lib-multisrc/kemono/build.gradle.kts
+++ b/lib-multisrc/kemono/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 14
+baseVersionCode = 15

--- a/lib-multisrc/kemono/src/eu/kanade/tachiyomi/multisrc/kemono/Kemono.kt
+++ b/lib-multisrc/kemono/src/eu/kanade/tachiyomi/multisrc/kemono/Kemono.kt
@@ -233,8 +233,8 @@ open class Kemono(
         GET("$baseUrl/$apiPath${chapter.url}", headers)
 
     override fun pageListParse(response: Response): List<Page> {
-        val post: KemonoPostDto = response.parseAs()
-        return post.images.mapIndexed { i, path -> Page(i, imageUrl = baseUrl + path) }
+        val postData: KemonoPostDtoWrapped = response.parseAs()
+        return postData.post.images.mapIndexed { i, path -> Page(i, imageUrl = baseUrl + path) }
     }
 
     override fun imageRequest(page: Page): Request {

--- a/lib-multisrc/kemono/src/eu/kanade/tachiyomi/multisrc/kemono/KemonoDto.kt
+++ b/lib-multisrc/kemono/src/eu/kanade/tachiyomi/multisrc/kemono/KemonoDto.kt
@@ -56,7 +56,6 @@ class KemonoPostDtoWrapped(
     val post: KemonoPostDto,
 )
 
-
 @Serializable
 class KemonoPostDto(
     private val id: String,

--- a/lib-multisrc/kemono/src/eu/kanade/tachiyomi/multisrc/kemono/KemonoDto.kt
+++ b/lib-multisrc/kemono/src/eu/kanade/tachiyomi/multisrc/kemono/KemonoDto.kt
@@ -52,6 +52,12 @@ class KemonoCreatorDto(
 }
 
 @Serializable
+class KemonoPostDtoWrapped(
+    val post: KemonoPostDto,
+)
+
+
+@Serializable
 class KemonoPostDto(
     private val id: String,
     private val service: String,


### PR DESCRIPTION
Checklist:

Closes #5883

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [X] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [X] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [X] Have removed `web_hi_res_512.png` when adding a new extension
