### PR TITLE
[RU]Nudemoon date find fix

### DIFF
--- a/src/ru/nudemoon/build.gradle
+++ b/src/ru/nudemoon/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Nude-Moon'
     extClass = '.Nudemoon'
-    extVersionCode = 20
+    extVersionCode = 21
     isNsfw = true
 }
 

--- a/src/ru/nudemoon/src/eu/kanade/tachiyomi/extension/ru/nudemoon/Nudemoon.kt
+++ b/src/ru/nudemoon/src/eu/kanade/tachiyomi/extension/ru/nudemoon/Nudemoon.kt
@@ -210,7 +210,7 @@ class Nudemoon : ParsedHttpSource(), ConfigurableSource {
             url = url.replace(baseUrl, "")
         }
         scanlator = document.selectFirst("table.news_pic2 a[href*=perevod]")?.text()
-        date_upload = document.selectFirst("table.news_pic2 span.small2:matches((0[1-9]|[12][0-9]|3[01])*(19|20)\d{2})")?.text()?.let {
+        date_upload = document.selectFirst("""table.news_pic2 span.small2:matches((0[1-9]|[12][0-9]|3[01])*(19|20)\d{2})""")?.text()?.let {
             dateParseWithReplace(it)
         } ?: 0L
         chapter_number = 0F
@@ -225,7 +225,7 @@ class Nudemoon : ParsedHttpSource(), ConfigurableSource {
         }
         val informBlock = element.selectFirst("tr[valign=top] td[align=left]")
         scanlator = informBlock?.selectFirst("a[href*=perevod]")?.text()
-        date_upload = informBlock?.selectFirst("span.small2:matches((0[1-9]|[12][0-9]|3[01])*(19|20)\d{2})")?.text()?.let {
+        date_upload = informBlock?.selectFirst("""span.small2:matches((0[1-9]|[12][0-9]|3[01])*(19|20)\d{2})""")?.text()?.let {
             dateParseWithReplace(it)
         } ?: 0L
         chapter_number = name.substringAfter("№").substringBefore(" ").toFloatOrNull() ?: -1f

--- a/src/ru/nudemoon/src/eu/kanade/tachiyomi/extension/ru/nudemoon/Nudemoon.kt
+++ b/src/ru/nudemoon/src/eu/kanade/tachiyomi/extension/ru/nudemoon/Nudemoon.kt
@@ -210,7 +210,7 @@ class Nudemoon : ParsedHttpSource(), ConfigurableSource {
             url = url.replace(baseUrl, "")
         }
         scanlator = document.selectFirst("table.news_pic2 a[href*=perevod]")?.text()
-        date_upload = document.selectFirst("table.news_pic2:has(a[href*=perevod]) span.small2")?.text()?.let {
+        date_upload = document.selectFirst("table.news_pic2 span.small2:matches((0[1-9]|[12][0-9]|3[01])*(19|20)\d{2})")?.text()?.let {
             dateParseWithReplace(it)
         } ?: 0L
         chapter_number = 0F
@@ -225,7 +225,7 @@ class Nudemoon : ParsedHttpSource(), ConfigurableSource {
         }
         val informBlock = element.selectFirst("tr[valign=top] td[align=left]")
         scanlator = informBlock?.selectFirst("a[href*=perevod]")?.text()
-        date_upload = informBlock?.selectFirst("span.small2")?.text()?.let {
+        date_upload = informBlock?.selectFirst("span.small2:matches((0[1-9]|[12][0-9]|3[01])*(19|20)\d{2})")?.text()?.let {
             dateParseWithReplace(it)
         } ?: 0L
         chapter_number = name.substringAfter("№").substringBefore(" ").toFloatOrNull() ?: -1f


### PR DESCRIPTION
Small fix for date find
Fix for https://nude-moon.org/12570-online--ronorim-wacchi-to-shippori-kezukuroi-bon---affectionate-grooming-with-me.html and some other titles
Current code find as first not date
![изображение](https://github.com/user-attachments/assets/9cf44fb0-68f3-45bb-8068-d251394e004c)
This regex have to limit result with only date

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
