### PR TITLE
honeyManga: filter payed chapters

### DIFF
--- a/src/uk/honeymanga/build.gradle
+++ b/src/uk/honeymanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'HoneyManga'
     extClass = '.HoneyManga'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/uk/honeymanga/src/eu/kanade/tachiyomi/extension/uk/honeymanga/HoneyManga.kt
+++ b/src/uk/honeymanga/src/eu/kanade/tachiyomi/extension/uk/honeymanga/HoneyManga.kt
@@ -28,8 +28,8 @@ import uy.kohesive.injekt.injectLazy
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-
 class HoneyManga : HttpSource() {
+
     override val name = "HoneyManga"
     override val baseUrl = "https://honey-manga.com.ua"
     override val lang = "uk"

--- a/src/uk/honeymanga/src/eu/kanade/tachiyomi/extension/uk/honeymanga/HoneyManga.kt
+++ b/src/uk/honeymanga/src/eu/kanade/tachiyomi/extension/uk/honeymanga/HoneyManga.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.extension.uk.honeymanga
 
-import android.annotation.SuppressLint
 import eu.kanade.tachiyomi.extension.uk.honeymanga.dtos.CompleteHoneyMangaDto
 import eu.kanade.tachiyomi.extension.uk.honeymanga.dtos.HoneyMangaChapterPagesDto
 import eu.kanade.tachiyomi.extension.uk.honeymanga.dtos.HoneyMangaChapterResponseDto

--- a/src/uk/honeymanga/src/eu/kanade/tachiyomi/extension/uk/honeymanga/HoneyManga.kt
+++ b/src/uk/honeymanga/src/eu/kanade/tachiyomi/extension/uk/honeymanga/HoneyManga.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.extension.uk.honeymanga
 
+import android.annotation.SuppressLint
 import eu.kanade.tachiyomi.extension.uk.honeymanga.dtos.CompleteHoneyMangaDto
 import eu.kanade.tachiyomi.extension.uk.honeymanga.dtos.HoneyMangaChapterPagesDto
 import eu.kanade.tachiyomi.extension.uk.honeymanga.dtos.HoneyMangaChapterResponseDto
@@ -28,8 +29,8 @@ import uy.kohesive.injekt.injectLazy
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class HoneyManga : HttpSource() {
 
+class HoneyManga : HttpSource() {
     override val name = "HoneyManga"
     override val baseUrl = "https://honey-manga.com.ua"
     override val lang = "uk"
@@ -106,7 +107,7 @@ class HoneyManga : HttpSource() {
 
     override fun chapterListParse(response: Response): List<SChapter> {
         val result = response.asClass<HoneyMangaChapterResponseDto>()
-        return result.data.map {
+        return result.data.filter { !it.isMonetized }.map {
             val suffix = if (it.subChapterNum == 0) "" else ".${it.subChapterNum}"
             SChapter.create().apply {
                 url = "$baseUrl/read/${it.id}/${it.mangaId}"

--- a/src/uk/honeymanga/src/eu/kanade/tachiyomi/extension/uk/honeymanga/dtos/HoneyMangaDto.kt
+++ b/src/uk/honeymanga/src/eu/kanade/tachiyomi/extension/uk/honeymanga/dtos/HoneyMangaDto.kt
@@ -46,4 +46,5 @@ data class HoneyMangaChapterDto(
     val subChapterNum: Int,
     val mangaId: String,
     val lastUpdated: String,
+    val isMonetized: Boolean,
 )


### PR DESCRIPTION
Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Have not changed source names
- [X] Have tested the modifications by compiling and running the extension through Android Studio

It's annoying to see notification about new chapters that you can't read and isMonetized: true is only on payed chapters, so that works just as needed