### PR TITLE
Fix mangaworld

### DIFF
--- a/lib-multisrc/mangaworld/build.gradle.kts
+++ b/lib-multisrc/mangaworld/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 3
+baseVersionCode = 4

--- a/lib-multisrc/mangaworld/src/eu/kanade/tachiyomi/multisrc/mangaworld/CookieRedirectInterceptor.kt
+++ b/lib-multisrc/mangaworld/src/eu/kanade/tachiyomi/multisrc/mangaworld/CookieRedirectInterceptor.kt
@@ -13,7 +13,7 @@ class CookieRedirectInterceptor(private val client: OkHttpClient) : Interceptor 
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
-        // dont intercept request coming from the cdn eg. skip images
+        
         val host = request.url.host
         if (host.startsWith("cdn", ignoreCase = true)) {
             return chain.proceed(request)

--- a/lib-multisrc/mangaworld/src/eu/kanade/tachiyomi/multisrc/mangaworld/CookieRedirectInterceptor.kt
+++ b/lib-multisrc/mangaworld/src/eu/kanade/tachiyomi/multisrc/mangaworld/CookieRedirectInterceptor.kt
@@ -13,6 +13,11 @@ class CookieRedirectInterceptor(private val client: OkHttpClient) : Interceptor 
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
+        //dont intercept request coming from the cdn eg. skip images
+        val host = request.url.host
+        if (host.startsWith("cdn", ignoreCase = true)) {
+            return chain.proceed(request)
+        }
         val response = chain.proceed(request)
         // ignore requests that already have completed the JS challenge
         if (response.headers["vary"] != null) return response

--- a/lib-multisrc/mangaworld/src/eu/kanade/tachiyomi/multisrc/mangaworld/CookieRedirectInterceptor.kt
+++ b/lib-multisrc/mangaworld/src/eu/kanade/tachiyomi/multisrc/mangaworld/CookieRedirectInterceptor.kt
@@ -13,7 +13,7 @@ class CookieRedirectInterceptor(private val client: OkHttpClient) : Interceptor 
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
-        //dont intercept request coming from the cdn eg. skip images
+        // dont intercept request coming from the cdn eg. skip images
         val host = request.url.host
         if (host.startsWith("cdn", ignoreCase = true)) {
             return chain.proceed(request)

--- a/lib-multisrc/mangaworld/src/eu/kanade/tachiyomi/multisrc/mangaworld/CookieRedirectInterceptor.kt
+++ b/lib-multisrc/mangaworld/src/eu/kanade/tachiyomi/multisrc/mangaworld/CookieRedirectInterceptor.kt
@@ -13,7 +13,6 @@ class CookieRedirectInterceptor(private val client: OkHttpClient) : Interceptor 
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
-        
         val host = request.url.host
         if (host.startsWith("cdn", ignoreCase = true)) {
             return chain.proceed(request)

--- a/lib-multisrc/mangaworld/src/eu/kanade/tachiyomi/multisrc/mangaworld/CookieRedirectInterceptor.kt
+++ b/lib-multisrc/mangaworld/src/eu/kanade/tachiyomi/multisrc/mangaworld/CookieRedirectInterceptor.kt
@@ -13,11 +13,13 @@ class CookieRedirectInterceptor(private val client: OkHttpClient) : Interceptor 
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
-        val host = request.url.host
-        if (host.startsWith("cdn", ignoreCase = true)) {
-            return chain.proceed(request)
-        }
         val response = chain.proceed(request)
+
+        val path = request.url.encodedPath
+        if (path.startsWith("/chapters", ignoreCase = true) || path.startsWith("/mangas", ignoreCase = true)) {
+            return response
+        }
+
         // ignore requests that already have completed the JS challenge
         if (response.headers["vary"] != null) return response
 

--- a/lib-multisrc/mangaworld/src/eu/kanade/tachiyomi/multisrc/mangaworld/CookieRedirectInterceptor.kt
+++ b/lib-multisrc/mangaworld/src/eu/kanade/tachiyomi/multisrc/mangaworld/CookieRedirectInterceptor.kt
@@ -15,8 +15,8 @@ class CookieRedirectInterceptor(private val client: OkHttpClient) : Interceptor 
         val request = chain.request()
         val response = chain.proceed(request)
 
-        val path = request.url.encodedPath
-        if (path.startsWith("/chapters", ignoreCase = true) || path.startsWith("/mangas", ignoreCase = true)) {
+        val contentType = response.header("content-type")
+        if (contentType != null && contentType.startsWith("image/", ignoreCase = true)) {
             return response
         }
 

--- a/src/it/mangaworld/build.gradle
+++ b/src/it/mangaworld/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Mangaworld'
     themePkg = 'mangaworld'
     baseUrl = 'https://www.mangaworld.nz'
-    overrideVersionCode = 8
+    overrideVersionCode = 7
     isNsfw = false
 }
 

--- a/src/it/mangaworld/build.gradle
+++ b/src/it/mangaworld/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Mangaworld'
     themePkg = 'mangaworld'
     baseUrl = 'https://www.mangaworld.nz'
-    overrideVersionCode = 7
+    overrideVersionCode = 8
     isNsfw = false
 }
 


### PR DESCRIPTION
 Skip interception for CDN hosts (e.g., for images or static assets).

Closes #7840


Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
