### PR TITLE
Mangahentai: use old madara search

### DIFF
--- a/src/en/mangahentai/build.gradle
+++ b/src/en/mangahentai/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaHentai'
     themePkg = 'madara'
     baseUrl = 'https://mangahentai.me'
-    overrideVersionCode = 3
+    overrideVersionCode = 4
     isNsfw = true
 }
 

--- a/src/en/mangahentai/src/eu/kanade/tachiyomi/extension/en/mangahentai/MangaHentai.kt
+++ b/src/en/mangahentai/src/eu/kanade/tachiyomi/extension/en/mangahentai/MangaHentai.kt
@@ -1,9 +1,21 @@
 package eu.kanade.tachiyomi.extension.en.mangahentai
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.POST
+import okhttp3.FormBody
+import okhttp3.Request
 
 class MangaHentai : Madara("Manga Hentai", "https://mangahentai.me", "en") {
     override val mangaSubString = "manga-hentai"
 
-    override val useNewChapterEndpoint: Boolean = true
+    override val useNewChapterEndpoint: Boolean = false
+
+    override fun oldXhrChaptersRequest(mangaId: String): Request {
+        val form = FormBody.Builder()
+            .add("action", "ajax_chap")
+            .add("post_id", mangaId)
+            .build()
+
+        return POST("$baseUrl/wp-admin/admin-ajax.php", xhrHeaders, form)
+    }
 }


### PR DESCRIPTION
Closes #4677

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
