### PR TITLE
Fix Iken Popular Page

### DIFF
--- a/lib-multisrc/iken/build.gradle.kts
+++ b/lib-multisrc/iken/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 5
+baseVersionCode = 6

--- a/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Iken.kt
+++ b/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Iken.kt
@@ -53,11 +53,9 @@ abstract class Iken(
 
     override fun popularMangaParse(response: Response): MangasPage {
         val document = response.asJsoup()
-        val slugs = document.select("div:contains(Popular) + div.swiper div.manga-swipe > a")
-            .map { it.absUrl("href").substringAfterLast("/series/") }
 
-        val entries = slugs.mapNotNull {
-            titleCache[it]?.toSManga()
+        val entries = document.select("aside a:has(img)").mapNotNull {
+            titleCache[it.absUrl("href").substringAfter("series/")]?.toSManga()
         }
 
         return MangasPage(entries, false)

--- a/src/en/infernalvoidscans/src/eu/kanade/tachiyomi/extension/en/infernalvoidscans/HiveScans.kt
+++ b/src/en/infernalvoidscans/src/eu/kanade/tachiyomi/extension/en/infernalvoidscans/HiveScans.kt
@@ -1,9 +1,6 @@
 package eu.kanade.tachiyomi.extension.en.infernalvoidscans
 
 import eu.kanade.tachiyomi.multisrc.iken.Iken
-import eu.kanade.tachiyomi.source.model.MangasPage
-import eu.kanade.tachiyomi.util.asJsoup
-import okhttp3.Response
 
 class HiveScans : Iken(
     "Hive Scans",
@@ -25,14 +22,4 @@ class HiveScans : Iken(
 
     override fun headersBuilder() = super.headersBuilder()
         .set("Cache-Control", "max-age=0")
-
-    override fun popularMangaParse(response: Response): MangasPage {
-        val document = response.asJsoup()
-
-        val entries = document.select(".group a").mapNotNull {
-            titleCache[it.absUrl("href").substringAfter("series/")]?.toSManga()
-        }
-
-        return MangasPage(entries, false)
-    }
 }

--- a/src/en/philiascans/src/eu/kanade/tachiyomi/extension/en/philiascans/PhiliaScans.kt
+++ b/src/en/philiascans/src/eu/kanade/tachiyomi/extension/en/philiascans/PhiliaScans.kt
@@ -5,5 +5,5 @@ import eu.kanade.tachiyomi.multisrc.iken.Iken
 class PhiliaScans : Iken(
     "Philia Scans",
     "en",
-    "https://philiascans.com",
+    "https://philiascans.org",
 )


### PR DESCRIPTION
Closes #6715
Closes #6448
Closes #6565

- fix Iken popolar results
- change philliascans url from .com -> .org
- remove unnecessary code from HiveScans 

Checklist:

- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [X] Have not changed source names
- [X] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio