### PR TITLE
Manga Crab: Fix url and selectors

### DIFF
--- a/src/es/mangacrab/build.gradle
+++ b/src/es/mangacrab/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaCrab'
     themePkg = 'madara'
     baseUrl = 'https://wikicrab.xyz'
-    overrideVersionCode = 10
+    overrideVersionCode = 11
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/mangacrab/src/eu/kanade/tachiyomi/extension/es/mangacrab/MangaCrab.kt
+++ b/src/es/mangacrab/src/eu/kanade/tachiyomi/extension/es/mangacrab/MangaCrab.kt
@@ -18,7 +18,7 @@ import java.util.Locale
 class MangaCrab :
     Madara(
         "Manga Crab",
-        "https://wikicrab.xyz",
+        "https://mangacrab.org",
         "es",
         SimpleDateFormat("dd/MM/yyyy", Locale("es")),
     ),
@@ -38,7 +38,10 @@ class MangaCrab :
     override val mangaSubString = "series"
     override val useLoadMoreRequest = LoadMoreStrategy.Never
 
+    override fun popularMangaSelector() = "div.manga__item"
+    override val popularMangaUrlSelector = "div.post-title a"
     override fun chapterListSelector() = "div.listing-chapters_wrap > ul > li"
+    override val mangaDetailsSelectorTitle = "h1.post-title"
     override val mangaDetailsSelectorDescription = "div.c-page__content div.modal-contenido"
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {


### PR DESCRIPTION
Closes #7762

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
