### PR TITLE
HattoriManga: Fix search and manga status

### DIFF
--- a/src/tr/hattorimanga/build.gradle
+++ b/src/tr/hattorimanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hattori Manga'
     extClass = '.HattoriManga'
-    extVersionCode = 40
+    extVersionCode = 41
     isNsfw = true
 }
 

--- a/src/tr/hattorimanga/src/eu/kanade/tachiyomi/extension/tr/hattorimanga/HattoriManga.kt
+++ b/src/tr/hattorimanga/src/eu/kanade/tachiyomi/extension/tr/hattorimanga/HattoriManga.kt
@@ -131,6 +131,15 @@ class HattoriManga : HttpSource() {
             description = document.selectFirst(".anime-details-text p")?.text()
             author = document.selectFirst(".anime-details-widget li:has(span:contains(Yazar))")?.ownText()
             artist = document.selectFirst(".anime-details-widget li:has(span:contains(Çizer))")?.ownText()
+
+            document.selectFirst(".anime-details-widget li:has(span:contains(Durum))")?.ownText()?.let {
+                status = when (it.lowercase()) {
+                    "devam ediyor" -> SManga.ONGOING
+                    "tamamlandı" -> SManga.COMPLETED
+                    else -> SManga.UNKNOWN
+                }
+            }
+
             genre = document.selectFirst(".anime-details-widget li:has(span:contains(Etiketler))")
                 ?.ownText()
                 ?.split(",")
@@ -224,9 +233,6 @@ class HattoriManga : HttpSource() {
             val mangas = response.parseAs<List<SearchManga>>().map {
                 SManga.create().apply {
                     title = it.title
-                    description = it.description
-                    author = it.author
-                    artist = it.artist
                     thumbnail_url = "$baseUrl/storage/${it.thumbnail}"
                     url = "/manga/${it.slug}"
                 }

--- a/src/tr/hattorimanga/src/eu/kanade/tachiyomi/extension/tr/hattorimanga/HattoriMangaDto.kt
+++ b/src/tr/hattorimanga/src/eu/kanade/tachiyomi/extension/tr/hattorimanga/HattoriMangaDto.kt
@@ -49,9 +49,6 @@ class LatestUpdateDto(
 class SearchManga(
     val slug: String,
     val title: String,
-    val description: String,
     @SerialName("cover_image")
     val thumbnail: String,
-    val author: String,
-    val artist: String,
 )


### PR DESCRIPTION
Closes #6440

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
