### PR TITLE
Nhentai | Fixed NPE in regex parser

### DIFF
--- a/src/all/nhentai/build.gradle
+++ b/src/all/nhentai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'NHentai'
     extClass = '.NHFactory'
-    extVersionCode = 49
+    extVersionCode = 50
     isNsfw = true
 }
 

--- a/src/all/nhentai/src/eu/kanade/tachiyomi/extension/all/nhentai/NHentai.kt
+++ b/src/all/nhentai/src/eu/kanade/tachiyomi/extension/all/nhentai/NHentai.kt
@@ -74,7 +74,7 @@ open class NHentai(
     }
 
     private val shortenTitleRegex = Regex("""(\[[^]]*]|[({][^)}]*[)}])""")
-    private val dataRegex = Regex("""JSON.parse\("([^*]*)"\)""")
+    private val dataRegex = Regex("""JSON\.parse\(\s*"([^"\\]*(?:\\.[^"\\]*)*)"\s*\)""")
     private val hentaiSelector = "script:containsData(JSON.parse):not(:containsData(media_server))"
     private fun String.shortenTitle() = this.replace(shortenTitleRegex, "").trim()
 

--- a/src/all/nhentai/src/eu/kanade/tachiyomi/extension/all/nhentai/NHentai.kt
+++ b/src/all/nhentai/src/eu/kanade/tachiyomi/extension/all/nhentai/NHentai.kt
@@ -242,10 +242,8 @@ open class NHentai(
     override fun chapterListParse(response: Response): List<SChapter> {
         val document = response.asJsoup()
         val script = document.selectFirst(hentaiSelector)!!.data()
-        Log.e("chapterListParse.script", "script: ${script.isEmpty()}")
 
         val json = dataRegex.find(script)?.groupValues!![1]
-        Log.e("chapterListParse.json", "json: ${json.isEmpty()}")
 
         val data = json.parseAs<Hentai>()
         return listOf(

--- a/src/all/nhentai/src/eu/kanade/tachiyomi/extension/all/nhentai/NHentai.kt
+++ b/src/all/nhentai/src/eu/kanade/tachiyomi/extension/all/nhentai/NHentai.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.extension.all.nhentai
 
 import android.app.Application
 import android.content.SharedPreferences
+import android.util.Log
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.extension.all.nhentai.NHUtils.getArtists
@@ -74,7 +75,7 @@ open class NHentai(
     }
 
     private val shortenTitleRegex = Regex("""(\[[^]]*]|[({][^)}]*[)}])""")
-    private val dataRegex = Regex("""JSON\.parse\(\s*"([^"\\]*(?:\\.[^"\\]*)*)"\s*\)""")
+    private val dataRegex = Regex("""JSON\.parse\(\s*"(.*)"\s*\)""")
     private val hentaiSelector = "script:containsData(JSON.parse):not(:containsData(media_server))"
     private fun String.shortenTitle() = this.replace(shortenTitleRegex, "").trim()
 
@@ -241,8 +242,10 @@ open class NHentai(
     override fun chapterListParse(response: Response): List<SChapter> {
         val document = response.asJsoup()
         val script = document.selectFirst(hentaiSelector)!!.data()
+        Log.e("chapterListParse.script", "script: ${script.isEmpty()}")
 
         val json = dataRegex.find(script)?.groupValues!![1]
+        Log.e("chapterListParse.json", "json: ${json.isEmpty()}")
 
         val data = json.parseAs<Hentai>()
         return listOf(

--- a/src/all/nhentai/src/eu/kanade/tachiyomi/extension/all/nhentai/NHentai.kt
+++ b/src/all/nhentai/src/eu/kanade/tachiyomi/extension/all/nhentai/NHentai.kt
@@ -2,7 +2,6 @@ package eu.kanade.tachiyomi.extension.all.nhentai
 
 import android.app.Application
 import android.content.SharedPreferences
-import android.util.Log
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.extension.all.nhentai.NHUtils.getArtists


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

Fixed NPE cause by regex because it can't parse the `JSON.parse` properly
For example: 264032