### PR TITLE
SpectralScan: Update domain

### DIFF
--- a/src/pt/spectralscan/build.gradle
+++ b/src/pt/spectralscan/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Spectral Scan'
     extClass = '.SpectralScan'
-    extVersionCode = 43
+    extVersionCode = 44
     isNsfw = false
 }
 

--- a/src/pt/spectralscan/src/eu/kanade/tachiyomi/extension/pt/spectralscan/SpectralScan.kt
+++ b/src/pt/spectralscan/src/eu/kanade/tachiyomi/extension/pt/spectralscan/SpectralScan.kt
@@ -20,7 +20,7 @@ class SpectralScan : ParsedHttpSource() {
 
     override val name = "Spectral Scan"
 
-    override val baseUrl = "https://spectralscan.xyz"
+    override val baseUrl = "https://www.spectral.wtf"
 
     override val supportsLatest = true
 


### PR DESCRIPTION
Closes #9365

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
