### PR TITLE
updated birdtoon domain

### DIFF
--- a/src/id/birdtoon/build.gradle
+++ b/src/id/birdtoon/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'BirdToon'
     extClass = '.BirdToon'
     themePkg = 'madara'
-    baseUrl = 'https://birdtoon.org'
+    baseUrl = 'https://birdtoon.shop'
     overrideVersionCode = 2
     isNsfw = true
 }

--- a/src/id/birdtoon/build.gradle
+++ b/src/id/birdtoon/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.BirdToon'
     themePkg = 'madara'
     baseUrl = 'https://birdtoon.org'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/id/birdtoon/src/eu/kanade/tachiyomi/extension/id/birdtoon/BirdToon.kt
+++ b/src/id/birdtoon/src/eu/kanade/tachiyomi/extension/id/birdtoon/BirdToon.kt
@@ -4,7 +4,7 @@ import eu.kanade.tachiyomi.multisrc.madara.Madara
 
 class BirdToon : Madara(
     "BirdToon",
-    "https://birdtoon.org",
+    "https://birdtoon.shop",
     "id",
 ) {
     override val mangaSubString = "komik"


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

closes #8861 
