### PR TITLE
MadTheme: Enhance chapter parse

### DIFF
--- a/lib-multisrc/madtheme/build.gradle.kts
+++ b/lib-multisrc/madtheme/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 14
+baseVersionCode = 15


### PR DESCRIPTION
Closes #3976

Now instead of just get chapters request by slug first try to get it by id.
Tested on all 14 extension that use it, but if someone found any other error please report.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
