### PR TITLE
HentaiCB: Fix http404 popularMangaRequest & latestUpdatesRequest

### DIFF
--- a/src/vi/hentaicube/build.gradle
+++ b/src/vi/hentaicube/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.HentaiCB'
     themePkg = 'madara'
     baseUrl = 'https://hentaicube.xyz'
-    overrideVersionCode = 10
+    overrideVersionCode = 11
     isNsfw = true
 }
 

--- a/src/vi/hentaicube/src/eu/kanade/tachiyomi/extension/vi/hentaicube/HentaiCB.kt
+++ b/src/vi/hentaicube/src/eu/kanade/tachiyomi/extension/vi/hentaicube/HentaiCB.kt
@@ -1,7 +1,9 @@
 package eu.kanade.tachiyomi.extension.vi.hentaicube
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.Page
+import okhttp3.Request
 import org.jsoup.nodes.Document
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -13,6 +15,20 @@ class HentaiCB : Madara("CBHentai", "https://hentaicube.xyz", "vi", SimpleDateFo
     override val mangaSubString = "read"
 
     override val filterNonMangaItems = false
+
+    override fun popularMangaRequest(page: Int): Request =
+        if (useLoadMoreRequest()) {
+            loadMoreRequest(page, popular = true)
+        } else {
+            GET("$baseUrl/$mangaSubString/${searchPage(page)}?s&post_type=wp-manga&m_orderby=views", headers)
+        }
+
+    override fun latestUpdatesRequest(page: Int): Request =
+        if (useLoadMoreRequest()) {
+            loadMoreRequest(page, popular = false)
+        } else {
+            GET("$baseUrl/$mangaSubString/${searchPage(page)}?s&post_type=wp-manga&m_orderby=latest", headers)
+        }
 
     override fun pageListParse(document: Document): List<Page> {
         return super.pageListParse(document).distinctBy { it.imageUrl }

--- a/src/vi/hentaicube/src/eu/kanade/tachiyomi/extension/vi/hentaicube/HentaiCB.kt
+++ b/src/vi/hentaicube/src/eu/kanade/tachiyomi/extension/vi/hentaicube/HentaiCB.kt
@@ -1,9 +1,7 @@
 package eu.kanade.tachiyomi.extension.vi.hentaicube
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
-import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.Page
-import okhttp3.Request
 import org.jsoup.nodes.Document
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -12,23 +10,7 @@ class HentaiCB : Madara("CBHentai", "https://hentaicube.xyz", "vi", SimpleDateFo
 
     override val id: Long = 823638192569572166
 
-    override val mangaSubString = "read"
-
     override val filterNonMangaItems = false
-
-    override fun popularMangaRequest(page: Int): Request =
-        if (useLoadMoreRequest()) {
-            loadMoreRequest(page, popular = true)
-        } else {
-            GET("$baseUrl/$mangaSubString/${searchPage(page)}?s&post_type=wp-manga&m_orderby=views", headers)
-        }
-
-    override fun latestUpdatesRequest(page: Int): Request =
-        if (useLoadMoreRequest()) {
-            loadMoreRequest(page, popular = false)
-        } else {
-            GET("$baseUrl/$mangaSubString/${searchPage(page)}?s&post_type=wp-manga&m_orderby=latest", headers)
-        }
 
     override fun pageListParse(document: Document): List<Page> {
         return super.pageListParse(document).distinctBy { it.imageUrl }


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
