### PR TITLE
MangaBuff: Fix

### DIFF
--- a/src/ru/mangabuff/build.gradle
+++ b/src/ru/mangabuff/build.gradle
@@ -1,8 +1,8 @@
 ext {
     extName = 'MangaBuff'
     extClass = '.MangaBuff'
-    extVersionCode = 1
-    isNsfw = false
+    extVersionCode = 2
+    isNsfw = true
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/MangaBuff.kt
+++ b/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/MangaBuff.kt
@@ -10,6 +10,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
+import eu.kanade.tachiyomi.util.asJsoup
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
@@ -23,6 +24,7 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import rx.Observable
 import uy.kohesive.injekt.injectLazy
+import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -46,6 +48,8 @@ class MangaBuff : ParsedHttpSource() {
 
         if (request.method == "POST" && request.header("X-CSRF-TOKEN") == null) {
             val newRequest = request.newBuilder()
+                .addHeader("X-Requested-With", "XMLHttpRequest")
+
             val token = getToken()
             val response = chain.proceed(
                 newRequest
@@ -53,7 +57,7 @@ class MangaBuff : ParsedHttpSource() {
                     .build(),
             )
 
-            if (response.code == 419) {
+            if (!response.isSuccessful && response.code == 419) {
                 response.close()
                 storedToken = null // reset the token
                 val newToken = getToken()
@@ -67,24 +71,25 @@ class MangaBuff : ParsedHttpSource() {
             return response
         }
 
-        val response = chain.proceed(request)
-
-        if (response.header("Content-Type")?.contains("text/html") != true) {
-            return response
-        }
-
-        storedToken = Jsoup.parse(response.peekBody(Long.MAX_VALUE).string())
-            .selectFirst("head meta[name*=csrf-token]")
-            ?.attr("content")
-
-        return response
+        return chain.proceed(request)
     }
 
     private fun getToken(): String {
         if (storedToken.isNullOrEmpty()) {
             val request = GET(baseUrl, headers)
-            client.newCall(request).execute().close() // updates token in interceptor
+            val response = client.newCall(request).execute()
+
+            val document = response.asJsoup()
+            val token = document.select("head meta[name*=csrf-token]")
+                .attr("content")
+
+            if (token.isEmpty()) {
+                throw IOException("Unable to find CSRF token")
+            }
+
+            storedToken = token
         }
+
         return storedToken!!
     }
 


### PR DESCRIPTION
Closes #7818 

Fix NullPointerException, specific to TachiJ2K app (using Akuma extension code) and update NSFW flag.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
