### PR TITLE
DeviantArt: Order chapter list chronologically instead of by source

### DIFF
--- a/src/all/deviantart/build.gradle
+++ b/src/all/deviantart/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'DeviantArt'
     extClass = '.DeviantArt'
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = true
 }
 


### PR DESCRIPTION
In Mihon's updates tab, chapters are ordered by source instead of chapter number, so to avoid updates being shown in reverse, disregard source order and order chronologically instead.

<details><summary>Before change (click to show)</summary>

![image](https://github.com/user-attachments/assets/dcd6269a-f380-4071-86bc-770df322f2be)
</details>

<details><summary>After change (click to show)</summary>

![image](https://github.com/user-attachments/assets/497b81ee-0035-47ee-b499-cb71a71a5164)
</details>

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] ~Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions~
- [ ] ~Referenced all related issues in the PR body (e.g. "Closes #xyz")~
- [ ] ~Added the `isNsfw = true` flag in `build.gradle` when appropriate~
- [x] Have not changed source names
- [ ] ~Have explicitly kept the `id` if a source's name or language were changed~
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] ~Have removed `web_hi_res_512.png` when adding a new extension~
