### PR TITLE
MangaReader: Fix crash on SY

### DIFF
--- a/src/all/mangareaderto/build.gradle
+++ b/src/all/mangareaderto/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaReaderFactory'
     themePkg = 'mangareader'
     baseUrl = 'https://mangareader.to'
-    overrideVersionCode = 4
+    overrideVersionCode = 5
     isNsfw = true
 }
 

--- a/src/all/mangareaderto/src/eu/kanade/tachiyomi/extension/all/mangareaderto/MangaReader.kt
+++ b/src/all/mangareaderto/src/eu/kanade/tachiyomi/extension/all/mangareaderto/MangaReader.kt
@@ -39,7 +39,8 @@ class MangaReader(
     // =============================== Search ===============================
 
     override fun searchMangaParse(response: Response): MangasPage {
-        var (entries, hasNextPage) = super.searchMangaParse(response)
+        val mangasPage = super.searchMangaParse(response)
+        var entries = mangasPage.mangas
         if (preferences.getBoolean(SHOW_VOLUME_PREF, false)) {
             entries = entries.flatMapTo(ArrayList(entries.size * 2)) { manga ->
                 val volume = SManga.create().apply {
@@ -50,7 +51,7 @@ class MangaReader(
                 listOf(manga, volume)
             }
         }
-        return MangasPage(entries, hasNextPage)
+        return MangasPage(entries, mangasPage.hasNextPage)
     }
 
     // ============================== Chapters ==============================


### PR DESCRIPTION
Closes #7659

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
