### PR TITLE
Kemono | Fixed some chapters/images not loading due to missing 'name'

### DIFF
--- a/lib-multisrc/kemono/build.gradle.kts
+++ b/lib-multisrc/kemono/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 15
+baseVersionCode = 16

--- a/lib-multisrc/kemono/src/eu/kanade/tachiyomi/multisrc/kemono/KemonoDto.kt
+++ b/lib-multisrc/kemono/src/eu/kanade/tachiyomi/multisrc/kemono/KemonoDto.kt
@@ -70,7 +70,7 @@ class KemonoPostDto(
 ) {
     val images: List<String>
         get() = buildList(attachments.size + 1) {
-            if (file.path != null) add(KemonoAttachmentDto(file.name!!, file.path))
+            if (file.path != null) add(KemonoAttachmentDto(file.name, file.path))
             addAll(attachments)
         }.filter {
             when (it.path.substringAfterLast('.').lowercase()) {
@@ -106,8 +106,8 @@ class KemonoFileDto(val name: String? = null, val path: String? = null)
 
 // name might have ".jpe" extension for JPEG, path might have ".m4v" extension for MP4
 @Serializable
-class KemonoAttachmentDto(val name: String, val path: String) {
-    override fun toString() = "$path?f=$name"
+class KemonoAttachmentDto(var name: String? = null, val path: String) {
+    override fun toString() = path + if (name != null) "?f=$name" else ""
 }
 
 private fun getApiDateFormat() =


### PR DESCRIPTION
This issue was mentioned by users on a closed issue: #5883

Checklist:
- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
