### PR TITLE
WeebCentral: Exclude special characters

### DIFF
--- a/src/en/weebcentral/build.gradle
+++ b/src/en/weebcentral/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Weeb Central'
     extClass = '.WeebCentral'
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = true
 }
 

--- a/src/en/weebcentral/src/eu/kanade/tachiyomi/extension/en/weebcentral/WeebCentral.kt
+++ b/src/en/weebcentral/src/eu/kanade/tachiyomi/extension/en/weebcentral/WeebCentral.kt
@@ -35,6 +35,8 @@ class WeebCentral : ParsedHttpSource() {
 
     private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ENGLISH)
 
+    private val excludedSearchCharacters = "[!#:()]".toRegex()
+
     // ============================== Popular ===============================
 
     override fun popularMangaRequest(page: Int): Request = searchMangaRequest(
@@ -64,11 +66,10 @@ class WeebCentral : ParsedHttpSource() {
     override fun latestUpdatesNextPageSelector(): String = searchMangaNextPageSelector()
 
     // =============================== Search ===============================
-
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         val filterList = filters.ifEmpty { getFilterList() }
         val url = "$baseUrl/search/data".toHttpUrl().newBuilder().apply {
-            addQueryParameter("text", query)
+            addQueryParameter("text", query.replace(excludedSearchCharacters, " ").trim())
             filterList.filterIsInstance<UriFilter>().forEach {
                 it.addToUri(this)
             }


### PR DESCRIPTION
Closes #7157

There are special characters that when searching gives an error or return empty results

Tested with:
- Don't Blush, Sekime-san!
- Golden Time (Umechazuke)
- #Killstagram
- ID:INVADED #BRAKE BROKEN

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
