### PR TITLE
Update domain for Catharsis World

### DIFF
--- a/src/es/catharsisworld/build.gradle
+++ b/src/es/catharsisworld/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Catharsis World'
     extClass = '.CatharsisWorld'
     themePkg = 'madara'
-    baseUrl = 'https://catharsisworld.akan01.com'
-    overrideVersionCode = 1
+    baseUrl = 'https://catharsisworld.dig-it.info'
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/es/catharsisworld/src/eu/kanade/tachiyomi/extension/es/catharsisworld/CatharsisWorld.kt
+++ b/src/es/catharsisworld/src/eu/kanade/tachiyomi/extension/es/catharsisworld/CatharsisWorld.kt
@@ -9,7 +9,7 @@ import org.jsoup.nodes.Element
 
 class CatharsisWorld : Madara(
     "Catharsis World",
-    "https://catharsisworld.akan01.com",
+    "https://catharsisworld.dig-it.info",
     "es",
 ) {
     override val versionId = 2


### PR DESCRIPTION
Closes #8020

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
