### PR TITLE
Arven Scans: Update domain

### DIFF
--- a/src/en/arvencomics/build.gradle
+++ b/src/en/arvencomics/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Arven Scans'
     extClass = '.ArvenComics'
     themePkg = 'keyoapp'
-    baseUrl = 'https://arvencomic.net'
-    overrideVersionCode = 25
+    baseUrl = 'https://arvencomics.com'
+    overrideVersionCode = 26
     isNsfw = false
 }
 

--- a/src/en/arvencomics/src/eu/kanade/tachiyomi/extension/en/arvencomics/ArvenComics.kt
+++ b/src/en/arvencomics/src/eu/kanade/tachiyomi/extension/en/arvencomics/ArvenComics.kt
@@ -4,7 +4,7 @@ import eu.kanade.tachiyomi.multisrc.keyoapp.Keyoapp
 
 class ArvenComics : Keyoapp(
     "Arven Scans",
-    "https://arvencomic.net",
+    "https://arvencomics.com",
     "en",
 ) {
     // migrated from Mangathemesia to Keyoapp


### PR DESCRIPTION
Closes #8262

They changed back to their old domain
![IMG_20250328_174056](https://github.com/user-attachments/assets/90a727cf-3cdf-4f4b-9976-d6a3e3ccc469)


Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
