### PR TITLE
Fix HentaiRead

### DIFF
--- a/src/en/hentairead/build.gradle
+++ b/src/en/hentairead/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Hentairead'
     themePkg = 'madara'
     baseUrl = 'https://hentairead.com'
-    overrideVersionCode = 8
+    overrideVersionCode = 9
     isNsfw = true
 }
 

--- a/src/en/hentairead/src/eu/kanade/tachiyomi/extension/en/hentairead/HentaiReadDTO.kt
+++ b/src/en/hentairead/src/eu/kanade/tachiyomi/extension/en/hentairead/HentaiReadDTO.kt
@@ -12,3 +12,28 @@ class Result(
     val id: Int,
     val text: String,
 )
+
+@Serializable
+class ImageBaseUrlDto(
+    val baseUrl: String,
+)
+
+@Serializable
+class PagesDto(
+    val data: Data,
+) {
+    @Serializable
+    class Data(
+        val chapter: Chapter,
+    ) {
+        @Serializable
+        class Chapter(
+            val images: List<Image>,
+        ) {
+            @Serializable
+            class Image(
+                val src: String,
+            )
+        }
+    }
+}

--- a/src/en/hentairead/src/eu/kanade/tachiyomi/extension/en/hentairead/Hentairead.kt
+++ b/src/en/hentairead/src/eu/kanade/tachiyomi/extension/en/hentairead/Hentairead.kt
@@ -185,8 +185,11 @@ class Hentairead : Madara("HentaiRead", "https://hentairead.com", "en", dateForm
         }
     }
 
-    private val chapterExtraDataRegex = Regex("= (\\{[^;]+)")
-    private val pagesDataRegex = Regex(".(ey\\S+).\\s")
+    // chapterExtraData = ({...});
+    private val chapterExtraDataRegex = Regex("""= (\{[^;]+)""")
+
+    // window.mMjM5MjM2 = '(eyJkYX...);
+    private val pagesDataRegex = Regex(""".(ey\S+).\s""")
 
     // From ManhwaHentai - modified
     override fun pageListParse(document: Document): List<Page> {

--- a/src/en/hentairead/src/eu/kanade/tachiyomi/extension/en/hentairead/Hentairead.kt
+++ b/src/en/hentairead/src/eu/kanade/tachiyomi/extension/en/hentairead/Hentairead.kt
@@ -185,17 +185,19 @@ class Hentairead : Madara("HentaiRead", "https://hentairead.com", "en", dateForm
         }
     }
 
+    private val chapterExtraDataRegex = Regex("= (\\{[^;]+)")
+    private val pagesDataRegex = Regex(".(ey\\S+).\\s")
+
     // From ManhwaHentai - modified
     override fun pageListParse(document: Document): List<Page> {
         launchIO { countViews(document) }
 
         val pageBaseUrl = document.selectFirst("[id=single-chapter-js-extra]")?.data()
-            ?.substringAfter("chapterExtraData = ")
-            ?.substringBefore(";")?.let { json.decodeFromString<ImageBaseUrlDto>(it).baseUrl }
+            ?.let { chapterExtraDataRegex.find(it)?.groups }?.get(1)?.value
+            ?.let { json.decodeFromString<ImageBaseUrlDto>(it).baseUrl }
 
         val pages = document.selectFirst("[id=single-chapter-js-before]")?.data()
-            ?.substringAfter("= '")
-            ?.substringBefore("'")
+            ?.let { pagesDataRegex.find(it)?.groups }?.get(1)?.value
             ?.let { json.decodeFromString<PagesDto>(String(Base64.decode(it, Base64.DEFAULT))) }
             ?: throw Exception("Failed to find page list. Non-English entries are not supported.")
 


### PR DESCRIPTION
Closes #6386

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [X] Have not changed source names
- [X] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio