### PR TITLE
Bato.to description: add extra info, format alternative titles

### DIFF
--- a/src/all/batoto/build.gradle
+++ b/src/all/batoto/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Bato.to'
     extClass = '.BatoToFactory'
-    extVersionCode = 45
+    extVersionCode = 46
     isNsfw = true
 }
 

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
@@ -335,14 +335,24 @@ open class BatoTo(
         Regex("\\([^()]*\\)|\\{[^{}]*\\}|\\[(?:(?!]).)*]|«[^»]*»|〘[^〙]*〙|「[^」]*」|『[^』]*』|≪[^≫]*≫|﹛[^﹜]*﹜|〖[^〖〗]*〗|𖤍.+?𖤍|《[^》]*》|⌜.+?⌝|⟨[^⟩]*⟩|\\/Official|\\/ Official", RegexOption.IGNORE_CASE)
 
     override fun mangaDetailsParse(document: Document): SManga {
-        val infoElement = document.select("div#mainer div.container-fluid")
+        val infoElement = document.selectFirst("div#mainer div.container-fluid")!!
         val manga = SManga.create()
         val workStatus = infoElement.select("div.attr-item:contains(original work) span").text()
         val uploadStatus = infoElement.select("div.attr-item:contains(upload status) span").text()
         val originalTitle = infoElement.select("h3").text().removeEntities()
-        val alternativeTitles = document.select("div.pb-2.alias-set.line-b-f").text()
-        val description = infoElement.select("div.limit-html").text() + "\n" +
-            infoElement.select(".episode-list > .alert-warning").text().trim()
+        val description = buildString {
+            append(infoElement.select("div.limit-html").text())
+            infoElement.selectFirst(".episode-list > .alert-warning")?.also {
+                append("\n\n${it.text()}")
+            }
+            infoElement.selectFirst("h5:containsOwn(Extra Info:) + div")?.also {
+                append("\n\nExtra Info:\n${it.text()}")
+            }
+            document.selectFirst("div.pb-2.alias-set.line-b-f")?.also {
+                append("\n\nAlternative Titles:\n${it.text()}")
+            }
+        }
+
         val cleanedTitle = if (isRemoveTitleVersion()) {
             originalTitle.replace(titleRegex, "").trim()
         } else {
@@ -354,8 +364,7 @@ open class BatoTo(
         manga.artist = infoElement.select("div.attr-item:contains(artist) span").text()
         manga.status = parseStatus(workStatus, uploadStatus)
         manga.genre = infoElement.select(".attr-item b:contains(genres) + span ").joinToString { it.text() }
-        manga.description = description +
-            if (alternativeTitles.isNotBlank()) "\n\nAlternative Titles:\n$alternativeTitles" else ""
+        manga.description = description
         manga.thumbnail_url = document.select("div.attr-cover img").attr("abs:src")
         return manga
     }

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
@@ -349,7 +349,8 @@ open class BatoTo(
                 append("\n\nExtra Info:\n${it.text()}")
             }
             document.selectFirst("div.pb-2.alias-set.line-b-f")?.also {
-                append("\n\nAlternative Titles:\n${it.text()}")
+                append("\n\nAlternative Titles:\n")
+                append(it.text().split('/').joinToString("\n") { "• ${it.trim()}" })
             }
         }
 


### PR DESCRIPTION
Closes #7149
Closes #7172

![image psd](https://github.com/user-attachments/assets/fabae31a-0ff8-4242-9688-4a43edfd5cc3)

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
