### PR TITLE
Batoto: Make statuses null if not exists

### DIFF
--- a/src/all/batoto/build.gradle
+++ b/src/all/batoto/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Bato.to'
     extClass = '.BatoToFactory'
-    extVersionCode = 47
+    extVersionCode = 48
     isNsfw = true
 }
 

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
@@ -337,8 +337,8 @@ open class BatoTo(
     override fun mangaDetailsParse(document: Document): SManga {
         val infoElement = document.selectFirst("div#mainer div.container-fluid")!!
         val manga = SManga.create()
-        val workStatus = infoElement.select("div.attr-item:contains(original work) span").text()
-        val uploadStatus = infoElement.select("div.attr-item:contains(upload status) span").text()
+        val workStatus = infoElement.selectFirst("div.attr-item:contains(original work) span")?.text()
+        val uploadStatus = infoElement.selectFirst("div.attr-item:contains(upload status) span")?.text()
         val originalTitle = infoElement.select("h3").text().removeEntities()
         val description = buildString {
             append(infoElement.select("div.limit-html").text())
@@ -352,7 +352,7 @@ open class BatoTo(
                 append("\n\nAlternative Titles:\n")
                 append(it.text().split('/').joinToString("\n") { "• ${it.trim()}" })
             }
-        }
+        }.trim()
 
         val cleanedTitle = if (isRemoveTitleVersion()) {
             originalTitle.replace(titleRegex, "").trim()


### PR DESCRIPTION
Closes #7374 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] ~Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions~
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] ~Added the `isNsfw = true` flag in `build.gradle` when appropriate~
- [x] Have not changed source names
- [ ] ~Have explicitly kept the `id` if a source's name or language were changed~
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] ~Have removed `web_hi_res_512.png` when adding a new extension~
