### PR TITLE
MadTheme: Fix chapter client

### DIFF
--- a/lib-multisrc/madtheme/build.gradle.kts
+++ b/lib-multisrc/madtheme/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 16
+baseVersionCode = 17


### PR DESCRIPTION
Closes #7341

Change client to the chapter client that is more limited and instead of calling both endpoints now we will check first by slug and if the chapters are different from the total chapters from the web site try by id

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
