### PR TITLE
Weeb Central: Fix description

### DIFF
--- a/src/en/weebcentral/build.gradle
+++ b/src/en/weebcentral/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Weeb Central'
     extClass = '.WeebCentral'
-    extVersionCode = 10
+    extVersionCode = 11
     isNsfw = true
 }
 

--- a/src/en/weebcentral/src/eu/kanade/tachiyomi/extension/en/weebcentral/WeebCentral.kt
+++ b/src/en/weebcentral/src/eu/kanade/tachiyomi/extension/en/weebcentral/WeebCentral.kt
@@ -107,27 +107,21 @@ class WeebCentral : ParsedHttpSource() {
             author = select("ul > li:has(strong:contains(Author)) > span > a").joinToString { it.text() }
             genre = select("ul > li:has(strong:contains(Tag),strong:contains(Type)) a").joinToString { it.text() }
             status = selectFirst("ul > li:has(strong:contains(Status)) > a").parseStatus()
-
-            if (selectFirst("ul > li > strong:contains(Official Translation) + a:contains(Yes)") != null) {
-                descBuilder.appendLine("Official Translation")
-                descBuilder.appendLine()
-            }
         }
 
         with(document.select("section[x-data] > section")[1]) {
             title = selectFirst("h1")!!.text()
 
-            val alternateTitles = select("li:has(strong:contains(Associated Name)) li")
-            if (alternateTitles.size > 0) {
-                descBuilder.appendLine("Associated Name(s):")
-                alternateTitles.forEach { descBuilder.appendLine(it.text()) }
-                descBuilder.appendLine()
-            }
-
             descBuilder.append(
                 selectFirst("li:has(strong:contains(Description)) > p")?.text()
                     ?.replace("NOTE: ", "\n\nNOTE: "),
             )
+
+            val alternateTitles = select("li:has(strong:contains(Associated Name)) li")
+            if (alternateTitles.size > 0) {
+                descBuilder.append("\n\nAssociated Name(s):")
+                alternateTitles.forEach { descBuilder.append("\n").append(it.text()) }
+            }
         }
 
         description = descBuilder.toString()
@@ -163,7 +157,7 @@ class WeebCentral : ParsedHttpSource() {
         element.selectFirst("svg")?.attr("stroke")?.also { stroke ->
             scanlator = when (stroke) {
                 "#d8b4fe" -> "Official"
-                "#4C4D54" -> "Unofficial"
+                "#4C4D54" -> "Unknown"
                 else -> null
             }
         }


### PR DESCRIPTION
Closes #7574 

- Removed `Official Translation` string from the description
- Moved `Associated Name` from the top to the bottom 
- Renamed `Unofficial` to `Unknown`, as many official chapters are not marked as official on the site 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
