### PR TITLE
CbHentai: Add override baseUrl, Change baseUrl, Fix Regex

### DIFF
--- a/src/vi/hentaicube/build.gradle
+++ b/src/vi/hentaicube/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'CBHentai'
     extClass = '.HentaiCB'
     themePkg = 'madara'
-    baseUrl = 'https://hentaicube.xyz'
-    overrideVersionCode = 12
+    baseUrl = 'https://hentaicb.love'
+    overrideVersionCode = 13
     isNsfw = true
 }
 

--- a/src/vi/hentaicube/src/eu/kanade/tachiyomi/extension/vi/hentaicube/HentaiCB.kt
+++ b/src/vi/hentaicube/src/eu/kanade/tachiyomi/extension/vi/hentaicube/HentaiCB.kt
@@ -1,25 +1,59 @@
 package eu.kanade.tachiyomi.extension.vi.hentaicube
 
+import android.content.SharedPreferences
+import android.widget.Toast
+import androidx.preference.EditTextPreference
+import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.asObservableSuccess
+import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SManga
+import keiyoushi.utils.getPreferences
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
 import org.jsoup.nodes.Document
 import rx.Observable
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class HentaiCB : Madara("CBHentai", "https://hentaicube.xyz", "vi", SimpleDateFormat("dd/MM/yyyy", Locale("vi"))) {
+class HentaiCB :
+    Madara(
+        "CBHentai",
+        "https://hentaicb.love",
+        "vi",
+        SimpleDateFormat("dd/MM/yyyy", Locale("vi")),
+    ),
+    ConfigurableSource {
 
     override val id: Long = 823638192569572166
 
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
+        .rateLimit(3)
+        .build()
+
+    private val preferences: SharedPreferences = getPreferences()
+
+    init {
+        preferences.getString(DEFAULT_BASE_URL_PREF, null).let { prefDefaultBaseUrl ->
+            if (prefDefaultBaseUrl != super.baseUrl) {
+                preferences.edit()
+                    .putString(BASE_URL_PREF, super.baseUrl)
+                    .putString(DEFAULT_BASE_URL_PREF, super.baseUrl)
+                    .apply()
+            }
+        }
+    }
+    private fun getPrefBaseUrl(): String = preferences.getString(BASE_URL_PREF, super.baseUrl)!!
+
+    override val baseUrl by lazy { getPrefBaseUrl() }
+
     override val filterNonMangaItems = false
 
-    // Changed from 'manga' to 'read'
     override val mangaSubString = "read"
 
     override val altNameSelector = ".post-content_item:contains(Tên khác) .summary-content"
@@ -27,7 +61,7 @@ class HentaiCB : Madara("CBHentai", "https://hentaicube.xyz", "vi", SimpleDateFo
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
         if (query.startsWith(URL_SEARCH_PREFIX)) {
             val mangaUrl = baseUrl.toHttpUrl().newBuilder().apply {
-                addPathSegment("manga")
+                addPathSegment(mangaSubString)
                 addPathSegment(query.substringAfter(URL_SEARCH_PREFIX))
             }.build()
             return client.newCall(GET(mangaUrl, headers))
@@ -51,15 +85,40 @@ class HentaiCB : Madara("CBHentai", "https://hentaicube.xyz", "vi", SimpleDateFo
         return super.fetchSearchManga(page, queryFixed, filters)
     }
 
-    private val oldMangaUrlRegex = Regex("""^$baseUrl/read/""")
+    private val oldMangaUrlRegex = Regex("^$baseUrl/\\w+/")
 
-    // Change old entries from 'read' to 'manga'
+    // Change old entries from mangaSubString
     override fun getMangaUrl(manga: SManga): String {
         return super.getMangaUrl(manga)
-            .replace(oldMangaUrlRegex, "$baseUrl/manga/")
+            .replace(oldMangaUrlRegex, "$baseUrl/$mangaSubString/")
     }
 
     override fun pageListParse(document: Document): List<Page> {
         return super.pageListParse(document).distinctBy { it.imageUrl }
+    }
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        EditTextPreference(screen.context).apply {
+            key = BASE_URL_PREF
+            title = BASE_URL_PREF_TITLE
+            summary = BASE_URL_PREF_SUMMARY
+            setDefaultValue(super.baseUrl)
+            dialogTitle = BASE_URL_PREF_TITLE
+            dialogMessage = "Default: ${super.baseUrl}"
+
+            setOnPreferenceChangeListener { _, _ ->
+                Toast.makeText(screen.context, RESTART_APP, Toast.LENGTH_LONG).show()
+                true
+            }
+        }.let(screen::addPreference)
+    }
+
+    companion object {
+        private const val DEFAULT_BASE_URL_PREF = "defaultBaseUrl"
+        private const val RESTART_APP = "Khởi chạy lại ứng dụng để áp dụng thay đổi."
+        private const val BASE_URL_PREF_TITLE = "Ghi đè URL cơ sở"
+        private const val BASE_URL_PREF = "overrideBaseUrl"
+        private const val BASE_URL_PREF_SUMMARY =
+            "Dành cho sử dụng tạm thời, cập nhật tiện ích sẽ xóa cài đặt."
     }
 }


### PR DESCRIPTION
Checklist:
- Fixed Regex bug because previously manga URLs were not just /read/ but could be /manga/ leading to double /manga/ in manga URL and use use mangaSubString instead of "manga" works more accurately
- Change baseUrl to resolve http 404 latestUpdatesRequest & popularMangaRequest
- Add override baseUrl Allow users to freely change the desired url.

- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
