### PR TITLE
Grouple: Add user token

### DIFF
--- a/lib-multisrc/grouple/build.gradle.kts
+++ b/lib-multisrc/grouple/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 28
+baseVersionCode = 29

--- a/lib-multisrc/grouple/src/eu/kanade/tachiyomi/multisrc/grouple/GroupLe.kt
+++ b/lib-multisrc/grouple/src/eu/kanade/tachiyomi/multisrc/grouple/GroupLe.kt
@@ -209,7 +209,9 @@ abstract class GroupLe(
     }
 
     protected open fun getChapterSearchParams(document: Document): String {
-        return "?mtr=true"
+        val scriptContent = document.selectFirst("script:containsData(user_hash)")?.data()
+        val userHash = scriptContent?.let { USER_HASH_REGEX.find(it)?.groupValues?.get(1) }
+        return userHash?.let { "?d=$it&mtr=true" } ?: "?mtr=true"
     }
 
     private fun chapterListParse(response: Response, manga: SManga): List<SChapter> {
@@ -436,5 +438,6 @@ abstract class GroupLe(
         private const val UAGENT_TITLE = "User-Agent(для некоторых стран)"
         private const val UAGENT_DEFAULT = "arora"
         const val PREFIX_SLUG_SEARCH = "slug:"
+        private val USER_HASH_REGEX = "user_hash.+'(.+)'".toRegex()
     }
 }

--- a/src/ru/allhentai/src/eu/kanade/tachiyomi/extension/ru/allhentai/AllHentai.kt
+++ b/src/ru/allhentai/src/eu/kanade/tachiyomi/extension/ru/allhentai/AllHentai.kt
@@ -8,7 +8,6 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import okhttp3.Request
-import org.jsoup.nodes.Document
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -18,16 +17,6 @@ class AllHentai : GroupLe("AllHentai", "https://20.allhen.online", "ru") {
     private val preferences = Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
 
     override val baseUrl by lazy { getPrefBaseUrl() }
-
-    override fun getChapterSearchParams(document: Document): String {
-        val html = document.html()
-
-        val userHashRegex = "user_hash.+'(.+)'".toRegex()
-
-        val userHash = userHashRegex.find(html)?.groupValues?.get(1)
-
-        return userHash?.let { "?d=$it" } ?: ""
-    }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         val url = super.searchMangaRequest(page, query, filters).url.newBuilder()

--- a/src/ru/mintmanga/src/eu/kanade/tachiyomi/extension/ru/mintmanga/MintManga.kt
+++ b/src/ru/mintmanga/src/eu/kanade/tachiyomi/extension/ru/mintmanga/MintManga.kt
@@ -8,7 +8,6 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import okhttp3.Request
-import org.jsoup.nodes.Document
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -20,14 +19,6 @@ class MintManga : GroupLe("MintManga", "https://2.mintmanga.one", "ru") {
         Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
 
     override val baseUrl by lazy { getPrefBaseUrl() }
-
-    override fun getChapterSearchParams(document: Document): String {
-        val scriptContent = document.selectFirst("script:containsData(user_hash)")?.data()
-
-        val userHash = scriptContent?.let { USER_HASH_REGEX.find(it)?.groupValues?.get(1) }
-
-        return userHash?.let { "?d=$it" } ?: ""
-    }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         val url = super.searchMangaRequest(page, query, filters).url.newBuilder()
@@ -210,6 +201,5 @@ class MintManga : GroupLe("MintManga", "https://2.mintmanga.one", "ru") {
         private const val DOMAIN_PREF = "Домен"
         private const val DEFAULT_DOMAIN_PREF = "pref_default_domain"
         private const val DOMAIN_TITLE = "Домен"
-        private val USER_HASH_REGEX = "user_hash.+'(.+)'".toRegex()
     }
 }

--- a/src/ru/readmanga/build.gradle
+++ b/src/ru/readmanga/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'ReadManga'
     extClass = '.ReadManga'
     themePkg = 'grouple'
-    baseUrl = 'https://1.readmanga.io'
+    baseUrl = 'https://zz.readmanga.io'
     overrideVersionCode = 46
 }
 

--- a/src/ru/readmanga/src/eu/kanade/tachiyomi/extension/ru/readmanga/ReadManga.kt
+++ b/src/ru/readmanga/src/eu/kanade/tachiyomi/extension/ru/readmanga/ReadManga.kt
@@ -11,7 +11,7 @@ import okhttp3.Request
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
-class ReadManga : GroupLe("ReadManga", "https://1.readmanga.io", "ru") {
+class ReadManga : GroupLe("ReadManga", "https://zz.readmanga.io", "ru") {
 
     override val id: Long = 5
 


### PR DESCRIPTION
Add the user token to all grouple extensions, as most grouple theme sites now require it. Also update the grouple readmanga domain.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
