### PR TITLE
MurimScan: fix mangaSubString

### DIFF
--- a/src/en/murimscan/build.gradle
+++ b/src/en/murimscan/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'MurimScan'
     extClass = '.MurimScan'
     themePkg = 'madara'
-    baseUrl = 'https://murimscan.run'
+    baseUrl = 'https://inkreads.com'
     overrideVersionCode = 1
     isNsfw = true
 }

--- a/src/en/murimscan/build.gradle
+++ b/src/en/murimscan/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MurimScan'
     themePkg = 'madara'
     baseUrl = 'https://murimscan.run'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/en/murimscan/src/eu/kanade/tachiyomi/extension/en/murimscan/MurimScan.kt
+++ b/src/en/murimscan/src/eu/kanade/tachiyomi/extension/en/murimscan/MurimScan.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.extension.en.murimscan
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 
-class MurimScan : Madara("MurimScan", "https://murimscan.run", "en") {
+class MurimScan : Madara("MurimScan", "https://inkreads.com", "en") {
     override val useNewChapterEndpoint = false
+    override val mangaSubString = "mangax"
 }


### PR DESCRIPTION
Closes #4676

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
