### PR TITLE
ReadComicOnline - Rewrite pageListParse implementation to decrypt image URL links in the extension

### DIFF
--- a/src/en/readcomiconline/build.gradle
+++ b/src/en/readcomiconline/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ReadComicOnline'
     extClass = '.Readcomiconline'
-    extVersionCode = 31
+    extVersionCode = 32
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
@@ -1,16 +1,6 @@
 package eu.kanade.tachiyomi.extension.en.readcomiconline
 
-import android.annotation.SuppressLint
-import android.app.Application
 import android.content.SharedPreferences
-import android.os.Handler
-import android.os.Looper
-import android.util.Log
-import android.view.View
-import android.webkit.ConsoleMessage
-import android.webkit.WebChromeClient
-import android.webkit.WebView
-import android.webkit.WebViewClient
 import eu.kanade.tachiyomi.lib.randomua.UserAgentType
 import eu.kanade.tachiyomi.lib.randomua.setRandomUserAgent
 import eu.kanade.tachiyomi.network.GET
@@ -23,8 +13,6 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
 import keiyoushi.utils.getPreferencesLazy
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
@@ -33,13 +21,8 @@ import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import rx.Observable
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
-import uy.kohesive.injekt.injectLazy
 import java.text.SimpleDateFormat
 import java.util.Locale
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
 
@@ -51,7 +34,8 @@ class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
 
     override val supportsLatest = true
 
-    private val json: Json by injectLazy()
+    private val scriptPageRegex = """(?s)pth\s*=\s*['"](.*?)['"]\s*;?""".toRegex()
+    private val urlDecryptionRegex = """l\s*\.replace\(\s*/(.*?)/([gimuy]*)\s*,\s*(['"`])(.*?)\3\s*\)""".toRegex()
 
     override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .setRandomUserAgent(
@@ -227,81 +211,45 @@ class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
         return GET(baseUrl + chapter.url + qualitySuffix, headers)
     }
 
