### PR TITLE
snowmtl: fix image intercept

### DIFF
--- a/src/en/snowmtl/build.gradle
+++ b/src/en/snowmtl/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Snow Machine Translations'
     extClass = '.Snowmtl'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/en/snowmtl/src/eu/kanade/tachiyomi/extension/en/snowmtl/ComposedImageInterceptor.kt
+++ b/src/en/snowmtl/src/eu/kanade/tachiyomi/extension/en/snowmtl/ComposedImageInterceptor.kt
@@ -32,7 +32,7 @@ import kotlin.math.sqrt
 // The Interceptor joins the captions and pages of the manga.
 @RequiresApi(Build.VERSION_CODES.O)
 class ComposedImageInterceptor(
-    private val baseUrl: String,
+    baseUrl: String,
     private val client: OkHttpClient,
 ) : Interceptor {
 
@@ -44,11 +44,16 @@ class ComposedImageInterceptor(
         "normal" to Pair<String, Typeface?>("$baseUrl/images/normal.ttf", null),
     )
 
+    private val imageRegex = Regex(
+        "$baseUrl.*?\\.(webp|png|jpg|jpeg)#\\[.*?]",
+        RegexOption.IGNORE_CASE,
+    )
+
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
         val url = request.url.toString()
 
-        val isPageImageUrl = url.contains("${baseUrl.substringAfterLast("/")}/storage/", true)
+        val isPageImageUrl = imageRegex.containsMatchIn(url)
         if (isPageImageUrl.not()) {
             return chain.proceed(request)
         }


### PR DESCRIPTION
Source use various path patterns. This should fixes it once and for all.

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
