### PR TITLE
Fix Baozi Manhua

### DIFF
--- a/src/zh/baozimanhua/build.gradle
+++ b/src/zh/baozimanhua/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Baozi Manhua'
     extClass = '.Baozi'
-    extVersionCode = 25
+    extVersionCode = 26
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/zh/baozimanhua/src/eu/kanade/tachiyomi/extension/zh/baozimanhua/Baozi.kt
+++ b/src/zh/baozimanhua/src/eu/kanade/tachiyomi/extension/zh/baozimanhua/Baozi.kt
@@ -53,7 +53,7 @@ class Baozi : ParsedHttpSource(), ConfigurableSource {
         level = preferences.getString(BaoziBanner.PREF, DEFAULT_LEVEL)!!.toInt(),
     )
 
-    override val client = network.cloudflareClient.newBuilder()
+    override val client = network.client.newBuilder()
         .rateLimit(2)
         .addInterceptor(bannerInterceptor)
         .addNetworkInterceptor(MissingImageInterceptor)


### PR DESCRIPTION
Closes https://github.com/keiyoushi/extensions-source/issues/8553

Changing it to a regular client seems to fix the connection reset errors.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
