### PR TITLE
Kemono fix image url path

### DIFF
--- a/lib-multisrc/kemono/build.gradle.kts
+++ b/lib-multisrc/kemono/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 21
+baseVersionCode = 22

--- a/lib-multisrc/kemono/src/eu/kanade/tachiyomi/multisrc/kemono/Kemono.kt
+++ b/lib-multisrc/kemono/src/eu/kanade/tachiyomi/multisrc/kemono/Kemono.kt
@@ -43,6 +43,8 @@ open class Kemono(
 
     private val apiPath = "api/v1"
 
+    private val dataPath = "data"
+
     private val imgCdnUrl = baseUrl.replace("//", "//img.")
 
     private var mangasCache: List<KemonoCreatorDto> = emptyList()
@@ -231,7 +233,7 @@ open class Kemono(
 
     override fun pageListParse(response: Response): List<Page> {
         val postData: KemonoPostDtoWrapped = response.parseAs()
-        return postData.post.images.mapIndexed { i, path -> Page(i, imageUrl = baseUrl + path) }
+        return postData.post.images.mapIndexed { i, path -> Page(i, imageUrl = "$baseUrl/$dataPath$path") }
     }
 
     override fun imageRequest(page: Page): Request {
@@ -242,7 +244,7 @@ open class Kemono(
         val index = imageUrl.indexOf('/', 8)
         val url = buildString {
             append(imageUrl, 0, index)
-            append("/thumbnail/data")
+            append("/thumbnail")
             append(imageUrl.substring(index))
         }
         return GET(url, headers)


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
fix #8404 