-    @SuppressLint("SetJavaScriptEnabled")
     override fun pageListParse(document: Document): List<Page> {
-        val handler = Handler(Looper.getMainLooper())
-        val latch = CountDownLatch(1)
-        var webView: WebView? = null
-        var images: List<String> = emptyList()
+        // Declare some important values first
+        val encryptedLinks = mutableListOf<String>()
+        val decryptionRegexKeys = mutableListOf<Pair<String, String>>()
 
-        val html = document.outerHtml()
-        val match = KEY_REGEX.find(html)
-        val key1 = match?.groups?.get(1)?.value ?: throw Exception("Fail to get image links. Logging in via WebView may fix this issue.")
-        val key2 = match?.groups?.get(2)?.value ?: throw Exception("Fail to get image links. Logging in via WebView may fix this issue.")
-        handler.post {
-            val innerWv = WebView(Injekt.get<Application>())
+        // Get script elements
+        val scripts = document.select("script[type=text/javascript]")
 
-            webView = innerWv
-            innerWv.settings.javaScriptEnabled = true
-            innerWv.settings.blockNetworkImage = true
-            innerWv.settings.domStorageEnabled = true
-            innerWv.settings.userAgentString = headers["User-Agent"]
-            innerWv.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
+        // We'll get a bunch of results on the selector but we only need 2: The script that contains the encrypted links and the script
+        // that contains the partial decryption key.
+        for (script in scripts) {
+            val scriptContent = script.data()
+            if (scriptContent.isNotEmpty()) {
+                val encryptedValues = scriptPageRegex.findAll(scriptContent)
+                val decryptionKeys = urlDecryptionRegex.findAll(scriptContent)
 
-            innerWv.webViewClient = object : WebViewClient() {
-                override fun onLoadResource(view: WebView?, url: String?) {
-                    view?.evaluateJavascript(
-                        """
-                        window['$key2'].map(i => $key1(i));
-                        """.trimIndent(),
-                    ) {
-                        try {
-                            images = json.decodeFromString<List<String>>(it)
-                            latch.countDown()
-                        } catch (e: Exception) {
-                            Log.e("RCO", e.stackTraceToString())
+                // We found the encrypted links
+                if (encryptedValues.count() > 0) {
+                    encryptedValues.forEach {
+                        val url = it.groupValues[1]
+
+                        if (url.isNotBlank()) {
+                            encryptedLinks.add(url)
                         }
                     }
-
-                    super.onLoadResource(view, url)
                 }
-            }
 
-            innerWv.webChromeClient = object : WebChromeClient() {
-                override fun onConsoleMessage(consoleMessage: ConsoleMessage?): Boolean {
-                    if (consoleMessage == null) { return false }
-                    val logContent = "wv: ${consoleMessage.message()} (${consoleMessage.sourceId()}, line ${consoleMessage.lineNumber()})"
-                    when (consoleMessage.messageLevel()) {
-                        ConsoleMessage.MessageLevel.DEBUG -> Log.d("RCO", logContent)
-                        ConsoleMessage.MessageLevel.ERROR -> Log.e("RCO", logContent)
-                        ConsoleMessage.MessageLevel.LOG -> Log.i("RCO", logContent)
-                        ConsoleMessage.MessageLevel.TIP -> Log.i("RCO", logContent)
-                        ConsoleMessage.MessageLevel.WARNING -> Log.w("RCO", logContent)
-                        else -> Log.d("RCO", logContent)
+                // We found the keys
+                if (decryptionKeys.count() > 0) {
+                    decryptionKeys.forEach {
+                        // Corresponds to Pair<RegexPattern, ReplacementValue>
+                        decryptionRegexKeys.add(Pair(it.groupValues[1], it.groupValues[4]))
                     }
-
-                    return true
                 }
             }
-
-            innerWv.loadDataWithBaseURL(
-                document.location(),
-                html,
-                "text/html",
-                "UTF-8",
-                null,
-            )
         }
 
-        latch.await(10, TimeUnit.SECONDS)
-        handler.post { webView?.destroy() }
-
-        if (latch.count == 1L) {
-            throw Exception("Timeout getting image links")
-        }
-
-        return images.mapIndexed { idx, img ->
-            Page(idx, imageUrl = img)
+        return encryptedLinks.mapIndexed { idx, rawUrl ->
+            Page(idx, imageUrl = decryptLink(rawUrl, decryptionRegexKeys, ""))
         }
     }
 

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/ReadcomiconlinePageListDecrypt.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/ReadcomiconlinePageListDecrypt.kt
@@ -1,0 +1,71 @@
+package eu.kanade.tachiyomi.extension.en.readcomiconline
+
+import android.util.Base64
+import java.net.URLDecoder
+
+private fun step1(param: String): String {
+    return param.substring(15, 15 + 18) + param.substring(15 + 18 + 17)
+}
+
+private fun step2(param: String): String {
+    return param.substring(0, param.length - (9 + 2)) +
+        param[param.length - 2] +
+        param[param.length - 1]
+}
+
+fun decryptLink(
+    firstStringFormat: String,
+    partialDecryptKeys: List<Pair<String, String>>,
+    formatter: String = "",
+): String {
+    var processedString = firstStringFormat
+
+    partialDecryptKeys.forEach {
+        processedString = processedString.replace(it.first.toRegex(), it.second)
+    }
+
+    processedString = processedString
+        .replace("pw_.g28x", "b")
+        .replace("d2pr.x_27", "h")
+
+    if (!processedString.startsWith("https")) {
+        val firstStringFormatLocalVar = processedString
+        val firstStringSubS = firstStringFormatLocalVar.substring(
+            firstStringFormatLocalVar.indexOf("?"),
+        )
+
+        processedString = if (firstStringFormatLocalVar.contains("=s0?")) {
+            firstStringFormatLocalVar.substring(0, firstStringFormatLocalVar.indexOf("=s0?"))
+        } else {
+            firstStringFormatLocalVar.substring(0, firstStringFormatLocalVar.indexOf("=s1600?"))
+        }
+
+        processedString = step1(processedString)
+        processedString = step2(processedString)
+
+        // Base64 decode and URL decode
+        val decodedBytes = Base64.decode(processedString, Base64.DEFAULT)
+        processedString = URLDecoder.decode(String(decodedBytes), "UTF-8")
+
+        processedString = processedString.substring(0, 13) +
+            processedString.substring(17)
+
+        processedString = if (firstStringFormat.contains("=s0")) {
+            processedString.substring(0, processedString.length - 2) + "=s0"
+        } else {
+            processedString.substring(0, processedString.length - 2) + "=s1600"
+        }
+
+        processedString += firstStringSubS
+        processedString = "https://2.bp.blogspot.com/$processedString"
+    }
+
+    if (formatter.isNotEmpty()) {
+        processedString = processedString.replace(
+            "https://2.bp.blogspot.com",
+            formatter,
+        )
+    }
+
+    return processedString
+}


### PR DESCRIPTION
Now it doesn't require you to login and won't spawn a WebView every time you select a chapter.

Implementation is a bit scuffed especially on the decryption (I did the manual obfuscation of their decryption logic on Javascript then lazily ported it here) so feel free to change/update some things in this PR. Closing this PR is also fine if a better, more robust implementation is found.

Pretty sure those regex can be improved or (even better) move it as a pref to reduce version bump occurence..

Closes #8484 
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
