### PR TITLE
FIX: 404 error when setting base_url_path in lanraragi

### DIFF
--- a/src/all/lanraragi/build.gradle
+++ b/src/all/lanraragi/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'LANraragi'
     extClass = '.LANraragiFactory'
-    extVersionCode = 19
+    extVersionCode = 20
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
+++ b/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
@@ -35,6 +35,7 @@ import rx.schedulers.Schedulers
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.io.IOException
+import java.net.URL
 import java.security.MessageDigest
 import kotlin.math.max
 
@@ -138,7 +139,12 @@ open class LANraragi(private val suffix: String = "") : ConfigurableSource, Unme
         val archivePage = json.decodeFromString<ArchivePage>(response.body.string())
 
         return archivePage.pages.mapIndexed { index, url ->
-            val uri = Uri.parse("${baseUrl}${url.trimStart('.')}")
+            var newUrl = url
+            val subPath = URL(baseUrl).path
+            if (!subPath.isNullOrEmpty()) {
+                newUrl = newUrl.replaceFirst(subPath, "")
+            }
+            val uri = Uri.parse("${baseUrl}${newUrl.trimStart('.')}")
             Page(index, uri.toString(), uri.toString(), uri)
         }
     }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

This PR fix 404 error when setting `base_url_path` in Lanraragi.
related isssue in LANreader's repo https://github.com/Doraemoe/LANreader/issues/254 .

When setting hostname like "https://example.com/lrr" as "Hostname" in source setting page. the call for `https://example.com/lrr/api/archives/:id/files` will return image paths url with duplicate prefix which cause 404 error. So I remove the duplicate prefix (if exists) to solve this issue. 