### PR TITLE
batcave: remove cross origin referer

### DIFF
--- a/src/en/batcave/build.gradle
+++ b/src/en/batcave/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'BatCave'
     extClass = '.BatCave'
-    extVersionCode = 3
+    extVersionCode = 4
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/batcave/src/eu/kanade/tachiyomi/extension/en/batcave/BatCave.kt
+++ b/src/en/batcave/src/eu/kanade/tachiyomi/extension/en/batcave/BatCave.kt
@@ -222,6 +222,16 @@ class BatCave : HttpSource() {
         }
     }
 
+    override fun imageRequest(page: Page): Request {
+        val imageHeaders = headersBuilder().apply {
+            if (!page.imageUrl!!.toHttpUrl().host.contains("batcave")) {
+                removeAll("Referer")
+            }
+        }.build()
+
+        return GET(page.imageUrl!!, imageHeaders)
+    }
+
     override fun imageUrlParse(response: Response): String {
         throw UnsupportedOperationException()
     }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
