### PR TITLE
AComics: replicate filters 1:1 from site

### DIFF
--- a/src/ru/acomics/build.gradle
+++ b/src/ru/acomics/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AComics'
     extClass = '.AComics'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = true
 }
 


### PR DESCRIPTION
Added filters from site:
- Тип комикса (Comic type)
- Подписка (Subscription)
- Минимум страниц (Minimum pages)
- Сортировка (Sorting)

Added categories:
- Детектив (Detective)
- Историческое (Historical)

Other:
- Search query parameter is now correctly encoded.
- Fixed pagination on text search (instead of spamming requests).
- Age rating is now using the same terminology as the site.
- Popular/Latest now follow the same code path as search.
- Query arguments follow the same format and order as on the site.\*

<sub>\* popular sort is the default, as opposed to latest.</sub>

I don't really like this implementation. It leaks the internal structure of filters so `searchMangaRequest()` has to know what index goes with what value, but not for categories/rankings.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
