### PR TITLE
Manga livre: Fix domain

### DIFF
--- a/src/pt/mangalivre/build.gradle
+++ b/src/pt/mangalivre/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Manga Livre'
     extClass = '.MangaLivre'
     themePkg = 'madara'
-    baseUrl = 'https://mangalivre.ru'
-    overrideVersionCode = 0
+    baseUrl = 'https://mangalivre.tv'
+    overrideVersionCode = 1
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
@@ -6,7 +6,7 @@ import java.util.Locale
 
 class MangaLivre : Madara(
     "Manga Livre",
-    "https://mangalivre.ru",
+    "https://mangalivre.tv",
     "pt-BR",
     SimpleDateFormat("MMMM dd, yyyy", Locale("pt")),
 ) {


### PR DESCRIPTION
Closes #8325

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
