### PR TITLE
TonizuToon: Update domain & status selector

### DIFF
--- a/src/tr/tonizutoon/build.gradle
+++ b/src/tr/tonizutoon/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.TonizuToon'
     themePkg = 'madara'
     baseUrl = 'https://tonizu.xyz'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
     isNsfw = true
 }
 

--- a/src/tr/tonizutoon/build.gradle
+++ b/src/tr/tonizutoon/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'TonizuToon'
     extClass = '.TonizuToon'
     themePkg = 'madara'
-    baseUrl = 'https://tonizu.xyz'
+    baseUrl = 'https://tonizu.top'
     overrideVersionCode = 3
     isNsfw = true
 }

--- a/src/tr/tonizutoon/src/eu/kanade/tachiyomi/extension/tr/tonizutoon/TonizuToon.kt
+++ b/src/tr/tonizutoon/src/eu/kanade/tachiyomi/extension/tr/tonizutoon/TonizuToon.kt
@@ -9,7 +9,7 @@ import java.util.Locale
 
 class TonizuToon : Madara(
     "TonizuToon",
-    "https://tonizu.xyz",
+    "https://tonizu.top",
     "tr",
     dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.ROOT),
 ) {

--- a/src/tr/tonizutoon/src/eu/kanade/tachiyomi/extension/tr/tonizutoon/TonizuToon.kt
+++ b/src/tr/tonizutoon/src/eu/kanade/tachiyomi/extension/tr/tonizutoon/TonizuToon.kt
@@ -19,7 +19,7 @@ class TonizuToon : Madara(
 
     override val mangaDetailsSelectorAuthor = ".summary-heading:contains(Yazar) ~ .summary-content"
 
-    override val mangaDetailsSelectorStatus = ".summary-heading:contains(Durumu) ~ .summary-content"
+    override val mangaDetailsSelectorStatus = ".summary-heading:contains(Durum) ~ .summary-content"
 
     override val client = network.cloudflareClient.newBuilder()
         .addNetworkInterceptor(::loginCheckInterceptor)


### PR DESCRIPTION
Closes #8384

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
