### PR TITLE
[multisrc/pizzareader] Fix: Handle null status from API

### DIFF
--- a/lib-multisrc/pizzareader/build.gradle.kts
+++ b/lib-multisrc/pizzareader/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 3
+baseVersionCode = 4

--- a/lib-multisrc/pizzareader/src/eu/kanade/tachiyomi/multisrc/pizzareader/PizzaReader.kt
+++ b/lib-multisrc/pizzareader/src/eu/kanade/tachiyomi/multisrc/pizzareader/PizzaReader.kt
@@ -95,7 +95,7 @@ abstract class PizzaReader(
         artist = comic.artist
         description = comic.description
         genre = comic.genres.joinToString(", ") { it.name }
-        status = comic.status.toStatus()
+        status = comic.status?.toStatus() ?: SManga.UNKNOWN
         thumbnail_url = comic.thumbnail
     }
 

--- a/lib-multisrc/pizzareader/src/eu/kanade/tachiyomi/multisrc/pizzareader/PizzaReaderDto.kt
+++ b/lib-multisrc/pizzareader/src/eu/kanade/tachiyomi/multisrc/pizzareader/PizzaReaderDto.kt
@@ -27,7 +27,7 @@ data class PizzaComicDto(
     val description: String = "",
     val genres: List<PizzaGenreDto> = emptyList(),
     @SerialName("last_chapter") val lastChapter: PizzaChapterDto? = null,
-    val status: String = "",
+    val status: String? = null,
     val title: String = "",
     val thumbnail: String = "",
     val url: String = "",


### PR DESCRIPTION
Closes #9097

The API can return a `null` value for a manga's status, which caused a JSON parsing error. 
This change makes the parser handle this case correctly by making the `status` field nullable.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
