### PR TITLE
Update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_report_issue.yml
+++ b/.github/ISSUE_TEMPLATE/01_report_issue.yml
@@ -1,5 +1,5 @@
 name: 🐞 Issue report
-description: Report a source issue in Tachiyomi
+description: Report a source issue in Keiyoushi
 labels: [Bug]
 body:
 
@@ -63,7 +63,7 @@ body:
       description: |
         You can find your Mihon/Tachiyomi version in **More → About**.
       placeholder: |
-        Example: "0.16.3"
+        Example: "0.18.0"
     validations:
       required: true
 
@@ -101,7 +101,7 @@ body:
           required: true
         - label: I have tried the [troubleshooting guide](https://mihon.app/docs/guides/troubleshooting/).
           required: true
-        - label: If this is an issue with the app itself, I should be opening an issue in the [app repository](https://github.com/tachiyomiorg/tachiyomi/issues/new/choose).
+        - label: If this is an issue with the app itself, I should be opening an issue in the app repository.
           required: true
         - label: I will fill out all of the requested information in this form.
           required: true


### PR DESCRIPTION
Removed link to tachiyomi repository and changed the description of the template.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
