### PR TITLE
Update domains

### DIFF
--- a/src/tr/domalfansub/build.gradle
+++ b/src/tr/domalfansub/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Domal Fansub'
     extClass = '.DomalFansub'
     themePkg = 'madara'
-    baseUrl = 'https://domalfansb.com.tr'
-    overrideVersionCode = 2
+    baseUrl = 'https://d0malfansub.com.tr'
+    overrideVersionCode = 3
     isNsfw = true
 }
 

--- a/src/tr/domalfansub/src/eu/kanade/tachiyomi/extension/tr/domalfansub/DomalFansub.kt
+++ b/src/tr/domalfansub/src/eu/kanade/tachiyomi/extension/tr/domalfansub/DomalFansub.kt
@@ -10,7 +10,7 @@ import java.util.Locale
 
 class DomalFansub : Madara(
     "Domal Fansub",
-    "https://domalfansb.com.tr",
+    "https://d0malfansub.com.tr",
     "tr",
     dateFormat = SimpleDateFormat("d MMMM yyyy", Locale("tr")),
 ) {

--- a/src/tr/mindafansub/build.gradle
+++ b/src/tr/mindafansub/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Minda Fansub'
     extClass = '.MindaFansub'
     themePkg = 'madara'
-    baseUrl = 'https://mindafansub.online'
-    overrideVersionCode = 0
+    baseUrl = 'https://mindafansub.pro'
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/tr/mindafansub/src/eu/kanade/tachiyomi/extension/tr/mindafansub/MindaFansub.kt
+++ b/src/tr/mindafansub/src/eu/kanade/tachiyomi/extension/tr/mindafansub/MindaFansub.kt
@@ -6,10 +6,9 @@ import java.util.Locale
 
 class MindaFansub : Madara(
     "Minda Fansub",
-    "https://mindafansub.online",
+    "https://mindafansub.pro",
     "tr",
     dateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("tr")),
 ) {
     override val useLoadMoreRequest = LoadMoreStrategy.Always
-    override val useNewChapterEndpoint = true
 }

--- a/src/tr/summertoon/build.gradle
+++ b/src/tr/summertoon/build.gradle
@@ -1,9 +1,9 @@
 ext {
     extName = 'SummerToon'
     extClass = '.SummerToon'
-    themePkg = 'mangathemesia'
-    baseUrl = 'https://summertoon.co'
-    overrideVersionCode = 4
+    themePkg = 'madara'
+    baseUrl = 'https://summertoons.com'
+    overrideVersionCode = 0
     isNsfw = false
 }
 

--- a/src/tr/summertoon/src/eu/kanade/tachiyomi/extension/tr/summertoon/SummerToon.kt
+++ b/src/tr/summertoon/src/eu/kanade/tachiyomi/extension/tr/summertoon/SummerToon.kt
@@ -1,13 +1,13 @@
 package eu.kanade.tachiyomi.extension.tr.summertoon
 
-import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class SummerToon : MangaThemesia(
+class SummerToon : Madara(
     "SummerToon",
-    "https://summertoon.co",
+    "https://summertoons.com",
     "tr",
     dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("tr")),
 ) {
@@ -15,6 +15,7 @@ class SummerToon : MangaThemesia(
         .rateLimit(1, 1)
         .build()
 
-    override val seriesStatusSelector = ".tsinfo .imptdt:contains(Durum) i"
-    override val seriesAuthorSelector = ".fmed b:contains(Yazar)+span"
+    override val useLoadMoreRequest = LoadMoreStrategy.Always
+
+    override val chapterUrlSelector = "div + a"
 }


### PR DESCRIPTION
Closes #8287
Closes #8286
Closes #8284

Note:

### SummerToon
Moved from MangaThemese to Madara and the urls are compatible

- Current: https://summertoons.com/manga/a-child-who-looks-like-me/
- Wayback Machine:  [https://summertoon.co/manga/a-child-who-looks-like-me/](https://web.archive.org/web/20241202111850/https://summertoon.co/manga/a-child-who-looks-like-me/)

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
