### PR TITLE
Update TopTruyen & DocTruyen3Q

### DIFF
--- a/src/vi/doctruyen3q/build.gradle
+++ b/src/vi/doctruyen3q/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'DocTruyen3Q'
     extClass = '.DocTruyen3Q'
     themePkg = 'wpcomics'
-    baseUrl = 'https://doctruyen3q3.net'
-    overrideVersionCode = 1
+    baseUrl = 'https://doctruyen3qui.com'
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/vi/doctruyen3q/src/eu/kanade/tachiyomi/extension/vi/doctruyen3q/DocTruyen3Q.kt
+++ b/src/vi/doctruyen3q/src/eu/kanade/tachiyomi/extension/vi/doctruyen3q/DocTruyen3Q.kt
@@ -17,7 +17,7 @@ import java.util.TimeZone
 
 class DocTruyen3Q : WPComics(
     "DocTruyen3Q",
-    "https://doctruyen3q3.net",
+    "https://doctruyen3qui.com",
     "vi",
     dateFormat = SimpleDateFormat("dd-MM-yyyy", Locale.ROOT).apply {
         timeZone = TimeZone.getTimeZone("Asia/Ho_Chi_Minh")
@@ -42,7 +42,7 @@ class DocTruyen3Q : WPComics(
             title = it.text()
             setUrlWithoutDomain(it.attr("abs:href"))
         }
-        thumbnail_url = element.selectFirst("img")?.attr("abs:src")
+        thumbnail_url = imageOrNull(element.selectFirst("img")!!)
     }
 
     override fun searchMangaSelector() = popularMangaSelector()
@@ -73,7 +73,7 @@ class DocTruyen3Q : WPComics(
         description = document.selectFirst("p.detail-summary")?.text()
         status = document.selectFirst("li.status p.detail-info span")?.text().toStatus()
         genre = document.select("li.category p.detail-info a")?.joinToString { it.text() }
-        thumbnail_url = document.selectFirst("img.image-comic")?.attr("abs:src")
+        thumbnail_url = imageOrNull(document.selectFirst("img.image-comic")!!)
     }
 
     override fun chapterListSelector() = "div.list-chapter li.row:not(.heading):not([style])"

--- a/src/vi/toptruyen/build.gradle
+++ b/src/vi/toptruyen/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Top Truyen'
     extClass = '.TopTruyen'
     themePkg = 'wpcomics'
-    baseUrl = 'https://www.toptruyen28.net'
-    overrideVersionCode = 5
+    baseUrl = 'https://www.toptruyentv.net'
+    overrideVersionCode = 6
     isNsfw = true
 }
 

--- a/src/vi/toptruyen/src/eu/kanade/tachiyomi/extension/vi/toptruyen/TopTruyen.kt
+++ b/src/vi/toptruyen/src/eu/kanade/tachiyomi/extension/vi/toptruyen/TopTruyen.kt
@@ -13,12 +13,15 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
+import java.util.TimeZone
 
 class TopTruyen : WPComics(
     "Top Truyen",
-    "https://www.toptruyen28.net",
+    "https://www.toptruyentv.net",
     "vi",
-    dateFormat = SimpleDateFormat("dd-MM-yyyy", Locale.getDefault()),
+    dateFormat = SimpleDateFormat("dd-MM-yyyy", Locale.ROOT).apply {
+        timeZone = TimeZone.getTimeZone("Asia/Ho_Chi_Minh")
+    },
     gmtOffset = null,
 ) {
     override val client = super.client.newBuilder()


### PR DESCRIPTION
- Update domain TopTruyen & DocTruyen3Q
- Fix timezone Toptruyen
- Fix blank thumbnail Doctruyen3Q

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
