### PR TITLE
Retsu: Fix search manga selector

### DIFF
--- a/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
+++ b/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
@@ -578,11 +578,13 @@ abstract class Madara(
 
     override fun searchMangaSelector() = "div.c-tabs-item__content"
 
+    protected open val searchMangaUrlSelector = "div.post-title a"
+
     override fun searchMangaFromElement(element: Element): SManga {
         val manga = SManga.create()
 
         with(element) {
-            selectFirst("div.post-title a")!!.let {
+            selectFirst(searchMangaUrlSelector)!!.let {
                 manga.setUrlWithoutDomain(it.attr("abs:href"))
                 manga.title = it.ownText()
             }

--- a/src/en/retsu/build.gradle
+++ b/src/en/retsu/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Retsu'
     themePkg = 'madara'
     baseUrl = 'https://retsu.org'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/en/retsu/src/eu/kanade/tachiyomi/extension/en/retsu/Retsu.kt
+++ b/src/en/retsu/src/eu/kanade/tachiyomi/extension/en/retsu/Retsu.kt
@@ -17,4 +17,7 @@ class Retsu : Madara(
 
     override val useLoadMoreRequest = LoadMoreStrategy.Always
     override val useNewChapterEndpoint = false
+
+    override fun searchMangaSelector() = ".manga__item"
+    override val searchMangaUrlSelector = ".post-title a"
 }


### PR DESCRIPTION
Closes #6422

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
