### PR TITLE
DeviantArt: Fix NullPointerException for some galleries

### DIFF
--- a/src/all/deviantart/build.gradle
+++ b/src/all/deviantart/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'DeviantArt'
     extClass = '.DeviantArt'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/all/deviantart/src/eu/kanade/tachiyomi/extension/all/deviantart/DeviantArt.kt
+++ b/src/all/deviantart/src/eu/kanade/tachiyomi/extension/all/deviantart/DeviantArt.kt
@@ -74,7 +74,7 @@ class DeviantArt : HttpSource() {
         val manga = SManga.create().apply {
             // If manga is sub-gallery then use sub-gallery name, else use gallery name
             title = subFolderGallery?.selectFirst("._2vMZg + ._2vMZg")?.text()?.substringBeforeLast(" ")
-                ?: document.selectFirst(".ds-card-selected h2")!!.text()
+                ?: subFolderGallery?.selectFirst("[aria-haspopup=listbox] > div")!!.ownText()
             author = document.title().substringBefore(" ")
             description = subFolderGallery?.selectFirst(".legacy-journal")?.wholeText()
             thumbnail_url = subFolderGallery?.selectFirst("img[property=contentUrl]")?.absUrl("src")


### PR DESCRIPTION
Closes #6794 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] ~Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions~
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] ~Added the `isNsfw = true` flag in `build.gradle` when appropriate~
- [x] Have not changed source names
- [ ] ~Have explicitly kept the `id` if a source's name or language were changed~
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] ~Have removed `web_hi_res_512.png` when adding a new extension~
