### PR TITLE
Fix thumbnail blurred image

### DIFF
--- a/src/vi/hentaicube/build.gradle
+++ b/src/vi/hentaicube/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'CBHentai'
     extClass = '.HentaiCB'
     themePkg = 'madara'
-    baseUrl = 'https://hentaicb.bar'
-    overrideVersionCode = 16
+    baseUrl = 'https://hentaicb.fit'
+    overrideVersionCode = 15
     isNsfw = true
 }
 

--- a/src/vi/hentaicube/build.gradle
+++ b/src/vi/hentaicube/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.HentaiCB'
     themePkg = 'madara'
     baseUrl = 'https://hentaicb.fit'
-    overrideVersionCode = 15
+    overrideVersionCode = 17
     isNsfw = true
 }
 

--- a/src/vi/hentaicube/src/eu/kanade/tachiyomi/extension/vi/hentaicube/HentaiCB.kt
+++ b/src/vi/hentaicube/src/eu/kanade/tachiyomi/extension/vi/hentaicube/HentaiCB.kt
@@ -59,22 +59,14 @@ class HentaiCB :
 
     override val altNameSelector = ".post-content_item:contains(Tên khác) .summary-content"
 
-    override fun popularMangaFromElement(element: Element): SManga {
-        val manga = SManga.create()
+    private val thumbnailOriginalUrlRegex = Regex("-\\d+x\\d+(\\.[a-zA-Z]+)$")
 
-        with(element) {
-            selectFirst(popularMangaUrlSelector)!!.let {
-                manga.setUrlWithoutDomain(it.attr("abs:href"))
-                manga.title = it.ownText()
-            }
-            selectFirst("img")?.let {
-                val getUrl = it.attr("abs:src")
-                val originalUrl = getUrl.replace(Regex("-\\d+x\\d+(\\.[a-zA-Z]+)$"), "$1")
-                manga.thumbnail_url = originalUrl
+    override fun popularMangaFromElement(element: Element): SManga {
+        return super.popularMangaFromElement(element).apply {
+            element.selectFirst("img")?.let { img ->
+                thumbnail_url = img.attr("abs:src").replace(thumbnailOriginalUrlRegex, "$1")
             }
         }
-
-        return manga
     }
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {

--- a/src/vi/hentaicube/src/eu/kanade/tachiyomi/extension/vi/hentaicube/HentaiCB.kt
+++ b/src/vi/hentaicube/src/eu/kanade/tachiyomi/extension/vi/hentaicube/HentaiCB.kt
@@ -17,6 +17,7 @@ import keiyoushi.utils.getPreferences
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
 import rx.Observable
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -24,7 +25,7 @@ import java.util.Locale
 class HentaiCB :
     Madara(
         "CBHentai",
-        "https://hentaicb.bar",
+        "https://hentaicb.fit",
         "vi",
         SimpleDateFormat("dd/MM/yyyy", Locale("vi")),
     ),
@@ -57,6 +58,24 @@ class HentaiCB :
     override val mangaSubString = "read"
 
     override val altNameSelector = ".post-content_item:contains(Tên khác) .summary-content"
+
+    override fun popularMangaFromElement(element: Element): SManga {
+        val manga = SManga.create()
+
+        with(element) {
+            selectFirst(popularMangaUrlSelector)!!.let {
+                manga.setUrlWithoutDomain(it.attr("abs:href"))
+                manga.title = it.ownText()
+            }
+            selectFirst("img")?.let {
+                val getUrl = it.attr("abs:src")
+                val originalUrl = getUrl.replace(Regex("-\\d+x\\d+(\\.[a-zA-Z]+)$"), "$1")
+                manga.thumbnail_url = originalUrl
+            }
+        }
+
+        return manga
+    }
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
         if (query.startsWith(URL_SEARCH_PREFIX)) {

--- a/src/vi/hentaicube/src/eu/kanade/tachiyomi/extension/vi/hentaicube/HentaiCB.kt
+++ b/src/vi/hentaicube/src/eu/kanade/tachiyomi/extension/vi/hentaicube/HentaiCB.kt
@@ -64,7 +64,7 @@ class HentaiCB :
     override fun popularMangaFromElement(element: Element): SManga {
         return super.popularMangaFromElement(element).apply {
             element.selectFirst("img")?.let { img ->
-                thumbnail_url = img.attr("abs:src").replace(thumbnailOriginalUrlRegex, "$1")
+                thumbnail_url = imageFromElement(img)?.replace(thumbnailOriginalUrlRegex, "$1")
             }
         }
     }


### PR DESCRIPTION
Fix thumbnail blurred image in CBHentai and update domain

Explain:
This image url make blurred image beacause it fixed to low res
`https://hentaicb.fit/wp-content/uploads/2018/08/XXX-168x237.jpg`
Removed `-168x237` to get original res
`https://hentaicb.fit/wp-content/uploads/2018/08/XXX.jpg`

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
