### PR TITLE
fix: change how Iken multisrc gets latest

### DIFF
--- a/lib-multisrc/iken/build.gradle.kts
+++ b/lib-multisrc/iken/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 9
+baseVersionCode = 10

--- a/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Iken.kt
+++ b/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Iken.kt
@@ -67,7 +67,19 @@ abstract class Iken(
         return MangasPage(entries, false)
     }
 
-    override fun latestUpdatesRequest(page: Int) = searchMangaRequest(page, "", getFilterList())
+    override fun latestUpdatesRequest(page: Int): Request {
+        val url = "$apiUrl/api/posts".toHttpUrl().newBuilder().apply {
+            addQueryParameter("page", page.toString())
+            addQueryParameter("perPage", perPage.toString())
+            if (apiUrl.startsWith("https://api.", true)) {
+                addQueryParameter("tag", "latestUpdate")
+                addQueryParameter("isNovel", "false")
+            }
+        }.build()
+
+        return GET(url, headers)
+    }
+
     override fun latestUpdatesParse(response: Response) = searchMangaParse(response)
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {


### PR DESCRIPTION
Alternative to #9000.

This PR fixes Vortex, Nyx, and MagusManga so that they now correctly get the latest posts. This is done by switching from using `/api/query` to `/api/posts` for latest posts. The other sources using this multisrc should behave the same (Hive, MangaPro, Aurora).

Iken seems to exist in two main configurations: one where the API is hosted on a subdomain(`api.example.com`), and another where it's served from the base URL. These configurations are mutually exclusive for any given instance.

In the base URL configuration, the latest posts are generally returned ordered by most recent by either `/api/query` or `/api/posts`. However, in the subdomain configuration, both `/api/query` and `/api/posts` return posts in the same, but arbitrary order. You can make the `/api/posts` endpoint return the most recently updated posts instead by adding the `tags=latestUpdate` query parameter. While `/api/query` supports filtering, it does not respect the `tags=latestUpdate` parameter regardless of the configuration while likewise `/api/posts` doesn't respect filters regardless of configuration.

Note that using `tags=latestUpdate` on the base URL configuration of `/api/posts` causes pagination issues as it returns the same results for all pages.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
