### PR TITLE
Colamanga: fix keyType not found

### DIFF
--- a/lib-multisrc/colamanga/build.gradle.kts
+++ b/lib-multisrc/colamanga/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 6
+baseVersionCode = 7
 
 dependencies {
     api(project(":lib:synchrony"))

--- a/lib-multisrc/colamanga/src/eu/kanade/tachiyomi/multisrc/colamanga/ColaManga.kt
+++ b/lib-multisrc/colamanga/src/eu/kanade/tachiyomi/multisrc/colamanga/ColaManga.kt
@@ -283,7 +283,7 @@ abstract class ColaManga(
         val readJs = Deobfuscator.deobfuscateScript(obfuscatedReadJs)
             ?: throw Exception(intl.couldNotDeobufscateScript)
 
-        keyMappingRegex.findAll(readJs).associate { it.groups[1]!!.value to it.groups[2]!!.value }
+        keyMappingRegex.findAll(readJs).associate { it.groups[2]!!.value to it.groups[3]!!.value }
     }
 
     private fun randomString() = buildString(15) {


### PR DESCRIPTION
Closes #7350

The original regex had an unaccounted for capture group. The correct offset for `keyType` and `key` is now used.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
