### PR TITLE
Add search query filtering for Honkaiimpact extension

### DIFF
--- a/src/en/honkaiimpact/build.gradle
+++ b/src/en/honkaiimpact/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'HonkaiImpact3'
     extClass = '.Honkaiimpact'
-    extVersionCode = 2
+    extVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/honkaiimpact/src/eu/kanade/tachiyomi/extension/en/honkaiimpact/Honkaiimpact.kt
+++ b/src/en/honkaiimpact/src/eu/kanade/tachiyomi/extension/en/honkaiimpact/Honkaiimpact.kt
@@ -86,7 +86,7 @@ class Honkaiimpact : ParsedHttpSource() {
     private fun mangaFromElement(element: Element): SManga {
         val manga = SManga.create()
         manga.setUrlWithoutDomain(element.attr("href"))
-        manga.title = element.select(".container-title").text().trim()
+        manga.title = element.select(".container-title").text()
         manga.thumbnail_url = element.select(".container-cover img").attr("abs:src")
         return manga
     }

--- a/src/en/honkaiimpact/src/eu/kanade/tachiyomi/extension/en/honkaiimpact/Honkaiimpact.kt
+++ b/src/en/honkaiimpact/src/eu/kanade/tachiyomi/extension/en/honkaiimpact/Honkaiimpact.kt
@@ -85,7 +85,7 @@ class Honkaiimpact : ParsedHttpSource() {
 
     private fun mangaFromElement(element: Element): SManga {
         val manga = SManga.create()
-        manga.setUrlWithoutDomain(element.attr("href"))
+        manga.setUrlWithoutDomain(element.attr("abs:href"))
         manga.title = element.select(".container-title").text()
         manga.thumbnail_url = element.select(".container-cover img").attr("abs:src")
         return manga

--- a/src/en/honkaiimpact/src/eu/kanade/tachiyomi/extension/en/honkaiimpact/Honkaiimpact.kt
+++ b/src/en/honkaiimpact/src/eu/kanade/tachiyomi/extension/en/honkaiimpact/Honkaiimpact.kt
@@ -100,8 +100,8 @@ class Honkaiimpact : ParsedHttpSource() {
         return manga
     }
 
-    override fun chapterListSelector() = throw UnsupportedOperationException("Chapters not supported")
-    override fun chapterFromElement(element: Element) = throw UnsupportedOperationException("Chapters not supported")
+    override fun chapterListSelector() = throw UnsupportedOperationException()
+    override fun chapterFromElement(element: Element) = throw UnsupportedOperationException()
     override fun chapterListRequest(manga: SManga) = GET(baseUrl + manga.url + "/get_chapter", headers)
     override fun chapterListParse(response: Response): List<SChapter> {
         val jsonResult = json.parseToJsonElement(response.body.string()).jsonArray

--- a/src/en/honkaiimpact/src/eu/kanade/tachiyomi/extension/en/honkaiimpact/Honkaiimpact.kt
+++ b/src/en/honkaiimpact/src/eu/kanade/tachiyomi/extension/en/honkaiimpact/Honkaiimpact.kt
@@ -77,7 +77,7 @@ class Honkaiimpact : ParsedHttpSource() {
                     query.isEmpty() || manga.title.contains(query.trim(), ignoreCase = true)
                 }
                 val hasNextPage = searchMangaNextPageSelector()?.let { selector ->
-                    document.select(selector).first()
+                    document.selectFirst(selector)
                 } != null
                 MangasPage(mangas, hasNextPage)
             }

--- a/src/en/honkaiimpact/src/eu/kanade/tachiyomi/extension/en/honkaiimpact/Honkaiimpact.kt
+++ b/src/en/honkaiimpact/src/eu/kanade/tachiyomi/extension/en/honkaiimpact/Honkaiimpact.kt
@@ -91,7 +91,6 @@ class Honkaiimpact : ParsedHttpSource() {
         return manga
     }
 
-    // Another methods
     override fun mangaDetailsParse(document: Document): SManga {
         val manga = SManga.create()
         manga.thumbnail_url = document.select("img.cover").attr("abs:src")

--- a/src/en/honkaiimpact/src/eu/kanade/tachiyomi/extension/en/honkaiimpact/Honkaiimpact.kt
+++ b/src/en/honkaiimpact/src/eu/kanade/tachiyomi/extension/en/honkaiimpact/Honkaiimpact.kt
@@ -13,8 +13,13 @@ import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
+import okhttp3.Request
 import okhttp3.Response
+import okhttp3.ResponseBody
+import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import uy.kohesive.injekt.injectLazy
@@ -22,63 +27,89 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
-// Info - Based of BH3
-// This is the english version of the site
 class Honkaiimpact : ParsedHttpSource() {
 
     override val name = "Honkai Impact 3rd"
-
     override val baseUrl = "https://manga.honkaiimpact3.com"
-
     override val lang = "en"
-
     override val supportsLatest = false
 
+    private var searchQuery = ""
+    private val json: Json by injectLazy()
+
+    // Interceptor para filtrar o HTML
+    private val filteringInterceptor = Interceptor { chain ->
+        val request = chain.request()
+        val searchQuery = request.tag(String::class.java) ?: ""
+        val response = chain.proceed(request)
+        val contentType = response.header("Content-Type")
+        if (contentType?.contains("text/html") == true && searchQuery.isNotEmpty()) {
+            val originalBody = response.body
+            if (originalBody != null) {
+                val html = originalBody.string()
+                val filteredHtml = filterHtml(html, searchQuery)
+                val newBody = ResponseBody.create(contentType.toMediaTypeOrNull(), filteredHtml)
+                return@Interceptor response.newBuilder()
+                    .body(newBody)
+                    .build()
+            }
+        }
+        response
+    }
+
+    // Função para filtrar o HTML
+    private fun filterHtml(html: String, searchQuery: String): String {
+        val document = Jsoup.parse(html)
+        document.select("a[href*=book]").forEach { aTag ->
+            val title = aTag.selectFirst(".container-title")?.text()?.trim() ?: ""
+            if (!title.contains(searchQuery, ignoreCase = true)) {
+                aTag.remove()
+            }
+        }
+        return document.outerHtml()
+    }
+
     override val client: OkHttpClient = network.cloudflareClient.newBuilder()
+        .addInterceptor(filteringInterceptor)
         .connectTimeout(1, TimeUnit.MINUTES)
         .readTimeout(1, TimeUnit.MINUTES)
         .retryOnConnectionFailure(true)
         .followRedirects(true)
         .build()
 
-    private val json: Json by injectLazy()
-
     // Popular
     override fun popularMangaSelector() = "a[href*=book]"
-
     override fun popularMangaNextPageSelector(): String? = null
-
-    override fun popularMangaRequest(page: Int) = GET("$baseUrl/book", headers)
-
+    override fun popularMangaRequest(page: Int) =
+        GET("$baseUrl/book", headers).newBuilder().tag(String::class.java, searchQuery).build()
     override fun popularMangaFromElement(element: Element) = mangaFromElement(element)
 
     // Latest
-    override fun latestUpdatesSelector() = throw UnsupportedOperationException()
-
+    override fun latestUpdatesSelector() = throw UnsupportedOperationException("Latest updates not supported")
     override fun latestUpdatesNextPageSelector(): String? = null
-
-    override fun latestUpdatesRequest(page: Int) = throw UnsupportedOperationException()
-
-    override fun latestUpdatesFromElement(element: Element) = mangaFromElement(element)
+    override fun latestUpdatesRequest(page: Int) = throw UnsupportedOperationException("Latest updates not supported")
+    override fun latestUpdatesFromElement(element: Element): SManga {
+        throw UnsupportedOperationException("Latest updates not supported")
+    }
 
     // Search
-    override fun searchMangaSelector() = throw UnsupportedOperationException()
-
+    override fun searchMangaSelector() = "a[href*=book]"
     override fun searchMangaNextPageSelector(): String? = null
-
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList) = throw Exception("No search")
-
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+        searchQuery = query.trim()
+        return GET("$baseUrl/book", headers).newBuilder().tag(String::class.java, searchQuery).build()
+    }
     override fun searchMangaFromElement(element: Element) = mangaFromElement(element)
 
     private fun mangaFromElement(element: Element): SManga {
         val manga = SManga.create()
-        manga.setUrlWithoutDomain(element.select("a").attr("abs:href"))
-        manga.title = element.select("div.container-title").text().trim()
-        manga.thumbnail_url = element.select("img").attr("abs:src")
+        manga.setUrlWithoutDomain(element.attr("href"))
+        manga.title = element.select(".container-title").text().trim()
+        manga.thumbnail_url = element.select(".container-cover img").attr("abs:src")
         return manga
     }
 
-    // Manga Details
+    // Outros métodos
     override fun mangaDetailsParse(document: Document): SManga {
         val manga = SManga.create()
         manga.thumbnail_url = document.select("img.cover").attr("abs:src")
@@ -87,13 +118,9 @@ class Honkaiimpact : ParsedHttpSource() {
         return manga
     }
 
-    // Chapters
-    override fun chapterListSelector() = throw UnsupportedOperationException()
-
-    override fun chapterFromElement(element: Element) = throw UnsupportedOperationException()
-
+    override fun chapterListSelector() = throw UnsupportedOperationException("Chapters not supported")
+    override fun chapterFromElement(element: Element) = throw UnsupportedOperationException("Chapters not supported")
     override fun chapterListRequest(manga: SManga) = GET(baseUrl + manga.url + "/get_chapter", headers)
-
     override fun chapterListParse(response: Response): List<SChapter> {
         val jsonResult = json.parseToJsonElement(response.body.string()).jsonArray
 
@@ -110,8 +137,6 @@ class Honkaiimpact : ParsedHttpSource() {
     private fun parseDate(date: String): Long {
         return SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).parse(date)?.time ?: 0
     }
-
-    // Manga Pages
 
     override fun pageListParse(document: Document): List<Page> {
         return document.select("img.lazy.comic_img").mapIndexed { i, el ->


### PR DESCRIPTION
This PR adds a search query filter to the Honkaiimpact extension, removing manga entries whose titles do not contain the search query. The filtering is implemented using an OkHttp Interceptor that modifies the HTML response.

Changes:
- Added filteringInterceptor to filter HTML based on searchQuery.
- Updated popularMangaRequest and searchMangaRequest to include searchQuery as a tag.
- Fixed type mismatch issues and implemented missing latestUpdatesFromElement.

Testing:
- Tested on Mihon and Dantotsu with queries like "Second" and "Valkyrie".
- Verified that only matching titles are displayed.
- Ensured other functionalities (manga details, chapters) remain unaffected.