### PR TITLE
ZinChanManga(.net/.com): Fix URL

### DIFF
--- a/src/en/zinchanmanga/build.gradle
+++ b/src/en/zinchanmanga/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'ZinChanManga'
     extClass = '.ZinChanManga'
     themePkg = 'madara'
-    baseUrl = 'https://zinchanmanga.net'
+    baseUrl = 'https://zinchangmanga.net'
     overrideVersionCode = 3
     isNsfw = true
 }

--- a/src/en/zinchanmanga/build.gradle
+++ b/src/en/zinchanmanga/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ZinChanManga'
     themePkg = 'madara'
     baseUrl = 'https://zinchanmanga.net'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
     isNsfw = true
 }
 

--- a/src/en/zinchanmanga/src/eu/kanade/tachiyomi/extension/en/zinchanmanga/ZinChanManga.kt
+++ b/src/en/zinchanmanga/src/eu/kanade/tachiyomi/extension/en/zinchanmanga/ZinChanManga.kt
@@ -6,7 +6,7 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 
 class ZinChanManga : Madara("ZinChanManga", "https://zinchangmanga.net", "en") {
-    override val versionId = 3
+    override val versionId = 2
     override val useNewChapterEndpoint = true
 
     override fun popularMangaFromElement(element: Element): SManga {

--- a/src/en/zinchanmanga/src/eu/kanade/tachiyomi/extension/en/zinchanmanga/ZinChanManga.kt
+++ b/src/en/zinchanmanga/src/eu/kanade/tachiyomi/extension/en/zinchanmanga/ZinChanManga.kt
@@ -5,8 +5,8 @@ import eu.kanade.tachiyomi.source.model.SManga
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 
-class ZinChanManga : Madara("ZinChanManga", "https://zinchanmanga.net", "en") {
-    override val versionId = 2
+class ZinChanManga : Madara("ZinChanManga", "https://zinchangmanga.net", "en") {
+    override val versionId = 3
     override val useNewChapterEndpoint = true
 
     override fun popularMangaFromElement(element: Element): SManga {

--- a/src/en/zinchanmangacom/build.gradle
+++ b/src/en/zinchanmangacom/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ZinChanMangaCom'
     themePkg = 'madara'
     baseUrl = 'https://zinchanmanga.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/en/zinchanmangacom/build.gradle
+++ b/src/en/zinchanmangacom/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'ZinChanManga.com'
     extClass = '.ZinChanMangaCom'
     themePkg = 'madara'
-    baseUrl = 'https://zinchanmanga.com'
+    baseUrl = 'https://zinchangmanga.com'
     overrideVersionCode = 2
     isNsfw = true
 }

--- a/src/en/zinchanmangacom/src/eu/kanade/tachiyomi/extension/en/zinchanmangacom/ZinChanMangaCom.kt
+++ b/src/en/zinchanmangacom/src/eu/kanade/tachiyomi/extension/en/zinchanmangacom/ZinChanMangaCom.kt
@@ -5,7 +5,7 @@ import eu.kanade.tachiyomi.source.model.SManga
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 
-class ZinChanMangaCom : Madara("ZinChanManga.com", "https://zinchanmanga.com", "en") {
+class ZinChanMangaCom : Madara("ZinChanManga.com", "https://zinchangmanga.com", "en") {
     override val useNewChapterEndpoint = true
 
     override fun popularMangaFromElement(element: Element): SManga {


### PR DESCRIPTION
closes #7847
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
