### PR TITLE
Fixed domain name for mangaonelove

### DIFF
--- a/src/ru/mangaonelove/build.gradle
+++ b/src/ru/mangaonelove/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaOneLove'
     themePkg = 'madara'
     baseUrl = 'https://mangaonelove.site'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/ru/mangaonelove/build.gradle
+++ b/src/ru/mangaonelove/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Manga One Love'
     extClass = '.MangaOneLove'
     themePkg = 'madara'
-    baseUrl = 'https://mangaonelove.site'
+    baseUrl = 'https://mangaonelove.ru'
     overrideVersionCode = 2
     isNsfw = true
 }

--- a/src/ru/mangaonelove/src/eu/kanade/tachiyomi/extension/ru/mangaonelove/MangaOneLove.kt
+++ b/src/ru/mangaonelove/src/eu/kanade/tachiyomi/extension/ru/mangaonelove/MangaOneLove.kt
@@ -4,4 +4,4 @@ import eu.kanade.tachiyomi.multisrc.madara.Madara
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class MangaOneLove : Madara("Manga One Love", "https://mangaonelove.site", "ru", SimpleDateFormat("dd.MM.yyyy", Locale.US))
+class MangaOneLove : Madara("Manga One Love", "https://mangaonelove.ru", "ru", SimpleDateFormat("dd.MM.yyyy", Locale.US))


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
