### PR TITLE
LuaScans: Fix missing chapters due to Timezone issue, closes #8292 & #7863

### DIFF
--- a/src/en/luascans/build.gradle
+++ b/src/en/luascans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.LuaScans'
     themePkg = 'heancms'
     baseUrl = 'https://luacomic.org'
-    overrideVersionCode = 19
+    overrideVersionCode = 20
     isNsfw = false
 }
 

--- a/src/en/luascans/src/eu/kanade/tachiyomi/extension/en/luascans/LuaScans.kt
+++ b/src/en/luascans/src/eu/kanade/tachiyomi/extension/en/luascans/LuaScans.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.extension.en.luascans
 import eu.kanade.tachiyomi.multisrc.heancms.HeanCms
 import java.text.SimpleDateFormat
 import java.util.Locale
+import java.util.TimeZone
 
 class LuaScans : HeanCms(
     "Lua Scans",
@@ -10,9 +11,9 @@ class LuaScans : HeanCms(
     "en",
 ) {
     // Moved from Keyoapp to HeanCms
-    override val versionId = 3
+    override val versionId = 4
 
     override val useNewChapterEndpoint = true
 
-    override val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+    override val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply { timeZone = TimeZone.getTimeZone("UTC") }
 }

--- a/src/en/luascans/src/eu/kanade/tachiyomi/extension/en/luascans/LuaScans.kt
+++ b/src/en/luascans/src/eu/kanade/tachiyomi/extension/en/luascans/LuaScans.kt
@@ -11,7 +11,7 @@ class LuaScans : HeanCms(
     "en",
 ) {
     // Moved from Keyoapp to HeanCms
-    override val versionId = 4
+    override val versionId = 3
 
     override val useNewChapterEndpoint = true
 


### PR DESCRIPTION
Closes #8292, Closes #7863

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
