### PR TITLE
Disasterscans: fix again

### DIFF
--- a/src/en/disasterscans/build.gradle
+++ b/src/en/disasterscans/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Disaster Scans'
     extClass = '.DisasterScans'
-    extVersionCode = 33
+    extVersionCode = 34
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/disasterscans/src/eu/kanade/tachiyomi/extension/en/disasterscans/DisasterScans.kt
+++ b/src/en/disasterscans/src/eu/kanade/tachiyomi/extension/en/disasterscans/DisasterScans.kt
@@ -84,7 +84,7 @@ class DisasterScans : ParsedHttpSource() {
                     "ongoing" -> SManga.ONGOING
                     else -> SManga.UNKNOWN
                 }
-                genre = this.joinToString { text() }
+                genre = this.joinToString { it.text() }
             }
         }
     }
@@ -95,7 +95,7 @@ class DisasterScans : ParsedHttpSource() {
 
     override fun chapterListParse(response: Response): List<SChapter> {
         chapterDataRegex.find(response.body.string())?.destructured?.also { (chapterData, mangaId) ->
-            return json.decodeFromString<List<ChapterDTO>>(chapterData).map { chapter ->
+            return json.decodeFromString<List<ChapterDTO>>(chapterData.replace("\\", "")).map { chapter ->
                 SChapter.create().apply {
                     name = "Chapter ${chapter.ChapterNumber} - ${chapter.ChapterName}"
                     setUrlWithoutDomain(


### PR DESCRIPTION


Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [X] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
