### PR TITLE
mangapro to Iken multisrc

### DIFF
--- a/src/ar/mangapro/build.gradle
+++ b/src/ar/mangapro/build.gradle
@@ -1,9 +1,9 @@
 ext {
     extName = 'Manga Pro'
     extClass = '.MangaPro'
-    themePkg = 'mangathemesia'
+    themePkg = 'iken'
     baseUrl = 'https://promanga.pro'
-    overrideVersionCode = 3
+    overrideVersionCode = 28
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/mangapro/src/eu/kanade/tachiyomi/extension/ar/mangapro/MangaPro.kt
+++ b/src/ar/mangapro/src/eu/kanade/tachiyomi/extension/ar/mangapro/MangaPro.kt
@@ -1,43 +1,11 @@
 package eu.kanade.tachiyomi.extension.ar.mangapro
 
-import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
-import eu.kanade.tachiyomi.source.model.Page
-import okhttp3.HttpUrl.Companion.toHttpUrl
-import org.jsoup.nodes.Document
-import java.text.SimpleDateFormat
-import java.util.Locale
+import eu.kanade.tachiyomi.multisrc.iken.Iken
 
-class MangaPro : MangaThemesia(
+class MangaPro : Iken(
     "Manga Pro",
-    "https://promanga.pro",
     "ar",
-    dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("ar")),
+    "https://promanga.pro",
 ) {
-    override val versionId = 3
-
-    override fun pageListParse(document: Document): List<Page> {
-        return super.pageListParse(document).onEach {
-            val httpUrl = it.imageUrl!!.toHttpUrl()
-
-            if (wpImgRegex.containsMatchIn(httpUrl.host)) {
-                it.imageUrl = StringBuilder().apply {
-                    val ssl = httpUrl.queryParameter("ssl")
-                    when (ssl) {
-                        null -> append(httpUrl.scheme)
-                        "0" -> append("http")
-                        else -> append("https")
-                    }
-                    append("://")
-                    append(httpUrl.pathSegments.joinToString("/"))
-                    val search = httpUrl.queryParameter("q")
-                    if (search != null) {
-                        append("?q=")
-                        append(search)
-                    }
-                }.toString()
-            }
-        }
-    }
+    override val versionId = 4
 }
-
-private val wpImgRegex = Regex("""i\d+\.wp\.com""")


### PR DESCRIPTION
Closes #6702

Checklist:

- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [X] Have not changed source names
- [X] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
