### PR TITLE
SussyToons: Fix manga details

### DIFF
--- a/src/pt/sussyscan/build.gradle
+++ b/src/pt/sussyscan/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.SussyToons'
     themePkg = 'greenshit'
     baseUrl = 'https://www.sussytoons.wtf'
-    overrideVersionCode = 55
+    overrideVersionCode = 56
     isNsfw = true
 }
 

--- a/src/pt/sussyscan/src/eu/kanade/tachiyomi/extension/pt/sussyscan/SussyToons.kt
+++ b/src/pt/sussyscan/src/eu/kanade/tachiyomi/extension/pt/sussyscan/SussyToons.kt
@@ -31,12 +31,19 @@ class SussyToons : GreenShit(
         return MangasPage(mangas, hasNextPage = false)
     }
 
-    override fun getChapterUrl(chapter: SChapter) = "$baseUrl${chapter.url}"
+    override fun getMangaUrl(manga: SManga) = "$baseUrl${manga.url}"
 
-    override fun chapterListRequest(manga: SManga): Request {
+    override fun mangaDetailsRequest(manga: SManga): Request {
         val pathSegment = manga.url.substringBeforeLast("/").replace("obra", "obras")
         return GET("$apiUrl$pathSegment", headers)
     }
+
+    override fun mangaDetailsParse(response: Response) =
+        response.parseAs<ResultDto<MangaDto>>().results.toSManga()
+
+    override fun getChapterUrl(chapter: SChapter) = "$baseUrl${chapter.url}"
+
+    override fun chapterListRequest(manga: SManga) = mangaDetailsRequest(manga)
 
     override fun chapterListParse(response: Response): List<SChapter> =
         response.parseAs<ResultDto<WrapperChapterDto>>().toSChapterList()


### PR DESCRIPTION
This was a scenario that I didn't test in the previous update, updating the manga details by the user

Checklist:


- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
