### PR TITLE
Manhua Plus: Fix `No Results Found` & search error

### DIFF
--- a/src/en/manhuaplus/build.gradle
+++ b/src/en/manhuaplus/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ManhuaPlus'
     themePkg = 'madara'
     baseUrl = 'https://manhuaplus.com'
-    overrideVersionCode = 6
+    overrideVersionCode = 7
     isNsfw = false
 }
 

--- a/src/en/manhuaplus/src/eu/kanade/tachiyomi/extension/en/manhuaplus/ManhuaPlus.kt
+++ b/src/en/manhuaplus/src/eu/kanade/tachiyomi/extension/en/manhuaplus/ManhuaPlus.kt
@@ -6,6 +6,6 @@ class ManhuaPlus : Madara("Manhua Plus", "https://manhuaplus.com", "en") {
 
     // The website does not flag the content.
     override val filterNonMangaItems = false
-
+    override val useLoadMoreRequest = LoadMoreStrategy.Never
     override val pageListParseSelector = ".read-container img"
 }


### PR DESCRIPTION
Closes #7645
* Setting the LoadMoreStrategy to Never seems to have resolved the error + search not working since it was stuck trying to load more or something

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
