### PR TITLE
Kdt Scans: update url

### DIFF
--- a/src/all/kdtscans/build.gradle
+++ b/src/all/kdtscans/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'KDT Scans'
     extClass = '.KdtScans'
     themePkg = 'madara'
-    baseUrl = 'https://kdt.akan01.com'
-    overrideVersionCode = 1
+    baseUrl = 'https://kdtscans.com'
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/all/kdtscans/src/eu/kanade/tachiyomi/extension/all/kdtscans/KdtScans.kt
+++ b/src/all/kdtscans/src/eu/kanade/tachiyomi/extension/all/kdtscans/KdtScans.kt
@@ -7,7 +7,7 @@ import org.jsoup.nodes.Element
 
 class KdtScans : Madara(
     "KDT Scans",
-    "https://kdt.akan01.com",
+    "https://kdtscans.com",
     "all",
 ) {
     override val useNewChapterEndpoint = true
@@ -36,5 +36,7 @@ class KdtScans : Madara(
     private fun String.cleanupTitle() = replace(titleCleanupRegex, "").trim()
 
     private val titleCleanupRegex =
-        Regex("""^\[(ESPAÑOL|English|HD)\]\s+(–\s+)?""", RegexOption.IGNORE_CASE)
+        Regex("""^\[(ESPAÑOL|English|HD|VIP)\]\s+(–\s+)?""", RegexOption.IGNORE_CASE)
+
+    override fun chapterListSelector() = "li.wp-manga-chapter:not(:has(.required-login))"
 }


### PR DESCRIPTION
closes #8525

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
