### PR TITLE
Improve GigaViewer chapter list parse to fix NullPointerException

### DIFF
--- a/lib-multisrc/gigaviewer/build.gradle.kts
+++ b/lib-multisrc/gigaviewer/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 5
+baseVersionCode = 6


### PR DESCRIPTION
Closes #4993
Closes #5410

Utilizes a more generic method of getting chapter information that resolves compatibility issues with sites that use a paginated version of the GigaViewer chapter list.

The `number_since` query parameter needs to be a number that is at least the number of chapters in the series, minus one. As a series is unlikely to have more chapters than `Int.MAX_SIZE` I've chosen to use that as the the value.

The `read_more_num` query parameter appears to max out at 150, any values above this result in an error message in the response.

Checklist:
- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
