### PR TITLE
Flame Comics: fix chapters naming

### DIFF
--- a/src/en/flamecomics/build.gradle
+++ b/src/en/flamecomics/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Flame Comics'
     extClass = '.FlameComics'
-    extVersionCode = 36
+    extVersionCode = 37
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComics.kt
+++ b/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComics.kt
@@ -25,6 +25,7 @@ import okhttp3.ResponseBody.Companion.toResponseBody
 import org.jsoup.nodes.Document
 import uy.kohesive.injekt.injectLazy
 import java.io.ByteArrayOutputStream
+import java.text.DecimalFormat
 
 class FlameComics : HttpSource() {
     override val name = "Flame Comics"
@@ -43,6 +44,7 @@ class FlameComics : HttpSource() {
         .build()
 
     private val removeSpecialCharsregex = Regex("[^A-Za-z0-9 ]")
+    private val chapterNumberFormat = DecimalFormat("#.####")
 
     private fun dataApiReqBuilder() = baseUrl.toHttpUrl().newBuilder().apply {
         addPathSegment("_next")
@@ -223,7 +225,7 @@ class FlameComics : HttpSource() {
                 chapter_number = chapter.chapter.toFloat()
                 date_upload = chapter.release_date * 1000
                 name = buildString {
-                    append("Chapter ${chapter.chapter.toInt()} ")
+                    append("Chapter ${chapterNumberFormat.format(chapter.chapter)} ")
                     append(chapter.title ?: "")
                 }
             }

--- a/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComics.kt
+++ b/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComics.kt
@@ -25,7 +25,6 @@ import okhttp3.ResponseBody.Companion.toResponseBody
 import org.jsoup.nodes.Document
 import uy.kohesive.injekt.injectLazy
 import java.io.ByteArrayOutputStream
-import java.text.DecimalFormat
 
 class FlameComics : HttpSource() {
     override val name = "Flame Comics"
@@ -44,7 +43,6 @@ class FlameComics : HttpSource() {
         .build()
 
     private val removeSpecialCharsregex = Regex("[^A-Za-z0-9 ]")
-    private val chapterNumberFormat = DecimalFormat("#.####")
 
     private fun dataApiReqBuilder() = baseUrl.toHttpUrl().newBuilder().apply {
         addPathSegment("_next")
@@ -225,7 +223,7 @@ class FlameComics : HttpSource() {
                 chapter_number = chapter.chapter.toFloat()
                 date_upload = chapter.release_date * 1000
                 name = buildString {
-                    append("Chapter ${chapterNumberFormat.format(chapter.chapter)} ")
+                    append("Chapter ${chapter.chapter.toString().removeSuffix(".0")} ")
                     append(chapter.title ?: "")
                 }
             }


### PR DESCRIPTION
Closes #6384 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
