### PR TITLE
FMReader: Fallback to absolute date if relative date fails

### DIFF
--- a/lib-multisrc/fmreader/build.gradle.kts
+++ b/lib-multisrc/fmreader/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 9
+baseVersionCode = 10

--- a/lib-multisrc/fmreader/src/eu/kanade/tachiyomi/multisrc/fmreader/FMReader.kt
+++ b/lib-multisrc/fmreader/src/eu/kanade/tachiyomi/multisrc/fmreader/FMReader.kt
@@ -19,6 +19,7 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import org.jsoup.select.Elements
 import java.nio.charset.Charset
+import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
@@ -246,7 +247,13 @@ abstract class FMReader(
                     name = element.attr(chapterNameAttrSelector).substringAfter("$mangaTitle ")
                 }
             }
-            date_upload = element.select(chapterTimeSelector).let { if (it.hasText()) parseRelativeDate(it.text()) else 0 }
+            date_upload = element.select(chapterTimeSelector).let { dateElement ->
+                if (dateElement.hasText()) {
+                    parseRelativeDate(dateElement.text()).takeIf { it != 0L } ?: parseAbsoluteDate(dateElement.text())
+                } else {
+                    0
+                }
+            }
         }
     }
 
@@ -257,55 +264,63 @@ abstract class FMReader(
     open val dateWordIndex = 1
 
     open fun parseRelativeDate(date: String): Long {
-        val value = date.split(' ')[dateValueIndex].toInt()
-        val dateWord = date.split(' ')[dateWordIndex].let {
-            if (it.contains("(")) {
-                it.substringBefore("(")
-            } else {
-                it.substringBefore("s")
+        try {
+            val value = date.split(' ')[dateValueIndex].toInt()
+            val dateWord = date.split(' ')[dateWordIndex].let {
+                if (it.contains("(")) {
+                    it.substringBefore("(")
+                } else {
+                    it.substringBefore("s")
+                }
             }
-        }
 
-        // languages: en, vi, es, tr
-        return when (dateWord) {
-            "min", "minute", "phút", "minuto", "dakika" -> Calendar.getInstance().apply {
-                add(Calendar.MINUTE, -value)
-                set(Calendar.SECOND, 0)
-                set(Calendar.MILLISECOND, 0)
-            }.timeInMillis
-            "hour", "giờ", "hora", "saat" -> Calendar.getInstance().apply {
-                add(Calendar.HOUR_OF_DAY, -value)
-                set(Calendar.SECOND, 0)
-                set(Calendar.MILLISECOND, 0)
-            }.timeInMillis
-            "day", "ngày", "día", "gün" -> Calendar.getInstance().apply {
-                add(Calendar.DATE, -value)
-                set(Calendar.SECOND, 0)
-                set(Calendar.MILLISECOND, 0)
-            }.timeInMillis
-            "week", "tuần", "semana", "hafta" -> Calendar.getInstance().apply {
-                add(Calendar.DATE, -value * 7)
-                set(Calendar.SECOND, 0)
-                set(Calendar.MILLISECOND, 0)
-            }.timeInMillis
-            "month", "tháng", "mes", "ay" -> Calendar.getInstance().apply {
-                add(Calendar.MONTH, -value)
-                set(Calendar.SECOND, 0)
-                set(Calendar.MILLISECOND, 0)
-            }.timeInMillis
-            "year", "năm", "año", "yıl" -> Calendar.getInstance().apply {
-                add(Calendar.YEAR, -value)
-                set(Calendar.SECOND, 0)
-                set(Calendar.MILLISECOND, 0)
-            }.timeInMillis
-            else -> {
-                return 0
+            // languages: en, vi, es, tr
+            return when (dateWord) {
+                "min", "minute", "phút", "minuto", "dakika" -> Calendar.getInstance().apply {
+                    add(Calendar.MINUTE, -value)
+                    set(Calendar.SECOND, 0)
+                    set(Calendar.MILLISECOND, 0)
+                }.timeInMillis
+                "hour", "giờ", "hora", "saat" -> Calendar.getInstance().apply {
+                    add(Calendar.HOUR_OF_DAY, -value)
+                    set(Calendar.SECOND, 0)
+                    set(Calendar.MILLISECOND, 0)
+                }.timeInMillis
+                "day", "ngày", "día", "gün" -> Calendar.getInstance().apply {
+                    add(Calendar.DATE, -value)
+                    set(Calendar.SECOND, 0)
+                    set(Calendar.MILLISECOND, 0)
+                }.timeInMillis
+                "week", "tuần", "semana", "hafta" -> Calendar.getInstance().apply {
+                    add(Calendar.DATE, -value * 7)
+                    set(Calendar.SECOND, 0)
+                    set(Calendar.MILLISECOND, 0)
+                }.timeInMillis
+                "month", "tháng", "mes", "ay" -> Calendar.getInstance().apply {
+                    add(Calendar.MONTH, -value)
+                    set(Calendar.SECOND, 0)
+                    set(Calendar.MILLISECOND, 0)
+                }.timeInMillis
+                "year", "năm", "año", "yıl" -> Calendar.getInstance().apply {
+                    add(Calendar.YEAR, -value)
+                    set(Calendar.SECOND, 0)
+                    set(Calendar.MILLISECOND, 0)
+                }.timeInMillis
+                else -> {
+                    return 0L
+                }
             }
+        } catch (_: Exception) {
+            return 0L
         }
     }
+
     open fun parseAbsoluteDate(dateStr: String): Long {
-        return runCatching { dateFormat.parse(dateStr)?.time }
-            .getOrNull() ?: 0L
+        return try {
+            dateFormat.parse(dateStr)?.time ?: 0L
+        } catch (_: ParseException) {
+            0L
+        }
     }
 
     open val pageListImageSelector = "img.chapter-img"

--- a/lib-multisrc/fmreader/src/eu/kanade/tachiyomi/multisrc/fmreader/FMReader.kt
+++ b/lib-multisrc/fmreader/src/eu/kanade/tachiyomi/multisrc/fmreader/FMReader.kt
@@ -251,7 +251,7 @@ abstract class FMReader(
                 if (dateElement.hasText()) {
                     parseRelativeDate(dateElement.text()).takeIf { it != 0L } ?: parseAbsoluteDate(dateElement.text())
                 } else {
-                    0
+                    0L
                 }
             }
         }

--- a/src/en/holymanga/src/eu/kanade/tachiyomi/extension/en/holymanga/HolyManga.kt
+++ b/src/en/holymanga/src/eu/kanade/tachiyomi/extension/en/holymanga/HolyManga.kt
@@ -1,8 +1,6 @@
 package eu.kanade.tachiyomi.extension.en.holymanga
 
 import eu.kanade.tachiyomi.multisrc.fmreader.FMReader
-import eu.kanade.tachiyomi.source.model.SChapter
-import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -15,10 +13,4 @@ class HolyManga : FMReader(
     override val versionId = 2
 
     override val chapterUrlSelector = ""
-
-    override fun chapterFromElement(element: Element, mangaTitle: String): SChapter {
-        return super.chapterFromElement(element, mangaTitle).apply {
-            date_upload = element.select(chapterTimeSelector).text().let { parseAbsoluteDate(it) }
-        }
-    }
 }


### PR DESCRIPTION
Related to #7861

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
