### PR TITLE
Noromax: Update mangaUrlDirectory

### DIFF
--- a/src/id/noromax/build.gradle
+++ b/src/id/noromax/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Noromax'
     themePkg = 'mangathemesia'
     baseUrl = 'https://noromax01.my.id'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/id/noromax/src/eu/kanade/tachiyomi/extension/id/noromax/Noromax.kt
+++ b/src/id/noromax/src/eu/kanade/tachiyomi/extension/id/noromax/Noromax.kt
@@ -2,7 +2,11 @@ package eu.kanade.tachiyomi.extension.id.noromax
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 
-class Noromax : MangaThemesia("Noromax", "https://noromax01.my.id", "id", "/Komik") {
+class Noromax : MangaThemesia(
+    "Noromax",
+    "https://noromax01.my.id",
+    "id",
+) {
 
     // Site changed from ZeistManga to MangaThemesia
     override val versionId = 2


### PR DESCRIPTION
Closes #8860

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
