### PR TITLE
Ignis Comic: Switch to Manhuaga URL

### DIFF
--- a/src/en/igniscomic/build.gradle
+++ b/src/en/igniscomic/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Ignis Comic'
     extClass = '.IgnisComic'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://igniscomic.com'
+    baseUrl = 'https://manhuaga.com'
     overrideVersionCode = 1
 }
 

--- a/src/en/igniscomic/build.gradle
+++ b/src/en/igniscomic/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.IgnisComic'
     themePkg = 'mangathemesia'
     baseUrl = 'https://igniscomic.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/igniscomic/src/eu/kanade/tachiyomi/extension/en/igniscomic/IgnisComic.kt
+++ b/src/en/igniscomic/src/eu/kanade/tachiyomi/extension/en/igniscomic/IgnisComic.kt
@@ -4,6 +4,6 @@ import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 
 class IgnisComic : MangaThemesia(
     "Ignis Comic",
-    "https://igniscomic.com",
+    "https://manhuaga.com",
     "en",
 )


### PR DESCRIPTION
Ignis & Manhuaga merged into current Manhuaga URL, extension works as is, but switching baseURL to not have redirect. Unrelated to PR for Manhuaga extension or the open Manhuaga issue request.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
