### PR TITLE
Read Mangas: Fix referer encode

### DIFF
--- a/src/pt/readmangas/build.gradle
+++ b/src/pt/readmangas/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Read Mangas'
     extClass = '.ReadMangas'
-    extVersionCode = 37
+    extVersionCode = 38
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/readmangas/src/eu/kanade/tachiyomi/extension/pt/readmangas/ReadMangas.kt
+++ b/src/pt/readmangas/src/eu/kanade/tachiyomi/extension/pt/readmangas/ReadMangas.kt
@@ -23,6 +23,7 @@ import okhttp3.Response
 import org.json.JSONObject
 import rx.Observable
 import uy.kohesive.injekt.injectLazy
+import java.net.URLEncoder
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -203,8 +204,10 @@ class ReadMangas() : HttpSource() {
             .addQueryParameter("input", input.toString())
             .build()
 
+        val encodedUrl = URLEncoder.encode(manga.url.substringBeforeLast("#"), "UTF-8")
+
         val apiHeaders = headers.newBuilder()
-            .set("Referer", "$baseUrl${manga.url.substringBeforeLast("#")}")
+            .set("Referer", "$baseUrl$encodedUrl")
             .set("Content-Type", "application/json")
             .set("Cache-Control", "no-cache")
             .build()


### PR DESCRIPTION
Closes #7492 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
