### PR TITLE
Comick: Better first cover selection

### DIFF
--- a/src/all/comickfun/build.gradle
+++ b/src/all/comickfun/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comick'
     extClass = '.ComickFactory'
-    extVersionCode = 49
+    extVersionCode = 50
     isNsfw = true
 }
 

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
@@ -396,23 +396,16 @@ abstract class Comick(
             val coversUrl =
                 "$apiUrl/comic/${mangaData.comic.slug ?: mangaData.comic.hid}/covers?tachiyomi=true"
             val covers = client.newCall(GET(coversUrl)).execute()
-                .parseAs<Covers>().mdCovers.reversed().toMutableList()
-            if (covers.any { it.vol == "1" }) covers.retainAll { it.vol == "1" }
-            if (
-                covers.any { comickLang.startsWith(it.locale.orEmpty()) }
-            ) {
-                covers.retainAll { comickLang.startsWith(it.locale.orEmpty()) }
-            } else if (
-                covers.any { mangaData.comic.isoLang.orEmpty().startsWith(it.locale.orEmpty()) }
-            ) {
-                covers.retainAll {
-                    mangaData.comic.isoLang.orEmpty().startsWith(it.locale.orEmpty())
-                }
-            }
+                .parseAs<Covers>().mdCovers.reversed()
+            val firstVol = covers.filter { it.vol == "1" }.ifEmpty { covers }
+            val originalCovers = firstVol
+                .filter { mangaData.comic.isoLang.orEmpty().startsWith(it.locale.orEmpty()) }
+            val localCovers = firstVol
+                .filter { comickLang.startsWith(it.locale.orEmpty()) }
             return mangaData.toSManga(
                 includeMuTags = preferences.includeMuTags,
                 scorePosition = preferences.scorePosition,
-                covers = covers,
+                covers = localCovers.ifEmpty { originalCovers }.ifEmpty { firstVol },
                 groupTags = preferences.groupTags,
             )
         }

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
@@ -399,9 +399,15 @@ abstract class Comick(
                 .parseAs<Covers>().mdCovers.reversed().toMutableList()
             if (covers.any { it.vol == "1" }) covers.retainAll { it.vol == "1" }
             if (
-                covers.any { it.locale == comickLang.split('-').first() }
+                covers.any { comickLang.startsWith(it.locale.orEmpty()) }
             ) {
-                covers.retainAll { it.locale == comickLang.split('-').first() }
+                covers.retainAll { comickLang.startsWith(it.locale.orEmpty()) }
+            } else if (covers.any {
+                    mangaData.comic.isoLang.orEmpty().startsWith(it.locale.orEmpty())
+                }) {
+                covers.retainAll {
+                    mangaData.comic.isoLang.orEmpty().startsWith(it.locale.orEmpty())
+                }
             }
             return mangaData.toSManga(
                 includeMuTags = preferences.includeMuTags,

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Comick.kt
@@ -402,9 +402,9 @@ abstract class Comick(
                 covers.any { comickLang.startsWith(it.locale.orEmpty()) }
             ) {
                 covers.retainAll { comickLang.startsWith(it.locale.orEmpty()) }
-            } else if (covers.any {
-                    mangaData.comic.isoLang.orEmpty().startsWith(it.locale.orEmpty())
-                }) {
+            } else if (
+                covers.any { mangaData.comic.isoLang.orEmpty().startsWith(it.locale.orEmpty()) }
+            ) {
                 covers.retainAll {
                     mangaData.comic.isoLang.orEmpty().startsWith(it.locale.orEmpty())
                 }
@@ -473,9 +473,10 @@ abstract class Comick(
             .map { it.toSChapter(mangaUrl) }
     }
 
-    private val publishedDateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ENGLISH).apply {
-        timeZone = TimeZone.getTimeZone("UTC")
-    }
+    private val publishedDateFormat =
+        SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ENGLISH).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
 
     override fun getChapterUrl(chapter: SChapter): String {
         return "$baseUrl${chapter.url}"

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Dto.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Dto.kt
@@ -112,6 +112,7 @@ class Comic(
     @SerialName("md_comic_md_genres") val mdGenres: List<MdGenres>,
     @SerialName("mu_comics") val muGenres: MuComicCategories = MuComicCategories(emptyList()),
     @SerialName("bayesian_rating") val score: String? = null,
+    @SerialName("iso639_1") val isoLang: String? = null,
 ) {
     val origination = when (country) {
         "jp" -> Name("Manga")


### PR DESCRIPTION
- Use `startsWith` to better handle compound languages
- Additional fallback to a cover on the entry's original language if none a re found in the extension's selected language. Handles weird edge-cases like the example below where the Ukranian cover would be picked for Japanese content regardless of the selected language since it's the first on the list.
![image](https://github.com/user-attachments/assets/01fb0cbd-4ef1-4393-8757-1043a56e90ce)

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
