### PR TITLE
Remove remaining usage of `network.client`

### DIFF
--- a/lib-multisrc/comicgamma/build.gradle.kts
+++ b/lib-multisrc/comicgamma/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 8
+baseVersionCode = 9
 
 dependencies {
     api(project(":lib:speedbinb"))

--- a/lib-multisrc/comicgamma/src/eu/kanade/tachiyomi/multisrc/comicgamma/ComicGamma.kt
+++ b/lib-multisrc/comicgamma/src/eu/kanade/tachiyomi/multisrc/comicgamma/ComicGamma.kt
@@ -28,7 +28,7 @@ open class ComicGamma(
 
     private val json = Injekt.get<Json>()
 
-    override val client = network.client.newBuilder()
+    override val client = network.cloudflareClient.newBuilder()
         .addInterceptor(SpeedBinbInterceptor(json))
         .build()
 

--- a/lib-multisrc/fansubscat/build.gradle.kts
+++ b/lib-multisrc/fansubscat/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 5
+baseVersionCode = 6

--- a/lib-multisrc/fansubscat/src/eu/kanade/tachiyomi/multisrc/fansubscat/FansubsCat.kt
+++ b/lib-multisrc/fansubscat/src/eu/kanade/tachiyomi/multisrc/fansubscat/FansubsCat.kt
@@ -39,7 +39,7 @@ abstract class FansubsCat(
     override fun headersBuilder(): Headers.Builder = Headers.Builder()
         .add("User-Agent", "Tachiyomi/${AppInfo.getVersionName()}")
 
-    override val client: OkHttpClient = network.client
+    override val client: OkHttpClient = network.cloudflareClient
 
     private val json: Json by injectLazy()
 

--- a/lib-multisrc/kemono/build.gradle.kts
+++ b/lib-multisrc/kemono/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 19
+baseVersionCode = 20

--- a/lib-multisrc/kemono/src/eu/kanade/tachiyomi/multisrc/kemono/Kemono.kt
+++ b/lib-multisrc/kemono/src/eu/kanade/tachiyomi/multisrc/kemono/Kemono.kt
@@ -32,7 +32,7 @@ open class Kemono(
 ) : HttpSource(), ConfigurableSource {
     override val supportsLatest = true
 
-    override val client = network.client.newBuilder().rateLimit(1).build()
+    override val client = network.cloudflareClient.newBuilder().rateLimit(1).build()
 
     override fun headersBuilder() = super.headersBuilder()
         .add("Referer", "$baseUrl/")

--- a/lib-multisrc/mangaesp/build.gradle.kts
+++ b/lib-multisrc/mangaesp/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 3
+baseVersionCode = 4
 
 dependencies {
   api(project(":lib:i18n"))

--- a/lib-multisrc/mangaesp/src/eu/kanade/tachiyomi/multisrc/mangaesp/MangaEsp.kt
+++ b/lib-multisrc/mangaesp/src/eu/kanade/tachiyomi/multisrc/mangaesp/MangaEsp.kt
@@ -48,7 +48,7 @@ abstract class MangaEsp(
 
     protected open val useApiSearch = false
 
-    override val client: OkHttpClient = network.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .rateLimitHost(baseUrl.toHttpUrl(), 2)
         .build()
 

--- a/lib-multisrc/mccms/build.gradle.kts
+++ b/lib-multisrc/mccms/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 6
+baseVersionCode = 7

--- a/lib-multisrc/mccms/src/eu/kanade/tachiyomi/multisrc/mccms/MCCMS.kt
+++ b/lib-multisrc/mccms/src/eu/kanade/tachiyomi/multisrc/mccms/MCCMS.kt
@@ -33,7 +33,7 @@ open class MCCMS(
     private val json: Json by injectLazy()
 
     override val client by lazy {
-        network.client.newBuilder()
+        network.cloudflareClient.newBuilder()
             .rateLimitHost(baseUrl.toHttpUrl(), 2)
             .build()
     }

--- a/lib-multisrc/mccms/src/eu/kanade/tachiyomi/multisrc/mccms/MCCMSWeb.kt
+++ b/lib-multisrc/mccms/src/eu/kanade/tachiyomi/multisrc/mccms/MCCMSWeb.kt
@@ -26,7 +26,7 @@ open class MCCMSWeb(
     override val supportsLatest get() = true
 
     override val client by lazy {
-        network.client.newBuilder()
+        network.cloudflareClient.newBuilder()
             .rateLimitHost(baseUrl.toHttpUrl(), 2)
             .build()
     }

--- a/lib-multisrc/multichan/build.gradle.kts
+++ b/lib-multisrc/multichan/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 3
+baseVersionCode = 4

--- a/lib-multisrc/multichan/src/eu/kanade/tachiyomi/multisrc/multichan/MultiChan.kt
+++ b/lib-multisrc/multichan/src/eu/kanade/tachiyomi/multisrc/multichan/MultiChan.kt
@@ -26,7 +26,7 @@ abstract class MultiChan(
 
     override val supportsLatest = true
 
-    override val client: OkHttpClient = network.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .connectTimeout(30, TimeUnit.SECONDS)
         .readTimeout(30, TimeUnit.SECONDS)
         .rateLimit(2)

--- a/lib-multisrc/senkuro/build.gradle.kts
+++ b/lib-multisrc/senkuro/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 3
+baseVersionCode = 4

--- a/lib-multisrc/senkuro/src/eu/kanade/tachiyomi/multisrc/senkuro/Senkuro.kt
+++ b/lib-multisrc/senkuro/src/eu/kanade/tachiyomi/multisrc/senkuro/Senkuro.kt
@@ -40,7 +40,7 @@ abstract class Senkuro(
         .add("Content-Type", "application/json")
 
     override val client: OkHttpClient =
-        network.client.newBuilder()
+        network.cloudflareClient.newBuilder()
             .rateLimit(3)
             .build()
 

--- a/lib-multisrc/sinmh/build.gradle.kts
+++ b/lib-multisrc/sinmh/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 11
+baseVersionCode = 12

--- a/lib-multisrc/sinmh/src/eu/kanade/tachiyomi/multisrc/sinmh/SinMH.kt
+++ b/lib-multisrc/sinmh/src/eu/kanade/tachiyomi/multisrc/sinmh/SinMH.kt
@@ -34,7 +34,7 @@ abstract class SinMH(
     protected open val mobileUrl = _baseUrl.replaceFirst("www.", "m.")
     override val supportsLatest = true
 
-    override val client = network.client.newBuilder().rateLimit(2).build()
+    override val client = network.cloudflareClient.newBuilder().rateLimit(2).build()
 
     override fun headersBuilder(): Headers.Builder = Headers.Builder()
         .add("User-Agent", System.getProperty("http.agent")!!)

--- a/lib-multisrc/webtoons/build.gradle.kts
+++ b/lib-multisrc/webtoons/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 3
+baseVersionCode = 4

--- a/lib-multisrc/webtoons/src/eu/kanade/tachiyomi/multisrc/webtoons/Webtoons.kt
+++ b/lib-multisrc/webtoons/src/eu/kanade/tachiyomi/multisrc/webtoons/Webtoons.kt
@@ -45,7 +45,7 @@ open class Webtoons(
 
     override val supportsLatest = true
 
-    override val client: OkHttpClient = super.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .cookieJar(
             object : CookieJar {
                 override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {}

--- a/src/all/akuma/build.gradle
+++ b/src/all/akuma/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Akuma'
     extClass = '.AkumaFactory'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = true
 }
 

--- a/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
+++ b/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
@@ -46,12 +46,12 @@ class Akuma(
 
     private var storedToken: String? = null
 
-    private val ddosGuardIntercept = DDosGuardInterceptor(network.client)
+    private val ddosGuardIntercept = DDosGuardInterceptor(network.cloudflareClient)
 
     private val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.ENGLISH).apply {
         timeZone = TimeZone.getTimeZone("UTC")
     }
-    override val client: OkHttpClient = network.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .addInterceptor(ddosGuardIntercept)
         .addInterceptor(::tokenInterceptor)
         .rateLimit(2)

--- a/src/all/comicfury/build.gradle
+++ b/src/all/comicfury/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comic Fury'
     extClass = '.ComicFuryFactory'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/all/comicfury/src/eu/kanade/tachiyomi/extension/all/comicfury/ComicFury.kt
+++ b/src/all/comicfury/src/eu/kanade/tachiyomi/extension/all/comicfury/ComicFury.kt
@@ -33,7 +33,7 @@ class ComicFury(
     override val name: String = "Comic Fury$extraName" // Used for No Text
     override val supportsLatest: Boolean = true
 
-    override val client = super.client.newBuilder().addInterceptor(TextInterceptor()).build()
+    override val client = network.cloudflareClient.newBuilder().addInterceptor(TextInterceptor()).build()
 
     /**
      * Archive is on a separate page from manga info

--- a/src/all/comico/build.gradle
+++ b/src/all/comico/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comico'
     extClass = '.ComicoFactory'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = true
 }
 

--- a/src/all/comico/src/eu/kanade/tachiyomi/extension/all/comico/Comico.kt
+++ b/src/all/comico/src/eu/kanade/tachiyomi/extension/all/comico/Comico.kt
@@ -62,7 +62,7 @@ open class Comico(
             this["Origin"] = baseUrl
         }.build()
 
-    override val client = network.client.newBuilder()
+    override val client = network.cloudflareClient.newBuilder()
         .cookieJar(
             object : CookieJar {
                 override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) =

--- a/src/all/holonometria/build.gradle
+++ b/src/all/holonometria/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'HOLONOMETRIA'
     extClass = '.HolonometriaFactory'
-    extVersionCode = 1
+    extVersionCode = 2
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/holonometria/src/eu/kanade/tachiyomi/extension/all/holonometria/Holonometria.kt
+++ b/src/all/holonometria/src/eu/kanade/tachiyomi/extension/all/holonometria/Holonometria.kt
@@ -26,7 +26,7 @@ class Holonometria(
 
     override val supportsLatest = false
 
-    override val client = network.client.newBuilder()
+    override val client = network.cloudflareClient.newBuilder()
         .readTimeout(60, TimeUnit.SECONDS)
         .build()
 

--- a/src/all/izneo/build.gradle
+++ b/src/all/izneo/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'izneo (webtoons)'
     extClass = '.IzneoFactory'
-    extVersionCode = 6
+    extVersionCode = 7
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/izneo/src/eu/kanade/tachiyomi/extension/all/izneo/Izneo.kt
+++ b/src/all/izneo/src/eu/kanade/tachiyomi/extension/all/izneo/Izneo.kt
@@ -36,7 +36,7 @@ class Izneo(override val lang: String) : ConfigurableSource, HttpSource() {
 
     override val versionId = 2
 
-    override val client = network.client.newBuilder()
+    override val client = network.cloudflareClient.newBuilder()
         .addInterceptor(ImageInterceptor).build()
 
     private val apiUrl = "$ORIGIN/$lang/api/catalog/detail/webtoon"

--- a/src/all/kiutaku/build.gradle
+++ b/src/all/kiutaku/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Kiutaku'
     extClass = '.Kiutaku'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/all/kiutaku/src/eu/kanade/tachiyomi/extension/all/kiutaku/Kiutaku.kt
+++ b/src/all/kiutaku/src/eu/kanade/tachiyomi/extension/all/kiutaku/Kiutaku.kt
@@ -31,7 +31,7 @@ class Kiutaku : ParsedHttpSource() {
     override val supportsLatest = true
 
     override val client by lazy {
-        network.client.newBuilder()
+        network.cloudflareClient.newBuilder()
             .rateLimitHost(baseUrl.toHttpUrl(), 2)
             .build()
     }

--- a/src/all/komga/build.gradle
+++ b/src/all/komga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Komga'
     extClass = '.KomgaFactory'
-    extVersionCode = 60
+    extVersionCode = 61
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/Komga.kt
+++ b/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/Komga.kt
@@ -85,7 +85,7 @@ open class Komga(private val suffix: String = "") : ConfigurableSource, Unmetere
         .set("User-Agent", "TachiyomiKomga/${AppInfo.getVersionName()}")
 
     override val client: OkHttpClient =
-        network.client.newBuilder()
+        network.cloudflareClient.newBuilder()
             .authenticator { _, response ->
                 if (response.request.header("Authorization") != null) {
                     null // Give up, we've already failed to authenticate.

--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaDex'
     extClass = '.MangaDexFactory'
-    extVersionCode = 200
+    extVersionCode = 201
     isNsfw = true
 }
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDex.kt
@@ -71,9 +71,9 @@ abstract class MangaDex(final override val lang: String, private val dexLang: St
         return builder
     }
 
-    override val client = network.client.newBuilder()
+    override val client = network.cloudflareClient.newBuilder()
         .rateLimit(3)
-        .addInterceptor(MdAtHomeReportInterceptor(network.client, headers))
+        .addInterceptor(MdAtHomeReportInterceptor(network.cloudflareClient, headers))
         .build()
 
     // Popular manga section

--- a/src/all/mangahosted/build.gradle
+++ b/src/all/mangahosted/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Manga Hosted'
     extClass = '.MangaHostedFactory'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/all/mangahosted/src/eu/kanade/tachiyomi/extension/all/mangahosted/MangaHosted.kt
+++ b/src/all/mangahosted/src/eu/kanade/tachiyomi/extension/all/mangahosted/MangaHosted.kt
@@ -32,7 +32,7 @@ class MangaHosted(private val langOption: LanguageOption) : HttpSource() {
 
     private val json: Json by injectLazy()
 
-    override val client = network.client.newBuilder()
+    override val client = network.cloudflareClient.newBuilder()
         .rateLimit(2)
         .build()
 

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlus.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlus.kt
@@ -48,7 +48,7 @@ class MangaPlus(
         .add("User-Agent", USER_AGENT)
         .add("SESSION-TOKEN", UUID.randomUUID().toString())
 
-    override val client: OkHttpClient = network.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .addInterceptor(::imageIntercept)
         .addInterceptor(::thumbnailIntercept)
         .rateLimitHost(API_URL.toHttpUrl(), 1)

--- a/src/all/mangatoon/build.gradle
+++ b/src/all/mangatoon/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'MangaToon (Limited)'
     extClass = '.MangaToonFactory'
-    extVersionCode = 5
+    extVersionCode = 6
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/mangatoon/src/eu/kanade/tachiyomi/extension/all/mangatoon/MangaToon.kt
+++ b/src/all/mangatoon/src/eu/kanade/tachiyomi/extension/all/mangatoon/MangaToon.kt
@@ -34,7 +34,7 @@ open class MangaToon(
 
     override val supportsLatest = true
 
-    override val client: OkHttpClient = network.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .rateLimit(1, 1, TimeUnit.SECONDS)
         .build()
 

--- a/src/all/mangaup/build.gradle
+++ b/src/all/mangaup/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'Manga UP!'
     extClass = '.MangaUpFactory'
-    extVersionCode = 3
+    extVersionCode = 4
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/mangaup/src/eu/kanade/tachiyomi/extension/all/mangaup/MangaUp.kt
+++ b/src/all/mangaup/src/eu/kanade/tachiyomi/extension/all/mangaup/MangaUp.kt
@@ -32,7 +32,7 @@ class MangaUp(override val lang: String) : HttpSource() {
         .add("Referer", baseUrl)
         .add("User-Agent", USER_AGENT)
 
-    override val client: OkHttpClient = network.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .addInterceptor(::thumbnailIntercept)
         .rateLimitHost(API_URL.toHttpUrl(), 1)
         .rateLimitHost(baseUrl.toHttpUrl(), 2)

--- a/src/all/mango/build.gradle
+++ b/src/all/mango/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Mango'
     extClass = '.Mango'
-    extVersionCode = 10
+    extVersionCode = 11
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/mango/src/eu/kanade/tachiyomi/extension/all/mango/Mango.kt
+++ b/src/all/mango/src/eu/kanade/tachiyomi/extension/all/mango/Mango.kt
@@ -215,7 +215,7 @@ class Mango : ConfigurableSource, UnmeteredSource, HttpSource() {
     private val preferences: SharedPreferences by getPreferencesLazy()
 
     override val client: OkHttpClient =
-        network.client.newBuilder()
+        network.cloudflareClient.newBuilder()
             .dns(Dns.SYSTEM)
             .addInterceptor { authIntercept(it) }
             .build()

--- a/src/all/namicomi/build.gradle
+++ b/src/all/namicomi/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'NamiComi'
     extClass = '.NamiComiFactory'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = false
 }
 

--- a/src/all/namicomi/src/eu/kanade/tachiyomi/extension/all/namicomi/NamiComi.kt
+++ b/src/all/namicomi/src/eu/kanade/tachiyomi/extension/all/namicomi/NamiComi.kt
@@ -48,7 +48,7 @@ abstract class NamiComi(final override val lang: String, private val extLang: St
         set("Origin", baseUrl)
     }
 
-    override val client = network.client.newBuilder()
+    override val client = network.cloudflareClient.newBuilder()
         .rateLimit(3)
         .addNetworkInterceptor { chain ->
             val response = chain.proceed(chain.request())

--- a/src/all/tappytoon/build.gradle
+++ b/src/all/tappytoon/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Tappytoon'
     extClass = '.TappytoonFactory'
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = true
 }
 

--- a/src/all/tappytoon/src/eu/kanade/tachiyomi/extension/all/tappytoon/Tappytoon.kt
+++ b/src/all/tappytoon/src/eu/kanade/tachiyomi/extension/all/tappytoon/Tappytoon.kt
@@ -31,7 +31,7 @@ class Tappytoon(override val lang: String) : HttpSource() {
 
     override val supportsLatest = true
 
-    override val client = network.client.newBuilder().addInterceptor { chain ->
+    override val client = network.cloudflareClient.newBuilder().addInterceptor { chain ->
         val res = chain.proceed(chain.request())
         val mime = res.headers["Content-Type"]
         if (res.isSuccessful) {

--- a/src/all/toomics/build.gradle
+++ b/src/all/toomics/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Toomics'
     extClass = '.ToomicsFactory'
-    extVersionCode = 8
+    extVersionCode = 9
     isNsfw = true
 }
 

--- a/src/all/toomics/src/eu/kanade/tachiyomi/extension/all/toomics/ToomicsGlobal.kt
+++ b/src/all/toomics/src/eu/kanade/tachiyomi/extension/all/toomics/ToomicsGlobal.kt
@@ -43,7 +43,7 @@ abstract class ToomicsGlobal(
 
     private val json: Json by injectLazy()
 
-    override val client: OkHttpClient = super.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .connectTimeout(1, TimeUnit.MINUTES)
         .readTimeout(1, TimeUnit.MINUTES)
         .writeTimeout(1, TimeUnit.MINUTES)

--- a/src/en/clowncorps/build.gradle
+++ b/src/en/clowncorps/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'Clown Corps'
     extClass = '.ClownCorps'
-    extVersionCode = 2
+    extVersionCode = 3
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/clowncorps/src/eu/kanade/tachiyomi/extension/en/clowncorps/ClownCorps.kt
+++ b/src/en/clowncorps/src/eu/kanade/tachiyomi/extension/en/clowncorps/ClownCorps.kt
@@ -34,7 +34,7 @@ class ClownCorps : ConfigurableSource, HttpSource() {
     override val name = "Clown Corps"
     override val supportsLatest = false
 
-    override val client = network.client.newBuilder()
+    override val client = network.cloudflareClient.newBuilder()
         .addInterceptor(TextInterceptor())
         .build()
 

--- a/src/en/digitalcomicmuseum/build.gradle
+++ b/src/en/digitalcomicmuseum/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'Digital Comic Museum'
     extClass = '.DigitalComicMuseum'
-    extVersionCode = 2
+    extVersionCode = 3
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/digitalcomicmuseum/src/eu/kanade/tachiyomi/extension/en/digitalcomicmuseum/DigitalComicMuseum.kt
+++ b/src/en/digitalcomicmuseum/src/eu/kanade/tachiyomi/extension/en/digitalcomicmuseum/DigitalComicMuseum.kt
@@ -24,7 +24,7 @@ class DigitalComicMuseum() : ParsedHttpSource() {
     override val name = "Digital Comic Museum"
     override val supportsLatest = true
 
-    override val client: OkHttpClient = super.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .addInterceptor(::errorIntercept)
         .build()
 

--- a/src/en/grrlpower/build.gradle
+++ b/src/en/grrlpower/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'Grrl Power Comic'
     extClass = '.GrrlPower'
-    extVersionCode = 3
+    extVersionCode = 4
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/grrlpower/src/eu/kanade/tachiyomi/extension/en/grrlpower/GrrlPower.kt
+++ b/src/en/grrlpower/src/eu/kanade/tachiyomi/extension/en/grrlpower/GrrlPower.kt
@@ -36,7 +36,7 @@ class GrrlPower(
     private val currentYear = Calendar.getInstance().get(Calendar.YEAR)
     private val dateFormat = SimpleDateFormat("MMM dd yyyy", Locale.US)
 
-    override val client = super.client.newBuilder().addInterceptor(TextInterceptor()).build()
+    override val client = network.cloudflareClient.newBuilder().addInterceptor(TextInterceptor()).build()
 
     override fun fetchPopularManga(page: Int): Observable<MangasPage> = Observable.just(
         MangasPage(

--- a/src/en/hentaidexy/build.gradle
+++ b/src/en/hentaidexy/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hentaidexy'
     extClass = '.Hentaidexy'
-    extVersionCode = 33
+    extVersionCode = 34
     isNsfw = true
 }
 

--- a/src/en/hentaidexy/src/eu/kanade/tachiyomi/extension/en/hentaidexy/Hentaidexy.kt
+++ b/src/en/hentaidexy/src/eu/kanade/tachiyomi/extension/en/hentaidexy/Hentaidexy.kt
@@ -34,7 +34,7 @@ class Hentaidexy : HttpSource() {
 
     private val json: Json by injectLazy()
 
-    override val client: OkHttpClient = super.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .rateLimitHost(baseUrl.toHttpUrl(), 1)
         .build()
 

--- a/src/en/madokami/build.gradle
+++ b/src/en/madokami/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Madokami'
     extClass = '.Madokami'
-    extVersionCode = 10
+    extVersionCode = 11
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
+++ b/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
@@ -47,7 +47,7 @@ class Madokami : ConfigurableSource, ParsedHttpSource() {
         return request.newBuilder().header("Authorization", credential).build()
     }
 
-    override val client: OkHttpClient = super.client.newBuilder().addInterceptor { chain ->
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder().addInterceptor { chain ->
         val response = chain.proceed(chain.request())
         if (response.code == 401) throw IOException("You are currently logged out.\nGo to Extensions > Details to input your credentials.")
         response

--- a/src/en/mangamo/build.gradle
+++ b/src/en/mangamo/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Mangamo'
     extClass = '.Mangamo'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = false
 }
 

--- a/src/en/mangamo/src/eu/kanade/tachiyomi/extension/en/mangamo/Mangamo.kt
+++ b/src/en/mangamo/src/eu/kanade/tachiyomi/extension/en/mangamo/Mangamo.kt
@@ -82,7 +82,7 @@ class Mangamo : ConfigurableSource, HttpSource() {
     private val exclusivesOnlyPref
         get() = preferences.getStringSet(MangamoConstants.EXCLUSIVES_ONLY_PREF, setOf())!!
 
-    override val client: OkHttpClient = super.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .addNetworkInterceptor {
             val request = it.request()
             val response = it.proceed(request)

--- a/src/en/mangaplanet/build.gradle
+++ b/src/en/mangaplanet/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = "Manga Planet"
     extClass = ".MangaPlanet"
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/en/mangaplanet/src/eu/kanade/tachiyomi/extension/en/mangaplanet/MangaPlanet.kt
+++ b/src/en/mangaplanet/src/eu/kanade/tachiyomi/extension/en/mangaplanet/MangaPlanet.kt
@@ -34,7 +34,7 @@ class MangaPlanet : ParsedHttpSource() {
     // No need to be lazy if you're going to use it immediately below.
     private val json = Injekt.get<Json>()
 
-    override val client = network.client.newBuilder()
+    override val client = network.cloudflareClient.newBuilder()
         .addInterceptor(SpeedBinbInterceptor(json))
         .addNetworkInterceptor(CookieInterceptor(baseUrl.toHttpUrl().host, "mpaconf" to "18"))
         .build()

--- a/src/en/manta/build.gradle
+++ b/src/en/manta/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Manta Comics'
     extClass = '.MantaComics'
-    extVersionCode = 4
+    extVersionCode = 5
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/manta/src/eu/kanade/tachiyomi/extension/en/manta/MantaComics.kt
+++ b/src/en/manta/src/eu/kanade/tachiyomi/extension/en/manta/MantaComics.kt
@@ -29,7 +29,7 @@ class MantaComics : HttpSource() {
 
     private var token: String? = null
 
-    override val client = network.client.newBuilder()
+    override val client = network.cloudflareClient.newBuilder()
         .cookieJar(
             object : CookieJar {
                 override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {

--- a/src/en/questionablecontent/build.gradle
+++ b/src/en/questionablecontent/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'Questionable Content'
     extClass = '.QuestionableContent'
-    extVersionCode = 8
+    extVersionCode = 9
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/questionablecontent/src/eu/kanade/tachiyomi/extension/en/questionablecontent/QuestionableContent.kt
+++ b/src/en/questionablecontent/src/eu/kanade/tachiyomi/extension/en/questionablecontent/QuestionableContent.kt
@@ -29,7 +29,7 @@ class QuestionableContent : ParsedHttpSource(), ConfigurableSource {
     override val lang = "en"
 
     override val supportsLatest = false
-    override val client: OkHttpClient = super.client.newBuilder().addInterceptor(TextInterceptor()).build()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder().addInterceptor(TextInterceptor()).build()
 
     override fun fetchPopularManga(page: Int): Observable<MangasPage> {
         val manga = SManga.create().apply {

--- a/src/en/tapastic/build.gradle
+++ b/src/en/tapastic/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Tapas'
     extClass = '.Tapastic'
-    extVersionCode = 21
+    extVersionCode = 22
     isNsfw = true
 }
 

--- a/src/en/tapastic/src/eu/kanade/tachiyomi/extension/en/tapastic/Tapastic.kt
+++ b/src/en/tapastic/src/eu/kanade/tachiyomi/extension/en/tapastic/Tapastic.kt
@@ -51,7 +51,7 @@ class Tapastic : ConfigurableSource, ParsedHttpSource() {
 
     private val webViewCookieManager: CookieManager by lazy { CookieManager.getInstance() }
 
-    override val client: OkHttpClient = super.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .cookieJar(
             // Syncs okhttp with webview cookies, allowing logged-in users do logged-in stuff
             object : CookieJar {

--- a/src/en/vizshonenjump/build.gradle
+++ b/src/en/vizshonenjump/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'VIZ'
     extClass = '.VizFactory'
-    extVersionCode = 20
+    extVersionCode = 21
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/vizshonenjump/src/eu/kanade/tachiyomi/extension/en/vizshonenjump/Viz.kt
+++ b/src/en/vizshonenjump/src/eu/kanade/tachiyomi/extension/en/vizshonenjump/Viz.kt
@@ -38,7 +38,7 @@ open class Viz(
 
     override val supportsLatest = true
 
-    override val client: OkHttpClient = network.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .addInterceptor(::headersIntercept)
         .addInterceptor(::authCheckIntercept)
         .addInterceptor(::authChapterCheckIntercept)

--- a/src/es/ravenmanga/build.gradle
+++ b/src/es/ravenmanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'RavenManga'
     extClass = '.RavenManga'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = false
 }
 

--- a/src/es/ravenmanga/src/eu/kanade/tachiyomi/extension/es/ravenmanga/RavenManga.kt
+++ b/src/es/ravenmanga/src/eu/kanade/tachiyomi/extension/es/ravenmanga/RavenManga.kt
@@ -37,7 +37,7 @@ class RavenManga : ParsedHttpSource() {
 
     override val supportsLatest = true
 
-    override val client: OkHttpClient = network.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .rateLimitHost(baseUrl.toHttpUrl(), 2)
         .build()
 

--- a/src/ja/comicmeteor/build.gradle
+++ b/src/ja/comicmeteor/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = "Comic Meteor"
     extClass = ".ComicMeteor"
-    extVersionCode = 1
+    extVersionCode = 2
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ja/comicmeteor/src/eu/kanade/tachiyomi/extension/ja/comicmeteor/ComicMeteor.kt
+++ b/src/ja/comicmeteor/src/eu/kanade/tachiyomi/extension/ja/comicmeteor/ComicMeteor.kt
@@ -33,7 +33,7 @@ class ComicMeteor : ParsedHttpSource() {
 
     private val json = Injekt.get<Json>()
 
-    override val client = network.client.newBuilder()
+    override val client = network.cloudflareClient.newBuilder()
         .addInterceptor(SpeedBinbInterceptor(json))
         .apply {
             val interceptors = interceptors()

--- a/src/ja/gaugaumonsterplus/build.gradle
+++ b/src/ja/gaugaumonsterplus/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = "Gaugau Monster Plus"
     extClass = ".GaugauMonsterPlus"
-    extVersionCode = 1
+    extVersionCode = 2
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ja/gaugaumonsterplus/src/eu/kanade/tachiyomi/extension/ja/gaugaumonsterplus/GaugauMonsterPlus.kt
+++ b/src/ja/gaugaumonsterplus/src/eu/kanade/tachiyomi/extension/ja/gaugaumonsterplus/GaugauMonsterPlus.kt
@@ -28,7 +28,7 @@ class GaugauMonsterPlus : ParsedHttpSource() {
 
     private val json = Injekt.get<Json>()
 
-    override val client = network.client.newBuilder()
+    override val client = network.cloudflareClient.newBuilder()
         .addInterceptor(SpeedBinbInterceptor(json))
         .build()
 

--- a/src/ja/kadocomi/build.gradle
+++ b/src/ja/kadocomi/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = "KadoComi"
     extClass = ".KadoComi"
-    extVersionCode = 1
+    extVersionCode = 2
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ja/kadocomi/src/eu/kanade/tachiyomi/extension/ja/kadocomi/KadoComi.kt
+++ b/src/ja/kadocomi/src/eu/kanade/tachiyomi/extension/ja/kadocomi/KadoComi.kt
@@ -54,7 +54,7 @@ class KadoComi : HttpSource() {
         }
     }
 
-    override val client = network.client.newBuilder()
+    override val client = network.cloudflareClient.newBuilder()
         .addNetworkInterceptor(imageDescrambler)
         .build()
 

--- a/src/ja/nicovideoseiga/build.gradle
+++ b/src/ja/nicovideoseiga/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'Nicovideo Seiga'
     extClass = '.NicovideoSeiga'
-    extVersionCode = 6
+    extVersionCode = 7
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ja/nicovideoseiga/src/eu/kanade/tachiyomi/extension/ja/nicovideoseiga/NicovideoSeiga.kt
+++ b/src/ja/nicovideoseiga/src/eu/kanade/tachiyomi/extension/ja/nicovideoseiga/NicovideoSeiga.kt
@@ -26,7 +26,7 @@ class NicovideoSeiga : HttpSource() {
     override val lang: String = "ja"
     override val name: String = "Nicovideo Seiga"
     override val supportsLatest: Boolean = false
-    override val client: OkHttpClient = network.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .addInterceptor(::imageIntercept)
         .build()
     override val versionId: Int = 2

--- a/src/ja/ohtawebcomic/build.gradle
+++ b/src/ja/ohtawebcomic/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = "Ohta Web Comic"
     extClass = ".OhtaWebComic"
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/ja/ohtawebcomic/src/eu/kanade/tachiyomi/extension/ja/ohtawebcomic/OhtaWebComic.kt
+++ b/src/ja/ohtawebcomic/src/eu/kanade/tachiyomi/extension/ja/ohtawebcomic/OhtaWebComic.kt
@@ -31,7 +31,7 @@ class OhtaWebComic : ParsedHttpSource() {
 
     private val json = Injekt.get<Json>()
 
-    override val client = network.client.newBuilder()
+    override val client = network.cloudflareClient.newBuilder()
         .addInterceptor(SpeedBinbInterceptor(json))
         .build()
 

--- a/src/ja/rawinu/build.gradle
+++ b/src/ja/rawinu/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.RawINU'
     themePkg = 'fmreader'
     baseUrl = 'https://rawinu.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/ja/rawinu/src/eu/kanade/tachiyomi/extension/ja/rawinu/RawINU.kt
+++ b/src/ja/rawinu/src/eu/kanade/tachiyomi/extension/ja/rawinu/RawINU.kt
@@ -20,7 +20,7 @@ class RawINU : FMReader(
     "https://rawinu.com",
     "ja",
 ) {
-    override val client = network.client.newBuilder()
+    override val client = super.client.newBuilder()
         .rateLimitHost(baseUrl.toHttpUrl(), 2)
         .addInterceptor(::ddosChallengeInterceptor)
         .build()

--- a/src/ja/yanmaga/build.gradle
+++ b/src/ja/yanmaga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = "Weekly Young Magazine"
     extClass = ".YanmagaFactory"
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/ja/yanmaga/src/eu/kanade/tachiyomi/extension/ja/yanmaga/Yanmaga.kt
+++ b/src/ja/yanmaga/src/eu/kanade/tachiyomi/extension/ja/yanmaga/Yanmaga.kt
@@ -33,7 +33,7 @@ abstract class Yanmaga(
 
     protected val json = Injekt.get<Json>()
 
-    override val client = network.client.newBuilder()
+    override val client = network.cloudflareClient.newBuilder()
         .addInterceptor(SpeedBinbInterceptor(json))
         .build()
 

--- a/src/ko/navercomic/build.gradle
+++ b/src/ko/navercomic/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'Naver Comic'
     extClass = '.NaverComicFactory'
-    extVersionCode = 5
+    extVersionCode = 6
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ko/navercomic/src/eu/kanade/tachiyomi/extension/ko/navercomic/NaverComicBase.kt
+++ b/src/ko/navercomic/src/eu/kanade/tachiyomi/extension/ko/navercomic/NaverComicBase.kt
@@ -29,7 +29,7 @@ abstract class NaverComicBase(protected val mType: String) : ParsedHttpSource() 
     override val baseUrl: String = "https://comic.naver.com"
     internal val mobileUrl = "https://m.comic.naver.com"
     override val supportsLatest = true
-    override val client: OkHttpClient = network.client
+    override val client: OkHttpClient = network.cloudflareClient
     internal val json: Json by injectLazy()
 
     private val mobileHeaders = super.headersBuilder()

--- a/src/pt/bakai/build.gradle
+++ b/src/pt/bakai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Bakai'
     extClass = '.Bakai'
-    extVersionCode = 9
+    extVersionCode = 10
     isNsfw = true
 }
 

--- a/src/pt/bakai/src/eu/kanade/tachiyomi/extension/pt/bakai/Bakai.kt
+++ b/src/pt/bakai/src/eu/kanade/tachiyomi/extension/pt/bakai/Bakai.kt
@@ -46,7 +46,7 @@ class Bakai : ParsedHttpSource() {
                         it.name.startsWith("ips4_") || it.path == searchPathSegment
                     }
 
-                    private val cookieJar = network.client.cookieJar
+                    private val cookieJar = network.cloudflareClient.cookieJar
 
                     override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) =
                         cookieJar.saveFromResponse(url, cookies.removeLimit())

--- a/src/pt/blackoutcomics/build.gradle
+++ b/src/pt/blackoutcomics/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Blackout Comics'
     extClass = '.BlackoutComics'
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = true
 }
 

--- a/src/pt/blackoutcomics/src/eu/kanade/tachiyomi/extension/pt/blackoutcomics/BlackoutComics.kt
+++ b/src/pt/blackoutcomics/src/eu/kanade/tachiyomi/extension/pt/blackoutcomics/BlackoutComics.kt
@@ -39,7 +39,7 @@ class BlackoutComics : ParsedHttpSource(), ConfigurableSource {
     override val supportsLatest = true
 
     override val client by lazy {
-        network.client.newBuilder()
+        network.cloudflareClient.newBuilder()
             .addInterceptor { chain ->
                 checkingCredentials()
 

--- a/src/pt/bruttal/build.gradle
+++ b/src/pt/bruttal/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'Bruttal'
     extClass = '.Bruttal'
-    extVersionCode = 6
+    extVersionCode = 7
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/bruttal/src/eu/kanade/tachiyomi/extension/pt/bruttal/Bruttal.kt
+++ b/src/pt/bruttal/src/eu/kanade/tachiyomi/extension/pt/bruttal/Bruttal.kt
@@ -30,7 +30,7 @@ class Bruttal : HttpSource() {
 
     override val supportsLatest = false
 
-    override val client: OkHttpClient = network.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .rateLimit(1, 2, TimeUnit.SECONDS)
         .build()
 

--- a/src/pt/maidsecret/build.gradle
+++ b/src/pt/maidsecret/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MaidSecret'
     themePkg = 'madara'
     baseUrl = 'https://maidsecret.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/pt/maidsecret/src/eu/kanade/tachiyomi/extension/pt/maidsecret/MaidSecret.kt
+++ b/src/pt/maidsecret/src/eu/kanade/tachiyomi/extension/pt/maidsecret/MaidSecret.kt
@@ -14,7 +14,7 @@ class MaidSecret : Madara(
 ) {
     override val useNewChapterEndpoint = true
 
-    override val client = network.client.newBuilder()
+    override val client = super.client.newBuilder()
         .rateLimit(1, 2, TimeUnit.SECONDS)
         .build()
 }

--- a/src/ru/acomics/build.gradle
+++ b/src/ru/acomics/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AComics'
     extClass = '.AComics'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = true
 }
 

--- a/src/ru/acomics/src/eu/kanade/tachiyomi/extension/ru/acomics/AComics.kt
+++ b/src/ru/acomics/src/eu/kanade/tachiyomi/extension/ru/acomics/AComics.kt
@@ -22,7 +22,7 @@ class AComics : ParsedHttpSource() {
 
     override val lang = "ru"
 
-    override val client = network.client.newBuilder()
+    override val client = network.cloudflareClient.newBuilder()
         .addNetworkInterceptor { chain ->
             val newReq = chain
                 .request()

--- a/src/ru/unicomics/build.gradle
+++ b/src/ru/unicomics/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'UniComics'
     extClass = '.UniComics'
-    extVersionCode = 6
+    extVersionCode = 7
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ru/unicomics/src/eu/kanade/tachiyomi/extension/ru/unicomics/UniComics.kt
+++ b/src/ru/unicomics/src/eu/kanade/tachiyomi/extension/ru/unicomics/UniComics.kt
@@ -31,7 +31,7 @@ class UniComics : ParsedHttpSource() {
 
     override val supportsLatest = true
 
-    override val client: OkHttpClient = network.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .connectTimeout(10, TimeUnit.SECONDS)
         .readTimeout(30, TimeUnit.SECONDS)
         .rateLimit(3)

--- a/src/uk/honeymanga/build.gradle
+++ b/src/uk/honeymanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'HoneyManga'
     extClass = '.HoneyManga'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/uk/honeymanga/src/eu/kanade/tachiyomi/extension/uk/honeymanga/HoneyManga.kt
+++ b/src/uk/honeymanga/src/eu/kanade/tachiyomi/extension/uk/honeymanga/HoneyManga.kt
@@ -39,7 +39,7 @@ class HoneyManga : HttpSource() {
         .add("Origin", baseUrl)
         .add("Referer", baseUrl)
 
-    override val client = network.client.newBuilder()
+    override val client = network.cloudflareClient.newBuilder()
         .rateLimitHost(API_URL.toHttpUrl(), 10)
         .build()
 

--- a/src/zh/cartoon18/build.gradle
+++ b/src/zh/cartoon18/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Cartoon18'
     extClass = '.Cartoon18'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/zh/cartoon18/src/eu/kanade/tachiyomi/extension/zh/cartoon18/Cartoon18.kt
+++ b/src/zh/cartoon18/src/eu/kanade/tachiyomi/extension/zh/cartoon18/Cartoon18.kt
@@ -31,7 +31,7 @@ class Cartoon18 : HttpSource(), ConfigurableSource {
 
     private val baseUrlWithLang get() = if (useTrad) baseUrl else "$baseUrl/zh-hans"
 
-    override val client = network.client.newBuilder().followRedirects(false).build()
+    override val client = network.cloudflareClient.newBuilder().followRedirects(false).build()
 
     override fun headersBuilder() = super.headersBuilder()
         .add("Referer", "$baseUrl/")

--- a/src/zh/dm5/build.gradle
+++ b/src/zh/dm5/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Dm5'
     extClass = '.Dm5'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/zh/dm5/src/eu/kanade/tachiyomi/extension/zh/dm5/Dm5.kt
+++ b/src/zh/dm5/src/eu/kanade/tachiyomi/extension/zh/dm5/Dm5.kt
@@ -27,7 +27,7 @@ class Dm5 : ParsedHttpSource(), ConfigurableSource {
     override val supportsLatest = true
     override val name = "动漫屋"
     override val baseUrl = "https://www.dm5.cn"
-    override val client: OkHttpClient = network.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .addInterceptor(CommentsInterceptor)
         .build()
 

--- a/src/zh/dmzj/build.gradle
+++ b/src/zh/dmzj/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'DMZJ'
     extClass = '.Dmzj'
-    extVersionCode = 43
+    extVersionCode = 44
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/zh/dmzj/src/eu/kanade/tachiyomi/extension/zh/dmzj/Dmzj.kt
+++ b/src/zh/dmzj/src/eu/kanade/tachiyomi/extension/zh/dmzj/Dmzj.kt
@@ -29,7 +29,7 @@ class Dmzj : ConfigurableSource, HttpSource() {
 
     private val preferences: SharedPreferences = getPreferences()
 
-    override val client: OkHttpClient = network.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .addInterceptor(ImageUrlInterceptor)
         .addInterceptor(CommentsInterceptor)
         .rateLimit(4)
@@ -43,7 +43,7 @@ class Dmzj : ConfigurableSource, HttpSource() {
         .build()
 
     // API v4 randomly fails
-    private val retryClient = network.client.newBuilder()
+    private val retryClient = network.cloudflareClient.newBuilder()
         .addInterceptor(RetryInterceptor)
         .rateLimit(2)
         .build()

--- a/src/zh/mangabz/build.gradle
+++ b/src/zh/mangabz/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'Mangabz'
     extClass = '.Mangabz'
-    extVersionCode = 9
+    extVersionCode = 10
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/zh/mangabz/src/eu/kanade/tachiyomi/extension/zh/mangabz/Mangabz.kt
+++ b/src/zh/mangabz/src/eu/kanade/tachiyomi/extension/zh/mangabz/Mangabz.kt
@@ -38,7 +38,7 @@ class Mangabz : MangabzTheme("Mangabz"), ConfigurableSource {
         urlSuffix = mirror.urlSuffix
 
         val cookieInterceptor = CookieInterceptor(mirror.domain, mirror.langCookie to preferences.lang)
-        client = network.client.newBuilder()
+        client = network.cloudflareClient.newBuilder()
             .rateLimit(5)
             .addNetworkInterceptor(cookieInterceptor)
             .build()

--- a/src/zh/manhuagui/build.gradle
+++ b/src/zh/manhuagui/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'ManHuaGui'
     extClass = '.Manhuagui'
-    extVersionCode = 23
+    extVersionCode = 24
+    isNsfw = true
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/zh/manhuagui/src/eu/kanade/tachiyomi/extension/zh/manhuagui/Manhuagui.kt
+++ b/src/zh/manhuagui/src/eu/kanade/tachiyomi/extension/zh/manhuagui/Manhuagui.kt
@@ -71,14 +71,14 @@ class Manhuagui(
     // Add rate limit to fix manga thumbnail load failure
     override val client: OkHttpClient =
         if (getShowR18()) {
-            network.client.newBuilder()
+            network.cloudflareClient.newBuilder()
                 .rateLimitHost(baseHttpUrl, preferences.getString(MAINSITE_RATELIMIT_PREF, MAINSITE_RATELIMIT_DEFAULT_VALUE)!!.toInt(), 10)
                 .rateLimitHost(imageServer[0].toHttpUrl(), preferences.getString(IMAGE_CDN_RATELIMIT_PREF, IMAGE_CDN_RATELIMIT_DEFAULT_VALUE)!!.toInt())
                 .rateLimitHost(imageServer[1].toHttpUrl(), preferences.getString(IMAGE_CDN_RATELIMIT_PREF, IMAGE_CDN_RATELIMIT_DEFAULT_VALUE)!!.toInt())
                 .addNetworkInterceptor(AddCookieHeaderInterceptor(baseHttpUrl.host))
                 .build()
         } else {
-            network.client.newBuilder()
+            network.cloudflareClient.newBuilder()
                 .rateLimitHost(baseHttpUrl, preferences.getString(MAINSITE_RATELIMIT_PREF, MAINSITE_RATELIMIT_DEFAULT_VALUE)!!.toInt(), 10)
                 .rateLimitHost(imageServer[0].toHttpUrl(), preferences.getString(IMAGE_CDN_RATELIMIT_PREF, IMAGE_CDN_RATELIMIT_DEFAULT_VALUE)!!.toInt())
                 .rateLimitHost(imageServer[1].toHttpUrl(), preferences.getString(IMAGE_CDN_RATELIMIT_PREF, IMAGE_CDN_RATELIMIT_DEFAULT_VALUE)!!.toInt())

--- a/src/zh/manhuaren/build.gradle
+++ b/src/zh/manhuaren/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Manhuaren'
     extClass = '.Manhuaren'
-    extVersionCode = 16
+    extVersionCode = 17
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/zh/manhuaren/src/eu/kanade/tachiyomi/extension/zh/manhuaren/Manhuaren.kt
+++ b/src/zh/manhuaren/src/eu/kanade/tachiyomi/extension/zh/manhuaren/Manhuaren.kt
@@ -61,7 +61,7 @@ class Manhuaren : HttpSource(), ConfigurableSource {
     private var userId: String = preferences.getString(USER_ID_PREF, null) ?: "-1"
     private val lastUsedTime: String by lazy { generateLastUsedTime() }
 
-    override val client: OkHttpClient = network.client
+    override val client: OkHttpClient = network.cloudflareClient
         .newBuilder()
         .apply { interceptors().removeAll { it.javaClass.simpleName == "BrotliInterceptor" } }
         .addInterceptor(ErrorResponseInterceptor(baseUrl, preferences))

--- a/src/zh/manwa/build.gradle
+++ b/src/zh/manwa/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Manwa'
     extClass = '.Manwa'
-    extVersionCode = 9
+    extVersionCode = 10
     isNsfw = true
 }
 

--- a/src/zh/manwa/src/eu/kanade/tachiyomi/extension/zh/manwa/Manwa.kt
+++ b/src/zh/manwa/src/eu/kanade/tachiyomi/extension/zh/manwa/Manwa.kt
@@ -63,7 +63,7 @@ class Manwa : ParsedHttpSource(), ConfigurableSource {
         }
     }
 
-    override val client: OkHttpClient = network.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .addNetworkInterceptor(rewriteOctetStream)
         .build()
 

--- a/src/zh/vomic/build.gradle
+++ b/src/zh/vomic/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'vomic'
     extClass = '.Vomic'
-    extVersionCode = 5
+    extVersionCode = 6
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/zh/vomic/src/eu/kanade/tachiyomi/extension/zh/vomic/Vomic.kt
+++ b/src/zh/vomic/src/eu/kanade/tachiyomi/extension/zh/vomic/Vomic.kt
@@ -51,7 +51,7 @@ class Vomic : HttpSource(), ConfigurableSource {
         }
     }
 
-    override val client = network.client.newBuilder().addInterceptor { chain ->
+    override val client = network.cloudflareClient.newBuilder().addInterceptor { chain ->
         try {
             val response = chain.proceed(chain.request())
             if (response.isSuccessful) {

--- a/src/zh/wnacg/build.gradle
+++ b/src/zh/wnacg/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'WNACG'
     extClass = '.wnacg'
-    extVersionCode = 18
+    extVersionCode = 19
     isNsfw = true
 }
 

--- a/src/zh/wnacg/src/eu/kanade/tachiyomi/extension/zh/wnacg/wnacg.kt
+++ b/src/zh/wnacg/src/eu/kanade/tachiyomi/extension/zh/wnacg/wnacg.kt
@@ -32,7 +32,7 @@ class wnacg : ParsedHttpSource(), ConfigurableSource {
 
     private val updateUrlInterceptor = UpdateUrlInterceptor(preferences)
 
-    override val client = network.client.newBuilder()
+    override val client = network.cloudflareClient.newBuilder()
         .addInterceptor(updateUrlInterceptor)
         .build()
 

--- a/src/zh/zaimanhua/build.gradle
+++ b/src/zh/zaimanhua/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'Zaimanhua'
     extClass = '.Zaimanhua'
-    extVersionCode = 6
+    extVersionCode = 7
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/zh/zaimanhua/src/eu/kanade/tachiyomi/extension/zh/zaimanhua/Zaimanhua.kt
+++ b/src/zh/zaimanhua/src/eu/kanade/tachiyomi/extension/zh/zaimanhua/Zaimanhua.kt
@@ -48,7 +48,7 @@ class Zaimanhua : HttpSource(), ConfigurableSource {
 
     private val preferences: SharedPreferences = getPreferences()
 
-    override val client: OkHttpClient = network.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .rateLimit(5)
         .addInterceptor(::authIntercept)
         .addInterceptor(::imageRetryInterceptor)


### PR DESCRIPTION
### Why
`network.cloudflareClient` is already the default in most apps compatible with keiyoushi extensions. Some forks (notably J2K) have still not switched over. We want to enforce the use of `network.cloudflareClient` since its omission is difficult for both users and contributors. It is also pretty mature now, so safe to enable globally.

### Method

#### Find incorrect use, direct
```bash
rg -n --column -g '*.kt' '\bnetwork\.client\b' ~/dev/keiyoushi-extensions/ | sort
```

#### Find incorrect use, indirect
```bash
rg -n --column -g '*.kt' -C9999 'super\.client' ~/dev/keiyoushi-extensions/ | grep -E 'eu\.kanade\.tachiyomi\.source\.online\.(Parsed)?HttpSource' | sed -E 's/\.kt-([0-9]+)-/.kt:\1  /' | sort
```
#### Check for double bump
```bash
git diff main HEAD --name-only -- '***.kt' ':!src/' | xargs cat | grep -E '(open|abstract) class' | grep -v 'Filter' | cut -d' ' -f3 | cut -d'(' -f1 | xargs | sed 's/ /|/g'
git diff main HEAD --name-only -- ':!lib-multisrc/' | xargs cat | grep -E 'ComicGamma|FansubsCat|Kemono|MangaEsp|MCCMS|MCCMSWeb|MultiChan|Senkuro|SinMH|Webtoons'
```

### Other
I did not evaluate the one remaining use for `network.client`, which is in `randomua`.

#### Extensions using `randomua` (some noise)
```bash
> rg randomua | cut -d: -f1 | cut -d/ -f1-3 | sort -u
lib-multisrc/mangahub/build.gradle.kts
lib-multisrc/mangahub/src
lib/randomua/src
src/all/nhentai
src/all/projectsuki
src/en/constellarscans
src/en/hiperdex
src/en/lunarscans
src/en/mangago
src/en/readcomiconline
src/en/sitemanga
src/en/theblank
src/en/webcomics
src/es/emperorscan
src/es/mangacrab
src/es/plottwistnofansub
src/fr/sushiscan
src/id/doujindesu
src/pt/hentaiteca
src/pt/mangaonline
src/pt/randomscan
src/pt/remangas
src/pt/sssscanlator
src/pt/yugenmangas
src/zh/jinmantiantang
```

#### `isNsfw`
NSFWness was set manually, only for touched `.gradle` files.

#### Testing
Testing is limited to CI in GitHub, which should be a sufficient check for typos. There are no other expected possible issues. The difficulty in testing is due to volume of extensions, not from the complexity of each individual change.


Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
