### PR TITLE
Visor Inari: Update domain and theme

### DIFF
--- a/src/es/inarimanga/build.gradle
+++ b/src/es/inarimanga/build.gradle
@@ -1,9 +1,9 @@
 ext {
     extName = 'Visor Inari'
     extClass = '.VisorInari'
-    themePkg = 'mangathemesia'
-    baseUrl = 'https://worldinari.org'
-    overrideVersionCode = 17
+    themePkg = 'madara'
+    baseUrl = 'https://vrinari.org'
+    overrideVersionCode = 9
     isNsfw = true
 }
 

--- a/src/es/inarimanga/src/eu/kanade/tachiyomi/extension/es/inarimanga/VisorInari.kt
+++ b/src/es/inarimanga/src/eu/kanade/tachiyomi/extension/es/inarimanga/VisorInari.kt
@@ -46,7 +46,7 @@ class VisorInari : Madara(
     override val mangaDetailsSelectorGenre = "div.wp-manga div[alt=type]:gt(0) > span"
     override val mangaDetailsSelectorDescription = "div.wp-manga div#expand_content"
 
-    override fun chapterListSelector() = "ul#list-chapters > li"
+    override fun chapterListSelector() = "ul#list-chapters li > a"
 
     override fun chapterFromElement(element: Element) = SChapter.create().apply {
         name = element.selectFirst("div.grid > span")!!.text()

--- a/src/es/inarimanga/src/eu/kanade/tachiyomi/extension/es/inarimanga/VisorInari.kt
+++ b/src/es/inarimanga/src/eu/kanade/tachiyomi/extension/es/inarimanga/VisorInari.kt
@@ -1,20 +1,59 @@
 package eu.kanade.tachiyomi.extension.es.inarimanga
 
-import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class VisorInari : MangaThemesia(
+class VisorInari : Madara(
     "Visor Inari",
-    "https://worldinari.org",
+    "https://vrinari.org",
     "es",
     dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("es")),
 ) {
-    override val id = 7949577653918285764
+    override val versionId = 2
+
+    override val mangaSubString = "series"
+
+    override val useLoadMoreRequest = LoadMoreStrategy.Always
 
     override val client = super.client.newBuilder()
         .rateLimitHost(baseUrl.toHttpUrl(), 3, 1)
         .build()
+
+    override fun popularMangaSelector() = "div.latest-poster"
+
+    override fun popularMangaFromElement(element: Element) = SManga.create().apply {
+        title = element.selectFirst("h3")!!.text()
+        thumbnail_url = element.selectFirst("a[style].bg-cover")?.imageFromStyle()
+        setUrlWithoutDomain(element.selectFirst("a")!!.attr("href"))
+    }
+
+    override fun searchMangaSelector() = "button.group > div.grid"
+
+    override fun searchMangaFromElement(element: Element) = SManga.create().apply {
+        title = element.selectFirst("h3")!!.text()
+        thumbnail_url = element.selectFirst("div[style].bg-cover")?.imageFromStyle()
+        setUrlWithoutDomain(element.selectFirst("a")!!.attr("href"))
+    }
+
+    override val mangaDetailsSelectorTitle = "div.wp-manga div.grid > h1"
+    override val mangaDetailsSelectorStatus = "div.wp-manga div[alt=type] > span"
+    override val mangaDetailsSelectorDescription = "div.wp-manga div#expand_content"
+
+    override fun chapterListSelector() = "ul#list-chapters > li"
+
+    override fun chapterFromElement(element: Element) = SChapter.create().apply {
+        name = element.selectFirst("div.grid > span")!!.text()
+        date_upload = element.selectFirst("div.grid > div")?.text()?.let { parseChapterDate(it) } ?: 0
+        setUrlWithoutDomain(element.selectFirst("a")!!.attr("href"))
+    }
+
+    private fun Element.imageFromStyle(): String {
+        return this.attr("style").substringAfter("url(").substringBefore(")")
+    }
 }

--- a/src/es/inarimanga/src/eu/kanade/tachiyomi/extension/es/inarimanga/VisorInari.kt
+++ b/src/es/inarimanga/src/eu/kanade/tachiyomi/extension/es/inarimanga/VisorInari.kt
@@ -42,7 +42,8 @@ class VisorInari : Madara(
     }
 
     override val mangaDetailsSelectorTitle = "div.wp-manga div.grid > h1"
-    override val mangaDetailsSelectorStatus = "div.wp-manga div[alt=type] > span"
+    override val mangaDetailsSelectorStatus = "div.wp-manga div[alt=type]:eq(0) > span"
+    override val mangaDetailsSelectorGenre = "div.wp-manga div[alt=type]:gt(0) > span"
     override val mangaDetailsSelectorDescription = "div.wp-manga div#expand_content"
 
     override fun chapterListSelector() = "ul#list-chapters > li"


### PR DESCRIPTION
Users will have to migrate

Closes #7541 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
