### PR TITLE
Migrate from fakeimg.pl to fakeimg.ryd.tools

### DIFF
--- a/src/all/xkcd/build.gradle
+++ b/src/all/xkcd/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'xkcd'
     extClass = '.XkcdFactory'
-    extVersionCode = 13
+    extVersionCode = 14
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/xkcd/src/eu/kanade/tachiyomi/extension/all/xkcd/Xkcd.kt
+++ b/src/all/xkcd/src/eu/kanade/tachiyomi/extension/all/xkcd/Xkcd.kt
@@ -137,10 +137,10 @@ open class Xkcd(
 
     companion object {
         private const val THUMBNAIL_URL =
-            "https://fakeimg.pl/550x780/ffffff/6e7b91/?font=museo&text=xkcd"
+            "https://fakeimg.ryd.tools/550x780/ffffff/6e7b91/?font=museo&text=xkcd"
 
         const val LATIN_ALT_TEXT_URL =
-            "https://fakeimg.pl/1500x2126/ffffff/000000/?font=museo&font_size=42"
+            "https://fakeimg.ryd.tools/1500x2126/ffffff/000000/?font=museo&font_size=42"
 
         const val CJK_ALT_TEXT_URL =
             "https://placehold.jp/42/ffffff/000000/1500x2126.png?css=" +

--- a/src/en/buttsmithy/build.gradle
+++ b/src/en/buttsmithy/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'buttsmithy'
     extClass = '.Buttsmithy'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/en/buttsmithy/src/eu/kanade/tachiyomi/extension/en/buttsmithy/Buttsmithy.kt
+++ b/src/en/buttsmithy/src/eu/kanade/tachiyomi/extension/en/buttsmithy/Buttsmithy.kt
@@ -255,7 +255,7 @@ class Buttsmithy : HttpSource() {
     }
 
     private fun generateImageUrlWithText(text: String): String {
-        return "https://fakeimg.pl/800x1236/?text=$text&font=lobster"
+        return "https://fakeimg.ryd.tools/800x1236/?text=$text&font=lobster"
     }
 
     private fun generateMangasPage(): MangasPage {

--- a/src/en/hiveworks/build.gradle
+++ b/src/en/hiveworks/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hiveworks Comics'
     extClass = '.Hiveworks'
-    extVersionCode = 8
+    extVersionCode = 9
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/hiveworks/src/eu/kanade/tachiyomi/extension/en/hiveworks/Hiveworks.kt
+++ b/src/en/hiveworks/src/eu/kanade/tachiyomi/extension/en/hiveworks/Hiveworks.kt
@@ -506,7 +506,7 @@ class Hiveworks : ParsedHttpSource() {
             charCount += i.length + 1
         }
 
-        return "https://fakeimg.pl/1500x2126/ffffff/000000/?text=$builder&font_size=42&font=museo"
+        return "https://fakeimg.ryd.tools/1500x2126/ffffff/000000/?text=$builder&font_size=42&font=museo"
     }
 
     // Used to throw custom error codes for http codes

--- a/src/en/latisbooks/build.gradle
+++ b/src/en/latisbooks/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Latis Books'
     extClass = '.Latisbooks'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = true
 }
 

--- a/src/en/latisbooks/src/eu/kanade/tachiyomi/extension/en/latisbooks/Latisbooks.kt
+++ b/src/en/latisbooks/src/eu/kanade/tachiyomi/extension/en/latisbooks/Latisbooks.kt
@@ -28,7 +28,7 @@ class Latisbooks : HttpSource() {
 
     override val client: OkHttpClient = network.cloudflareClient
 
-    private val textToImageURL = "https://fakeimg.pl/1500x2126/ffffff/000000/?font=museo&font_size=42"
+    private val textToImageURL = "https://fakeimg.ryd.tools/1500x2126/ffffff/000000/?font=museo&font_size=42"
 
     private fun String.image() = textToImageURL + "&text=" + encode(this)
 

--- a/src/en/swordscomic/build.gradle
+++ b/src/en/swordscomic/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Swords Comic'
     extClass = '.SwordsComic'
-    extVersionCode = 3
+    extVersionCode = 4
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/swordscomic/src/eu/kanade/tachiyomi/extension/en/swordscomic/SwordsComic.kt
+++ b/src/en/swordscomic/src/eu/kanade/tachiyomi/extension/en/swordscomic/SwordsComic.kt
@@ -106,7 +106,7 @@ class SwordsComic : HttpSource() {
             builder.append("+")
         }
 
-        return listOf(Page(0, "", imageElement.attr("abs:src")), Page(1, "", "https://fakeimg.pl/1800x2252/978B65/000000/?text=$builder&font_size=60&font=comic+sans"))
+        return listOf(Page(0, "", imageElement.attr("abs:src")), Page(1, "", "https://fakeimg.ryd.tools/1800x2252/978B65/000000/?text=$builder&font_size=60&font=comic+sans"))
     }
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension

Closes https://github.com/keiyoushi/extensions-source/issues/8974. I tested this by compiling a new version of the xkcd source and verifying that it fixes downloads.
