### PR TITLE
Fix SirenKomik

### DIFF
--- a/src/id/mangkomik/build.gradle
+++ b/src/id/mangkomik/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.SirenKomik'
     themePkg = 'mangathemesia'
     baseUrl = 'https://sirenkomik.my.id'
-    overrideVersionCode = 4
+    overrideVersionCode = 5
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/mangkomik/src/eu/kanade/tachiyomi/extension/id/mangkomik/SirenKomik.kt
+++ b/src/id/mangkomik/src/eu/kanade/tachiyomi/extension/id/mangkomik/SirenKomik.kt
@@ -27,6 +27,8 @@ class SirenKomik : MangaThemesia(
 
     override fun chapterListSelector() = ".list-chapter a"
 
+    override val pageSelector: String = "Deactivate html search"
+
     override fun chapterFromElement(element: Element) = SChapter.create().apply {
         name = element.selectFirst(".nomer-chapter")!!.text()
         date_upload = element.selectFirst(".tgl-chapter")?.text().parseChapterDate()

--- a/src/id/mangkomik/src/eu/kanade/tachiyomi/extension/id/mangkomik/SirenKomik.kt
+++ b/src/id/mangkomik/src/eu/kanade/tachiyomi/extension/id/mangkomik/SirenKomik.kt
@@ -27,7 +27,8 @@ class SirenKomik : MangaThemesia(
 
     override fun chapterListSelector() = ".list-chapter a"
 
-    override val pageSelector: String = "Deactivate html search"
+    // Overridden since MangeThemesia doesn't search for jsonData in script tags, because it finds the bait images with the default selector
+    override val pageSelector: String = ":not(*)"
 
     override fun chapterFromElement(element: Element) = SChapter.create().apply {
         name = element.selectFirst(".nomer-chapter")!!.text()


### PR DESCRIPTION
Closes : #6421

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [X] Have not changed source names
- [X] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
