### PR TITLE
Feat/pixiv deeplink

### DIFF
--- a/src/all/pixiv/AndroidManifest.xml
+++ b/src/all/pixiv/AndroidManifest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity
+            android:name=".all.pixiv.PixivUrlActivity"
+            android:excludeFromRecents="true"
+            android:exported="true"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:host="pixiv.net" />
+                <data android:host="www.pixiv.net" />
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+
+                <data android:pathPattern="/en/artworks/..*" />
+                <data android:pathPattern="/artworks/..*" />
+                <data android:pathPattern="/en/users/..*" />
+                <data android:pathPattern="/users/..*" />
+                <data android:pathPattern="/user/..*/series/..*" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/src/all/pixiv/build.gradle
+++ b/src/all/pixiv/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Pixiv'
     extClass = '.PixivFactory'
-    extVersionCode = 9
+    extVersionCode = 10
     isNsfw = true
 }
 

--- a/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/Pixiv.kt
+++ b/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/Pixiv.kt
@@ -89,12 +89,16 @@ class Pixiv(override val lang: String) : HttpSource() {
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
         // Deeplink selection of specific IDs: simply fetch the single object and return
-        if (query.startsWith(ID_ILLUST_PREFIX)) {
+        if (query.startsWith(ID_ILLUST_PREFIX) &&
+            query.removePrefix(ID_ILLUST_PREFIX).matches("\\d+".toRegex())
+        ) {
             val illustId = query.removePrefix(ID_ILLUST_PREFIX)
             val manga = getIllustCached(illustId).toSManga()
             return Observable.just(MangasPage(listOf(manga), hasNextPage = false))
         }
-        if (query.startsWith(ID_SERIES_PREFIX)) {
+        if (query.startsWith(ID_SERIES_PREFIX) &&
+            query.removePrefix(ID_SERIES_PREFIX).matches("\\d+".toRegex())
+        ) {
             val seriesId = query.removePrefix(ID_SERIES_PREFIX)
             // TODO: caching!
             val series = ApiCall("/touch/ajax/illust/series/$seriesId")

--- a/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/Pixiv.kt
+++ b/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/Pixiv.kt
@@ -277,6 +277,7 @@ class Pixiv(override val lang: String) : HttpSource() {
             manga.thumbnail_url = url
             return manga
         } else {
+            val series = series.copy(userId = series.userId ?: author_details?.user_name)
             val manga = series.toSManga().apply {
                 thumbnail_url = thumbnail_url ?: this@toSManga.url
             }

--- a/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivConstants.kt
+++ b/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivConstants.kt
@@ -1,0 +1,7 @@
+package eu.kanade.tachiyomi.extension.all.pixiv
+
+object PixivConstants {
+    val ID_ILLUST_PREFIX = "aid:"
+    val ID_SERIES_PREFIX = "sid:"
+    val ID_USER_PREFIX = "user:"
+}

--- a/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivConstants.kt
+++ b/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivConstants.kt
@@ -1,7 +1,3 @@
 package eu.kanade.tachiyomi.extension.all.pixiv
 
-object PixivConstants {
-    val ID_ILLUST_PREFIX = "aid:"
-    val ID_SERIES_PREFIX = "sid:"
-    val ID_USER_PREFIX = "user:"
-}
+internal val KNOWN_LOCALES = listOf("en")

--- a/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivLinkUtil.kt
+++ b/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivLinkUtil.kt
@@ -33,7 +33,7 @@ sealed class PixivTarget {
                 return null
             }
 
-            var pathSegments = uri.pathSegments ?: return null
+            var pathSegments = uri.pathSegments.ifEmpty { null } ?: return null
 
             if (KNOWN_LOCALES.contains(pathSegments[0])) {
                 pathSegments = pathSegments.subList(1, pathSegments.size)

--- a/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivLinkUtil.kt
+++ b/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivLinkUtil.kt
@@ -1,0 +1,101 @@
+package eu.kanade.tachiyomi.extension.all.pixiv
+
+import android.net.Uri
+
+interface PixivTargetCompanion<out T : PixivTarget> {
+    val SEARCH_PREFIX: String
+    fun fromSearchQuery(query: String): T? {
+        if (!query.startsWith(SEARCH_PREFIX)) return null
+        val id = query.removePrefix(SEARCH_PREFIX)
+        if (!id.matches("\\d+".toRegex())) return null
+        return fromSearchQueryId(id)
+    }
+
+    fun fromSearchQueryId(id: String): T?
+}
+
+sealed class PixivTarget {
+    companion object {
+        val BASE_URI = Uri.parse("https://www.pixiv.net")
+
+        fun fromSearchQuery(query: String) =
+            sequenceOf<PixivTargetCompanion<*>>(User, Series, Illustration)
+                .firstNotNullOfOrNull { it.fromSearchQuery(query) }
+
+        fun fromUri(uri: String) = fromUri(Uri.parse(uri))
+        fun fromUri(uri: Uri): PixivTarget? {
+            // if an absolute domain is specified, check if it matches. Tolerate relative urls as-is.
+            if (!(
+                uri.scheme in listOf(null, "http", "https") &&
+                    uri.host?.let { "pixiv.net" == it.removePrefix("www.") } != false
+                )
+            ) {
+                return null
+            }
+
+            var pathSegments = uri.pathSegments ?: return null
+
+            if (KNOWN_LOCALES.contains(pathSegments[0])) {
+                pathSegments = pathSegments.subList(1, pathSegments.size)
+            }
+            if (pathSegments.size < 2) return null
+
+            with(pathSegments[0]) {
+                return when {
+                    equals("artworks") -> Illustration(pathSegments[1])
+                    equals("users") -> User(pathSegments[1])
+                    equals("user") &&
+                        (pathSegments.size >= 4 && pathSegments[2].equals("series")) ->
+                        Series(pathSegments[3], pathSegments[1])
+
+                    else -> null
+                }
+            }
+        }
+    }
+
+    abstract fun toUri(): Uri
+
+    abstract fun toSearchQuery(): String
+
+    data class User(val userId: String) : PixivTarget() {
+        companion object : PixivTargetCompanion<User> {
+            override val SEARCH_PREFIX = "user:"
+            override fun fromSearchQueryId(id: String) = User(id)
+        }
+
+        override fun toUri(): Uri =
+            BASE_URI.buildUpon().appendPath("users").appendPath(userId).build()
+
+        override fun toSearchQuery(): String = SEARCH_PREFIX + userId
+    }
+
+    data class Illustration(val illustId: String) : PixivTarget() {
+        companion object : PixivTargetCompanion<Illustration> {
+            override val SEARCH_PREFIX = "aid:"
+            override fun fromSearchQueryId(id: String) = Illustration(id)
+        }
+
+        override fun toUri(): Uri =
+            BASE_URI.buildUpon().appendPath("artworks").appendPath(illustId).build()
+
+        override fun toSearchQuery(): String = SEARCH_PREFIX + illustId
+    }
+
+    data class Series(val seriesId: String, val authorUserId: String? = null) : PixivTarget() {
+        companion object : PixivTargetCompanion<Series> {
+            override val SEARCH_PREFIX = "sid:"
+            override fun fromSearchQueryId(id: String) = Series(id)
+        }
+
+        override fun toUri(): Uri {
+            if (authorUserId == null) {
+                TODO("Not yet implemented")
+            }
+            return BASE_URI.buildUpon().appendPath("user").appendPath(authorUserId)
+                .appendPath("series").appendPath(seriesId).build()
+        }
+
+        override fun toSearchQuery(): String = SEARCH_PREFIX + seriesId
+    }
+}

--- a/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivTypes.kt
+++ b/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivTypes.kt
@@ -1,11 +1,14 @@
 package eu.kanade.tachiyomi.extension.all.pixiv
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 
 @Serializable
-internal data class PixivApiResponse<T>(
-    val body: T? = null,
+internal data class PixivApiResponse(
+    val error: Boolean = false,
+    val message: String? = null,
+    val body: JsonElement? = null,
 )
 
 @Serializable
@@ -92,4 +95,5 @@ internal data class PixivRankings(
 @Serializable
 internal data class PixivRankingEntry(
     val illustId: String? = null,
+    val rank: Int? = null,
 )

--- a/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivTypes.kt
+++ b/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivTypes.kt
@@ -58,6 +58,7 @@ internal data class PixivIllustPageUrls(
 
 @Serializable
 internal data class PixivAuthorDetails(
+    val user_id: String? = null,
     val user_name: String? = null,
 )
 
@@ -72,6 +73,9 @@ internal data class PixivSeries(
     val coverImage: JsonPrimitive? = null,
     val id: String? = null,
     val title: String? = null,
+    /**
+     * CAUTION: sometimes this isn't passed!
+     */
     val userId: String? = null,
 )
 

--- a/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivUrlActivity.kt
+++ b/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivUrlActivity.kt
@@ -1,0 +1,70 @@
+package eu.kanade.tachiyomi.extension.all.pixiv
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import eu.kanade.tachiyomi.extension.all.pixiv.PixivConstants.ID_ILLUST_PREFIX
+import eu.kanade.tachiyomi.extension.all.pixiv.PixivConstants.ID_SERIES_PREFIX
+import eu.kanade.tachiyomi.extension.all.pixiv.PixivConstants.ID_USER_PREFIX
+import kotlin.system.exitProcess
+
+/**
+ * Springboard that accepts https://mangadex.com/title/xxx intents and redirects them to
+ * the main tachiyomi process. The idea is to not install the intent filter unless
+ * you have this extension installed, but still let the main tachiyomi app control
+ * things.
+ *
+ * Main goal was to make it easier to open manga in Tachiyomi in spite of the DDoS blocking
+ * the usual search screen from working.
+ */
+class PixivUrlActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        var couldBuildIntent = false
+
+        do {
+            var pathSegments = intent?.data?.pathSegments ?: break
+
+            if ("en".equals(pathSegments[0])) {
+                pathSegments = pathSegments.subList(1, pathSegments.size)
+            }
+            if (pathSegments.size < 2) break
+
+            val query = with(pathSegments[0]) {
+                when {
+                    equals("artworks") -> "${ID_ILLUST_PREFIX}${pathSegments[1]}"
+                    equals("users") -> "${ID_USER_PREFIX}${pathSegments[1]}"
+                    equals("user") &&
+                        (pathSegments.size >= 4 && pathSegments[2].equals("series")) ->
+                        "${ID_SERIES_PREFIX}${pathSegments[3]}"
+                    else -> null
+                }
+            }
+            if (query == null) break
+
+            val mainIntent = Intent().apply {
+                action = "eu.kanade.tachiyomi.SEARCH"
+                putExtra("query", query)
+                putExtra("filter", packageName)
+            }
+            couldBuildIntent = true
+
+            try {
+                startActivity(mainIntent)
+            } catch (e: ActivityNotFoundException) {
+                Log.e("PixivUrlActivity", e.toString())
+            }
+        } while (false)
+
+        if (!couldBuildIntent) {
+            Log.e("PixivUrlActivity", "Could not parse URI from intent $intent")
+        }
+
+        finish()
+        exitProcess(0)
+    }
+}

--- a/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivUrlActivity.kt
+++ b/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivUrlActivity.kt
@@ -5,9 +5,6 @@ import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
-import eu.kanade.tachiyomi.extension.all.pixiv.PixivConstants.ID_ILLUST_PREFIX
-import eu.kanade.tachiyomi.extension.all.pixiv.PixivConstants.ID_SERIES_PREFIX
-import eu.kanade.tachiyomi.extension.all.pixiv.PixivConstants.ID_USER_PREFIX
 import kotlin.system.exitProcess
 
 /**
@@ -24,43 +21,19 @@ class PixivUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        var couldBuildIntent = false
-
-        do {
-            var pathSegments = intent?.data?.pathSegments ?: break
-
-            if ("en".equals(pathSegments[0])) {
-                pathSegments = pathSegments.subList(1, pathSegments.size)
-            }
-            if (pathSegments.size < 2) break
-
-            val query = with(pathSegments[0]) {
-                when {
-                    equals("artworks") -> "${ID_ILLUST_PREFIX}${pathSegments[1]}"
-                    equals("users") -> "${ID_USER_PREFIX}${pathSegments[1]}"
-                    equals("user") &&
-                        (pathSegments.size >= 4 && pathSegments[2].equals("series")) ->
-                        "${ID_SERIES_PREFIX}${pathSegments[3]}"
-                    else -> null
-                }
-            }
-            if (query == null) break
-
+        if (intent?.data != null) {
             val mainIntent = Intent().apply {
                 action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", query)
+                putExtra("query", intent.data.toString())
                 putExtra("filter", packageName)
             }
-            couldBuildIntent = true
 
             try {
                 startActivity(mainIntent)
             } catch (e: ActivityNotFoundException) {
                 Log.e("PixivUrlActivity", e.toString())
             }
-        } while (false)
-
-        if (!couldBuildIntent) {
+        } else {
             Log.e("PixivUrlActivity", "Could not parse URI from intent $intent")
         }
 


### PR DESCRIPTION
Closes #9452.

The propsed implementation adds three new dummy search handlers:

- `aid:12345` for direct deeplinks to a specific illustration
- `sid:12345` for direct deeplinks to a specific series (both of these will be treated as "manga", and an illustration within the series points to the same manga as the series itself)
- `user:12345` to filter for only the illustrations by a specific user. This differs from the corresponding filter in that
  1. it is accessible to a deeplink
  2. it uses the user ID instead of the name
  3. it therefore works with users whose names contain spaces, unlike the filter variant

I chose these patterns so they hopefully won't be accidentally encountered by a user. I decided to make the last one more speaking, because it is potentially useful for regular searching (though its functionality could be expanded by allowing it to appear beside regular search terms). All of these decisions can obviously be debated, and would ideally be approved by someone who is more primarily responsible for this plugin.

It seems that the entire search mechanism of this plugin could benefit from a general overhaul (for example, to prevent the constant `IllegalArgumentException`s when "violating the [nonexistent] contract" by retrying a search). But without changing more than necessary, this is the best I can do so far.


Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
