### PR TITLE
hitomi: handle gifs

### DIFF
--- a/src/all/hitomi/build.gradle
+++ b/src/all/hitomi/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hitomi'
     extClass = '.HitomiFactory'
-    extVersionCode = 38
+    extVersionCode = 39
     isNsfw = true
 }
 

--- a/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/HitomiDto.kt
+++ b/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/HitomiDto.kt
@@ -22,7 +22,10 @@ class Gallery(
 @Serializable
 class ImageFile(
     val hash: String,
-)
+    private val name: String,
+) {
+    val isGif get() = name.endsWith(".gif")
+}
 
 @Serializable
 class Tag(


### PR DESCRIPTION
closes #8378

Checklist:
- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

app doesn't handle animated avif
```
getSize: not supported!
getSize: not supported!
getSize: not supported!
No decoder found to handle this stream
Failed to initialise bitmap decoder
java.lang.IllegalStateException: Image decoder failed to initialize and get image size
	at com.davemorrissey.labs.subscaleview.decoder.Decoder.init(Unknown Source:82)
	at com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView$TilesInitTask.doInBackground(SourceFile:8)
	at com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView$TilesInitTask.doInBackground(SourceFile:1)
	at android.os.AsyncTask$3.call(AsyncTask.java:394)
	at java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
	at java.lang.Thread.run(Thread.java:1012)
```

