### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Force \n line ending, trailing newline
+b72776e1f528c56ae6a9ef3a6f8d72533b00d39f


### PR DESCRIPTION
Why this should be added ?
Because this commit changed tausend of lines without really editing anything. It's just noise.

Does this change how works [any tool other than git blame] ?
No
