### PR TITLE
MangaSwat: fix latest tab

### DIFF
--- a/src/ar/mangaswat/build.gradle
+++ b/src/ar/mangaswat/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaSwat'
     themePkg = 'mangathemesia'
     baseUrl = 'https://swatscans.com'
-    overrideVersionCode = 24
+    overrideVersionCode = 25
 }
 
 apply from: "$rootDir/common.gradle"


### PR DESCRIPTION
Since the regular 'update' page is broken the entries have to be loaded from the home page. The home page uses an API to load the entires, which requires a CSRF token.

Closes #4758

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
