### PR TITLE
Astratoons: Fix no pages found

### DIFF
--- a/src/pt/astratoons/build.gradle
+++ b/src/pt/astratoons/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Astratoons'
     extClass = '.Astratoons'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = false
 }
 

--- a/src/pt/astratoons/src/eu/kanade/tachiyomi/extension/pt/astratoons/Astratoons.kt
+++ b/src/pt/astratoons/src/eu/kanade/tachiyomi/extension/pt/astratoons/Astratoons.kt
@@ -119,8 +119,8 @@ class Astratoons : ParsedHttpSource() {
     // ======================== Pages ===========================
 
     override fun pageListParse(document: Document): List<Page> {
-        return document.select(".chapter-image-wrapper img").mapIndexed { index, element ->
-            Page(index, imageUrl = element.absUrl("src"))
+        return document.select(".chapter-image-canvas").mapIndexed { index, element ->
+            Page(index, imageUrl = element.absUrl("data-src-url"))
         }
     }
 


### PR DESCRIPTION
Closes #9443

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
