### PR TITLE
Doujin.io: only use images as pages

### DIFF
--- a/src/en/doujinio/build.gradle
+++ b/src/en/doujinio/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Doujin.io - J18'
     extClass = '.Doujinio'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/en/doujinio/src/eu/kanade/tachiyomi/extension/en/doujinio/DoujinioDto.kt
+++ b/src/en/doujinio/src/eu/kanade/tachiyomi/extension/en/doujinio/DoujinioDto.kt
@@ -60,7 +60,10 @@ class Chapter(
 class ChapterMetadata(val identifier: String)
 
 @Serializable
-class ChapterPage(val href: String)
+class ChapterPage(
+    val href: String,
+    val type: String,
+)
 
 @Serializable
 class ChapterManifest(
@@ -68,13 +71,17 @@ class ChapterManifest(
     @SerialName("readingOrder")
     private val pages: List<ChapterPage>,
 ) {
-    fun toPageList() = pages.mapIndexed { i, page ->
-        Page(
-            index = i,
-            url = metadata.identifier,
-            imageUrl = page.href,
-        )
-    }
+    fun toPageList() =
+        pages
+            .filter { page ->
+                page.type.startsWith("image")
+            }.mapIndexed { i, page ->
+                Page(
+                    index = i,
+                    url = metadata.identifier,
+                    imageUrl = page.href,
+                )
+            }
 }
 
 @Serializable


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
