### PR TITLE
Raijin Scans: Update domain

### DIFF
--- a/src/fr/raijinscans/build.gradle
+++ b/src/fr/raijinscans/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Raijin Scans'
     extClass = '.RaijinScans'
     themePkg = 'madara'
-    baseUrl = 'https://raijinscans.fr'
-    overrideVersionCode = 2
+    baseUrl = 'https://raijinscans.net'
+    overrideVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
+++ b/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
@@ -4,6 +4,7 @@ import eu.kanade.tachiyomi.multisrc.madara.Madara
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class RaijinScans : Madara("Raijin Scans", "https://raijinscans.fr", "fr", dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.FRENCH)) {
+class RaijinScans : Madara("Raijin Scans", "https://raijinscans.net", "fr", dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.FRENCH)) {
     override val useNewChapterEndpoint = true
+    override val mangaDetailsSelectorStatus = "div.summary-heading:contains(Statut) + div.summary-content"
 }


### PR DESCRIPTION
Checklist:

Closes #6425 

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
