### PR TITLE
XOXO Comics: escape search, add headers

### DIFF
--- a/src/en/xoxocomics/build.gradle
+++ b/src/en/xoxocomics/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.XoxoComics'
     themePkg = 'wpcomics'
     baseUrl = 'https://xoxocomic.com'
-    overrideVersionCode = 4
+    overrideVersionCode = 5
     isNsfw = false
 }
 

--- a/src/en/xoxocomics/src/eu/kanade/tachiyomi/extension/en/xoxocomics/XoxoComics.kt
+++ b/src/en/xoxocomics/src/eu/kanade/tachiyomi/extension/en/xoxocomics/XoxoComics.kt
@@ -61,7 +61,12 @@ class XoxoComics : WPComics(
         val filterList = filters.let { if (it.isEmpty()) getFilterList() else it }
         return if (query.isNotEmpty() || filterList.isEmpty()) {
             // Search won't work together with filter
-            return GET("$baseUrl/$searchPath?keyword=$query&page=$page", headers)
+            val url = baseUrl.toHttpUrl().newBuilder()
+                .addPathSegment(searchPath)
+                .addQueryParameter("keyword", query)
+                .addQueryParameter("page", page.toString())
+                .build()
+            return GET(url, headers)
         } else {
             val url = baseUrl.toHttpUrl().newBuilder()
 
@@ -109,7 +114,7 @@ class XoxoComics : WPComics(
         }
     }
 
-    override fun pageListRequest(chapter: SChapter): Request = GET(baseUrl + "${chapter.url}/all")
+    override fun pageListRequest(chapter: SChapter): Request = GET(baseUrl + "${chapter.url}/all", headers)
 
     override fun genresRequest() = GET("$baseUrl/comic-list", headers)
 


### PR DESCRIPTION
Closes #6787 (couldn't reproduce)

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
