### PR TITLE
Update URL Ikiru

### DIFF
--- a/src/id/mangatale/build.gradle
+++ b/src/id/mangatale/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Ikiru'
     extClass = '.Ikiru'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://ikiru.world'
-    overrideVersionCode = 7
+    baseUrl = 'https://id.ikiru.wtf'
+    overrideVersionCode = 8
     isNsfw = true
 }
 

--- a/src/id/mangatale/src/eu/kanade/tachiyomi/extension/id/mangatale/Ikiru.kt
+++ b/src/id/mangatale/src/eu/kanade/tachiyomi/extension/id/mangatale/Ikiru.kt
@@ -7,7 +7,7 @@ import okhttp3.OkHttpClient
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.jsoup.nodes.Document
 
-class Ikiru : MangaThemesia("Ikiru", "https://ikiru.world", "id") {
+class Ikiru : MangaThemesia("Ikiru", "https://id.ikiru.wtf", "id") {
 
     override val id = 1532456597012176985
 


### PR DESCRIPTION
Update domain ikiru.
Closes #8437 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
