### PR TITLE
Bakai: Fix selector

### DIFF
--- a/src/pt/bakai/build.gradle
+++ b/src/pt/bakai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Bakai'
     extClass = '.Bakai'
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = true
 }
 

--- a/src/pt/bakai/src/eu/kanade/tachiyomi/extension/pt/bakai/Bakai.kt
+++ b/src/pt/bakai/src/eu/kanade/tachiyomi/extension/pt/bakai/Bakai.kt
@@ -78,7 +78,7 @@ class Bakai : ParsedHttpSource() {
 
     override fun popularMangaRequest(page: Int) = GET("$baseUrl/$popularPathSegment/page/$page/")
 
-    override fun popularMangaSelector() = "#elCmsPageWrap ul > li > article"
+    override fun popularMangaSelector() = "[id*=elCmsPageWrap] ul > li > article"
 
     override fun popularMangaFromElement(element: Element) = SManga.create().apply {
         thumbnail_url = element.selectFirst("img")?.imgAttr()


### PR DESCRIPTION
Closes #7406

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
