### PR TITLE
Koharu: do not use network on main thread

### DIFF
--- a/src/all/koharu/build.gradle
+++ b/src/all/koharu/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'SchaleNetwork'
     extClass = '.KoharuFactory'
-    extVersionCode = 13
+    extVersionCode = 14
     isNsfw = true
 }
 

--- a/src/all/koharu/src/eu/kanade/tachiyomi/extension/all/koharu/TurnstileInterceptor.kt
+++ b/src/all/koharu/src/eu/kanade/tachiyomi/extension/all/koharu/TurnstileInterceptor.kt
@@ -12,6 +12,8 @@ import eu.kanade.tachiyomi.extension.all.koharu.Koharu.Companion.authorization
 import eu.kanade.tachiyomi.extension.all.koharu.Koharu.Companion.token
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import okhttp3.Headers
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
@@ -120,7 +122,9 @@ class TurnstileInterceptor(
                             try {
                                 val noRedirectClient = client.newBuilder().followRedirects(false).build()
                                 val authHeaders = authHeaders(authHeader)
-                                val response = noRedirectClient.newCall(POST(authUrl, authHeaders)).execute()
+                                val response = runBlocking(Dispatchers.IO) {
+                                    noRedirectClient.newCall(POST(authUrl, authHeaders)).execute()
+                                }
                                 response.use {
                                     if (response.isSuccessful) {
                                         with(response) {
@@ -176,7 +180,9 @@ class TurnstileInterceptor(
                     try {
                         val noRedirectClient = client.newBuilder().followRedirects(false).build()
                         val authHeaders = authHeaders("Bearer $token")
-                        val response = noRedirectClient.newCall(GET(authUrl, authHeaders)).execute()
+                        val response = runBlocking(Dispatchers.IO) {
+                            noRedirectClient.newCall(GET(authUrl, authHeaders)).execute()
+                        }
                         response.use {
                             if (response.isSuccessful) {
                                 return true


### PR DESCRIPTION
Closes #8199

I was able to consistently crash in TachiyomiAZ without this fix. The change has no effect on Mihon.

`close()` might not be required.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
