### PR TITLE
MangaGun: Fix Chapter list parsing

### DIFF
--- a/src/ja/mangagun/build.gradle
+++ b/src/ja/mangagun/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaGun'
     themePkg = 'fmreader'
     baseUrl = 'https://mangagun.net'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
     isNsfw = true
 }
 

--- a/src/ja/mangagun/src/eu/kanade/tachiyomi/extension/ja/mangagun/MangaGun.kt
+++ b/src/ja/mangagun/src/eu/kanade/tachiyomi/extension/ja/mangagun/MangaGun.kt
@@ -48,7 +48,7 @@ class MangaGun : FMReader("MangaGun", "https://$DOMAIN", "ja") {
     }
 
     override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> {
-        val slug = manga.url.substringAfter("manga-").substringBefore(".html")
+        val slug = manga.url.substringAfter("raw-").substringBefore(".html")
 
         return client.newCall(
             GET(


### PR DESCRIPTION
Closes #9406 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
