### PR TITLE
ResetScans: BaseUrl update

### DIFF
--- a/src/en/resetscans/build.gradle
+++ b/src/en/resetscans/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Reset Scans'
     extClass = '.ResetScans'
     themePkg = 'madara'
-    baseUrl = 'https://reset-scans.co'
-    overrideVersionCode = 9
+    baseUrl = 'https://reset-scans.org'
+    overrideVersionCode = 10
     isNsfw = false
 }
 

--- a/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
+++ b/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
@@ -6,7 +6,7 @@ import java.util.Locale
 
 class ResetScans : Madara(
     "Reset Scans",
-    "https://reset-scans.co",
+    "https://reset-scans.org",
     "en",
     dateFormat = SimpleDateFormat("MMM dd", Locale.US),
 ) {


### PR DESCRIPTION
closes #8653

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
