### PR TITLE
Thunder-/Night-Scans: do not use :is() selector

### DIFF
--- a/lib-multisrc/mangathemesia/src/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaPaidChapterHelper.kt
+++ b/lib-multisrc/mangathemesia/src/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaPaidChapterHelper.kt
@@ -25,6 +25,11 @@ class MangaThemesiaPaidChapterHelper(
             return baseChapterListSelector
         }
 
-        return ":is($baseChapterListSelector):not($lockedChapterSelector):not(:has($lockedChapterSelector))"
+        // Fragile
+        val selectors = baseChapterListSelector.split(", ")
+
+        return selectors
+            .map { "$it:not($lockedChapterSelector):not(:has($lockedChapterSelector))" }
+            .joinToString()
     }
 }

--- a/src/all/thunderscans/build.gradle
+++ b/src/all/thunderscans/build.gradle
@@ -3,7 +3,8 @@ ext {
     extClass = '.ThunderScansFactory'
     themePkg = 'mangathemesia'
     baseUrl = 'https://en-thunderscans.com'
-    overrideVersionCode = 8
+    overrideVersionCode = 9
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/nightscans/build.gradle
+++ b/src/en/nightscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.NightScans'
     themePkg = 'mangathemesia'
     baseUrl = 'https://nightsup.net'
-    overrideVersionCode = 9
+    overrideVersionCode = 10
     isNsfw = true
 }
 


### PR DESCRIPTION
Closes #6793
Closes #6886

Replacing the `:is()` selector (supported since Jsoup 1.17.1) with the equivalent-ish alternative. This will allow J2K users to use the extension again. Added a comment saying it's fragile since it relies on format and that it doesn't check depth.

Only bumping ThunderScans and NightScans since they are the only extensions using `MangaThemesiaPaidChapterHelper`.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
