### PR TITLE
MangaHub: try to refresh api key for all api requests

### DIFF
--- a/lib-multisrc/mangahub/build.gradle.kts
+++ b/lib-multisrc/mangahub/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 33
+baseVersionCode = 34
 
 dependencies {
     //noinspection UseTomlInstead

--- a/lib-multisrc/mangahub/src/eu/kanade/tachiyomi/multisrc/mangahub/MangaHub.kt
+++ b/lib-multisrc/mangahub/src/eu/kanade/tachiyomi/multisrc/mangahub/MangaHub.kt
@@ -1,7 +1,6 @@
 package eu.kanade.tachiyomi.multisrc.mangahub
 
 import android.content.SharedPreferences
-import android.util.Log
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.network.GET
@@ -139,10 +138,8 @@ abstract class MangaHub(
     }
 
     private fun apiAuthInterceptor(chain: Interceptor.Chain): Response {
-        Log.d("hub", "in apiAuthInterceptor")
         val request = chain.request()
         val tag = request.tag(GraphQLTag::class.java)
-            .also { Log.d("hub", "tag: $it") }
             ?: return chain.proceed(request) // We won't intercept non-graphql requests (like image retrieval)
 
         return try {

--- a/lib-multisrc/mangahub/src/eu/kanade/tachiyomi/multisrc/mangahub/MangaHubQueries.kt
+++ b/lib-multisrc/mangahub/src/eu/kanade/tachiyomi/multisrc/mangahub/MangaHubQueries.kt
@@ -1,6 +1,8 @@
 package eu.kanade.tachiyomi.multisrc.mangahub
 
-class GraphQLTag
+class GraphQLTag(
+    val refreshUrl: String? = null,
+)
 
 val searchQuery = { mangaSource: String, query: String, genre: String, order: String, page: Int ->
     """


### PR DESCRIPTION
currently, manga details and chapter list fail when no cookies are set, as api key is not fetched/refreshed there.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
