### PR TITLE
Madara: Expose genresList

### DIFF
--- a/lib-multisrc/madara/build.gradle.kts
+++ b/lib-multisrc/madara/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 39
+baseVersionCode = 40
 
 dependencies {
     api(project(":lib:cryptoaes"))

--- a/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
+++ b/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
@@ -82,7 +82,12 @@ abstract class Madara(
     /**
      * Automatically fetched genres from the source to be used in the filters.
      */
-    private var genresList: List<Genre> = emptyList()
+    protected open var genresList: List<Genre> = emptyList()
+
+    /**
+     * Whether genres have been fetched
+     */
+    private var genresFetched: Boolean = false
 
     /**
      * Inner variable to control how much tries the genres request was called.
@@ -1069,10 +1074,17 @@ abstract class Madara(
      * Fetch the genres from the source to be used in the filters.
      */
     protected fun fetchGenres() {
-        if (fetchGenres && fetchGenresAttempts < 3 && genresList.isEmpty()) {
+        if (fetchGenres && fetchGenresAttempts < 3 && !genresFetched) {
             try {
-                genresList = client.newCall(genresRequest()).execute()
+                client.newCall(genresRequest()).execute()
                     .use { parseGenres(it.asJsoup()) }
+                    .also {
+                        genresFetched = true
+                    }
+                    .takeIf { it.isNotEmpty() }
+                    ?.also {
+                        genresList = it
+                    }
             } catch (_: Exception) {
             } finally {
                 fetchGenresAttempts++

--- a/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
+++ b/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
@@ -242,11 +242,14 @@ abstract class Madara(
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
         if (query.startsWith(URL_SEARCH_PREFIX)) {
-            val mangaUrl = "/$mangaSubString/${query.substringAfter(URL_SEARCH_PREFIX)}/"
-            return client.newCall(GET("$baseUrl$mangaUrl", headers))
+            val mangaUrl = baseUrl.toHttpUrl().newBuilder().apply {
+                addPathSegment(mangaSubString)
+                addPathSegment(query.substringAfter(URL_SEARCH_PREFIX))
+            }.build()
+            return client.newCall(GET(mangaUrl, headers))
                 .asObservableSuccess().map { response ->
                     val manga = mangaDetailsParse(response).apply {
-                        url = mangaUrl
+                        setUrlWithoutDomain(mangaUrl.toString())
                     }
 
                     MangasPage(listOf(manga), false)

--- a/src/en/gourmetscans/src/eu/kanade/tachiyomi/extension/en/gourmetscans/GourmetScans.kt
+++ b/src/en/gourmetscans/src/eu/kanade/tachiyomi/extension/en/gourmetscans/GourmetScans.kt
@@ -61,24 +61,22 @@ class GourmetScans : Madara(
     override fun genresRequest(): Request = GET("$baseUrl/$mangaSubString", headers)
 
     override fun parseGenres(document: Document): List<Genre> {
-        genresList = document.select("div.row.genres ul li a")
+        return document.select("div.row.genres ul li a")
             .orEmpty()
             .map { li ->
-                Pair(
+                Genre(
                     li.text(),
                     li.attr("href").split("/").last { it.isNotBlank() },
                 )
             }
-
-        return emptyList()
     }
 
-    private var genresList: List<Pair<String, String>> = emptyList()
-
-    class GenreFilter(vals: List<Pair<String, String>>) :
-        UriPartFilter("Genre", vals.toTypedArray())
+    class GenreFilter(vals: List<Genre>) :
+        UriPartFilter("Genre", vals.map { Pair(it.name, it.id) }.toTypedArray())
 
     override fun getFilterList(): FilterList {
+        launchIO { fetchGenres() }
+
         val filters = buildList(4) {
             add(YearFilter(intl["year_filter_title"]))
             add(
@@ -93,7 +91,7 @@ class GourmetScans : Madara(
             if (genresList.isEmpty()) {
                 add(Filter.Header(intl["genre_missing_warning"]))
             } else {
-                add(GenreFilter(listOf(Pair("<select>", "")) + genresList))
+                add(GenreFilter(listOf(Genre("<select>", "")) + genresList))
             }
         }
 

--- a/src/en/manga18fx/src/eu/kanade/tachiyomi/extension/en/manga18fx/Manga18fx.kt
+++ b/src/en/manga18fx/src/eu/kanade/tachiyomi/extension/en/manga18fx/Manga18fx.kt
@@ -68,7 +68,7 @@ class Manga18fx : Madara(
         if (query.isEmpty()) {
             filters.forEach { filter ->
                 if (filter is GenreFilter) {
-                    return GET(filter.vals[filter.state].second, headers)
+                    return GET(filter.vals[filter.state].id, headers)
                 }
             }
             return latestUpdatesRequest(page)
@@ -94,23 +94,22 @@ class Manga18fx : Madara(
 
     override fun chapterDateSelector() = "span.chapter-time"
 
-    class GenreFilter(val vals: List<Pair<String, String>>) :
-        Filter.Select<String>("Genre", vals.map { it.first }.toTypedArray())
+    class GenreFilter(val vals: List<Genre>) :
+        Filter.Select<String>("Genre", vals.map { it.name }.toTypedArray())
 
     private fun loadGenres(document: Document) {
         genresList = document.select(".header-bottom li a").map {
             val href = it.attr("href")
             val url = if (href.startsWith("http")) href else "$baseUrl/$href"
 
-            Pair(it.text(), url)
+            Genre(it.text(), url)
         }
     }
 
-    private var genresList: List<Pair<String, String>> = emptyList()
-    private var hardCodedTypes: List<Pair<String, String>> = listOf(
-        Pair("Manhwa", "$baseUrl/manga-genre/manhwa"),
-        Pair("Manhua", "$baseUrl/manga-genre/manhua"),
-        Pair("Raw", "$baseUrl/manga-genre/raw"),
+    private var hardCodedTypes: List<Genre> = listOf(
+        Genre("Manhwa", "$baseUrl/manga-genre/manhwa"),
+        Genre("Manhua", "$baseUrl/manga-genre/manhua"),
+        Genre("Raw", "$baseUrl/manga-genre/raw"),
     )
 
     override fun getFilterList(): FilterList {

--- a/src/en/manycomic/src/eu/kanade/tachiyomi/extension/en/manycomic/ManyComic.kt
+++ b/src/en/manycomic/src/eu/kanade/tachiyomi/extension/en/manycomic/ManyComic.kt
@@ -5,7 +5,6 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
-import eu.kanade.tachiyomi.util.asJsoup
 import okhttp3.FormBody
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
@@ -67,7 +66,7 @@ class ManyComic : Madara("ManyComic", "https://manycomic.com", "en") {
     override fun searchMangaSelector() = popularMangaSelector()
 
     override fun getFilterList(): FilterList {
-        launchIO { fetchGenres_() }
+        launchIO { fetchGenres() }
 
         val filters: MutableList<Filter<out Any>> = mutableListOf(
             OrderByFilter(
@@ -77,18 +76,18 @@ class ManyComic : Madara("ManyComic", "https://manycomic.com", "en") {
             ),
         )
 
-        if (genresList.isNotEmpty()) {
-            filters += listOf(
+        filters += if (genresList.isNotEmpty()) {
+            listOf(
                 Filter.Separator(),
                 Filter.Header("Genre filter is ignored when searching by title"),
                 GenreFilter(
                     title = intl["genre_filter_title"],
-                    options = genresList,
+                    options = listOf(Genre("<All>", "")) + genresList,
                     state = 0,
                 ),
             )
-        } else if (fetchGenres) {
-            filters += listOf(
+        } else {
+            listOf(
                 Filter.Separator(),
                 Filter.Header(intl["genre_missing_warning"]),
             )
@@ -105,22 +104,6 @@ class ManyComic : Madara("ManyComic", "https://manycomic.com", "en") {
         intl["order_by_filter_views"] to "views",
         intl["order_by_filter_new"] to "new-manga",
     )
-
-    private var genresList: List<Genre> = emptyList()
-    private var fetchGenresAttempts: Int = 0
-
-    private fun fetchGenres_() {
-        if (fetchGenres && fetchGenresAttempts < 3 && genresList.isEmpty()) {
-            try {
-                genresList = listOf(Genre("<All>", "")) +
-                    client.newCall(genresRequest()).execute()
-                        .use { parseGenres(it.asJsoup()) }
-            } catch (_: Exception) {
-            } finally {
-                fetchGenresAttempts++
-            }
-        }
-    }
 
     private class GenreFilter(title: String, options: List<Genre>, state: Int = 0) :
         UriPartFilter(title, options.map { Pair(it.name, it.id) }.toTypedArray(), state)

--- a/src/en/manytoon/src/eu/kanade/tachiyomi/extension/en/manytoon/ManyToon.kt
+++ b/src/en/manytoon/src/eu/kanade/tachiyomi/extension/en/manytoon/ManyToon.kt
@@ -5,7 +5,6 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
-import eu.kanade.tachiyomi.util.asJsoup
 import okhttp3.FormBody
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
@@ -94,35 +93,22 @@ class ManyToon : Madara("ManyToon", "https://manytoon.com", "en") {
         intl["order_by_filter_new"] to "new-manga",
     )
 
-    private var genresList: List<Pair<String, String>> = emptyList()
-    private var fetchGenresAttempts: Int = 0
-
-    private fun fetchGenresMe() {
-        if (fetchGenres && fetchGenresAttempts < 3 && genresList.isEmpty()) {
-            try {
-                genresList = client.newCall(genresRequest()).execute()
-                    .use { parseGenresMe(it.asJsoup()) }
-            } catch (_: Exception) {
-            } finally {
-                fetchGenresAttempts++
-            }
-        }
-    }
-
-    private fun parseGenresMe(document: Document): List<Pair<String, String>> {
+    override fun parseGenres(document: Document): List<Genre> {
         return document.selectFirst("div.genres")
             ?.select("a")
             .orEmpty()
             .map { a ->
-                a.ownText() to
-                    a.attr("href").substringBeforeLast("/").substringAfterLast("/")
+                Genre(
+                    a.ownText(),
+                    a.attr("href").substringBeforeLast("/").substringAfterLast("/"),
+                )
             }.let {
-                listOf(("All" to "all")) + it
+                listOf(Genre("All", "all")) + it
             }
     }
 
     override fun getFilterList(): FilterList {
-        launchIO { fetchGenresMe() }
+        launchIO { fetchGenres() }
 
         val filters = mutableListOf(
             Filter.Header("All filters except the orderby filter are incompatible with each other"),
@@ -135,17 +121,16 @@ class ManyToon : Madara("ManyToon", "https://manytoon.com", "en") {
             ),
         )
 
-        if (genresList.isNotEmpty()) {
-            filters += listOf(
+        filters += if (genresList.isNotEmpty()) {
+            listOf(
                 Filter.Separator(),
-                Filter.Header(intl["genre_filter_header"]),
                 GenreConditionFilter(
                     title = intl["genre_filter_title"],
-                    options = genresList,
+                    options = genresList.map { it.name to it.id },
                 ),
             )
-        } else if (fetchGenres) {
-            filters += listOf(
+        } else {
+            listOf(
                 Filter.Separator(),
                 Filter.Header(intl["genre_missing_warning"]),
             )

--- a/src/es/leermanga/src/eu/kanade/tachiyomi/extension/es/leermanga/LeerManga.kt
+++ b/src/es/leermanga/src/eu/kanade/tachiyomi/extension/es/leermanga/LeerManga.kt
@@ -80,19 +80,16 @@ class LeerManga : Madara(
 
     // =============================== Filters ===============================
 
-    private var genresList: List<Genre> = emptyList()
-
     override fun getFilterList(): FilterList {
         val filters = mutableListOf<Filter<*>>()
         if (genresList.isNotEmpty()) {
             filters += listOf(
-                Filter.Header(intl["genre_filter_header"]),
                 GenreGroup(
                     displayName = intl["genre_filter_title"],
                     genres = genresList,
                 ),
             )
-        } else if (fetchGenres) {
+        } else {
             filters += Filter.Header(intl["genre_missing_warning"])
         }
         return FilterList(filters)

--- a/src/id/pojokmanga/src/eu/kanade/tachiyomi/extension/id/pojokmanga/PojokManga.kt
+++ b/src/id/pojokmanga/src/eu/kanade/tachiyomi/extension/id/pojokmanga/PojokManga.kt
@@ -83,7 +83,7 @@ class PojokManga : Madara("Pojok Manga", "https://pojokmanga.info", "id", Simple
 
     override val mangaDetailsSelectorTag = "#toNotBeUsed"
 
-    protected class ProjectFilter : UriPartFilter(
+    private class ProjectFilter : UriPartFilter(
         "Filter Project",
         arrayOf(
             Pair("Show all manga", ""),


### PR DESCRIPTION
Expose genresList so that:
- Extensions be able to read/write the genresList. Some of the extensions here (updated along in this PR) had duplicated code to load genresList in its own way.
- Extensions can also hard-code a list of genres so they have something ready before actually querying website for genres list. Given that genres list rarely changes. If the genres list does change completely then the hard-code list might be useless, but with the former way genres filter is useless before any loading, anyway. This would also help forks like SY which support saved-search based on filters' value.
- Also update the `fetchSearchManga` to using `HttpUrlBuilder`

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
