### PR TITLE
Taiyo: Fix token

### DIFF
--- a/src/pt/taiyo/build.gradle
+++ b/src/pt/taiyo/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Taiyō'
     extClass = '.Taiyo'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = true
 }
 

--- a/src/pt/taiyo/src/eu/kanade/tachiyomi/extension/pt/taiyo/Taiyo.kt
+++ b/src/pt/taiyo/src/eu/kanade/tachiyomi/extension/pt/taiyo/Taiyo.kt
@@ -317,7 +317,7 @@ class Taiyo : ParsedHttpSource() {
         val script = getScriptContainingToken(scripts)
             ?: throw Exception("Não foi possivel localizar o token")
 
-        return TOKEN_REGEX.find(script)?.groups?.get(1)?.value
+        return TOKEN_REGEX.find(script)?.groups?.get(2)?.value
             ?: throw Exception("Não foi possivel extrair o token")
     }
 


### PR DESCRIPTION
Closes #8125

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
