### PR TITLE
JeazScans: Bump versionCode

### DIFF
--- a/src/es/jeazscans/build.gradle
+++ b/src/es/jeazscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.JeazScans'
     themePkg = 'mangathemesia'
     baseUrl = 'https://lectorhub.j5z.xyz'
-    overrideVersionCode = 15
+    overrideVersionCode = 17
     isNsfw = false
 }
 


### PR DESCRIPTION
Previous version had the extension at 1.4.46, the migrated theme version puts the extension at 1.4.45, so the update never registered for any existing users.

Closes closed #8994 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
