### PR TITLE
RealmOasis: remove 0ms

### DIFF
--- a/src/en/rizzcomic/build.gradle
+++ b/src/en/rizzcomic/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.RealmOasis'
     themePkg = 'mangathemesia'
     baseUrl = 'https://realmoasis.com'
-    overrideVersionCode = 6
+    overrideVersionCode = 7
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/rizzcomic/src/eu/kanade/tachiyomi/extension/en/rizzcomic/RealmOasis.kt
+++ b/src/en/rizzcomic/src/eu/kanade/tachiyomi/extension/en/rizzcomic/RealmOasis.kt
@@ -5,7 +5,7 @@ import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.asObservableSuccess
-import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
+import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
@@ -36,7 +36,7 @@ class RealmOasis : MangaThemesia(
 ) {
 
     override val client = super.client.newBuilder()
-        .rateLimitHost(baseUrl.toHttpUrl(), 1, 3)
+        .rateLimit(1, 3)
         .addInterceptor { chain ->
             val request = chain.request()
             val isApiRequest = request.header("X-API-Request") != null
@@ -136,7 +136,7 @@ class RealmOasis : MangaThemesia(
                 author = listOfNotNull(comic.author, comic.serialization).joinToString()
                 artist = comic.artist
                 status = comic.status.parseStatus()
-                thumbnail_url = comic.cover?.let { "https://x.0ms.dev/q70/$baseUrl/assets/images/$it" }
+                thumbnail_url = comic.cover?.let { "$baseUrl/assets/images/$it" }
                 genre = buildList {
                     add(comic.type?.capitalize())
                     comic.genreIds?.onEach { gId ->
@@ -225,7 +225,7 @@ class RealmOasis : MangaThemesia(
             .set("Referer", "$baseUrl/")
             .build()
 
-        return GET("https://x.0ms.dev/q70/" + page.imageUrl!!, newHeaders)
+        return GET(page.imageUrl!!, newHeaders)
     }
 
     private inline fun <reified T> Response.parseAs(): T =


### PR DESCRIPTION
they would rather get ddosed by tachi users directly than let a caching proxy do its thing

closes #7588

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
