### PR TITLE
MangaPoisk: fix search encoding

### DIFF
--- a/src/ru/mangapoisk/src/eu/kanade/tachiyomi/extension/ru/mangapoisk/MangaPoisk.kt
+++ b/src/ru/mangapoisk/src/eu/kanade/tachiyomi/extension/ru/mangapoisk/MangaPoisk.kt
@@ -41,7 +41,11 @@ class MangaPoisk : ParsedHttpSource() {
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         val url = if (query.isNotBlank()) {
-            "$baseUrl/search?q=$query&page=$page"
+            "$baseUrl/search".toHttpUrl().newBuilder()
+                .addQueryParameter("q", query)
+                .addQueryParameter("page", page.toString())
+                .build()
+                .toString()
         } else {
             val url = "$baseUrl/manga?page=$page".toHttpUrl().newBuilder()
             (if (filters.isEmpty()) getFilterList() else filters).forEach { filter ->


### PR DESCRIPTION
Not bumping the version since it's still broken overall. Extension compiles.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
