### PR TITLE
Webtoon Hatti: fix popular and latest tabs

### DIFF
--- a/src/tr/webtoonhatti/build.gradle
+++ b/src/tr/webtoonhatti/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.WebtoonHatti'
     themePkg = 'madara'
     baseUrl = 'https://webtoonhatti.me'
-    overrideVersionCode = 5
+    overrideVersionCode = 6
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/tr/webtoonhatti/src/eu/kanade/tachiyomi/extension/tr/webtoonhatti/WebtoonHatti.kt
+++ b/src/tr/webtoonhatti/src/eu/kanade/tachiyomi/extension/tr/webtoonhatti/WebtoonHatti.kt
@@ -12,6 +12,8 @@ class WebtoonHatti : Madara(
 ) {
     override val useNewChapterEndpoint = false
 
+    override val mangaSubString = "webtoon"
+
     // Skip fake image
     // OK: <div class="page-break no-gaps">
     // NG: <div style="display:none" class="page-break no-gaps">


### PR DESCRIPTION
Closes #6988 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
