### PR TITLE
fixes image load (403) for MadaraDex

### DIFF
--- a/src/en/madaradex/build.gradle
+++ b/src/en/madaradex/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MadaraDex'
     themePkg = 'madara'
     baseUrl = 'https://madaradex.org'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/en/madaradex/src/eu/kanade/tachiyomi/extension/en/madaradex/MadaraDex.kt
+++ b/src/en/madaradex/src/eu/kanade/tachiyomi/extension/en/madaradex/MadaraDex.kt
@@ -10,5 +10,7 @@ class MadaraDex : Madara(
     "en",
     dateFormat = SimpleDateFormat("MMM d, yyyy", Locale.US),
 ) {
+    override fun headersBuilder() = super.headersBuilder()
+        .set("sec-fetch-site", "same-site")
     override val mangaSubString = "title"
 }


### PR DESCRIPTION
closes #6670

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
