### PR TITLE
Readcomiconline - Fix Script String Encoding

### DIFF
--- a/src/en/readcomiconline/build.gradle
+++ b/src/en/readcomiconline/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ReadComicOnline'
     extClass = '.Readcomiconline'
-    extVersionCode = 37
+    extVersionCode = 38
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
@@ -249,7 +249,7 @@ class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
         for (script in scripts) {
             QuickJs.create().use {
                 val eval =
-                    "let _encryptedString = `${script.data()}`;let _useServer2 = $useSecondServer;${remoteConfigItem!!.imageDecryptEval}"
+                    "let _encryptedString = ${Json.encodeToString(script.data().trimIndent())};let _useServer2 = $useSecondServer;${remoteConfigItem!!.imageDecryptEval}"
                 val evalResult = (it.evaluate(eval) as String).parseAs<List<String>>()
 
                 // Add results to 'encryptedLinks'


### PR DESCRIPTION
Closes #8998 

It now encodes to JSON string which automagically escapes `script.data()`. Old implementation (interpolating `script.data()` inside backticks) apparently doesn't sit well with obfuscated script codes. 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
