### PR TITLE
Tortuga Ceviri: Fix chapters order

### DIFF
--- a/src/tr/tortugaceviri/build.gradle
+++ b/src/tr/tortugaceviri/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.TortugaCeviri'
     themePkg = 'madara'
     baseUrl = 'https://tortuga-ceviri.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/tr/tortugaceviri/src/eu/kanade/tachiyomi/extension/tr/tortugaceviri/TortugaCeviri.kt
+++ b/src/tr/tortugaceviri/src/eu/kanade/tachiyomi/extension/tr/tortugaceviri/TortugaCeviri.kt
@@ -1,8 +1,6 @@
 package eu.kanade.tachiyomi.extension.tr.tortugaceviri
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
-import eu.kanade.tachiyomi.source.model.SChapter
-import okhttp3.Response
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -15,7 +13,4 @@ class TortugaCeviri : Madara(
     override val versionId = 2
 
     override val useNewChapterEndpoint = true
-
-    override fun chapterListParse(response: Response): List<SChapter> =
-        super.chapterListParse(response).reversed()
 }


### PR DESCRIPTION
Closes #6510 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
