### PR TITLE
Fix MangaHub (multisrc) Chapter List Selector

### DIFF
--- a/lib-multisrc/mangahub/build.gradle.kts
+++ b/lib-multisrc/mangahub/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 31
+baseVersionCode = 32
 
 dependencies {
     api(project(":lib:randomua"))

--- a/lib-multisrc/mangahub/src/eu/kanade/tachiyomi/multisrc/mangahub/MangaHub.kt
+++ b/lib-multisrc/mangahub/src/eu/kanade/tachiyomi/multisrc/mangahub/MangaHub.kt
@@ -276,7 +276,7 @@ abstract class MangaHub(
 
     private fun chapterFromElement(element: Element, head: Element): SChapter {
         val chapter = SChapter.create()
-        val potentialLinks = element.select("a[href*='$baseUrl/chapter/']")
+        val potentialLinks = element.select("a[href*='$baseUrl/chapter/'][class^=_3pfyN]")
         var visibleLink = ""
         potentialLinks.forEach { a ->
             val className = a.className()


### PR DESCRIPTION
Closes #8390
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
