### PR TITLE
Update domains and migrate sources

### DIFF
--- a/src/en/magusmanga/build.gradle
+++ b/src/en/magusmanga/build.gradle
@@ -1,9 +1,9 @@
 ext {
     extName = 'Magus Manga'
     extClass = '.MagusManga'
-    themePkg = 'keyoapp'
-    baseUrl = 'https://magustoon.com'
-    overrideVersionCode = 35
+    themePkg = 'iken'
+    baseUrl = 'https://magustoon.org'
+    overrideVersionCode = 44
     isNsfw = false
 }
 

--- a/src/en/magusmanga/src/eu/kanade/tachiyomi/extension/en/magusmanga/MagusManga.kt
+++ b/src/en/magusmanga/src/eu/kanade/tachiyomi/extension/en/magusmanga/MagusManga.kt
@@ -1,41 +1,33 @@
 package eu.kanade.tachiyomi.extension.en.magusmanga
 
-import eu.kanade.tachiyomi.multisrc.keyoapp.Keyoapp
+import eu.kanade.tachiyomi.multisrc.iken.Iken
+import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.util.asJsoup
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.Interceptor
 import okhttp3.Response
-import okio.IOException
-import org.jsoup.Jsoup
 
-class MagusManga : Keyoapp(
+class MagusManga : Iken(
     "Magus Manga",
-    "https://magustoon.com",
     "en",
+    "https://magustoon.org",
+    "https://api.magustoon.org",
 ) {
-    override val versionId = 2
+    // Moved from Keyoapp to Iken
+    override val versionId = 3
 
     override val client = network.cloudflareClient.newBuilder()
-        .addInterceptor(::captchaInterceptor)
         .rateLimitHost(baseUrl.toHttpUrl(), 1)
         .build()
 
-    private fun captchaInterceptor(chain: Interceptor.Chain): Response {
-        val request = chain.request()
-        val response = chain.proceed(request)
+    override fun popularMangaRequest(page: Int) = GET(baseUrl, headers)
 
-        if (response.code == 401) {
-            val document = Jsoup.parse(
-                response.peekBody(Long.MAX_VALUE).string(),
-                response.request.url.toString(),
-            )
-
-            if (document.selectFirst(".g-recaptcha") != null) {
-                response.close()
-                throw IOException("Solve Captcha in WebView")
-            }
-        }
-
-        return response
+    override fun popularMangaParse(response: Response): MangasPage {
+        val entries = response.asJsoup().select(".splide__track li > a").mapNotNull {
+            titleCache[it.absUrl("href").substringAfter("series/")]?.toSManga()
+        }.distinctBy(SManga::url)
+        return MangasPage(entries, false)
     }
 }

--- a/src/es/jeazscans/build.gradle
+++ b/src/es/jeazscans/build.gradle
@@ -1,9 +1,9 @@
 ext {
     extName = 'Jeaz Scans'
     extClass = '.JeazScans'
-    themePkg = 'madara'
-    baseUrl = 'https://marcialhub.xyz'
-    overrideVersionCode = 4
+    themePkg = 'mangathemesia'
+    baseUrl = 'https://lectorhub.j5z.xyz'
+    overrideVersionCode = 15
     isNsfw = false
 }
 

--- a/src/es/jeazscans/src/eu/kanade/tachiyomi/extension/es/jeazscans/JeazScans.kt
+++ b/src/es/jeazscans/src/eu/kanade/tachiyomi/extension/es/jeazscans/JeazScans.kt
@@ -1,19 +1,18 @@
 package eu.kanade.tachiyomi.extension.es.jeazscans
 
-import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import okhttp3.OkHttpClient
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class JeazScans : Madara(
-    "JeazScans",
-    "https://marcialhub.xyz",
+class JeazScans : MangaThemesia(
+    "Jeaz Scans",
+    "https://lectorhub.j5z.xyz",
     "es",
-    SimpleDateFormat("d MMMM, yyyy", Locale("es")),
+    dateFormat = SimpleDateFormat("MMM d, yyyy", Locale("es")),
 ) {
-    override val useLoadMoreRequest = LoadMoreStrategy.Always
-    override val useNewChapterEndpoint = true
+    override val id = 5292079548510508306
 
     override val client: OkHttpClient = super.client.newBuilder()
         .rateLimit(2)

--- a/src/vi/teamlanhlung/AndroidManifest.xml
+++ b/src/vi/teamlanhlung/AndroidManifest.xml
@@ -13,7 +13,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:host="teamlanhlung5.shop"
+                    android:host="teamlanhlung9.shop"
                     android:pathPattern="/truyen-tranh/..*"
                     android:scheme="https"
                 />

--- a/src/vi/teamlanhlung/build.gradle
+++ b/src/vi/teamlanhlung/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Team Lanh Lung'
     extClass = '.TeamLanhLung'
-    extVersionCode = 22
+    extVersionCode = 23
     isNsfw = true
 }
 

--- a/src/vi/teamlanhlung/src/eu/kanade/tachiyomi/extension/vi/teamlanhlung/TeamLanhLung.kt
+++ b/src/vi/teamlanhlung/src/eu/kanade/tachiyomi/extension/vi/teamlanhlung/TeamLanhLung.kt
@@ -32,7 +32,7 @@ class TeamLanhLung : ParsedHttpSource() {
 
     override val name: String = "Team Lạnh Lùng"
 
-    override val baseUrl: String = "https://teamlanhlung5.shop"
+    override val baseUrl: String = "https://teamlanhlung9.shop"
 
     override val lang: String = "vi"
 


### PR DESCRIPTION
Closes #8951
Closes #8948
Closes #8914

- JeazScans migrated from madara to mangathemesia, and some url are compatible, maybe users need to migrate some entries:
  - https://web.archive.org/web/20250324002720/https://marcialhub.xyz/manga/me-hice-cargo-de-la-academia-con-un-solo-cuchillo-de-sashimi/
   - https://lectorhub.j5z.xyz/manga/me-hice-cargo-de-la-academia-con-un-solo-cuchillo-de-sashimi/

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
