### PR TITLE
RCO: don't crash the app for now

### DIFF
--- a/src/en/readcomiconline/build.gradle
+++ b/src/en/readcomiconline/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ReadComicOnline'
     extClass = '.Readcomiconline'
-    extVersionCode = 34
+    extVersionCode = 35
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
@@ -224,6 +224,10 @@ class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
 
     private val dateFormat = SimpleDateFormat("MM/dd/yyyy", Locale.getDefault())
 
+    override fun fetchPageList(chapter: SChapter): Observable<List<Page>> {
+        throw Exception("Extension is broken")
+    }
+
     override fun pageListRequest(chapter: SChapter): Request {
         val qualitySuffix = if ((qualitypref() != "lq" && serverpref() != "s2") || (qualitypref() == "lq" && serverpref() == "s2")) {
             "&s=${serverpref()}&quality=${qualitypref()}&readType=1"

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
@@ -225,7 +225,7 @@ class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
     private val dateFormat = SimpleDateFormat("MM/dd/yyyy", Locale.getDefault())
 
     override fun fetchPageList(chapter: SChapter): Observable<List<Page>> {
-        throw Exception("Extension is broken")
+        throw Exception("Extension is broken. Migrate to another source")
     }
 
     override fun pageListRequest(chapter: SChapter): Request {


### PR DESCRIPTION
closes #8572

Will keep this around for a 1 or 2 weeks, to let users update to this version and prevent app crash due to oom. Extension will be removed after that, unless someone makes a working solution
