### PR TITLE
Fix: extract images from canvas instead of img in TeamX

### DIFF
--- a/src/ar/teamx/build.gradle
+++ b/src/ar/teamx/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Team X'
     extClass = '.TeamX'
-    extVersionCode = 20
+    extVersionCode = 21
     isNsfw = false
 }
 

--- a/src/ar/teamx/src/eu/kanade/tachiyomi/extension/ar/teamx/TeamX.kt
+++ b/src/ar/teamx/src/eu/kanade/tachiyomi/extension/ar/teamx/TeamX.kt
@@ -215,8 +215,8 @@ class TeamX : ParsedHttpSource(), ConfigurableSource {
     // Pages
 
     override fun pageListParse(document: Document): List<Page> {
-        return document.select("div.image_list img[src]").mapIndexed { i, img ->
-            Page(i, "", img.absUrl("src"))
+        return document.select("div.image_list canvas[data-src]").mapIndexed { i, img ->
+            Page(i, "", img.absUrl("data-src"))
         }
     }
 


### PR DESCRIPTION
Closes #8600
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
