### PR TITLE
Hitomi: retry on stream reset exception with internal error from server

### DIFF
--- a/src/all/hitomi/build.gradle
+++ b/src/all/hitomi/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hitomi'
     extClass = '.HitomiFactory'
-    extVersionCode = 39
+    extVersionCode = 40
     isNsfw = true
 }
 

--- a/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Hitomi.kt
+++ b/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Hitomi.kt
@@ -15,6 +15,7 @@ import keiyoushi.utils.tryParse
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -24,6 +25,7 @@ import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
+import okhttp3.internal.http2.ErrorCode
 import okhttp3.internal.http2.StreamResetException
 import rx.Observable
 import java.nio.ByteBuffer
@@ -53,9 +55,6 @@ class Hitomi(
 
     override val client = network.cloudflareClient.newBuilder()
         .addInterceptor(::imageUrlInterceptor)
-        .apply {
-            interceptors().add(0, ::streamResetRetry)
-        }
         .build()
 
     override fun headersBuilder() = super.headersBuilder()
@@ -118,7 +117,19 @@ class Hitomi(
             }
         }
 
-        return client.newCall(request).awaitSuccess().use { it.body.bytes() }
+        repeat(5) { attempt ->
+            try {
+                return client.newCall(request).awaitSuccess().use { it.body.bytes() }
+            } catch (e: StreamResetException) {
+                if (e.errorCode == ErrorCode.INTERNAL_ERROR) {
+                    if (attempt == 4) throw e // last attempt, rethrow
+                    Log.e(name, "Stream reset attempt ${attempt + 1}", e)
+                    delay((attempt + 1).seconds)
+                }
+            }
+        }
+
+        throw Exception("Unreachable code")
     }
 
     private suspend fun hitomiSearch(
@@ -665,20 +676,6 @@ class Hitomi(
     // real_full_path_from_hash <-- common.js
     private fun thumbPathFromHash(hash: String): String {
         return hash.replace(Regex("""^.*(..)(.)$"""), "$2/$1")
-    }
-
-    private fun streamResetRetry(chain: Interceptor.Chain): Response {
-        return try {
-            chain.proceed(chain.request())
-        } catch (e: StreamResetException) {
-            Log.e(name, "reset", e)
-            if (e.message.orEmpty().contains("INTERNAL_ERROR")) {
-                Thread.sleep(2.seconds.inWholeMilliseconds)
-                chain.proceed(chain.request())
-            } else {
-                throw e
-            }
-        }
     }
 
     private fun imageUrlInterceptor(chain: Interceptor.Chain): Response {

--- a/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Hitomi.kt
+++ b/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Hitomi.kt
@@ -117,14 +117,17 @@ class Hitomi(
             }
         }
 
-        repeat(5) { attempt ->
+        val tries = 5
+        repeat(tries) { attempt ->
             try {
                 return client.newCall(request).awaitSuccess().use { it.body.bytes() }
             } catch (e: StreamResetException) {
                 if (e.errorCode == ErrorCode.INTERNAL_ERROR) {
-                    if (attempt == 4) throw e // last attempt, rethrow
+                    if (attempt == tries - 1) throw e // last attempt, rethrow
                     Log.e(name, "Stream reset attempt ${attempt + 1}", e)
                     delay((attempt + 1).seconds)
+                } else {
+                    throw e
                 }
             }
         }


### PR DESCRIPTION
this exception doesn't pass through interceptor so need to retry on call site.
closes #9408 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
