### PR TITLE
fix(buondua): enhance Cloudflare challenge bypass

### DIFF
--- a/src/all/buondua/build.gradle
+++ b/src/all/buondua/build.gradle
@@ -1,8 +1,12 @@
 ext {
     extName = 'Buon Dua'
     extClass = '.BuonDua'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 
 apply from: "$rootDir/common.gradle"
+
+dependencies {
+    implementation(project(":lib:randomua"))
+}


### PR DESCRIPTION
- Add rate limiting (max 10 requests/second)
- Implement random User-Agent rotation
- Inject Referer header
- Version bump 2 → 3

closes: #8079

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
