### PR TITLE
Remove self-promotion, ads: TopTruyen, DocTruyen3Q

### DIFF
--- a/src/vi/doctruyen3q/build.gradle
+++ b/src/vi/doctruyen3q/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.DocTruyen3Q'
     themePkg = 'wpcomics'
     baseUrl = 'https://doctruyen3qui.pro'
-    overrideVersionCode = 4
+    overrideVersionCode = 5
     isNsfw = true
 }
 

--- a/src/vi/doctruyen3q/src/eu/kanade/tachiyomi/extension/vi/doctruyen3q/DocTruyen3Q.kt
+++ b/src/vi/doctruyen3q/src/eu/kanade/tachiyomi/extension/vi/doctruyen3q/DocTruyen3Q.kt
@@ -37,7 +37,7 @@ class DocTruyen3Q :
         .build()
 
     override fun pageListParse(document: Document): List<Page> {
-        return document.select(".page-chapter a img, .page-chapter img").mapIndexed { index, element ->
+        return document.select(".page-chapter[id] a img, .page-chapter[id] img").mapIndexed { index, element ->
             val img = element.attr("abs:src").takeIf { it.isNotBlank() } ?: element.attr("abs:data-original")
             Page(index, imageUrl = img)
         }.distinctBy { it.imageUrl }

--- a/src/vi/toptruyen/build.gradle
+++ b/src/vi/toptruyen/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.TopTruyen'
     themePkg = 'wpcomics'
     baseUrl = 'https://www.toptruyentv.pro'
-    overrideVersionCode = 8
+    overrideVersionCode = 9
     isNsfw = true
 }
 

--- a/src/vi/toptruyen/src/eu/kanade/tachiyomi/extension/vi/toptruyen/TopTruyen.kt
+++ b/src/vi/toptruyen/src/eu/kanade/tachiyomi/extension/vi/toptruyen/TopTruyen.kt
@@ -37,7 +37,7 @@ class TopTruyen :
         .build()
 
     override fun pageListParse(document: Document): List<Page> {
-        return document.select(".page-chapter img")
+        return document.select(".page-chapter[id] img")
             .mapNotNull(::imageOrNull)
             .distinct()
             .mapIndexed { i, image -> Page(i, imageUrl = image) }


### PR DESCRIPTION
These sites added self-promotion and ad images that are not relevant to the translation team.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
