### PR TITLE
Truyenqq: fix download not able to complete

### DIFF
--- a/src/vi/truyenqq/build.gradle
+++ b/src/vi/truyenqq/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'TruyenQQ'
     extClass = '.TruyenQQ'
-    extVersionCode = 17
+    extVersionCode = 18
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/vi/truyenqq/src/eu/kanade/tachiyomi/extension/vi/truyenqq/TruyenQQ.kt
+++ b/src/vi/truyenqq/src/eu/kanade/tachiyomi/extension/vi/truyenqq/TruyenQQ.kt
@@ -133,12 +133,9 @@ class TruyenQQ : ParsedHttpSource() {
 
     // Pages
     override fun pageListParse(document: Document): List<Page> =
-        document.select(".page-chapter img")
+        document.select(".page-chapter img:not([src*='stress.gif'])")
             .mapIndexedNotNull { idx, it ->
-                val pageUrl = it.attr("abs:src")
-                    .takeUnless { it.contains("stress.gif") }
-                    ?: return@mapIndexedNotNull null
-                Page(idx, imageUrl = pageUrl)
+                Page(idx, imageUrl = it.attr("abs:src"))
             }
 
     override fun imageUrlParse(document: Document): String =

--- a/src/vi/truyenqq/src/eu/kanade/tachiyomi/extension/vi/truyenqq/TruyenQQ.kt
+++ b/src/vi/truyenqq/src/eu/kanade/tachiyomi/extension/vi/truyenqq/TruyenQQ.kt
@@ -134,8 +134,11 @@ class TruyenQQ : ParsedHttpSource() {
     // Pages
     override fun pageListParse(document: Document): List<Page> =
         document.select(".page-chapter img")
-            .mapIndexed { idx, it ->
-                Page(idx, imageUrl = it.attr("abs:src"))
+            .mapIndexedNotNull { idx, it ->
+                val pageUrl = it.attr("abs:src")
+                    .takeUnless { it.contains("stress.gif") }
+                    ?: return@mapIndexedNotNull null
+                Page(idx, imageUrl = pageUrl)
             }
 
     override fun imageUrlParse(document: Document): String =

--- a/src/vi/truyenqq/src/eu/kanade/tachiyomi/extension/vi/truyenqq/TruyenQQ.kt
+++ b/src/vi/truyenqq/src/eu/kanade/tachiyomi/extension/vi/truyenqq/TruyenQQ.kt
@@ -134,7 +134,7 @@ class TruyenQQ : ParsedHttpSource() {
     // Pages
     override fun pageListParse(document: Document): List<Page> =
         document.select(".page-chapter img:not([src*='stress.gif'])")
-            .mapIndexedNotNull { idx, it ->
+            .mapIndexed { idx, it ->
                 Page(idx, imageUrl = it.attr("abs:src"))
             }
 


### PR DESCRIPTION
Non-existed existed picture references to another site.

Example: https://truyenqqto.com/truyen-tranh/tu-vong-hoi-639-chap-25.html

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
