### PR TITLE
RCO: dedupe URLs, sort by most likely URL

### DIFF
--- a/src/en/readcomiconline/assets/script.js
+++ b/src/en/readcomiconline/assets/script.js
@@ -15,20 +15,22 @@
     const multiMaybeFn = [];
 
     customProps.forEach(k => {
-        const obj = window[k];
-        if (
-            Array.isArray(obj) &&
-            obj.length !== 0 &&
-            obj.every(el => typeof el === 'string') &&
-            obj.every(el => el.length > 8)
-        ) {
-            multiMaybeUrls.push(obj);
-        } else if (
-            typeof obj === 'function' &&
-            obj.length >= 1
-        ) {
-            multiMaybeFn.push(obj);
-        }
+        try {
+            const obj = window[k];
+            if (
+                Array.isArray(obj) &&
+                obj.length !== 0 &&
+                obj.every(el => typeof el === 'string') &&
+                obj.every(el => el.length > 8)
+            ) {
+                multiMaybeUrls.push(obj);
+            } else if (
+                typeof obj === 'function' &&
+                obj.length >= 1
+            ) {
+                multiMaybeFn.push(obj);
+            }
+        } catch(_) {}
     });
 
     const isValidUrl = (maybeUrl) => {
@@ -43,6 +45,7 @@
     const results = [];
 
     multiMaybeUrls.forEach(maybeUrls => {
+        const maybeUrlsLength = maybeUrls.length;
         multiMaybeFn.forEach(maybeFn => {
             const maybeFnArgCount = maybeFn.length;
 
@@ -56,7 +59,7 @@
 
                     if (
                         Array.isArray(maybeUrlsDecoded) &&
-                        maybeUrlsDecoded.length !== 0 &&
+                        maybeUrlsDecoded.length === maybeUrlsLength &&
                         maybeUrlsDecoded.every(el => typeof el === 'string') &&
                         maybeUrlsDecoded.every(isValidUrl)
                     ) {

--- a/src/en/readcomiconline/build.gradle
+++ b/src/en/readcomiconline/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ReadComicOnline'
     extClass = '.Readcomiconline'
-    extVersionCode = 34
+    extVersionCode = 35
 }
 
 apply from: "$rootDir/common.gradle"


### PR DESCRIPTION
This will produce less network requests, and improves performance slightly by using a stricter pre-filter for arrays. On some older chapters I have observed 1 miss before it found the correct set of URLs, which adds ~1s. Does not address #8514.

Removing `break;` to make it more resilient to counter-measures.

This PR is _NOT_ necessary for RCO to work.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
