### PR TITLE
Mitaku: Fix browse 

### DIFF
--- a/src/all/mitaku/build.gradle
+++ b/src/all/mitaku/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Mitaku'
     extClass = '.Mitaku'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/all/mitaku/src/eu/kanade/tachiyomi/extension/all/mitaku/Mitaku.kt
+++ b/src/all/mitaku/src/eu/kanade/tachiyomi/extension/all/mitaku/Mitaku.kt
@@ -26,7 +26,7 @@ class Mitaku : ParsedHttpSource() {
     // ============================== Popular ===============================
     override fun popularMangaRequest(page: Int) = GET("$baseUrl/category/ero-cosplay/page/$page", headers)
 
-    override fun popularMangaSelector() = "div.article-container article"
+    override fun popularMangaSelector() = "div.cm-primary article"
 
     override fun popularMangaFromElement(element: Element) = SManga.create().apply {
         setUrlWithoutDomain(element.selectFirst("a")!!.absUrl("href"))


### PR DESCRIPTION
Closes #6829

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
