### PR TITLE
Replace troubleshooting link in acknowledgements

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_report_issue.yml
+++ b/.github/ISSUE_TEMPLATE/01_report_issue.yml
@@ -99,7 +99,7 @@ body:
           required: true
         - label: I have updated all installed extensions.
           required: true
-        - label: I have tried the [troubleshooting guide](https://tachiyomi.org/help/guides/troubleshooting/).
+        - label: I have tried the [troubleshooting guide](https://mihon.app/docs/guides/troubleshooting/).
           required: true
         - label: If this is an issue with the app itself, I should be opening an issue in the [app repository](https://github.com/tachiyomiorg/tachiyomi/issues/new/choose).
           required: true


### PR DESCRIPTION
Replace dead Tachiyomi troubleshooting link in Issue Request Template

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
