### PR TITLE
MayoTune: Build chapter page using API

### DIFF
--- a/src/en/mayotune/build.gradle
+++ b/src/en/mayotune/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MayoTune'
     extClass = '.MayoTune'
-    extVersionCode = 1
+    extVersionCode = 2
     baseUrl = 'https://mayotune.xyz'
     isNsfw = false
 }

--- a/src/en/mayotune/src/eu/kanade/tachiyomi/extension/en/mayotune/ChapterDto.kt
+++ b/src/en/mayotune/src/eu/kanade/tachiyomi/extension/en/mayotune/ChapterDto.kt
@@ -17,12 +17,18 @@ data class ChapterDto(
     @Contextual
     private val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.US)
 
-    fun getChapterURL(): String = "/chapter/${this.id}"
+    fun getChapterURL(): String = "/api/chapters?id=${this.id}"
+
+    fun getNumberStr(): String = if (this.number % 1 == 0f) {
+        this.number.toInt().toString()
+    } else {
+        this.number.toString()
+    }
 
     fun getChapterTitle(): String = if (!this.title.isEmpty()) {
-        "Chapter ${this.number.asString()}: ${this.title}"
+        "Chapter ${this.getNumberStr()}: ${this.title}"
     } else {
-        "Chapter ${this.number.asString()}"
+        "Chapter ${this.getNumberStr()}"
     }
 
     fun getDateTimestamp(): Long = this.sdf.tryParse(this.date)

--- a/src/en/mayotune/src/eu/kanade/tachiyomi/extension/en/mayotune/ChapterDto.kt
+++ b/src/en/mayotune/src/eu/kanade/tachiyomi/extension/en/mayotune/ChapterDto.kt
@@ -19,17 +19,19 @@ data class ChapterDto(
 
     fun getChapterURL(): String = "/chapter/${this.id}"
 
-    fun getNumberStr(): String = if (this.number % 1 == 0f) {
-        this.number.toInt().toString()
-    } else {
-        this.number.toString()
-    }
-
     fun getChapterTitle(): String = if (!this.title.isEmpty()) {
-        "Chapter ${this.getNumberStr()}: ${this.title}"
+        "Chapter ${this.number.asString()}: ${this.title}"
     } else {
-        "Chapter ${this.getNumberStr()}"
+        "Chapter ${this.number.asString()}"
     }
 
     fun getDateTimestamp(): Long = this.sdf.tryParse(this.date)
+
+    companion object {
+        fun Float.asString(): String = if (this % 1 == 0f) {
+            this.toInt().toString()
+        } else {
+            this.toString()
+        }
+    }
 }

--- a/src/en/mayotune/src/eu/kanade/tachiyomi/extension/en/mayotune/ChapterDto.kt
+++ b/src/en/mayotune/src/eu/kanade/tachiyomi/extension/en/mayotune/ChapterDto.kt
@@ -17,7 +17,8 @@ data class ChapterDto(
     @Contextual
     private val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.US)
 
-    fun getChapterURL(): String = "/api/chapters?id=${this.id}"
+    fun getChapterURL(): String =
+        "/api/chapters?id=$id&number=${this.getNumberStr()}"
 
     fun getNumberStr(): String = if (this.number % 1 == 0f) {
         this.number.toInt().toString()
@@ -25,7 +26,7 @@ data class ChapterDto(
         this.number.toString()
     }
 
-    fun getChapterTitle(): String = if (!this.title.isEmpty()) {
+    fun getChapterTitle(): String = if (this.title.isNotBlank()) {
         "Chapter ${this.getNumberStr()}: ${this.title}"
     } else {
         "Chapter ${this.getNumberStr()}"

--- a/src/en/mayotune/src/eu/kanade/tachiyomi/extension/en/mayotune/ChapterDto.kt
+++ b/src/en/mayotune/src/eu/kanade/tachiyomi/extension/en/mayotune/ChapterDto.kt
@@ -26,12 +26,4 @@ data class ChapterDto(
     }
 
     fun getDateTimestamp(): Long = this.sdf.tryParse(this.date)
-
-    companion object {
-        fun Float.asString(): String = if (this % 1 == 0f) {
-            this.toInt().toString()
-        } else {
-            this.toString()
-        }
-    }
 }

--- a/src/en/mayotune/src/eu/kanade/tachiyomi/extension/en/mayotune/Float.kt
+++ b/src/en/mayotune/src/eu/kanade/tachiyomi/extension/en/mayotune/Float.kt
@@ -1,7 +1,0 @@
-package eu.kanade.tachiyomi.extension.en.mayotune
-
-fun Float.asString(): String = if (this % 1 == 0f) {
-    this.toInt().toString()
-} else {
-    this.toString()
-}

--- a/src/en/mayotune/src/eu/kanade/tachiyomi/extension/en/mayotune/Float.kt
+++ b/src/en/mayotune/src/eu/kanade/tachiyomi/extension/en/mayotune/Float.kt
@@ -1,0 +1,7 @@
+package eu.kanade.tachiyomi.extension.en.mayotune
+
+fun Float.asString(): String = if (this % 1 == 0f) {
+    this.toInt().toString()
+} else {
+    this.toString()
+}

--- a/src/en/mayotune/src/eu/kanade/tachiyomi/extension/en/mayotune/MayoTune.kt
+++ b/src/en/mayotune/src/eu/kanade/tachiyomi/extension/en/mayotune/MayoTune.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.extension.en.mayotune
 
-import eu.kanade.tachiyomi.extension.en.mayotune.ChapterDto.Companion.asString
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage

--- a/src/en/mayotune/src/eu/kanade/tachiyomi/extension/en/mayotune/MayoTune.kt
+++ b/src/en/mayotune/src/eu/kanade/tachiyomi/extension/en/mayotune/MayoTune.kt
@@ -74,14 +74,10 @@ class MayoTune() : HttpSource() {
         return GET("$baseUrl/api/chapters", headers)
     }
 
-    override fun pageListRequest(chapter: SChapter): Request {
-        val url = "$baseUrl/api/chapters".toHttpUrl().newBuilder().apply {
-            addQueryParameter("number", chapter.chapter_number.asString())
-        }
-        return GET(url.toString(), headers)
+    override fun getChapterUrl(chapter: SChapter): String {
+        val id = (baseUrl + chapter.url).toHttpUrl().queryParameter("id")
+        return "$baseUrl/chapter/$id"
     }
-
-    override fun getChapterUrl(chapter: SChapter): String = baseUrl + chapter.url
 
     // Details
     override fun mangaDetailsParse(response: Response): SManga = SManga.create().apply {
@@ -121,8 +117,8 @@ class MayoTune() : HttpSource() {
             }
         }
     }
-    // Pages
 
+    // Pages
     override fun pageListParse(response: Response): List<Page> {
         val chapter = response.parseAs<ChapterDto>()
         return List(chapter.pageCount) { index ->


### PR DESCRIPTION
Build chapter page via API instead of web scrapping, as per webmaster's request

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
