### PR TITLE
GenzToons: Fix popularManga

### DIFF
--- a/src/en/suryascans/build.gradle
+++ b/src/en/suryascans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.GenzToons'
     themePkg = 'keyoapp'
     baseUrl = 'https://genzupdates.com'
-    overrideVersionCode = 30
+    overrideVersionCode = 31
     isNsfw = false
 }
 

--- a/src/en/suryascans/src/eu/kanade/tachiyomi/extension/en/suryascans/GenzToons.kt
+++ b/src/en/suryascans/src/eu/kanade/tachiyomi/extension/en/suryascans/GenzToons.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.extension.en.suryascans
 
 import eu.kanade.tachiyomi.multisrc.keyoapp.Keyoapp
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.source.model.FilterList
 import java.util.concurrent.TimeUnit
 
 class GenzToons : Keyoapp(
@@ -16,4 +17,6 @@ class GenzToons : Keyoapp(
         .writeTimeout(90, TimeUnit.SECONDS)
         .readTimeout(90, TimeUnit.SECONDS)
         .build()
+
+    override fun fetchPopularManga(page: Int) = fetchSearchManga(page, "", FilterList())
 }


### PR DESCRIPTION
Closes #8866

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
