### PR TITLE
RizzComic: handle edge case for slugs

### DIFF
--- a/src/en/rizzcomic/build.gradle
+++ b/src/en/rizzcomic/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.RizzComic'
     themePkg = 'mangathemesia'
     baseUrl = 'https://rizzfables.com'
-    overrideVersionCode = 11
+    overrideVersionCode = 12
     isNsfw = false
 }
 

--- a/src/en/rizzcomic/src/eu/kanade/tachiyomi/extension/en/rizzcomic/RizzComic.kt
+++ b/src/en/rizzcomic/src/eu/kanade/tachiyomi/extension/en/rizzcomic/RizzComic.kt
@@ -110,14 +110,17 @@ class RizzComic : MangaThemesiaAlt(
         @SerialName("genre_id") val genres: String? = null,
     ) {
         val slug get() = title.trim().lowercase()
+            .replace("'", "")
             .replace(slugRegex, "-")
             .replace("-s-", "s-")
             .replace("-ll-", "ll-")
+            .replace(slugCleanupRegex, "")
 
         val genreIds get() = genres?.split(",")?.map(String::trim)
 
         companion object {
             private val slugRegex = Regex("""[^a-z0-9]+""")
+            private val slugCleanupRegex = Regex("""^-+|-+$""")
         }
     }
 

--- a/src/en/rizzcomic/src/eu/kanade/tachiyomi/extension/en/rizzcomic/RizzComic.kt
+++ b/src/en/rizzcomic/src/eu/kanade/tachiyomi/extension/en/rizzcomic/RizzComic.kt
@@ -114,13 +114,12 @@ class RizzComic : MangaThemesiaAlt(
             .replace(slugRegex, "-")
             .replace("-s-", "s-")
             .replace("-ll-", "ll-")
-            .replace(slugCleanupRegex, "")
+            .trim('-')
 
         val genreIds get() = genres?.split(",")?.map(String::trim)
 
         companion object {
             private val slugRegex = Regex("""[^a-z0-9]+""")
-            private val slugCleanupRegex = Regex("""^-+|-+$""")
         }
     }
 


### PR DESCRIPTION
closes #8611

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
