### PR TITLE
Azora: Fix description text

### DIFF
--- a/src/ar/azora/build.gradle
+++ b/src/ar/azora/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Azora'
     themePkg = 'madara'
     baseUrl = 'https://azoramoon.com'
-    overrideVersionCode = 7
+    overrideVersionCode = 8
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/azora/src/eu/kanade/tachiyomi/extension/ar/azora/Azora.kt
+++ b/src/ar/azora/src/eu/kanade/tachiyomi/extension/ar/azora/Azora.kt
@@ -8,7 +8,7 @@ class Azora : Madara("Azora", "https://azoramoon.com", "ar") {
     override val mangaSubString = "series"
     override val useNewChapterEndpoint = false
     override fun chapterListSelector() = "li.wp-manga-chapter:not(.premium-block)" // Filter fake chapters
-    override val mangaDetailsSelectorDescription = "div.tab-summary > div.summary_content_wrap > div > div.post-content > div.manga-summary"
+    override val mangaDetailsSelectorDescription = ".manga-summary"
     override fun chapterFromElement(element: Element): SChapter {
         val chapter = SChapter.create()
 

--- a/src/ar/azora/src/eu/kanade/tachiyomi/extension/ar/azora/Azora.kt
+++ b/src/ar/azora/src/eu/kanade/tachiyomi/extension/ar/azora/Azora.kt
@@ -8,6 +8,7 @@ class Azora : Madara("Azora", "https://azoramoon.com", "ar") {
     override val mangaSubString = "series"
     override val useNewChapterEndpoint = false
     override fun chapterListSelector() = "li.wp-manga-chapter:not(.premium-block)" // Filter fake chapters
+    override val mangaDetailsSelectorDescription = "div.tab-summary > div.summary_content_wrap > div > div.post-content > div.manga-summary"
     override fun chapterFromElement(element: Element): SChapter {
         val chapter = SChapter.create()
 


### PR DESCRIPTION
Closes #7163 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
