### PR TITLE
VortexScans: actually get latest chapters

### DIFF
--- a/src/en/arvenscans/build.gradle
+++ b/src/en/arvenscans/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Vortex Scans'
     extClass = '.VortexScans'
     themePkg = 'iken'
-    overrideVersionCode = 37
+    overrideVersionCode = 38
     isNsfw = false
 }
 

--- a/src/en/arvenscans/src/eu/kanade/tachiyomi/extension/en/arvenscans/VortexScans.kt
+++ b/src/en/arvenscans/src/eu/kanade/tachiyomi/extension/en/arvenscans/VortexScans.kt
@@ -2,6 +2,8 @@ package eu.kanade.tachiyomi.extension.en.arvenscans
 
 import eu.kanade.tachiyomi.multisrc.iken.Iken
 import eu.kanade.tachiyomi.network.GET
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Request
 
 class VortexScans : Iken(
     "Vortex Scans",
@@ -10,4 +12,18 @@ class VortexScans : Iken(
     "https://api.vortexscans.org",
 ) {
     override fun popularMangaRequest(page: Int) = GET(baseUrl, headers)
+
+    override fun latestUpdatesRequest(page: Int) = latestMangaRequest(page)
+    private fun latestMangaRequest(page: Int): Request {
+        val url = "$apiUrl/api/posts".toHttpUrl().newBuilder().apply {
+            addQueryParameter("page", page.toString())
+            addQueryParameter("perPage", latestPerPage.toString())
+            addQueryParameter("tag", "latestUpdate")
+            addQueryParameter("isNovel", "false")
+        }.build()
+
+        return GET(url, headers)
+    }
 }
+
+private const val latestPerPage = 18

--- a/src/en/arvenscans/src/eu/kanade/tachiyomi/extension/en/arvenscans/VortexScans.kt
+++ b/src/en/arvenscans/src/eu/kanade/tachiyomi/extension/en/arvenscans/VortexScans.kt
@@ -13,8 +13,7 @@ class VortexScans : Iken(
 ) {
     override fun popularMangaRequest(page: Int) = GET(baseUrl, headers)
 
-    override fun latestUpdatesRequest(page: Int) = latestMangaRequest(page)
-    private fun latestMangaRequest(page: Int): Request {
+    override fun latestUpdatesRequest(page: Int): Request {
         val url = "$apiUrl/api/posts".toHttpUrl().newBuilder().apply {
             addQueryParameter("page", page.toString())
             addQueryParameter("perPage", latestPerPage.toString())


### PR DESCRIPTION
Their homepage uses a different endpoint that can get posts by most recent update. JSON returned is the same as `query` endpoint. I believe `posts` accepts search terms, but not filters. 

On their website they get 48 per page when using this endpoint, however the parse function uses 18 so I used that value instead. `perPage` in the Iken multisrc is private and I wasn't sure whether I should make it public, so instead I just gave Vortex its own private value.

Edit: It appears both `Nyx Scans` and `Magus Manga` would benefit from this change as well. For the the other implementations of Iken, the `query` endpoint already seems to sort them by latest and while they do have a posts endpoint, if requested to with the query `tag=latestUpdate` causes them to only return the same page of results regardless of the page number (Hive, Aurora, MangaPro). It seems the pattern is that sources with their API on a subdomain support the query param.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
