### PR TITLE
Keyoapp: extract manga details selectors

### DIFF
--- a/lib-multisrc/keyoapp/build.gradle.kts
+++ b/lib-multisrc/keyoapp/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 11
+baseVersionCode = 12
 
 dependencies {
     api(project(":lib:i18n"))

--- a/lib-multisrc/keyoapp/build.gradle.kts
+++ b/lib-multisrc/keyoapp/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 12
+baseVersionCode = 11
 
 dependencies {
     api(project(":lib:i18n"))

--- a/lib-multisrc/keyoapp/src/eu/kanade/tachiyomi/multisrc/keyoapp/Keyoapp.kt
+++ b/lib-multisrc/keyoapp/src/eu/kanade/tachiyomi/multisrc/keyoapp/Keyoapp.kt
@@ -206,16 +206,21 @@ abstract class Keyoapp(
     }
 
     // Details
+    protected open val descriptionSelector: String = "div:containsOwn(Synopsis) ~ div"
+    protected open val statusSelector: String = "div:has(span:containsOwn(Status)) ~ div"
+    protected open val authorSelector: String = "div:has(span:containsOwn(Author)) ~ div"
+    protected open val artistSelector: String = "div:has(span:containsOwn(Artist)) ~ div"
+    protected open val genreSelector: String = "div:has(span:containsOwn(Type)) ~ div"
 
     override fun mangaDetailsParse(document: Document): SManga = SManga.create().apply {
         title = document.selectFirst("div.grid > h1")!!.text()
         thumbnail_url = document.getImageUrl("div[class*=photoURL]")
-        description = document.selectFirst("div:containsOwn(Synopsis) ~ div")?.text()
-        status = document.selectFirst("div:has(span:containsOwn(Status)) ~ div").parseStatus()
-        author = document.selectFirst("div:has(span:containsOwn(Author)) ~ div")?.text()
-        artist = document.selectFirst("div:has(span:containsOwn(Artist)) ~ div")?.text()
+        description = document.selectFirst(descriptionSelector)?.text()
+        status = document.selectFirst(statusSelector).parseStatus()
+        author = document.selectFirst(authorSelector)?.text()
+        artist = document.selectFirst(artistSelector)?.text()
         genre = buildList {
-            document.selectFirst("div:has(span:containsOwn(Type)) ~ div")?.text()?.replaceFirstChar {
+            document.selectFirst(genreSelector)?.text()?.replaceFirstChar {
                 if (it.isLowerCase()) {
                     it.titlecase(
                         Locale.getDefault(),

--- a/src/en/rezoscans/build.gradle
+++ b/src/en/rezoscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.RezoScans'
     themePkg = 'keyoapp'
     baseUrl = 'https://rezoscans.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
 }
 

--- a/src/en/rezoscans/src/eu/kanade/tachiyomi/extension/en/rezoscans/RezoScans.kt
+++ b/src/en/rezoscans/src/eu/kanade/tachiyomi/extension/en/rezoscans/RezoScans.kt
@@ -6,4 +6,10 @@ class RezoScans : Keyoapp(
     "Rezo Scans",
     "https://rezoscans.com",
     "en",
-)
+) {
+    override val descriptionSelector: String = "div.grid > div.overflow-hidden > p"
+    override val statusSelector: String = "div[alt=Status]"
+    override val authorSelector: String = "div[alt=Author]"
+    override val artistSelector: String = "div[alt=Artist]"
+    override val genreSelector: String = "div[alt='Series Type']"
+}


### PR DESCRIPTION
Closes #7074

I am open to any suggestions.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
