### PR TITLE
LeerCapitulo: Fix unable to find the script

### DIFF
--- a/src/es/leercapitulo/build.gradle
+++ b/src/es/leercapitulo/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'LeerCapitulo'
     extClass = '.LeerCapitulo'
-    extVersionCode = 10
+    extVersionCode = 11
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/leercapitulo/src/eu/kanade/tachiyomi/extension/es/leercapitulo/LeerCapitulo.kt
+++ b/src/es/leercapitulo/src/eu/kanade/tachiyomi/extension/es/leercapitulo/LeerCapitulo.kt
@@ -180,7 +180,7 @@ class LeerCapitulo : ParsedHttpSource() {
 
         val arrayData = document.selectFirst("#array_data")!!.text()
 
-        val scripts = document.select("head > script[src^=/assets/][src$=.js]").map { it.attr("abs:src") }.reversed().toMutableList()
+        val scripts = document.select("head > script[src^=/assets/][src*=.js]").map { it.attr("abs:src") }.reversed().toMutableList()
 
         var dataScript: String? = null
 


### PR DESCRIPTION
Closes #7377

Now js scripts have a time param so it didn't take it correctly
(`/assets/d0b51f86/8E/8FMwRY-V.V.W.js?time=1738035883847`)

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
