### PR TITLE
Weeb Central: specify offical and unofficial scans

### DIFF
--- a/src/en/weebcentral/build.gradle
+++ b/src/en/weebcentral/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Weeb Central'
     extClass = '.WeebCentral'
-    extVersionCode = 9
+    extVersionCode = 10
     isNsfw = true
 }
 

--- a/src/en/weebcentral/src/eu/kanade/tachiyomi/extension/en/weebcentral/WeebCentral.kt
+++ b/src/en/weebcentral/src/eu/kanade/tachiyomi/extension/en/weebcentral/WeebCentral.kt
@@ -160,6 +160,13 @@ class WeebCentral : ParsedHttpSource() {
         element.selectFirst("time[datetime]")?.also {
             date_upload = it.attr("datetime").parseDate()
         }
+        element.selectFirst("svg")?.attr("stroke")?.also { stroke ->
+            scanlator = when (stroke) {
+                "#d8b4fe" -> "Official"
+                "#4C4D54" -> "Unofficial"
+                else -> null
+            }
+        }
     }
 
     private fun String.parseDate(): Long {


### PR DESCRIPTION
Closes #7407
Supersedes #7559 

Tested on Mihon 0.17.1. Per my check, existing downloads from the old extension are getting renamed and correctly recognized during manga update with the new extension. However, I am not sure about cases when unofficial scans are replaced with official ones.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
