### PR TITLE
AnimeSama: fix chapter listing

### DIFF
--- a/src/fr/animesama/build.gradle
+++ b/src/fr/animesama/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeSama'
     extClass = '.AnimeSama'
-    extVersionCode = 4
+    extVersionCode = 5
 }
 
 apply from: "$rootDir/common.gradle"


### PR DESCRIPTION
Closes #5075

Since the javascript parsing is similar between `pageListParse` and `parseChapterFromResponse`, it might be better to initialise a map property in `parseChapterFromResponse` for use in `pageListParse`.

Also I think that the part for handling special chapters (if I'm not mistaken) is outdated.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
