### PR TITLE
Add migration reminders for Manganato, Mangakakalot and Mangabat.

### DIFF
--- a/src/en/mangabat/build.gradle
+++ b/src/en/mangabat/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Mangabat'
     themePkg = 'mangabox'
     baseUrl = 'https://www.mangabats.com'
-    overrideVersionCode = 6
+    overrideVersionCode = 7
     isNsfw = true
 }
 

--- a/src/en/mangabat/src/eu/kanade/tachiyomi/extension/en/mangabat/Mangabat.kt
+++ b/src/en/mangabat/src/eu/kanade/tachiyomi/extension/en/mangabat/Mangabat.kt
@@ -1,6 +1,8 @@
 package eu.kanade.tachiyomi.extension.en.mangabat
 
 import eu.kanade.tachiyomi.multisrc.mangabox.MangaBox
+import eu.kanade.tachiyomi.source.model.SManga
+import okhttp3.Request
 
 class Mangabat : MangaBox(
     "Mangabat",
@@ -8,4 +10,14 @@ class Mangabat : MangaBox(
         "www.mangabats.com",
     ),
     "en",
-)
+) {
+    override fun mangaDetailsRequest(manga: SManga): Request {
+        if (manga.url.contains("mangabat.com/")) {
+            throw Exception(MIGRATE_MESSAGE)
+        }
+        return super.mangaDetailsRequest(manga)
+    }
+    companion object {
+        private const val MIGRATE_MESSAGE = "Migrate this entry from \"Mangabat\" to \"Mangabat\" to continue reading"
+    }
+}

--- a/src/en/mangakakalot/build.gradle
+++ b/src/en/mangakakalot/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Mangakakalot'
     themePkg = 'mangabox'
     baseUrl = 'https://www.mangakakalot.gg'
-    overrideVersionCode = 5
+    overrideVersionCode = 6
     isNsfw = true
 }
 

--- a/src/en/mangakakalot/src/eu/kanade/tachiyomi/extension/en/mangakakalot/Mangakakalot.kt
+++ b/src/en/mangakakalot/src/eu/kanade/tachiyomi/extension/en/mangakakalot/Mangakakalot.kt
@@ -1,6 +1,8 @@
 package eu.kanade.tachiyomi.extension.en.mangakakalot
 
 import eu.kanade.tachiyomi.multisrc.mangabox.MangaBox
+import eu.kanade.tachiyomi.source.model.SManga
+import okhttp3.Request
 
 class Mangakakalot : MangaBox(
     "Mangakakalot",
@@ -9,4 +11,20 @@ class Mangakakalot : MangaBox(
         "www.mangakakalove.com",
     ),
     "en",
-)
+) {
+    override fun mangaDetailsRequest(manga: SManga): Request {
+        if (LEGACY_DOMAINS.any { manga.url.startsWith(it) }) {
+            throw Exception(MIGRATE_MESSAGE)
+        }
+        return super.mangaDetailsRequest(manga)
+    }
+    companion object {
+        private val LEGACY_DOMAINS = arrayOf(
+            "https://chapmanganato.to/",
+            "https://mangakakalot.com/",
+            "https://manganelo.com/",
+            "https://readmanganato.com/",
+        )
+        private const val MIGRATE_MESSAGE = "Migrate this entry from \"Mangakakalot\" to \"Mangakakalot\" to continue reading"
+    }
+}

--- a/src/en/manganelo/build.gradle
+++ b/src/en/manganelo/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Manganato'
     themePkg = 'mangabox'
     baseUrl = 'https://www.natomanga.com'
-    overrideVersionCode = 4
+    overrideVersionCode = 5
     isNsfw = true
 }
 

--- a/src/en/manganelo/src/eu/kanade/tachiyomi/extension/en/manganelo/Manganato.kt
+++ b/src/en/manganelo/src/eu/kanade/tachiyomi/extension/en/manganelo/Manganato.kt
@@ -1,6 +1,8 @@
 package eu.kanade.tachiyomi.extension.en.manganelo
 
 import eu.kanade.tachiyomi.multisrc.mangabox.MangaBox
+import eu.kanade.tachiyomi.source.model.SManga
+import okhttp3.Request
 
 class Manganato : MangaBox(
     "Manganato",
@@ -13,4 +15,19 @@ class Manganato : MangaBox(
 ) {
 
     override val id: Long = 1024627298672457456
+
+    override fun mangaDetailsRequest(manga: SManga): Request {
+        if (LEGACY_DOMAINS.any { manga.url.startsWith(it) }) {
+            throw Exception(MIGRATE_MESSAGE)
+        }
+        return super.mangaDetailsRequest(manga)
+    }
+    companion object {
+        private val LEGACY_DOMAINS = arrayOf(
+            "https://chapmanganato.to/",
+            "https://manganato.com/",
+            "https://readmanganato.com/",
+        )
+        private const val MIGRATE_MESSAGE = "Migrate this entry from \"Manganato\" to \"Manganato\" to continue reading"
+    }
 }


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
