### PR TITLE
Lunar Scans: remove redundant overrides

### DIFF
--- a/src/en/lunarscans/build.gradle
+++ b/src/en/lunarscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.LunarScans'
     themePkg = 'mangathemesia'
     baseUrl = 'https://lunarscan.org'
-    overrideVersionCode = 3
+    overrideVersionCode = 4
     isNsfw = true
 }
 

--- a/src/en/lunarscans/src/eu/kanade/tachiyomi/extension/en/lunarscans/LunarScans.kt
+++ b/src/en/lunarscans/src/eu/kanade/tachiyomi/extension/en/lunarscans/LunarScans.kt
@@ -6,17 +6,11 @@ import eu.kanade.tachiyomi.lib.randomua.getPrefCustomUA
 import eu.kanade.tachiyomi.lib.randomua.getPrefUAType
 import eu.kanade.tachiyomi.lib.randomua.setRandomUserAgent
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
-import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
-import eu.kanade.tachiyomi.source.model.Page
 import keiyoushi.utils.getPreferences
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.decodeFromString
-import okhttp3.Request
-import org.jsoup.nodes.Document
 
 class LunarScans :
     MangaThemesia(
@@ -36,14 +30,6 @@ class LunarScans :
         )
         .rateLimit(1)
         .build()
-
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        return if (query.isEmpty()) {
-            super.searchMangaRequest(page, query, filters)
-        } else {
-            GET("$baseUrl/?s=$query&page=$page", headers)
-        }
-    }
 
     override fun getFilterList(): FilterList {
         val filters = mutableListOf<Filter<*>>(
@@ -78,27 +64,7 @@ class LunarScans :
         return FilterList(filters)
     }
 
-    override fun pageListParse(document: Document): List<Page> {
-        val scriptContent = document.selectFirst("script:containsData(ts_reader)")?.data()
-            ?: return super.pageListParse(document)
-        val jsonString = scriptContent.substringAfter("ts_reader.run(").substringBefore(");")
-        val tsReader = json.decodeFromString<TSReader>(jsonString)
-        val imageUrls = tsReader.sources.firstOrNull()?.images ?: return emptyList()
-        return imageUrls.mapIndexed { index, imageUrl -> Page(index, document.location(), imageUrl) }
-    }
-
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         addRandomUAPreferenceToScreen(screen)
     }
-
-    @Serializable
-    data class TSReader(
-        val sources: List<ReaderImageSource>,
-    )
-
-    @Serializable
-    data class ReaderImageSource(
-        val source: String,
-        val images: List<String>,
-    )
 }


### PR DESCRIPTION
Removes `ts_reader.run(...)` logic, might fit better in parent class. Search now allows special characters otherwise not encoded.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
