### PR TITLE
coffeemanga: fix loading image in old chapters

### DIFF
--- a/src/en/coffeemanga/build.gradle
+++ b/src/en/coffeemanga/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.CoffeeManga'
     themePkg = 'madara'
     baseUrl = 'https://coffeemanga.io'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/coffeemanga/src/eu/kanade/tachiyomi/extension/en/coffeemanga/CoffeeManga.kt
+++ b/src/en/coffeemanga/src/eu/kanade/tachiyomi/extension/en/coffeemanga/CoffeeManga.kt
@@ -1,17 +1,7 @@
 package eu.kanade.tachiyomi.extension.en.coffeemanga
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
-import org.jsoup.nodes.Element
 
 class CoffeeManga : Madara("Coffee Manga", "https://coffeemanga.io", "en") {
     override val useNewChapterEndpoint = false
-
-    override fun imageFromElement(element: Element): String? {
-        return when {
-            element.hasAttr("data-src") && element.attr("data-src").isNotEmpty() -> element.attr("abs:data-src")
-            element.hasAttr("data-lazy-src") && element.attr("data-lazy-src").isNotEmpty() -> element.attr("abs:data-lazy-src")
-            element.hasAttr("srcset") && element.attr("srcset").isNotEmpty() -> element.attr("abs:srcset").substringBefore(" ")
-            else -> element.attr("abs:src")
-        }
-    }
 }


### PR DESCRIPTION
Fix #7277

Old chapters using `data-cfsrc` which is missing from ext but available in multi-src

Reference: https://coffeemanga.io/manga/the-wallflower-who-was-proposed-to-by-the-tyrant/chapter-1

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
