### PR TITLE
Hentaidex: Fix manga directory

### DIFF
--- a/src/en/hentaidex/build.gradle
+++ b/src/en/hentaidex/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.HentaiDex'
     themePkg = 'mangathemesia'
     baseUrl = 'https://dexhentai.com'
-    overrideVersionCode  = 1
+    overrideVersionCode  = 2
     isNsfw = true
 }
 

--- a/src/en/hentaidex/src/eu/kanade/tachiyomi/extension/en/hentaidex/HentaiDex.kt
+++ b/src/en/hentaidex/src/eu/kanade/tachiyomi/extension/en/hentaidex/HentaiDex.kt
@@ -17,7 +17,6 @@ class HentaiDex : MangaThemesia(
     "https://dexhentai.com",
     "en",
     dateFormat = SimpleDateFormat("MMMM d, yyyy", Locale.US),
-    mangaUrlDirectory = "/title",
 ) {
     override fun chapterListParse(response: Response): List<SChapter> =
         super.chapterListParse(response).sortedByDescending { it.chapter_number }
@@ -32,6 +31,9 @@ class HentaiDex : MangaThemesia(
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         val url = baseUrl.toHttpUrl().newBuilder()
+            .addPathSegment(mangaUrlDirectory.substring(1))
+            .addPathSegment("")
+            .addQueryParameter("page", page.toString())
 
         // Can't use filter if is a global search
         if (query.isNotEmpty()) {
@@ -84,8 +86,6 @@ class HentaiDex : MangaThemesia(
                 }
             }
         }
-        url.addPathSegment(mangaUrlDirectory.substring(1))
-            .addQueryParameter("page", page.toString())
         return GET(url.build(), headers)
     }
 


### PR DESCRIPTION
Closes #7344

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
