### PR TITLE
Webtoons: Fix covers

### DIFF
--- a/lib-multisrc/webtoons/build.gradle.kts
+++ b/lib-multisrc/webtoons/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 2
+baseVersionCode = 3

--- a/lib-multisrc/webtoons/src/eu/kanade/tachiyomi/multisrc/webtoons/Webtoons.kt
+++ b/lib-multisrc/webtoons/src/eu/kanade/tachiyomi/multisrc/webtoons/Webtoons.kt
@@ -197,7 +197,7 @@ open class Webtoons(
     open fun parseDetailsThumbnail(document: Document): String? {
         val picElement = document.select("#content > div.cont_box > div.detail_body")
         val discoverPic = document.select("#content > div.cont_box > div.detail_header > span.thmb")
-        return picElement.attr("style").substringAfter("url(").substringBeforeLast(")")
+        return picElement.attr("style").substringAfter("url(").substringBeforeLast(")").removeSurrounding("\"").removeSurrounding("'")
             .ifBlank { discoverPic.select("img").not("[alt='Representative image']").first()?.attr("src") }
     }
 


### PR DESCRIPTION
Closes #7817

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
