### PR TITLE
Manga Ship: fix search encoding

### DIFF
--- a/src/tr/mangaship/src/eu/kanade/tachiyomi/extension/tr/mangaship/MangaShip.kt
+++ b/src/tr/mangaship/src/eu/kanade/tachiyomi/extension/tr/mangaship/MangaShip.kt
@@ -8,6 +8,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.jsoup.nodes.Document
@@ -62,7 +63,12 @@ class MangaShip : ParsedHttpSource() {
     // Search
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        return GET("$baseUrl/Tr/Search?kelime=$query&tur=Manga&page=$page", headers)
+        val url = "$baseUrl/Tr/Search".toHttpUrl().newBuilder()
+            .addQueryParameter("kelime", query)
+            .addQueryParameter("tur", "Manga")
+            .addQueryParameter("page", page.toString())
+            .build()
+        return GET(url, headers)
     }
 
     override fun searchMangaSelector() = popularMangaSelector()


### PR DESCRIPTION
Not related to #1100.

Not bumping the version since it's still broken overall. Extension compiles.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
