### PR TITLE
Kemono fix search pages

### DIFF
--- a/lib-multisrc/kemono/build.gradle.kts
+++ b/lib-multisrc/kemono/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 16
+baseVersionCode = 17

--- a/lib-multisrc/kemono/src/eu/kanade/tachiyomi/multisrc/kemono/Kemono.kt
+++ b/lib-multisrc/kemono/src/eu/kanade/tachiyomi/multisrc/kemono/Kemono.kt
@@ -132,7 +132,7 @@ open class Kemono(
 
                 includeType && !excludeType && isFavourited &&
                     regularSearch
-            }.also { mangasCache = mangas }
+            }.also { mangasCache = it }
         }
 
         val sorted = when (sort.first) {

--- a/lib-multisrc/kemono/src/eu/kanade/tachiyomi/multisrc/kemono/Kemono.kt
+++ b/lib-multisrc/kemono/src/eu/kanade/tachiyomi/multisrc/kemono/Kemono.kt
@@ -107,7 +107,7 @@ open class Kemono(
         }
 
         var mangas = mangasCache
-        if (page == 1) {
+        if (page == 1 || mangasCache.isEmpty()) {
             var favourites: List<KemonoFavouritesDto> = emptyList()
             if (fav != null) {
                 val favores = client.newCall(GET("$baseUrl/$apiPath/account/favorites", headers)).execute()


### PR DESCRIPTION
Save mangasCache, reload mangasCache when empty

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
