### PR TITLE
Manga 18x: increase timeout

### DIFF
--- a/src/en/manga18x/build.gradle
+++ b/src/en/manga18x/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Manga18x'
     themePkg = 'madara'
     baseUrl = 'https://manga18x.net'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/en/manga18x/src/eu/kanade/tachiyomi/extension/en/manga18x/Manga18x.kt
+++ b/src/en/manga18x/src/eu/kanade/tachiyomi/extension/en/manga18x/Manga18x.kt
@@ -1,7 +1,12 @@
 package eu.kanade.tachiyomi.extension.en.manga18x
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import java.util.concurrent.TimeUnit
 
 class Manga18x : Madara("Manga 18x", "https://manga18x.net", "en") {
+    override val client = super.client.newBuilder()
+        .readTimeout(2, TimeUnit.MINUTES)
+        .build()
+
     override val useNewChapterEndpoint = true
 }


### PR DESCRIPTION
Closes #5360

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
