### PR TITLE
zh/manwa: Add status indicator

### DIFF
--- a/src/zh/manwa/build.gradle
+++ b/src/zh/manwa/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Manwa'
     extClass = '.Manwa'
-    extVersionCode = 11
+    extVersionCode = 12
     isNsfw = true
 }
 

--- a/src/zh/manwa/src/eu/kanade/tachiyomi/extension/zh/manwa/Manwa.kt
+++ b/src/zh/manwa/src/eu/kanade/tachiyomi/extension/zh/manwa/Manwa.kt
@@ -228,6 +228,11 @@ class Manwa : ParsedHttpSource(), ConfigurableSource {
         thumbnail_url = document.selectFirst("div.detail-main-cover > img")!!.attr("data-original")
         author = document.select("p.detail-main-info-author > span.detail-main-info-value > a").text()
         artist = author
+        status = when (document.select("p.detail-main-info-author:contains(更新状态) > span.detail-main-info-value")!!.text()) {
+            "连载中" -> SManga.ONGOING
+            "已完结" -> SManga.COMPLETED
+            else -> SManga.UNKNOWN
+        }
         genre = document.select("div.detail-main-info-class > a.info-tag").eachText().joinToString(", ")
         description = document.selectFirst("#detail > p.detail-desc")!!.text()
     }


### PR DESCRIPTION
This PR adds the status indicator to the Manwa source (by detecting the status text on the site's manga detail pages).

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
