### PR TITLE
LilyManga: Fix baseUrl

### DIFF
--- a/src/en/lilymanga/build.gradle
+++ b/src/en/lilymanga/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Lily Manga'
     extClass = '.LilyManga'
     themePkg = 'madara'
-    baseUrl = 'https://lilymanga.net'
-    overrideVersionCode = 4
+    baseUrl = 'https://lilymanga.xyz'
+    overrideVersionCode = 5
     isNsfw = true
 }
 

--- a/src/en/lilymanga/src/eu/kanade/tachiyomi/extension/en/lilymanga/LilyManga.kt
+++ b/src/en/lilymanga/src/eu/kanade/tachiyomi/extension/en/lilymanga/LilyManga.kt
@@ -8,7 +8,7 @@ import java.util.Locale
 
 class LilyManga : Madara(
     "Lily Manga",
-    "https://lilymanga.net",
+    "https://lilymanga.xyz",
     "en",
     dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US),
 ) {
@@ -16,7 +16,7 @@ class LilyManga : Madara(
         .rateLimitHost(baseUrl.toHttpUrl(), 1, 2)
         .build()
 
-    override val mangaSubString = "ys"
+    override val mangaSubString = "gl"
 
     override val useNewChapterEndpoint = true
 


### PR DESCRIPTION
Closes #9405 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
