### PR TITLE
MangaGun: Fix image load

### DIFF
--- a/src/ja/mangagun/build.gradle
+++ b/src/ja/mangagun/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaGun'
     themePkg = 'fmreader'
     baseUrl = 'https://mangagun.net'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ja/mangagun/src/eu/kanade/tachiyomi/extension/ja/mangagun/MangaGun.kt
+++ b/src/ja/mangagun/src/eu/kanade/tachiyomi/extension/ja/mangagun/MangaGun.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.extension.ja.mangagun
 
+import android.util.Base64
 import eu.kanade.tachiyomi.multisrc.fmreader.FMReader
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.asObservableSuccess
@@ -116,21 +117,10 @@ class MangaGun : FMReader("MangaGun", "https://$DOMAIN", "ja") {
             handleDdosProtect(document)
         } else {
             document
-        }.select("script:containsData(load_image)")
-            .html()
-            .substringAfter("(")
-            .substringBefore(",")
-            .let { cid ->
-                client.newCall(
-                    GET(
-                        "$baseUrl/app/manga/controllers/cont.Showimage.php?cid=$cid",
-                        headers,
-                    ),
-                ).execute().asJsoup()
-            }
-            .select(".lazyload")
-            .mapIndexed { i, e ->
-                Page(i, "", e.attr("abs:data-srcset"))
+        }.select(".chapter-content img.chapter-img")
+            .eachAttr("data-img")
+            .mapIndexed { index, img ->
+                Page(index, "", Base64.decode(img, Base64.DEFAULT).decodeToString())
             }
     }
 }


### PR DESCRIPTION
Closes #7916 
Closes #7912 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
