### PR TITLE
[RU]Nudemoon 3 fixes

### DIFF
--- a/src/ru/nudemoon/build.gradle
+++ b/src/ru/nudemoon/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Nude-Moon'
     extClass = '.Nudemoon'
-    extVersionCode = 19
+    extVersionCode = 20
     isNsfw = true
 }
 

--- a/src/ru/nudemoon/src/eu/kanade/tachiyomi/extension/ru/nudemoon/Nudemoon.kt
+++ b/src/ru/nudemoon/src/eu/kanade/tachiyomi/extension/ru/nudemoon/Nudemoon.kt
@@ -43,7 +43,6 @@ class Nudemoon : ParsedHttpSource(), ConfigurableSource {
     override val baseUrl by lazy { getPrefBaseUrl() }
 
     private val dateParseRu = SimpleDateFormat("d MMMM yyyy", Locale("ru"))
-    private val dateParseSlash = SimpleDateFormat("d/MM/yyyy", Locale("ru"))
 
     private val cookieManager by lazy { CookieManager.getInstance() }
 
@@ -160,12 +159,12 @@ class Nudemoon : ParsedHttpSource(), ConfigurableSource {
 
     override fun mangaDetailsParse(document: Document): SManga {
         val manga = SManga.create()
-        val infoElement = document.select("table.news_pic2").first()!!
-        manga.title = document.select("h1").first()!!.text().substringBefore(" / ").substringBefore(" №")
-        manga.author = infoElement.select("a[href*=mangaka]").text()
-        manga.genre = infoElement.select("div.tag-links a").joinToString { it.text() }
+        val infoElement = document.selectFirst("table.news_pic2")
+        manga.title = document.selectFirst("h1")?.text()?.substringBefore(" / ")?.substringBefore(" №") ?: "No title"
+        manga.author = infoElement?.select("a[href*=mangaka]")?.text()
+        manga.genre = infoElement?.select("div.tag-links a")?.joinToString { it.text() }
         manga.description = document.select(".description").text()
-        manga.thumbnail_url = document.selectFirst("meta[property=og:image]")!!.attr("abs:content")
+        manga.thumbnail_url = document.selectFirst("meta[property=og:image]")?.attr("abs:content")
 
         return manga
     }
@@ -207,15 +206,15 @@ class Nudemoon : ParsedHttpSource(), ConfigurableSource {
     }
 
     private fun chapterFromSinglePage(document: Document, responseUrl: HttpUrl): SChapter = SChapter.create().apply {
-        val chapterName = document.select("table td.bg_style1 h1").text()
+        val chapterName = document.selectFirst("table td.bg_style1 h1")?.text()
         val chapterUrl = responseUrl.toString()
         setUrlWithoutDomain(chapterUrl)
         if (url.contains(baseUrl)) {
             url = url.replace(baseUrl, "")
         }
         name = "$chapterName Сингл"
-        scanlator = document.select("table.news_pic2 a[href*=perevod]").text()
-        date_upload = document.select("table.news_pic2:has(a[href*=perevod]) span.small2:not(:contains(тыс))").first()!!.text().replace("Май", "Мая").let {
+        scanlator = document.selectFirst("table.news_pic2 a[href*=perevod]")?.text()
+        date_upload = document.selectFirst("table.news_pic2:has(a[href*=perevod]) span.small2")?.text()?.replace("Май", "Мая").let {
             try {
                 dateParseRu.parse(it)?.time ?: 0L
             } catch (e: Exception) {

--- a/src/ru/nudemoon/src/eu/kanade/tachiyomi/extension/ru/nudemoon/Nudemoon.kt
+++ b/src/ru/nudemoon/src/eu/kanade/tachiyomi/extension/ru/nudemoon/Nudemoon.kt
@@ -177,11 +177,7 @@ class Nudemoon : ParsedHttpSource(), ConfigurableSource {
     override fun chapterListParse(response: Response): List<SChapter> = mutableListOf<SChapter>().apply {
         val document = response.asJsoup()
 
-        val allPageElement = document.select("td.button a:contains(Все главы)")
-
-        if (allPageElement.isEmpty()) {
-            add(chapterFromSinglePage(document, response.request.url.toString()))
-        } else {
+        document.selectFirst("td.button a:contains(Все главы)")?.let { allPageElement ->
             var pageListDocument: Document
             val pageListLink = allPageElement.attr("href")
             client.newCall(
@@ -201,6 +197,8 @@ class Nudemoon : ParsedHttpSource(), ConfigurableSource {
                         add(chapterFromElement(it))
                     }
             }
+        } ?: run {
+            add(chapterFromSinglePage(document, response.request.url.toString()))
         }
     }
 

--- a/src/ru/nudemoon/src/eu/kanade/tachiyomi/extension/ru/nudemoon/Nudemoon.kt
+++ b/src/ru/nudemoon/src/eu/kanade/tachiyomi/extension/ru/nudemoon/Nudemoon.kt
@@ -160,7 +160,7 @@ class Nudemoon : ParsedHttpSource(), ConfigurableSource {
     override fun mangaDetailsParse(document: Document): SManga {
         val manga = SManga.create()
         val infoElement = document.selectFirst("table.news_pic2")
-        manga.title = document.selectFirst("h1")?.text()?.substringBefore(" / ")?.substringBefore(" №") ?: "No title"
+        manga.title = document.selectFirst("h1")!!.text().substringBefore(" / ").substringBefore(" №")
         manga.author = infoElement?.select("a[href*=mangaka]")?.text()
         manga.genre = infoElement?.select("div.tag-links a")?.joinToString { it.text() }
         manga.description = document.select(".description").text()

--- a/src/ru/nudemoon/src/eu/kanade/tachiyomi/extension/ru/nudemoon/Nudemoon.kt
+++ b/src/ru/nudemoon/src/eu/kanade/tachiyomi/extension/ru/nudemoon/Nudemoon.kt
@@ -206,10 +206,13 @@ class Nudemoon : ParsedHttpSource(), ConfigurableSource {
         }
     }
 
-    private fun chapterFromSinglePage(document: Document, url: HttpUrl): SChapter = SChapter.create().apply {
+    private fun chapterFromSinglePage(document: Document, responseUrl: HttpUrl): SChapter = SChapter.create().apply {
         val chapterName = document.select("table td.bg_style1 h1").text()
-        val chapterUrl = url.toString()
+        val chapterUrl = responseUrl.toString()
         setUrlWithoutDomain(chapterUrl)
+        if (url.contains(baseUrl)) {
+            url = url.replace(baseUrl, "")
+        }
         name = "$chapterName Сингл"
         scanlator = document.select("table.news_pic2 a[href*=perevod]").text()
         date_upload = document.select("table.news_pic2:has(a[href*=perevod]) span.small2:not(:contains(тыс))").first()!!.text().replace("Май", "Мая").let {

--- a/src/ru/nudemoon/src/eu/kanade/tachiyomi/extension/ru/nudemoon/Nudemoon.kt
+++ b/src/ru/nudemoon/src/eu/kanade/tachiyomi/extension/ru/nudemoon/Nudemoon.kt
@@ -188,9 +188,9 @@ class Nudemoon : ParsedHttpSource(), ConfigurableSource {
                     setUrlWithoutDomain(chapterUrl)
                     name = "$chapterName Сингл"
                     scanlator = document.select("table.news_pic2 a[href*=perevod]").text()
-                    date_upload = document.select("table.news_pic2 span.small2:contains(/)").text().let {
+                    date_upload = document.select("table.news_pic2:has(a[href*=perevod]) span.small2:not(:contains(тыс))").first()!!.text().replace("Май", "Мая").let {
                         try {
-                            dateParseSlash.parse(it)?.time ?: 0L
+                            dateParseRu.parse(it)?.time ?: 0L
                         } catch (e: Exception) {
                             0
                         }


### PR DESCRIPTION
Fix date parse in titles with single chapter
Fallback to parse as title with single chapter if page with all chapters is empty
Fix for some old titles when url not cleared correctly and app try to open http://nude-moon.orghttps://nude-moon.org/* (already implemented for titles with multiple chapters, added for titles with single chapter)

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
