### PR TITLE
Manga Gezgini(tr): Update Domain, and Fix typo in Genre

### DIFF
--- a/src/id/doujindesu/build.gradle
+++ b/src/id/doujindesu/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'DoujinDesu'
     extClass = '.DoujinDesu'
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = true
 }
 

--- a/src/id/doujindesu/src/eu/kanade/tachiyomi/extension/id/doujindesu/DoujinDesu.kt
+++ b/src/id/doujindesu/src/eu/kanade/tachiyomi/extension/id/doujindesu/DoujinDesu.kt
@@ -136,7 +136,7 @@ class DoujinDesu : ParsedHttpSource(), ConfigurableSource {
         Genre("Cunnilingus"),
         Genre("Dark Skin"),
         Genre("Daughter"),
-        Genre("Defloartion"),
+        Genre("Defloration"),
         Genre("Demon"),
         Genre("Demon Girl"),
         Genre("Dick Growth"),

--- a/src/tr/mangagezgini/build.gradle
+++ b/src/tr/mangagezgini/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'MangaGezgini'
     extClass = '.MangaGezgini'
     themePkg = 'madara'
-    baseUrl = 'https://mangagezgini.vip'
-    overrideVersionCode = 5
+    baseUrl = 'https://mangagezgini.site'
+    overrideVersionCode = 6
     isNsfw = false
 }
 

--- a/src/tr/mangagezgini/src/eu/kanade/tachiyomi/extension/tr/mangagezgini/MangaGezgini.kt
+++ b/src/tr/mangagezgini/src/eu/kanade/tachiyomi/extension/tr/mangagezgini/MangaGezgini.kt
@@ -11,7 +11,7 @@ import java.util.Locale
 
 class MangaGezgini : Madara(
     "MangaGezgini",
-    "https://mangagezgini.vip",
+    "https://mangagezgini.site",
     "tr",
     SimpleDateFormat("dd/MM/yyyy", Locale.ROOT),
 ) {


### PR DESCRIPTION
Closes #7614
Closes #7602 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions **(Doujin Desu)**
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions **(Manga Gezgini)**
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
