### PR TITLE
Lua Scans: Fix date parse

### DIFF
--- a/src/en/luascans/build.gradle
+++ b/src/en/luascans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.LuaScans'
     themePkg = 'heancms'
     baseUrl = 'https://luacomic.org'
-    overrideVersionCode = 18
+    overrideVersionCode = 19
     isNsfw = false
 }
 

--- a/src/en/luascans/src/eu/kanade/tachiyomi/extension/en/luascans/LuaScans.kt
+++ b/src/en/luascans/src/eu/kanade/tachiyomi/extension/en/luascans/LuaScans.kt
@@ -1,6 +1,8 @@
 package eu.kanade.tachiyomi.extension.en.luascans
 
 import eu.kanade.tachiyomi.multisrc.heancms.HeanCms
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 class LuaScans : HeanCms(
     "Lua Scans",
@@ -11,4 +13,6 @@ class LuaScans : HeanCms(
     override val versionId = 3
 
     override val useNewChapterEndpoint = true
+
+    override val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
 }


### PR DESCRIPTION
Closes #7801

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
