### PR TITLE
NineAnime: encode search

### DIFF
--- a/src/en/nineanime/build.gradle
+++ b/src/en/nineanime/build.gradle
@@ -2,6 +2,7 @@ ext {
     extName = 'NineAnime'
     extClass = '.NineAnime'
     extVersionCode = 5
+    isNsfw = true
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/nineanime/src/eu/kanade/tachiyomi/extension/en/nineanime/NineAnime.kt
+++ b/src/en/nineanime/src/eu/kanade/tachiyomi/extension/en/nineanime/NineAnime.kt
@@ -9,6 +9,7 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
 import eu.kanade.tachiyomi.util.asJsoup
 import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.jsoup.nodes.Document
@@ -77,7 +78,12 @@ class NineAnime : ParsedHttpSource() {
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         return if (query.isNotBlank()) {
-            GET("$baseUrl/search/?name=$query&page=$page.html", headers)
+            val url = "$baseUrl/search/".toHttpUrl().newBuilder()
+                .addQueryParameter("name", query)
+                .addQueryParameter("page", "$page.html")
+                .build()
+
+            GET(url, headers)
         } else {
             var url = "$baseUrl/category/"
             for (filter in if (filters.isEmpty()) getFilterList() else filters) {


### PR DESCRIPTION
Extension is still broken (see #8036), so not bumping the version.

Search has been tested and is working with special characters.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
