### PR TITLE
Rumanhua: limit search keyword length to 12

### DIFF
--- a/src/zh/rumanhua/build.gradle
+++ b/src/zh/rumanhua/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Rumanhua'
     extClass = '.Rumanhua'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/zh/rumanhua/src/eu/kanade/tachiyomi/extension/zh/rumanhua/Rumanhua.kt
+++ b/src/zh/rumanhua/src/eu/kanade/tachiyomi/extension/zh/rumanhua/Rumanhua.kt
@@ -228,7 +228,7 @@ class Rumanhua : HttpSource(), ConfigurableSource {
         val urlBuilder = baseUrl.toHttpUrl().newBuilder()
 
         if (query != "" && !query.contains("-")) {
-            val body = FormBody.Builder().add("k", query).build()
+            val body = FormBody.Builder().add("k", query.take(12)).build()
             return POST(
                 urlBuilder.encodedPath("/s").build().toString(),
                 headers,


### PR DESCRIPTION
When the length of the keyword is greater than 12, no search results are returned

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
