### PR TITLE
VlogTruyen, LXHentai bump version

### DIFF
--- a/src/vi/lxhentai/build.gradle
+++ b/src/vi/lxhentai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'LXManga'
     extClass = '.LxHentai'
-    extVersionCode = 16
+    extVersionCode = 17
     isNsfw = true
 }
 

--- a/src/vi/vlogtruyen/build.gradle
+++ b/src/vi/vlogtruyen/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'VlogTruyen'
     extClass = '.VlogTruyen'
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = true
 }
 


### PR DESCRIPTION
Checklist:
I forgot bump version for VlogTruyen :< #7972
Commit #7970 also forgot to bump version for LXHentai
- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
