### PR TITLE
Readmangas: Fixed to the pagination of the chapters and the domain

### DIFF
--- a/src/pt/readmangas/build.gradle
+++ b/src/pt/readmangas/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Read Mangas'
     extClass = '.ReadMangas'
-    extVersionCode = 32
+    extVersionCode = 33
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/readmangas/src/eu/kanade/tachiyomi/extension/pt/readmangas/ReadMangas.kt
+++ b/src/pt/readmangas/src/eu/kanade/tachiyomi/extension/pt/readmangas/ReadMangas.kt
@@ -32,7 +32,7 @@ class ReadMangas() : HttpSource() {
 
     override val name = "Read Mangas"
 
-    override val baseUrl = "https://readmangas.org"
+    override val baseUrl = "https://app.loobyt.com"
 
     override val lang = "pt-BR"
 
@@ -247,13 +247,12 @@ class ReadMangas() : HttpSource() {
 
     override fun pageListParse(response: Response): List<Page> {
         val document = response.asJsoup()
-        val script = document.select("script").map { it.data() }
-            .firstOrNull { IMAGE_URL_REGEX.containsMatchIn(it) }
-            ?: return emptyList()
-
-        return IMAGE_URL_REGEX.findAll(script).mapIndexed { index, match ->
+        val scripts = document.select("script").joinToString("\n") { it.data() }
+        val pages = IMAGE_URL_REGEX.findAll(scripts).mapIndexed { index, match ->
             Page(index, imageUrl = match.groups["imageUrl"]!!.value)
         }.toList()
+
+        return pages
     }
 
     override fun imageUrlParse(response: Response) = ""


### PR DESCRIPTION
Closes #6719 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
