### PR TITLE
DeviantArt: Preserve token in multi-image posts

### DIFF
--- a/src/all/deviantart/build.gradle
+++ b/src/all/deviantart/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'DeviantArt'
     extClass = '.DeviantArt'
-    extVersionCode = 8
+    extVersionCode = 9
     isNsfw = true
 }
 

--- a/src/all/deviantart/src/eu/kanade/tachiyomi/extension/all/deviantart/DeviantArt.kt
+++ b/src/all/deviantart/src/eu/kanade/tachiyomi/extension/all/deviantart/DeviantArt.kt
@@ -13,6 +13,7 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.tryParse
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
@@ -20,7 +21,6 @@ import okhttp3.Response
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.parser.Parser
-import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -41,14 +41,6 @@ class DeviantArt : HttpSource(), ConfigurableSource {
 
     private val dateFormat by lazy {
         SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH)
-    }
-
-    private fun parseDate(dateStr: String?): Long {
-        return try {
-            dateFormat.parse(dateStr ?: "")!!.time
-        } catch (_: ParseException) {
-            0L
-        }
     }
 
     override fun popularMangaRequest(page: Int): Request {
@@ -142,7 +134,7 @@ class DeviantArt : HttpSource(), ConfigurableSource {
             SChapter.create().apply {
                 setUrlWithoutDomain(it.selectFirst("link")!!.text())
                 name = it.selectFirst("title")!!.text()
-                date_upload = parseDate(it.selectFirst("pubDate")?.text())
+                date_upload = dateFormat.tryParse(it.selectFirst("pubDate")?.text())
                 scanlator = it.selectFirst("media|credit")?.text()
             }
         }

--- a/src/all/deviantart/src/eu/kanade/tachiyomi/extension/all/deviantart/DeviantArt.kt
+++ b/src/all/deviantart/src/eu/kanade/tachiyomi/extension/all/deviantart/DeviantArt.kt
@@ -160,8 +160,8 @@ class DeviantArt : HttpSource(), ConfigurableSource {
             else -> buttons.mapIndexed { i, button ->
                 // Remove everything past "/v1/" to get original instead of thumbnail
                 // But need to preserve the query parameter where the token is
-                val thumbnailUrl = button.selectFirst("img")?.absUrl("src")
-                val imageUrl = thumbnailUrl?.replaceFirst(Regex("""/v1(/.*)?(?=\?)"""), "")
+                val imageUrl = button.selectFirst("img")?.absUrl("src")
+                    ?.replaceFirst(Regex("""/v1(/.*)?(?=\?)"""), "")
                 Page(i, imageUrl = imageUrl)
             }
         }

--- a/src/all/deviantart/src/eu/kanade/tachiyomi/extension/all/deviantart/DeviantArt.kt
+++ b/src/all/deviantart/src/eu/kanade/tachiyomi/extension/all/deviantart/DeviantArt.kt
@@ -154,12 +154,12 @@ class DeviantArt : HttpSource(), ConfigurableSource {
 
     override fun pageListParse(response: Response): List<Page> {
         val document = response.asJsoup()
-        return when (val buttons = document.selectFirst("[draggable=false]")?.children()) {
-            null -> {
-                val imageUrl = document.selectFirst("img[fetchpriority=high]")?.absUrl("src")
-                listOf(Page(0, imageUrl = imageUrl))
-            }
-            else -> buttons.mapIndexed { i, button ->
+        val buttons = document.selectFirst("[draggable=false]")?.children()
+        return if (buttons == null) {
+            val imageUrl = document.selectFirst("img[fetchpriority=high]")?.absUrl("src")
+            listOf(Page(0, imageUrl = imageUrl))
+        } else {
+            buttons.mapIndexed { i, button ->
                 // Remove everything past "/v1/" to get original instead of thumbnail
                 // But need to preserve the query parameter where the token is
                 val imageUrl = button.selectFirst("img")?.absUrl("src")

--- a/src/all/deviantart/src/eu/kanade/tachiyomi/extension/all/deviantart/DeviantArt.kt
+++ b/src/all/deviantart/src/eu/kanade/tachiyomi/extension/all/deviantart/DeviantArt.kt
@@ -154,9 +154,11 @@ class DeviantArt : HttpSource(), ConfigurableSource {
 
     override fun pageListParse(response: Response): List<Page> {
         val document = response.asJsoup()
-        val firstImageUrl = document.selectFirst("img[fetchpriority=high]")?.absUrl("src")
         return when (val buttons = document.selectFirst("[draggable=false]")?.children()) {
-            null -> listOf(Page(0, imageUrl = firstImageUrl))
+            null -> {
+                val imageUrl = document.selectFirst("img[fetchpriority=high]")?.absUrl("src")
+                listOf(Page(0, imageUrl = imageUrl))
+            }
             else -> buttons.mapIndexed { i, button ->
                 // Remove everything past "/v1/" to get original instead of thumbnail
                 // But need to preserve the query parameter where the token is

--- a/src/all/deviantart/src/eu/kanade/tachiyomi/extension/all/deviantart/DeviantArt.kt
+++ b/src/all/deviantart/src/eu/kanade/tachiyomi/extension/all/deviantart/DeviantArt.kt
@@ -167,11 +167,10 @@ class DeviantArt : HttpSource(), ConfigurableSource {
             null -> listOf(Page(0, imageUrl = firstImageUrl))
             else -> buttons.mapIndexed { i, button ->
                 // Remove everything past "/v1/" to get original instead of thumbnail
-                val imageUrl = button.selectFirst("img")?.absUrl("src")?.substringBefore("/v1/")
+                // But need to preserve the query parameter where the token is
+                val thumbnailUrl = button.selectFirst("img")?.absUrl("src")
+                val imageUrl = thumbnailUrl?.replaceFirst(Regex("""/v1(/.*)?(?=\?)"""), "")
                 Page(i, imageUrl = imageUrl)
-            }.also {
-                // First image needs token to get original, which is included in firstImageUrl
-                it[0].imageUrl = firstImageUrl
             }
         }
     }

--- a/src/all/deviantart/src/eu/kanade/tachiyomi/extension/all/deviantart/DeviantArt.kt
+++ b/src/all/deviantart/src/eu/kanade/tachiyomi/extension/all/deviantart/DeviantArt.kt
@@ -86,9 +86,9 @@ class DeviantArt : HttpSource(), ConfigurableSource {
         return SManga.create().apply {
             setUrlWithoutDomain(response.request.url.toString())
             author = document.title().substringBefore(" ")
-            title = when (artistInTitle) {
-                true -> "$author - $galleryName"
-                false -> galleryName
+            title = when {
+                artistInTitle -> "$author - $galleryName"
+                else -> galleryName
             }
             description = gallery?.selectFirst(".legacy-journal")?.wholeText()
             thumbnail_url = gallery?.selectFirst("img[property=contentUrl]")?.absUrl("src")


### PR DESCRIPTION
Closes #9147

Tests:
- `gallery:horminum` "cook and engineer" (Ch 221), "001" (Ch 225): These still work without the token and with the token now added they continue to work
- `gallery:al3ksgts/96690616`: Bugged case provided by reporter, now works

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] ~Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions~
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] ~Added the `isNsfw = true` flag in `build.gradle` when appropriate~
- [x] Have not changed source names
- [ ] ~Have explicitly kept the `id` if a source's name or language were changed~
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] ~Have removed `web_hi_res_512.png` when adding a new extension~
