### PR TITLE
West Manga: Update domain URL

### DIFF
--- a/src/id/westmanga/build.gradle
+++ b/src/id/westmanga/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'West Manga'
     extClass = '.WestManga'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://westmanga.fun'
+    baseUrl = 'https://westmanga.me'
     overrideVersionCode = 5
     isNsfw = true
 }

--- a/src/id/westmanga/build.gradle
+++ b/src/id/westmanga/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.WestManga'
     themePkg = 'mangathemesia'
     baseUrl = 'https://westmanga.fun'
-    overrideVersionCode = 4
+    overrideVersionCode = 5
     isNsfw = true
 }
 

--- a/src/id/westmanga/src/eu/kanade/tachiyomi/extension/id/westmanga/WestManga.kt
+++ b/src/id/westmanga/src/eu/kanade/tachiyomi/extension/id/westmanga/WestManga.kt
@@ -7,7 +7,7 @@ import okhttp3.OkHttpClient
 import org.jsoup.nodes.Document
 import java.util.Locale
 
-class WestManga : MangaThemesia("West Manga", "https://westmanga.fun", "id") {
+class WestManga : MangaThemesia("West Manga", "https://westmanga.me", "id") {
     // Formerly "West Manga (WP Manga Stream)"
     override val id = 8883916630998758688
 


### PR DESCRIPTION
Closes #8603, supercedes PR #8612
* Checked entry/details, chapters, search, and some of the filters, seems to work fine

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
