### PR TITLE
SMBC: Handle 500 "error" on archive page

### DIFF
--- a/src/en/hiveworks/build.gradle
+++ b/src/en/hiveworks/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hiveworks Comics'
     extClass = '.Hiveworks'
-    extVersionCode = 9
+    extVersionCode = 10
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/hiveworks/src/eu/kanade/tachiyomi/extension/en/hiveworks/Hiveworks.kt
+++ b/src/en/hiveworks/src/eu/kanade/tachiyomi/extension/en/hiveworks/Hiveworks.kt
@@ -55,7 +55,6 @@ class Hiveworks : ParsedHttpSource() {
             if (response.code == 500) {
                 val newResponse = response.newBuilder()
                     .code(200)
-                    .body(response.body)
                     .build()
                 newResponse
             } else {
@@ -201,7 +200,6 @@ class Hiveworks : ParsedHttpSource() {
     // Included to call custom error codes
     override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> {
         return if (manga.status != SManga.LICENSED) {
-            val uri = Uri.parse(manga.url).buildUpon()
             client.newCall(chapterListRequest(manga))
                 .asObservableSuccess()
                 .map { response ->

--- a/src/en/hiveworks/src/eu/kanade/tachiyomi/extension/en/hiveworks/Hiveworks.kt
+++ b/src/en/hiveworks/src/eu/kanade/tachiyomi/extension/en/hiveworks/Hiveworks.kt
@@ -39,6 +39,29 @@ class Hiveworks : ParsedHttpSource() {
         .readTimeout(1, TimeUnit.MINUTES)
         .retryOnConnectionFailure(true)
         .followRedirects(true)
+        .addNetworkInterceptor { chain ->
+            val request = chain.request()
+            if (!request.url.toString().contains("smbc-comics")) {
+                return@addNetworkInterceptor chain.proceed(request)
+            }
+
+            val response = chain.proceed(request)
+            // As of March 2025, SMBC chapter list page returns status code 500 even
+            // though it still has correct data. Do not throw an error in this case.
+            //
+            // I reported this error to SMBC on 2025-05-28 and it was not fixed by
+            // 2025-06-11, but even if it is fixed eventually, the same problem might
+            // occur again in the future.
+            if (response.code == 500) {
+                val newResponse = response.newBuilder()
+                    .code(200)
+                    .body(response.body)
+                    .build()
+                newResponse
+            } else {
+                response
+            }
+        }
         .build()
 
     // Popular
@@ -180,25 +203,7 @@ class Hiveworks : ParsedHttpSource() {
         return if (manga.status != SManga.LICENSED) {
             val uri = Uri.parse(manga.url).buildUpon()
             client.newCall(chapterListRequest(manga))
-                .asObservable()
-                .doOnNext { response ->
-                    if (!response.isSuccessful) {
-                        if ("smbc-comics" in uri.toString() && response.code == 500) {
-                            // As of March 2025, SMBC chapter list page returns
-                            // status code 500 even though it still has correct data.
-                            // Do not throw an error in this case.
-                            //
-                            // I reported this error to SMBC on 2025-05-28, but even if
-                            // it is fixed, the same problem might occur again in the future.
-                            return@doOnNext
-                        }
-                        // Otherwise, an unsuccessful response status indicates that
-                        // there is an error. Apparently, HttpException isn't able to
-                        // be imported from extensions-lib, so we have to copy and paste.
-                        response.close()
-                        throw Exception("HTTP error ${response.code}")
-                    }
-                }
+                .asObservableSuccess()
                 .map { response ->
                     chapterListParse(response)
                 }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension

See the added comment which explains this change. I haven't been able to update SMBC since late February; with the modified extension from this PR branch, it again works fine.
