### PR TITLE
EgoToons: Fix loading content

### DIFF
--- a/src/pt/egotoons/build.gradle
+++ b/src/pt/egotoons/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.EgoToons'
     themePkg = 'yuyu'
     baseUrl = 'https://egotoons.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/pt/egotoons/src/eu/kanade/tachiyomi/extension/pt/egotoons/EgoToons.kt
+++ b/src/pt/egotoons/src/eu/kanade/tachiyomi/extension/pt/egotoons/EgoToons.kt
@@ -9,6 +9,9 @@ class EgoToons : YuYu(
     "pt-BR",
 ) {
 
+    override fun headersBuilder() = super.headersBuilder()
+        .set("Accept-Encoding", "")
+
     override val client = super.client.newBuilder()
         .rateLimit(2)
         .build()


### PR DESCRIPTION
Closes #8353

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
