### PR TITLE
GalleryAdults & Fox additions

### DIFF
--- a/lib-multisrc/galleryadults/build.gradle.kts
+++ b/lib-multisrc/galleryadults/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 3
+baseVersionCode = 4

--- a/lib-multisrc/galleryadults/src/eu/kanade/tachiyomi/multisrc/galleryadults/GalleryAdults.kt
+++ b/lib-multisrc/galleryadults/src/eu/kanade/tachiyomi/multisrc/galleryadults/GalleryAdults.kt
@@ -814,8 +814,8 @@ abstract class GalleryAdults(
                 val tags = mutableListOf<Genre>()
                 runBlocking {
                     val jobsPool = mutableListOf<Job>()
-                    // Get first 3 pages
-                    (1..3).forEach { page ->
+                    // Get first 5 pages
+                    (1..5).forEach { page ->
                         jobsPool.add(
                             launchIO {
                                 runCatching {

--- a/lib-multisrc/galleryadults/src/eu/kanade/tachiyomi/multisrc/galleryadults/GalleryAdults.kt
+++ b/lib-multisrc/galleryadults/src/eu/kanade/tachiyomi/multisrc/galleryadults/GalleryAdults.kt
@@ -777,7 +777,7 @@ abstract class GalleryAdults(
 
     /* Filters */
     private val scope = CoroutineScope(Dispatchers.IO)
-    private fun launchIO(block: () -> Unit) = scope.launch { block() }
+    protected fun launchIO(block: () -> Unit) = scope.launch { block() }
     private var tagsFetched = false
     private var tagsFetchAttempt = 0
 

--- a/lib-multisrc/galleryadults/src/eu/kanade/tachiyomi/multisrc/galleryadults/GalleryAdults.kt
+++ b/lib-multisrc/galleryadults/src/eu/kanade/tachiyomi/multisrc/galleryadults/GalleryAdults.kt
@@ -777,7 +777,7 @@ abstract class GalleryAdults(
 
     /* Filters */
     private val scope = CoroutineScope(Dispatchers.IO)
-    protected fun launchIO(block: () -> Unit) = scope.launch { block() }
+    private fun launchIO(block: () -> Unit) = scope.launch { block() }
     private var tagsFetched = false
     private var tagsFetchAttempt = 0
 

--- a/src/all/hentaifox/build.gradle
+++ b/src/all/hentaifox/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.HentaiFoxFactory'
     themePkg = 'galleryadults'
     baseUrl = 'https://hentaifox.com'
-    overrideVersionCode = 6
+    overrideVersionCode = 7
     isNsfw = true
 }
 

--- a/src/all/hentaifox/build.gradle
+++ b/src/all/hentaifox/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.HentaiFoxFactory'
     themePkg = 'galleryadults'
     baseUrl = 'https://hentaifox.com'
-    overrideVersionCode = 7
+    overrideVersionCode = 6
     isNsfw = true
 }
 

--- a/src/all/hentaifox/src/eu/kanade/tachiyomi/extension/all/hentaifox/HentaiFox.kt
+++ b/src/all/hentaifox/src/eu/kanade/tachiyomi/extension/all/hentaifox/HentaiFox.kt
@@ -146,25 +146,17 @@ class HentaiFox(
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         // Sidebar mangas should always override any other search, so they should appear first
-        // in the case/when and only propagate to super when a "normal" search is issued
+        // and only propagate to super when a "normal" search is issued
         val sortOrderFilter = filters.filterIsInstance<SortOrderFilter>().firstOrNull()
 
-        return when {
-            sortOrderFilter?.state == 2 ->
-                sidebarRequest("top_rated")
-
-            sortOrderFilter?.state == 3 ->
-                sidebarRequest("top_faved")
-
-            sortOrderFilter?.state == 4 ->
-                sidebarRequest("top_fapped")
-
-            sortOrderFilter?.state == 5 ->
-                sidebarRequest("top_downloaded")
-
-            else ->
-                super.searchMangaRequest(page, query, filters)
+        sortOrderFilter?.let {
+            if (sortOrderFilter.state > 1) {
+                return sidebarRequest(
+                    sidebarCategoriesFilterStateMap.getValue(sortOrderFilter.state),
+                )
+            }
         }
+        return super.searchMangaRequest(page, query, filters)
     }
 
     private var csrfToken: String? = null
@@ -224,5 +216,14 @@ class HentaiFox(
             Pair("Most Fapped", "mf"),
             Pair("Most Downloaded", "md"),
         )
+    }
+
+    companion object {
+        private val sidebarCategoriesFilterStateMap = mapOf(
+            2 to "top_rated",
+            3 to "top_faved",
+            4 to "top_fapped",
+            5 to "top_downloaded",
+        ).withDefault { "top_rated" }
     }
 }

--- a/src/all/hentaifox/src/eu/kanade/tachiyomi/extension/all/hentaifox/HentaiFox.kt
+++ b/src/all/hentaifox/src/eu/kanade/tachiyomi/extension/all/hentaifox/HentaiFox.kt
@@ -126,6 +126,13 @@ class HentaiFox(
     private fun Element.sidebarMangaThumbnail() =
         selectFirst("img")?.imgAttr()
 
+    private var csrfToken: String? = null
+
+    override fun tagsParser(document: Document): List<Genre> {
+        csrfToken = csrfParser(document)
+        return super.tagsParser(document)
+    }
+
     private fun csrfParser(document: Document): String {
         return document.select("[name=csrf-token]").attr("content")
     }
@@ -152,13 +159,6 @@ class HentaiFox(
             }
         }
         return super.searchMangaRequest(page, query, filters)
-    }
-
-    private var csrfToken: String? = null
-
-    override fun tagsParser(document: Document): List<Genre> {
-        csrfToken = csrfParser(document)
-        return super.tagsParser(document)
     }
 
     private fun sidebarRequest(category: String): Request {

--- a/src/all/hentaifox/src/eu/kanade/tachiyomi/extension/all/hentaifox/HentaiFox.kt
+++ b/src/all/hentaifox/src/eu/kanade/tachiyomi/extension/all/hentaifox/HentaiFox.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.runBlocking
 import okhttp3.FormBody
 import okhttp3.Headers
 import okhttp3.HttpUrl
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
@@ -182,9 +181,9 @@ class HentaiFox(
             }.join()
         }
 
-        val url = "$baseUrl/$sidebarPath".toHttpUrl().newBuilder()
+        val url = "$baseUrl/$sidebarPath"
         return POST(
-            url.build().toString(),
+            url,
             setSidebarHeaders(csrfToken),
             FormBody.Builder()
                 .add("type", category)
@@ -193,7 +192,7 @@ class HentaiFox(
     }
 
     override fun searchMangaParse(response: Response): MangasPage {
-        if (response.request.url.toString().endsWith(sidebarPath)) {
+        if (response.request.url.encodedPath.endsWith(sidebarPath)) {
             val document = response.asJsoup()
             val mangas = document.select(sidebarMangaSelector())
                 .map {

--- a/src/all/hentaifox/src/eu/kanade/tachiyomi/extension/all/hentaifox/HentaiFox.kt
+++ b/src/all/hentaifox/src/eu/kanade/tachiyomi/extension/all/hentaifox/HentaiFox.kt
@@ -152,9 +152,10 @@ class HentaiFox(
         val sortOrderFilter = filters.filterIsInstance<SortOrderFilter>().firstOrNull()
 
         sortOrderFilter?.let {
-            if (sortOrderFilter.state > 1) {
+            val selectedCategory = sortOrderFilter.values.get(sortOrderFilter.state)
+            if (sidebarCategoriesFilterStateMap.containsKey(selectedCategory)) {
                 return sidebarRequest(
-                    sidebarCategoriesFilterStateMap.getValue(sortOrderFilter.state),
+                    sidebarCategoriesFilterStateMap.getValue(selectedCategory),
                 )
             }
         }
@@ -199,20 +200,15 @@ class HentaiFox(
     }
 
     override fun getSortOrderURIs(): List<Pair<String, String>> {
-        return super.getSortOrderURIs() + listOf(
-            Pair("Top Rated", "tr"),
-            Pair("Most Faved", "mv"),
-            Pair("Most Fapped", "mf"),
-            Pair("Most Downloaded", "md"),
-        )
+        return super.getSortOrderURIs() + sidebarCategoriesFilterStateMap.toList()
     }
 
     companion object {
         private val sidebarCategoriesFilterStateMap = mapOf(
-            2 to "top_rated",
-            3 to "top_faved",
-            4 to "top_fapped",
-            5 to "top_downloaded",
+            "Top Rated" to "top_rated",
+            "Most Faved" to "top_faved",
+            "Most Fapped" to "top_fapped",
+            "Most Downloaded" to "top_downloaded",
         ).withDefault { "top_rated" }
     }
 }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

This PR aims achieves 2 goals:
- GalleryAdults multisrc-lib now fetches tags from 5 pages instead of 3. This was necessary due to some sources having very few tags per page
- Implemented search for the 4 types of "currently trending" galleries which appear in the sidebar of HentaiFox's homepage