### PR TITLE
Fix PerfScan : Complete rewrite for new site and API

### DIFF
--- a/src/fr/perfscan/build.gradle
+++ b/src/fr/perfscan/build.gradle
@@ -1,9 +1,8 @@
 ext {
     extName = 'Perf Scan'
     extClass = '.PerfScan'
-    themePkg = 'heancms'
-    baseUrl = 'https://perf-scan.fr'
-    overrideVersionCode = 0
+    baseUrl = 'https://perf-scan.net'
+    extVersionCode = 30
     isNsfw = true
 }
 

--- a/src/fr/perfscan/src/eu/kanade/tachiyomi/extension/fr/perfscan/PerfScan.kt
+++ b/src/fr/perfscan/src/eu/kanade/tachiyomi/extension/fr/perfscan/PerfScan.kt
@@ -1,24 +1,136 @@
 package eu.kanade.tachiyomi.extension.fr.perfscan
 
-import eu.kanade.tachiyomi.multisrc.heancms.HeanCms
-import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
-import okhttp3.HttpUrl.Companion.toHttpUrl
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.parseAs
+import okhttp3.Headers
 import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import java.text.DecimalFormat
+import java.text.SimpleDateFormat
+import java.util.Locale
 
-class PerfScan : HeanCms("Perf Scan", "https://perf-scan.fr", "fr") {
+class PerfScan : HttpSource() {
+    override val name = "Perf Scan"
+    override val baseUrl = "https://perf-scan.net"
+    private val apiUrl = "https://api.perf-scan.net"
+    override val lang = "fr"
+    override val supportsLatest = true
+    override val versionId = 2
 
-    override val client: OkHttpClient = super.client.newBuilder()
-        .rateLimitHost(apiUrl.toHttpUrl(), 1, 2)
-        .build()
+    override val client: OkHttpClient = network.cloudflareClient
 
-    init {
-        preferences.run {
-            if (contains("pref_url_map")) {
-                edit().remove("pref_url_map").apply()
+    private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+    private val chapterNumberFormat = DecimalFormat("#.##")
+
+    override fun headersBuilder(): Headers.Builder = Headers.Builder()
+        .add("Referer", "$baseUrl/")
+        .add("Origin", baseUrl)
+
+    // ============================== Popular ===============================
+    override fun popularMangaRequest(page: Int): Request {
+        return GET("$apiUrl/series?ranking=POPULAR&rankingType=YEARLY&type=COMIC&page=$page&take=24", headers)
+    }
+
+    override fun popularMangaParse(response: Response): MangasPage {
+        val result = response.parseAs<PerfScanResponse<List<PerfScanSeries>>>()
+        val mangaList = result.data.map { series ->
+            SManga.create().apply {
+                url = "/series/${series.slug}"
+                title = series.title
+                thumbnail_url = "$apiUrl/cdn/${series.thumbnail}"
             }
+        }
+        val hasNextPage = result.data.size == 24
+        return MangasPage(mangaList, hasNextPage)
+    }
+
+    // =============================== Latest ===============================
+    override fun latestUpdatesRequest(page: Int): Request {
+        return GET("$apiUrl/series?type=COMIC&page=$page&take=24&latestUpdate=true", headers)
+    }
+
+    override fun latestUpdatesParse(response: Response): MangasPage = popularMangaParse(response)
+
+    // =============================== Search ===============================
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+        return GET("$apiUrl/series?type=COMIC&title=$query&page=$page&take=24", headers)
+    }
+
+    override fun searchMangaParse(response: Response): MangasPage = popularMangaParse(response)
+
+    override fun getMangaUrl(manga: SManga): String {
+        return baseUrl + manga.url
+    }
+
+    // =========================== Manga Details ============================
+    override fun mangaDetailsRequest(manga: SManga): Request {
+        val slug = manga.url.substringAfterLast("/")
+        return GET("$apiUrl/series/$slug", headers)
+    }
+
+    override fun mangaDetailsParse(response: Response): SManga {
+        val result = response.parseAs<PerfScanResponse<PerfScanSeriesDetails>>()
+        val series = result.data
+        return SManga.create().apply {
+            url = "/series/${series.slug}"
+            title = series.title
+            author = series.author
+            artist = series.artist
+            description = series.description
+            status = parseStatus(series.statusObject?.name)
+            genre = series.seriesGenre.joinToString { it.genre.name }
+            thumbnail_url = "$apiUrl/cdn/${series.thumbnail}"
+            initialized = true
         }
     }
 
-    override val useNewQueryEndpoint = true
-    override val useNewChapterEndpoint = true
+    private fun parseStatus(status: String?): Int {
+        return when (status?.lowercase()) {
+            "en cours" -> SManga.ONGOING
+            "terminé" -> SManga.COMPLETED
+            "en pause" -> SManga.ON_HIATUS
+            "annulé" -> SManga.CANCELLED
+            else -> SManga.UNKNOWN
+        }
+    }
+
+    // ============================== Chapters ==============================
+    override fun chapterListRequest(manga: SManga): Request = mangaDetailsRequest(manga)
+
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val result = response.parseAs<PerfScanResponse<PerfScanSeriesDetails>>()
+        val seriesSlug = result.data.slug
+        return result.data.chapters
+            .sortedByDescending { it.index }
+            .map { chapter ->
+                SChapter.create().apply {
+                    val chapterIndex = chapterNumberFormat.format(chapter.index)
+                    url = "/series/$seriesSlug/chapter/$chapterIndex"
+                    name = "Chapitre $chapterIndex" + if (!chapter.title.isNullOrEmpty() && chapter.title != "-") " - ${chapter.title}" else ""
+                    date_upload = runCatching { dateFormat.parse(chapter.createdAt)?.time }.getOrNull() ?: 0L
+                    scanlator = chapter.season.name
+                }
+            }
+    }
+
+    // =============================== Pages ================================
+    override fun pageListRequest(chapter: SChapter): Request {
+        return GET(apiUrl + chapter.url, headers)
+    }
+
+    override fun pageListParse(response: Response): List<Page> {
+        val result = response.parseAs<PerfScanResponse<PerfScanPageList>>()
+        return result.data.content.mapIndexed { index, image ->
+            Page(index, imageUrl = "$apiUrl/cdn/${image.value}")
+        }
+    }
+
+    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException("Not used.")
 }

--- a/src/fr/perfscan/src/eu/kanade/tachiyomi/extension/fr/perfscan/PerfScan.kt
+++ b/src/fr/perfscan/src/eu/kanade/tachiyomi/extension/fr/perfscan/PerfScan.kt
@@ -37,7 +37,14 @@ class PerfScan : HttpSource() {
 
     // ============================== Popular ===============================
     override fun popularMangaRequest(page: Int): Request {
-        return GET("$apiUrl/series?ranking=POPULAR&rankingType=YEARLY&type=COMIC&page=$page&take=24", headers)
+        val url = "$apiUrl/series".toHttpUrl().newBuilder()
+            .addQueryParameter("ranking", "POPULAR")
+            .addQueryParameter("rankingType", "YEARLY")
+            .addQueryParameter("type", "COMIC")
+            .addQueryParameter("page", page.toString())
+            .addQueryParameter("take", "24")
+            .build()
+        return GET(url, headers)
     }
 
     override fun popularMangaParse(response: Response): MangasPage {
@@ -55,7 +62,13 @@ class PerfScan : HttpSource() {
 
     // =============================== Latest ===============================
     override fun latestUpdatesRequest(page: Int): Request {
-        return GET("$apiUrl/series?type=COMIC&page=$page&take=24&latestUpdate=true", headers)
+        val url = "$apiUrl/series".toHttpUrl().newBuilder()
+            .addQueryParameter("type", "COMIC")
+            .addQueryParameter("page", page.toString())
+            .addQueryParameter("take", "24")
+            .addQueryParameter("latestUpdate", "true")
+            .build()
+        return GET(url, headers)
     }
 
     override fun latestUpdatesParse(response: Response): MangasPage = popularMangaParse(response)

--- a/src/fr/perfscan/src/eu/kanade/tachiyomi/extension/fr/perfscan/PerfScanDto.kt
+++ b/src/fr/perfscan/src/eu/kanade/tachiyomi/extension/fr/perfscan/PerfScanDto.kt
@@ -1,0 +1,68 @@
+package eu.kanade.tachiyomi.extension.fr.perfscan
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+class PerfScanResponse<T>(
+    val data: T,
+)
+
+@Serializable
+class PerfScanSeries(
+    val slug: String,
+    val title: String,
+    val thumbnail: String,
+)
+
+@Serializable
+class PerfScanSeriesDetails(
+    val title: String,
+    val slug: String,
+    val thumbnail: String,
+    val description: String? = null,
+    val author: String? = null,
+    val artist: String? = null,
+    @SerialName("SeriesGenre") val seriesGenre: List<PerfScanGenreObject> = emptyList(),
+    @SerialName("Status") val statusObject: PerfScanStatusObject? = null,
+    @SerialName("Chapter") val chapters: List<PerfScanChapter> = emptyList(),
+)
+
+@Serializable
+class PerfScanGenreObject(
+    @SerialName("Genre") val genre: PerfScanGenre,
+)
+
+@Serializable
+class PerfScanGenre(
+    val name: String,
+)
+
+@Serializable
+class PerfScanStatusObject(
+    val name: String,
+)
+
+@Serializable
+class PerfScanChapter(
+    val id: String,
+    val index: Float,
+    val title: String?,
+    val createdAt: String,
+    @SerialName("Season") val season: PerfScanSeason,
+)
+
+@Serializable
+class PerfScanSeason(
+    val name: String,
+)
+
+@Serializable
+class PerfScanPageList(
+    val content: List<PerfScanImage>,
+)
+
+@Serializable
+class PerfScanImage(
+    val value: String,
+)


### PR DESCRIPTION
Complete rewrite to support the new site and its dedicated API, as the old `HeanCms` version is defunct

Closes #8048

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
