### PR TITLE
MangaPark: fixes & improvements

### DIFF
--- a/src/all/mangapark/build.gradle
+++ b/src/all/mangapark/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaPark'
     extClass = '.MangaParkFactory'
-    extVersionCode = 21
+    extVersionCode = 22
     isNsfw = true
 }
 

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaPark.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaPark.kt
@@ -265,7 +265,7 @@ class MangaPark(
             summary = "Uses first or last chapter page as cover"
             entries = arrayOf("Off", "First Chapter", "Last Chapter")
             entryValues = arrayOf("off", "first", "last")
-            setDefaultValue("first")
+            setDefaultValue("off")
         }.also(screen::addPreference)
     }
 

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaPark.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaPark.kt
@@ -30,9 +30,7 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
-import java.io.IOException
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 class MangaPark(
@@ -289,13 +287,7 @@ class MangaPark(
 
                 latch.countDown()
             } else {
-                latch.await(10, TimeUnit.SECONDS)
-
-                if (latch.count == 1L) {
-                    cookiesNotSet.set(true)
-
-                    throw IOException("Unable to set necessary cookies")
-                }
+                latch.await()
             }
         }
 

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaPark.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaPark.kt
@@ -97,7 +97,7 @@ class MangaPark(
 
     override fun searchMangaParse(response: Response): MangasPage {
         val result = response.parseAs<SearchResponse>()
-        val pageAsCover = preference.getString(UNCENSORED_COVER_PREF, "first")!!
+        val pageAsCover = preference.getString(UNCENSORED_COVER_PREF, "off")!!
         val shortenTitle = preference.getBoolean(SHORTEN_TITLE_PREF, false)
 
         val entries = result.data.searchComics.items.map { it.data.toSManga(shortenTitle, pageAsCover) }
@@ -167,7 +167,7 @@ class MangaPark(
 
     override fun mangaDetailsParse(response: Response): SManga {
         val result = response.parseAs<DetailsResponse>()
-        val pageAsCover = preference.getString(UNCENSORED_COVER_PREF, "first")!!
+        val pageAsCover = preference.getString(UNCENSORED_COVER_PREF, "off")!!
         val shortenTitle = preference.getBoolean(SHORTEN_TITLE_PREF, false)
 
         return result.data.comic.data.toSManga(shortenTitle, pageAsCover)
@@ -247,7 +247,7 @@ class MangaPark(
         SwitchPreferenceCompat(screen.context).apply {
             key = SHORTEN_TITLE_PREF
             title = "Remove extra information from title"
-            summary = "Clear database to apply changes\n" +
+            summary = "Clear database to apply changes\n\n" +
                 "Note: doesn't not work for entries in library"
             setDefaultValue(false)
         }.also(screen::addPreference)

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaPark.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaPark.kt
@@ -17,20 +17,19 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.firstInstanceOrNull
 import keiyoushi.utils.getPreferences
+import keiyoushi.utils.parseAs
+import keiyoushi.utils.toJsonString
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
-import uy.kohesive.injekt.injectLazy
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -53,8 +52,6 @@ class MangaPark(
     override val baseUrl = "https://$domain"
 
     private val apiUrl = "$baseUrl/apo/"
-
-    private val json: Json by injectLazy()
 
     override val client = network.cloudflareClient.newBuilder()
         .addInterceptor(::siteSettingsInterceptor)
@@ -244,14 +241,8 @@ class MangaPark(
         }.also(screen::addPreference)
     }
 
-    private inline fun <reified T> Response.parseAs(): T =
-        use { body.string() }.let(json::decodeFromString)
-
-    private inline fun <reified T> List<*>.firstInstanceOrNull(): T? =
-        filterIsInstance<T>().firstOrNull()
-
     private inline fun <reified T : Any> T.toJsonRequestBody() =
-        json.encodeToString(this).toRequestBody(JSON_MEDIA_TYPE)
+       toJsonString().toRequestBody(JSON_MEDIA_TYPE)
 
     private val cookiesNotSet = AtomicBoolean(true)
     private val latch = CountDownLatch(1)

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaPark.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaPark.kt
@@ -96,8 +96,9 @@ class MangaPark(
 
     override fun searchMangaParse(response: Response): MangasPage {
         val result = response.parseAs<SearchResponse>()
+        val pageAsCover = preference.getString(UNCENSORED_COVER_PREF, "first")!!
 
-        val entries = result.data.searchComics.items.map { it.data.toSManga() }
+        val entries = result.data.searchComics.items.map { it.data.toSManga(baseUrl, pageAsCover) }
         val hasNextPage = entries.size == size
 
         return MangasPage(entries, hasNextPage)
@@ -164,8 +165,9 @@ class MangaPark(
 
     override fun mangaDetailsParse(response: Response): SManga {
         val result = response.parseAs<DetailsResponse>()
+        val pageAsCover = preference.getString(UNCENSORED_COVER_PREF, "first")!!
 
-        return result.data.comic.data.toSManga()
+        return result.data.comic.data.toSManga(baseUrl, pageAsCover)
     }
 
     override fun getMangaUrl(manga: SManga) = baseUrl + manga.url.substringBeforeLast("#")
@@ -230,6 +232,15 @@ class MangaPark(
             title = "Fetch Duplicate Chapters"
             summary = "Refresh chapter list to apply changes"
             setDefaultValue(false)
+        }.also(screen::addPreference)
+
+        ListPreference(screen.context).apply {
+            key = UNCENSORED_COVER_PREF
+            title = "Attempt to use Uncensored Cover for Hentai"
+            summary = "Uses first or last chapter page as cover"
+            entries = arrayOf("Off", "First Chapter", "Last Chapter")
+            entryValues = arrayOf("off", "first", "last")
+            setDefaultValue("first")
         }.also(screen::addPreference)
     }
 
@@ -299,5 +310,6 @@ class MangaPark(
         )
 
         private const val DUPLICATE_CHAPTER_PREF_KEY = "pref_dup_chapters"
+        private const val UNCENSORED_COVER_PREF = "pref_uncensored_cover"
     }
 }

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaPark.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaPark.kt
@@ -115,8 +115,9 @@ class MangaPark(
     override fun searchMangaParse(response: Response): MangasPage {
         val result = response.parseAs<SearchResponse>()
         val pageAsCover = preference.getString(UNCENSORED_COVER_PREF, "first")!!
+        val shortenTitle = preference.getBoolean(SHORTEN_TITLE_PREF, false)
 
-        val entries = result.data.searchComics.items.map { it.data.toSManga(pageAsCover) }
+        val entries = result.data.searchComics.items.map { it.data.toSManga(shortenTitle, pageAsCover) }
         val hasNextPage = entries.size == size
 
         return MangasPage(entries, hasNextPage)
@@ -184,8 +185,9 @@ class MangaPark(
     override fun mangaDetailsParse(response: Response): SManga {
         val result = response.parseAs<DetailsResponse>()
         val pageAsCover = preference.getString(UNCENSORED_COVER_PREF, "first")!!
+        val shortenTitle = preference.getBoolean(SHORTEN_TITLE_PREF, false)
 
-        return result.data.comic.data.toSManga(pageAsCover)
+        return result.data.comic.data.toSManga(shortenTitle, pageAsCover)
     }
 
     override fun getMangaUrl(manga: SManga) = baseUrl + manga.url.substringBeforeLast("#")
@@ -259,6 +261,14 @@ class MangaPark(
             setDefaultValue(true)
         }.also(screen::addPreference)
 
+        SwitchPreferenceCompat(screen.context).apply {
+            key = SHORTEN_TITLE_PREF
+            title = "Remove extra information from title"
+            summary = "Clear database to apply changes\n" +
+                "Note: doesn't not work for entries in library"
+            setDefaultValue(false)
+        }.also(screen::addPreference)
+
         ListPreference(screen.context).apply {
             key = UNCENSORED_COVER_PREF
             title = "Attempt to use Uncensored Cover for Hentai"
@@ -330,6 +340,7 @@ class MangaPark(
 
         private const val ENABLE_NSFW = "pref_nsfw"
         private const val DUPLICATE_CHAPTER_PREF_KEY = "pref_dup_chapters"
+        private const val SHORTEN_TITLE_PREF = "pref_shorten_title"
         private const val UNCENSORED_COVER_PREF = "pref_uncensored_cover"
     }
 }

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkDto.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkDto.kt
@@ -91,7 +91,13 @@ class MangaParkComic(
             }
             "hiatus" -> SManga.ON_HIATUS
             "cancelled" -> SManga.CANCELLED
-            else -> SManga.UNKNOWN
+            else -> when (uploadStatus) {
+                "ongoing" -> SManga.ONGOING
+                "completed" -> SManga.COMPLETED
+                "hiatus" -> SManga.ON_HIATUS
+                "cancelled" -> SManga.CANCELLED
+                else -> SManga.UNKNOWN
+            }
         }
         initialized = true
     }

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkDto.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkDto.kt
@@ -44,9 +44,13 @@ class MangaParkComic(
     @SerialName("max_chapterNode") private val latestChapter: Data<ImageFiles>,
     @SerialName("first_chapterNode") private val firstChapter: Data<ImageFiles>,
 ) {
-    fun toSManga(pageAsCover: String) = SManga.create().apply {
+    fun toSManga(shortenTitle: Boolean, pageAsCover: String) = SManga.create().apply {
         url = "$urlPath#$id"
-        title = name
+        title = if (shortenTitle) {
+            name.replace(shortenTitleRegex, "").trim()
+        } else {
+            name
+        }
         thumbnail_url = if (pageAsCover != "off" && useLatestPageAsCover(genres)) {
             if (pageAsCover == "first") {
                 firstChapter.data.imageFile.urlList.firstOrNull()
@@ -65,6 +69,10 @@ class MangaParkComic(
         author = authors?.joinToString()
         artist = artists?.joinToString()
         description = buildString {
+            if (shortenTitle) {
+                append(name)
+                append("\n\n")
+            }
             summary?.also {
                 append(Jsoup.parse(it).wholeText().trim())
                 append("\n\n")
@@ -126,6 +134,8 @@ class MangaParkComic(
                 it.contains("hentai") && !it.contains("webtoon")
             }
         }
+
+        private val shortenTitleRegex = Regex("""(\[[^]]*]|[({][^)}]*[)}])""")
     }
 }
 

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkDto.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkDto.kt
@@ -38,6 +38,7 @@ class MangaParkComic(
     private val originalStatus: String? = null,
     private val uploadStatus: String? = null,
     private val summary: String? = null,
+    private val extraInfo: String? = null,
     @SerialName("urlCoverOri") private val cover: String? = null,
     private val urlPath: String,
     @SerialName("max_chapterNode") private val latestChapter: Data<ImageFiles>,
@@ -64,21 +65,22 @@ class MangaParkComic(
         author = authors?.joinToString()
         artist = artists?.joinToString()
         description = buildString {
-            val desc = summary?.let { Jsoup.parse(it).text() }
-            val names = altNames?.takeUnless { it.isEmpty() }
-                ?.joinToString("\n") { "• ${it.trim()}" }
-
-            if (desc.isNullOrEmpty()) {
-                if (!names.isNullOrEmpty()) {
-                    append("Alternative Names:\n", names)
-                }
-            } else {
-                append(desc)
-                if (!names.isNullOrEmpty()) {
-                    append("\n\nAlternative Names:\n", names)
-                }
+            summary?.also {
+                append(Jsoup.parse(it).wholeText().trim())
+                append("\n\n")
             }
-        }
+            extraInfo?.takeUnless(String::isBlank)?.also {
+                append("Extra Info:\n")
+                append(Jsoup.parse(it).wholeText().trim())
+                append("\n\n")
+            }
+            altNames?.takeUnless { it.isEmpty() }
+                ?.joinToString(
+                    prefix = "Alternative Names:\n",
+                    separator = "\n",
+                ) { "• ${it.trim()}" }
+                ?.also(::append)
+        }.trim()
         genre = genres?.joinToString { it.replace("_", " ").toCamelCase() }
         status = when (originalStatus) {
             "ongoing" -> SManga.ONGOING

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkDto.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkDto.kt
@@ -4,7 +4,6 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.jsoup.Jsoup
 
 typealias SearchResponse = Data<SearchComics>

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkDto.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkDto.kt
@@ -94,7 +94,7 @@ class MangaParkComic(
                 ?.also(::append)
         }.trim()
         genre = genres?.joinToString { it.replace("_", " ").toCamelCase() }
-        status = when (originalStatus) {
+        status = when (originalStatus ?: uploadStatus) {
             "ongoing" -> SManga.ONGOING
             "completed" -> {
                 if (uploadStatus == "ongoing") {
@@ -105,13 +105,7 @@ class MangaParkComic(
             }
             "hiatus" -> SManga.ON_HIATUS
             "cancelled" -> SManga.CANCELLED
-            else -> when (uploadStatus) {
-                "ongoing" -> SManga.ONGOING
-                "completed" -> SManga.COMPLETED
-                "hiatus" -> SManga.ON_HIATUS
-                "cancelled" -> SManga.CANCELLED
-                else -> SManga.UNKNOWN
-            }
+            else -> SManga.UNKNOWN
         }
         initialized = true
     }

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkDto.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkDto.kt
@@ -41,8 +41,8 @@ class MangaParkComic(
     private val extraInfo: String? = null,
     @SerialName("urlCoverOri") private val cover: String? = null,
     private val urlPath: String,
-    @SerialName("max_chapterNode") private val latestChapter: Data<ImageFiles>,
-    @SerialName("first_chapterNode") private val firstChapter: Data<ImageFiles>,
+    @SerialName("max_chapterNode") private val latestChapter: Data<ImageFiles>? = null,
+    @SerialName("first_chapterNode") private val firstChapter: Data<ImageFiles>? = null,
 ) {
     fun toSManga(shortenTitle: Boolean, pageAsCover: String) = SManga.create().apply {
         url = "$urlPath#$id"
@@ -51,19 +51,23 @@ class MangaParkComic(
         } else {
             name
         }
-        thumbnail_url = if (pageAsCover != "off" && useLatestPageAsCover(genres)) {
-            if (pageAsCover == "first") {
-                firstChapter.data.imageFile.urlList.firstOrNull()
-            } else {
-                latestChapter.data.imageFile.urlList.firstOrNull()
-            }
-        } else {
-            cover?.let {
+        thumbnail_url = run {
+            val coverUrl = cover?.let {
                 when {
                     it.startsWith("http") -> it
                     it.startsWith("/") -> "https://$THUMBNAIL_LOOPBACK_HOST$it"
                     else -> null
                 }
+            }
+
+            if (pageAsCover != "off" && useLatestPageAsCover(genres)) {
+                if (pageAsCover == "first") {
+                    firstChapter?.data?.imageFile?.urlList?.firstOrNull() ?: coverUrl
+                } else {
+                    latestChapter?.data?.imageFile?.urlList?.firstOrNull() ?: coverUrl
+                }
+            } else {
+                coverUrl
             }
         }
         author = authors?.joinToString()

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkDto.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkDto.kt
@@ -4,6 +4,7 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.jsoup.Jsoup
 
 typealias SearchResponse = Data<SearchComics>
@@ -43,7 +44,7 @@ class MangaParkComic(
     @SerialName("max_chapterNode") private val latestChapter: Data<ImageFiles>,
     @SerialName("first_chapterNode") private val firstChapter: Data<ImageFiles>,
 ) {
-    fun toSManga(baseUrl: String, pageAsCover: String) = SManga.create().apply {
+    fun toSManga(pageAsCover: String) = SManga.create().apply {
         url = "$urlPath#$id"
         title = name
         thumbnail_url = if (pageAsCover != "off" && useLatestPageAsCover(genres)) {
@@ -56,7 +57,7 @@ class MangaParkComic(
             cover?.let {
                 when {
                     it.startsWith("http") -> it
-                    it.startsWith("/") -> baseUrl + it
+                    it.startsWith("/") -> "https://$THUMBNAIL_LOOPBACK_HOST$it"
                     else -> null
                 }
             }

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkDto.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkDto.kt
@@ -47,7 +47,12 @@ class MangaParkComic(
     fun toSManga(shortenTitle: Boolean, pageAsCover: String) = SManga.create().apply {
         url = "$urlPath#$id"
         title = if (shortenTitle) {
-            name.replace(shortenTitleRegex, "").trim()
+            var shortName = name
+            while (shortenTitleRegex.containsMatchIn(shortName)) {
+                shortName = shortName.replace(shortenTitleRegex, "").trim()
+            }
+
+            shortName
         } else {
             name
         }
@@ -86,7 +91,7 @@ class MangaParkComic(
                 append(Jsoup.parse(it).wholeText().trim())
                 append("\n\n")
             }
-            altNames?.takeUnless { it.isEmpty() }
+            altNames?.takeUnless(List<String>::isEmpty)
                 ?.joinToString(
                     prefix = "Alternative Names:\n",
                     separator = "\n",
@@ -133,7 +138,7 @@ class MangaParkComic(
             }
         }
 
-        private val shortenTitleRegex = Regex("""(\[[^]]*]|[({][^)}]*[)}])""")
+        private val shortenTitleRegex = Regex("""^(\[[^]]+\])|^(\([^)]+\))|^(\{[^}]+\})|(\[[^]]+\])${'$'}|(\([^)]+\))${'$'}|(\{[^}]+\})${'$'}""")
     }
 }
 

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkQueries.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkQueries.kt
@@ -25,6 +25,7 @@ val SEARCH_QUERY = buildQuery {
         				originalStatus
                         uploadStatus
         				summary
+                        extraInfo
         				urlCoverOri
         				urlPath
                         max_chapterNode {
@@ -66,6 +67,7 @@ val DETAILS_QUERY = buildQuery {
                     originalStatus
                     uploadStatus
                     summary
+                    extraInfo
                     urlCoverOri
                     urlPath
                     max_chapterNode {

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkQueries.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaParkQueries.kt
@@ -27,6 +27,20 @@ val SEARCH_QUERY = buildQuery {
         				summary
         				urlCoverOri
         				urlPath
+                        max_chapterNode {
+                            data {
+                                imageFile {
+                                    urlList
+                                }
+                            }
+                        }
+                        first_chapterNode {
+                            data {
+                                imageFile {
+                                    urlList
+                                }
+                            }
+                        }
         			}
         		}
         	}
@@ -54,6 +68,20 @@ val DETAILS_QUERY = buildQuery {
                     summary
                     urlCoverOri
                     urlPath
+                    max_chapterNode {
+                        data {
+                            imageFile {
+                                urlList
+                            }
+                        }
+                    }
+                    first_chapterNode {
+                        data {
+                            imageFile {
+                                urlList
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
- fix covers
  - closes #8471
- uncensored covers for hentai
- sfw setting
  - closes #8251
- extra info in description
  - closes #7289
- use upload status if original status is unknown
  - closes #7208
- cleanup title 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
