### PR TITLE
SlimeReadTheme: remove use of incompatible API

### DIFF
--- a/lib-multisrc/slimereadtheme/build.gradle.kts
+++ b/lib-multisrc/slimereadtheme/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 1
+baseVersionCode = 2

--- a/lib-multisrc/slimereadtheme/src/eu/kanade/tachiyomi/multisrc/slimereadtheme/SlimeReadTheme.kt
+++ b/lib-multisrc/slimereadtheme/src/eu/kanade/tachiyomi/multisrc/slimereadtheme/SlimeReadTheme.kt
@@ -54,8 +54,8 @@ abstract class SlimeReadTheme(
         if (!scriptResponse.isSuccessful) throw Exception("HTTP error ${scriptResponse.code}")
         val script = scriptResponse.body.string()
         val apiUrl = FUNCTION_REGEX.find(script)?.let { result ->
-            val varBlock = result.groups["script"]?.value ?: return@let null
-            val varUrlInfix = result.groups["infix"]?.value ?: return@let null
+            val varBlock = result.groupValues[1]
+            val varUrlInfix = result.groupValues[2]
 
             val block = """${varBlock.replace(varUrlInfix, "\"$urlInfix\"")}.toString()"""
 


### PR DESCRIPTION
Not updating `FUNCTION_REGEX` so it can be merged together with #6918 without merge conflicts. Ideally `FUNCTION_REGEX` should be changed since I'm unsure if Android <9 silently fails to parse the regex. Thoughts?

Due to region blocking it has not been tested in context. Change does in any case match the expected behavior:
https://pl.kotl.in/yfc7GcqEm

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
