### PR TITLE
zh/BoyLove: Fix chapter list parsing and enable upload dates display in chapters

### DIFF
--- a/src/zh/boylove/build.gradle
+++ b/src/zh/boylove/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'BoyLove'
     extClass = '.BoyLove'
-    extVersionCode = 13
+    extVersionCode = 14
     isNsfw = true
 }
 

--- a/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLove.kt
+++ b/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLove.kt
@@ -92,10 +92,11 @@ class BoyLove : HttpSource(), ConfigurableSource {
     override fun mangaDetailsParse(response: Response) = throw UnsupportedOperationException()
 
     override fun chapterListRequest(manga: SManga): Request =
-        GET("$baseUrl/home/api/chapter_list/tp/${manga.url}-0-0-10", headers)
+        GET("$baseUrl/home/api/chapter_list/tp/${manga.url}", headers)
 
-    override fun chapterListParse(response: Response): List<SChapter> =
-        response.parseAs<ListPageDto<ChapterDto>>().list.map { it.toSChapter() }
+    override fun chapterListParse(response: Response): List<SChapter> {
+        return response.parseAs<ListPageDto<ChapterDto>>().list.map { it.toSChapter() }.reversed()
+    }
 
     override fun fetchPageList(chapter: SChapter): Observable<List<Page>> {
         val chapterUrl = chapter.url

--- a/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLoveDto.kt
+++ b/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLoveDto.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.extension.zh.boylove
 
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
+import keiyoushi.utils.tryParse
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.long
@@ -61,7 +62,7 @@ class ChapterDto(
     fun toSChapter() = SChapter.create().apply {
         url = "/home/book/capter/id/$id"
         name = title.trim()
-        date_upload = dateFormat.parse(create_time)!!.time
+        date_upload = dateFormat.tryParse(create_time)
     }
 }
 

--- a/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLoveDto.kt
+++ b/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLoveDto.kt
@@ -56,10 +56,12 @@ fun String.toImageUrl() =
 class ChapterDto(
     private val id: Int,
     private val title: String,
+    private val create_time: String,
 ) {
     fun toSChapter() = SChapter.create().apply {
         url = "/home/book/capter/id/$id"
         name = title.trim()
+        date_upload = dateFormat.parse(create_time)!!.time
     }
 }
 


### PR DESCRIPTION
This PR updates the code for parsing the chapter list API in the Boylove source, which was changed after the site CMS upgrade a few days ago and returned 400 errors when retrieving the chapters:
```
! Unexpected JSON token at offset 19: Expected start of the object '{', but had '[' instead at path: $.result
JSON input: {"code":1,"result":[],"msg":"","succ":400}
```
A reverse order function has been added as the updated API's JSON now only returns chapters in positive order. The new API also includes upload dates for each chapter, this PR complements the related strings and functions to display them.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
