### PR TITLE
BacaKomik: update domain, skip popular/latest redirect

### DIFF
--- a/src/id/bacakomik/build.gradle
+++ b/src/id/bacakomik/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'BacaKomik'
     extClass = '.BacaKomik'
-    extVersionCode = 11
+    extVersionCode = 12
+    isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/bacakomik/src/eu/kanade/tachiyomi/extension/id/bacakomik/BacaKomik.kt
+++ b/src/id/bacakomik/src/eu/kanade/tachiyomi/extension/id/bacakomik/BacaKomik.kt
@@ -20,7 +20,7 @@ import java.util.Locale
 
 class BacaKomik : ParsedHttpSource() {
     override val name = "BacaKomik"
-    override val baseUrl = "https://bacakomik.one"
+    override val baseUrl = "https://bacakomik.my"
     override val lang = "id"
     override val supportsLatest = true
     private val dateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale.US)
@@ -34,12 +34,14 @@ class BacaKomik : ParsedHttpSource() {
         .rateLimit(12, 3)
         .build()
 
+    private fun pagePath(page: Int) = if (page > 1) "page/$page/" else ""
+
     override fun popularMangaRequest(page: Int): Request {
-        return GET("$baseUrl/daftar-komik/page/$page/?order=popular", headers)
+        return GET("$baseUrl/daftar-komik/${pagePath(page)}?order=popular", headers)
     }
 
     override fun latestUpdatesRequest(page: Int): Request {
-        return GET("$baseUrl/daftar-komik/page/$page/?order=update", headers)
+        return GET("$baseUrl/daftar-komik/${pagePath(page)}?order=update", headers)
     }
 
     override fun popularMangaSelector() = "div.animepost"
@@ -66,7 +68,6 @@ class BacaKomik : ParsedHttpSource() {
         val builtUrl = if (page == 1) "$baseUrl/daftar-komik/" else "$baseUrl/daftar-komik/page/$page/?order="
         val url = builtUrl.toHttpUrl().newBuilder()
         url.addQueryParameter("title", query)
-        url.addQueryParameter("page", page.toString())
         filters.forEach { filter ->
             when (filter) {
                 is AuthorFilter -> {

--- a/src/id/komikindoid/src/eu/kanade/tachiyomi/extension/id/komikindoid/KomikIndoID.kt
+++ b/src/id/komikindoid/src/eu/kanade/tachiyomi/extension/id/komikindoid/KomikIndoID.kt
@@ -24,7 +24,7 @@ class KomikIndoID : ParsedHttpSource() {
     override val client: OkHttpClient = network.cloudflareClient
     private val dateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale.US)
 
-    // similar/modified theme of "https://bacakomik.one"
+    // similar/modified theme of "https://bacakomik.my"
     override fun popularMangaRequest(page: Int): Request {
         return GET("$baseUrl/daftar-manga/page/$page/?order=popular", headers)
     }


### PR DESCRIPTION
Was looking into the redirects on search. For example `?genre[]=action` redirects to `?genre[0]=action`. Minor issue, not addressed in this PR. Otherwise on any other page than 1 it also does not like empty query values. These can be normalized locally with:
```kt
if (page > 1) {
    // Removes `=` for empty query parameters. Skips a redirect. 
    val httpUrl = url.build()
    for (queryParameterName in httpUrl.queryParameterNames) {
        if (httpUrl.queryParameter(queryParameterName) == "") {
            url.setQueryParameter(queryParameterName, null)
        }
    }
}
```

Not changing in this PR since that doesn't fully solve the problem.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
