### PR TITLE
fix (Poseidonscans/PhenixScans) : Update Poseidon Scans and Phenix Scans

### DIFF
--- a/src/fr/phenixscans/build.gradle
+++ b/src/fr/phenixscans/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'PhenixScans'
     extClass = '.PhenixScans'
     baseUrl = 'https://phenix-scans.com'
-    extVersionCode = 34
+    extVersionCode = 35
     isNsfw = false
 }
 

--- a/src/fr/phenixscans/src/eu/kanade/tachiyomi/extension/fr/phenixscans/PhenixScans.kt
+++ b/src/fr/phenixscans/src/eu/kanade/tachiyomi/extension/fr/phenixscans/PhenixScans.kt
@@ -18,7 +18,7 @@ import java.util.Locale
 
 class PhenixScans : HttpSource() {
     override val baseUrl = "https://phenix-scans.com"
-    private val apiBaseUrl = "https://api.phenix-scans.com"
+    private val apiBaseUrl = "https://phenix-scans.com/api"
     override val lang = "fr"
     override val name = "Phenix Scans"
     override val supportsLatest = true

--- a/src/fr/poseidonscans/build.gradle
+++ b/src/fr/poseidonscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.PoseidonScans'
     baseUrl = 'https://poseidonscans.fr'
     overrideVersionCode = 0
-    extVersionCode = 43
+    extVersionCode = 44
     isNsfw = false
 }
 

--- a/src/fr/poseidonscans/src/eu/kanade/tachiyomi/extension/fr/poseidonscans/PoseidonScans.kt
+++ b/src/fr/poseidonscans/src/eu/kanade/tachiyomi/extension/fr/poseidonscans/PoseidonScans.kt
@@ -392,7 +392,10 @@ class PoseidonScans : HttpSource() {
             ?.mapNotNull { ch ->
                 val chapterNumberString = ch.number.toString().removeSuffix(".0")
                 SChapter.create().apply {
-                    name = ch.title?.takeIf { it.isNotBlank() } ?: "Chapitre $chapterNumberString"
+                    val baseName = "Chapitre $chapterNumberString"
+                    name = ch.title?.trim()?.takeIf { it.isNotBlank() }
+                        ?.let { title -> "$baseName - $title" }
+                        ?: baseName
                     setUrlWithoutDomain("/serie/${mangaDto.slug}/chapter/$chapterNumberString")
                     date_upload = parseIsoDate(ch.createdAt)
                     chapter_number = ch.number


### PR DESCRIPTION
*   **Poseidon Scans:** Fix chapter name parsing to include both the chapter number and title when available (e.g., "Chapitre 55 - Début Saison 2").
*   **Phenix Scans:** Update the API base URL to the new endpoint to fix the source.

Close #9142

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
