### PR TITLE
Fix/revert to img

### DIFF
--- a/src/ar/teamx/build.gradle
+++ b/src/ar/teamx/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Team X'
     extClass = '.TeamX'
-    extVersionCode = 21
+    extVersionCode = 22
     isNsfw = false
 }
 

--- a/src/ar/teamx/src/eu/kanade/tachiyomi/extension/ar/teamx/TeamX.kt
+++ b/src/ar/teamx/src/eu/kanade/tachiyomi/extension/ar/teamx/TeamX.kt
@@ -215,9 +215,14 @@ class TeamX : ParsedHttpSource(), ConfigurableSource {
     // Pages
 
     override fun pageListParse(document: Document): List<Page> {
-        return document.select("div.image_list img[src]").mapIndexed { i, img ->
-            Page(i, "", img.absUrl("src"))
-        }
+        return document.select("div.image_list canvas[data-src], div.image_list img[src]")
+            .mapIndexed { i, element ->
+                val url = when {
+                    element.hasAttr("src") -> element.absUrl("src")
+                    else -> element.absUrl("data-src")
+                }
+                Page(i, "", url)
+            }
     }
 
     override fun imageUrlParse(document: Document): String = throw UnsupportedOperationException()

--- a/src/ar/teamx/src/eu/kanade/tachiyomi/extension/ar/teamx/TeamX.kt
+++ b/src/ar/teamx/src/eu/kanade/tachiyomi/extension/ar/teamx/TeamX.kt
@@ -215,8 +215,8 @@ class TeamX : ParsedHttpSource(), ConfigurableSource {
     // Pages
 
     override fun pageListParse(document: Document): List<Page> {
-        return document.select("div.image_list canvas[data-src]").mapIndexed { i, img ->
-            Page(i, "", img.absUrl("data-src"))
+        return document.select("div.image_list img[src]").mapIndexed { i, img ->
+            Page(i, "", img.absUrl("src"))
         }
     }
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

TeamX switched back from `canvas`  to `img`.
This PR updates the image extraction logic accordingly.

Closes #8633
