### PR TITLE
YushukeMangas: Fix manga id not found

### DIFF
--- a/src/pt/yushukemangas/build.gradle
+++ b/src/pt/yushukemangas/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.YushukeMangas'
     themePkg = 'yuyu'
     baseUrl = 'https://new.yushukemangas.com'
-    overrideVersionCode = 6
+    overrideVersionCode = 7
     isNsfw = false
 }
 

--- a/src/pt/yushukemangas/src/eu/kanade/tachiyomi/extension/pt/yushukemangas/ChapterDto.kt
+++ b/src/pt/yushukemangas/src/eu/kanade/tachiyomi/extension/pt/yushukemangas/ChapterDto.kt
@@ -1,0 +1,25 @@
+package eu.kanade.tachiyomi.extension.pt.yushukemangas
+
+import eu.kanade.tachiyomi.extension.pt.yushukemangas.YushukeMangas.Companion.dateFormat
+import eu.kanade.tachiyomi.source.model.SChapter
+import keiyoushi.utils.tryParse
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+class ChapterDto(
+    val id: Int,
+    @SerialName("numero")
+    val number: Float,
+    @SerialName("titulo")
+    val name: String,
+    @SerialName("data_publicacao")
+    val date: String,
+) {
+    fun toSChapter(chapterUrl: String) = SChapter.create().apply {
+        name = this@ChapterDto.name
+        chapter_number = number
+        date_upload = dateFormat.tryParse(date)
+        url = "$chapterUrl/capitulo/$id"
+    }
+}

--- a/src/pt/yushukemangas/src/eu/kanade/tachiyomi/extension/pt/yushukemangas/YushukeMangas.kt
+++ b/src/pt/yushukemangas/src/eu/kanade/tachiyomi/extension/pt/yushukemangas/YushukeMangas.kt
@@ -1,7 +1,17 @@
 package eu.kanade.tachiyomi.extension.pt.yushukemangas
 
 import eu.kanade.tachiyomi.multisrc.yuyu.YuYu
+import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import keiyoushi.utils.parseAs
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Response
+import org.jsoup.nodes.Document
+import rx.Observable
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 class YushukeMangas : YuYu(
     "Yushuke Mangas",
@@ -10,8 +20,68 @@ class YushukeMangas : YuYu(
 ) {
 
     override val client = super.client.newBuilder()
-        .rateLimit(1, 2)
+        .rateLimit(2)
         .build()
 
     override val versionId = 2
+
+    override fun mangaDetailsParse(document: Document): SManga {
+        if (document.location().contains(MANGA_URL_ID_REGEX).not()) {
+            return super.mangaDetailsParse(document)
+        }
+
+        return SManga.create().apply {
+            title = document.selectFirst("h1")!!.text()
+            thumbnail_url = document.selectFirst(".detalhe-capa-img")?.absUrl("src")
+            genre = document.select(".detalhe-tags-chips span").joinToString { it.text() }
+            description = document.selectFirst(".detalhe-sinopse")?.text()
+            document.selectFirst(".detalhe-chip.status")?.ownText()?.let {
+                status = it.toStatus()
+            }
+        }
+    }
+
+    override fun getMangaId(manga: SManga): String {
+        return when {
+            manga.isOldEntry() -> super.getMangaId(manga)
+            else -> MANGA_URL_ID_REGEX.find(manga.url)?.groups?.get(1)?.value ?: ""
+        }
+    }
+
+    private fun SManga.isOldEntry(): Boolean = MANGA_URL_ID_REGEX.containsMatchIn(url).not()
+
+    override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> {
+        if (manga.isOldEntry()) {
+            return super.fetchChapterList(manga)
+        }
+
+        val mangaId = getMangaId(manga).takeIf(String::isNotBlank)
+            ?: throw Exception("Manga ID não encontrado")
+
+        val chapters = mutableListOf<SChapter>()
+        var page = 1
+        val url = manga.url.replace("/$mangaId", "")
+        do {
+            val chaptersDto = fetchChapterListPage(mangaId, page++).parseAs<ChaptersDto<List<ChapterDto>>>()
+            chapters += chaptersDto.chapters.map { it.toSChapter(url) }
+        } while (chaptersDto.hasNext())
+
+        return Observable.just(chapters)
+    }
+
+    private fun fetchChapterListPage(mangaId: String, page: Int): Response {
+        val url = "$baseUrl/ajax/get_chapters.php".toHttpUrl().newBuilder()
+            .addQueryParameter("manga_id", mangaId)
+            .addQueryParameter("page", page.toString())
+            .build()
+
+        return client
+            .newCall(GET(url, headers))
+            .execute()
+    }
+
+    companion object {
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.ROOT)
+        private val MANGA_URL_ID_REGEX = """\/obra\/(\d+)\/.+$""".toRegex()
+    }
 }


### PR DESCRIPTION
Closes #9269

This source contains two pages for the same entry, maybe they are updating the site 

- https://new.yushukemangas.com/obra/272/g%C3%AAnio-da-esgrima-da-academia
- https://new.yushukemangas.com/manga/G%C3%AAnio-da-Esgrima-da-Academia

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
