### PR TITLE
Serimanga: Fix latest and popular tabs

### DIFF
--- a/src/tr/serimanga/build.gradle
+++ b/src/tr/serimanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'SeriManga'
     extClass = '.SeriManga'
-    extVersionCode = 5
+    extVersionCode = 6
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/tr/serimanga/src/eu/kanade/tachiyomi/extension/tr/serimanga/SeriManga.kt
+++ b/src/tr/serimanga/src/eu/kanade/tachiyomi/extension/tr/serimanga/SeriManga.kt
@@ -30,31 +30,31 @@ class SeriManga : ParsedHttpSource() {
 
     override fun popularMangaRequest(page: Int): Request {
         return if (page == 1) {
-            GET("$baseUrl/mangalar", headers)
+            GET("$baseUrl/mangalar?filtrele=goruntulenme&sirala=DESC", headers)
         } else {
-            GET("$baseUrl/mangalar?page=$page", headers)
+            GET("$baseUrl/mangalar?filtrele=goruntulenme&sirala=DESC&page=$page", headers)
         }
     }
 
     override fun popularMangaFromElement(element: Element) = SManga.create().apply {
         setUrlWithoutDomain(element.attr("href"))
         title = element.select("span.mlb-name").text()
-        thumbnail_url = styleToUrl(element).removeSurrounding("'")
+        thumbnail_url = styleToUrl(element)
     }
 
     private fun styleToUrl(element: Element): String {
-        return element.attr("style").substringAfter("(").substringBefore(")")
+        return element.attr("style").substringAfter("('").substringBefore("')")
     }
 
     override fun popularMangaNextPageSelector() = "[rel=next]"
 
-    override fun latestUpdatesSelector() = "a.sli2-img"
+    override fun latestUpdatesSelector() = "a.mlist-bg"
 
-    override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/?a=a&page=$page", headers)
+    override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/?page=$page", headers)
 
     override fun latestUpdatesFromElement(element: Element) = SManga.create().apply {
         setUrlWithoutDomain(element.attr("href"))
-        title = element.attr("title")
+        title = element.attr("title").substringBefore(" Manga Oku")
         thumbnail_url = styleToUrl(element)
     }
 


### PR DESCRIPTION
Closes #6454 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
