### PR TITLE
IkigaiMangas: Update default domain

### DIFF
--- a/src/es/ikigaimangas/build.gradle
+++ b/src/es/ikigaimangas/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Ikigai Mangas'
     extClass = '.IkigaiMangas'
-    extVersionCode = 19
+    extVersionCode = 20
     isNsfw = true
 }
 

--- a/src/es/ikigaimangas/src/eu/kanade/tachiyomi/extension/es/ikigaimangas/IkigaiMangas.kt
+++ b/src/es/ikigaimangas/src/eu/kanade/tachiyomi/extension/es/ikigaimangas/IkigaiMangas.kt
@@ -40,7 +40,7 @@ class IkigaiMangas : HttpSource(), ConfigurableSource {
         else -> preferences.getPrefBaseUrl()
     }
 
-    private val defaultBaseUrl: String = "https://lectorikigai.acamu.net"
+    private val defaultBaseUrl: String = "https://lectorikigai.bakeni.net"
 
     private val fetchedDomainUrl: String by lazy {
         if (!preferences.fetchDomainPref()) preferences.getPrefBaseUrl()


### PR DESCRIPTION
Closes #6640

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
