### PR TITLE
RCO: Add workaround for Tachimanga.

### DIFF
--- a/src/en/readcomiconline/build.gradle
+++ b/src/en/readcomiconline/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ReadComicOnline'
     extClass = '.Readcomiconline'
-    extVersionCode = 32
+    extVersionCode = 33
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
@@ -252,12 +252,12 @@ class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
             innerWv.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
 
             innerWv.webViewClient = object : WebViewClient() {
-                private val emptyResponse = WebResourceResponse("text/plain", "utf-8", 200, "OK", mapOf(), "".byteInputStream())
-
                 override fun shouldInterceptRequest(
                     view: WebView?,
                     request: WebResourceRequest?,
                 ): WebResourceResponse? {
+                    val emptyResponse = WebResourceResponse("text/plain", "utf-8", 200, "OK", mapOf(), "".byteInputStream())
+
                     val url = request?.url?.toString()
 
                     url ?: return emptyResponse
@@ -330,11 +330,15 @@ class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
                         .headers(headers)
                         .build()
 
-                    val response = client.newCall(request).await()
-                    val contentType = response.headers["content-type"] ?: ""
-                    val size = response.headers["content-length"]?.toLongOrNull() ?: 0L
+                    try {
+                        val response = client.newCall(request).await()
+                        val contentType = response.headers["content-type"] ?: ""
+                        val size = response.headers["content-length"]?.toLongOrNull() ?: 0L
 
-                    response.isSuccessful && contentType.startsWith("image") && size > 100
+                        response.isSuccessful && contentType.startsWith("image") && size > 100
+                    } catch (e: Exception) {
+                        false
+                    }
                 }
             }.awaitAll()
 

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
@@ -314,7 +314,7 @@ class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
             )
         }
 
-        latch.await(10, TimeUnit.SECONDS)
+        latch.await(30, TimeUnit.SECONDS)
         handler.post { webView?.destroy() }
 
         if (latch.count == 1L) {


### PR DESCRIPTION
Tachimanga throws an HttpException when the request is not successful and does not implement shouldInterceptRequest and WebResourceResponse.

https://github.com/tachimanga/Tachidesk-Server/blob/d210b349c9e169508ddf6f49fb9e720b759a397f/server/src/main/kotlin/eu/kanade/tachiyomi/network/OkHttpExtensions.kt#L68


Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
