### PR TITLE
Manta Comics: encode search, mark as NSFW

### DIFF
--- a/src/en/manta/build.gradle
+++ b/src/en/manta/build.gradle
@@ -2,6 +2,7 @@ ext {
     extName = 'Manta Comics'
     extClass = '.MantaComics'
     extVersionCode = 5
+    isNsfw = true
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/manta/src/eu/kanade/tachiyomi/extension/en/manta/MantaComics.kt
+++ b/src/en/manta/src/eu/kanade/tachiyomi/extension/en/manta/MantaComics.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.json.jsonObject
 import okhttp3.Cookie
 import okhttp3.CookieJar
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import uy.kohesive.injekt.injectLazy
@@ -53,7 +54,11 @@ class MantaComics : HttpSource() {
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList) =
         filters.category.ifEmpty { if (query.isEmpty()) "New" else "" }.let {
-            GET("$baseUrl/manta/v1/search/series?cat=$it&q=$query", headers)
+            val url = "$baseUrl/manta/v1/search/series".toHttpUrl().newBuilder()
+                .addQueryParameter("cat", it)
+                .addQueryParameter("q", query)
+                .build()
+            GET(url, headers)
         }
 
     override fun searchMangaParse(response: Response) =


### PR DESCRIPTION
The extension is still broken, so not bumping the ext version.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
