### PR TITLE
Bakai: Fix path

### DIFF
--- a/src/pt/bakai/build.gradle
+++ b/src/pt/bakai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Bakai'
     extClass = '.Bakai'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = true
 }
 

--- a/src/pt/bakai/src/eu/kanade/tachiyomi/extension/pt/bakai/Bakai.kt
+++ b/src/pt/bakai/src/eu/kanade/tachiyomi/extension/pt/bakai/Bakai.kt
@@ -62,7 +62,7 @@ class Bakai : ParsedHttpSource() {
         .set("Sec-GPC", "1")
 
     // ============================== Popular ===============================
-    override fun popularMangaRequest(page: Int) = GET("$baseUrl/home3/page/$page/")
+    override fun popularMangaRequest(page: Int) = GET("$baseUrl/home/page/$page/")
 
     override fun popularMangaSelector() = "#elCmsPageWrap ul > li > article"
 
@@ -111,7 +111,7 @@ class Bakai : ParsedHttpSource() {
     }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        val url = "$baseUrl/search3/".toHttpUrl().newBuilder()
+        val url = "$baseUrl/search/".toHttpUrl().newBuilder()
             .addQueryParameter("q", query)
             .addQueryParameter("type", "cms_records1")
             .addQueryParameter("page", page.toString())


### PR DESCRIPTION
Closes #7292

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
