### PR TITLE
Batoto: Fix extra info + Hide empty alt titles + Fall back to upload status

### DIFF
--- a/src/all/batoto/build.gradle
+++ b/src/all/batoto/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Bato.to'
     extClass = '.BatoToFactory'
-    extVersionCode = 46
+    extVersionCode = 47
     isNsfw = true
 }
 


### PR DESCRIPTION
Closes #7207
Closes #7275
Closes #7288

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] ~Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions~
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] ~Added the `isNsfw = true` flag in `build.gradle` when appropriate~
- [x] Have not changed source names
- [ ] ~Have explicitly kept the `id` if a source's name or language were changed~
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] ~Have removed `web_hi_res_512.png` when adding a new extension~
