### PR TITLE
ImperioDaBritannia: Fix null pointer

### DIFF
--- a/src/pt/imperiodabritannia/build.gradle
+++ b/src/pt/imperiodabritannia/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ImperioDaBritannia'
     themePkg = 'madara'
     baseUrl = 'https://imperiodabritannia.com'
-    overrideVersionCode = 4
+    overrideVersionCode = 5
     isNsfw = false
 }
 

--- a/src/pt/imperiodabritannia/src/eu/kanade/tachiyomi/extension/pt/imperiodabritannia/ImperioDaBritannia.kt
+++ b/src/pt/imperiodabritannia/src/eu/kanade/tachiyomi/extension/pt/imperiodabritannia/ImperioDaBritannia.kt
@@ -3,8 +3,6 @@ package eu.kanade.tachiyomi.extension.pt.imperiodabritannia
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import okhttp3.OkHttpClient
-import java.net.HttpURLConnection.HTTP_FORBIDDEN
-import java.net.HttpURLConnection.HTTP_OK
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.concurrent.TimeUnit
@@ -19,15 +17,6 @@ class ImperioDaBritannia : Madara(
     override val client: OkHttpClient = super.client.newBuilder()
         .rateLimit(1, 2, TimeUnit.SECONDS)
         .readTimeout(1, TimeUnit.MINUTES)
-        .addInterceptor { chain ->
-            val response = chain.proceed(chain.request())
-            if (response.code == HTTP_FORBIDDEN) {
-                return@addInterceptor response.newBuilder()
-                    .code(HTTP_OK)
-                    .build()
-            }
-            response
-        }
         .build()
 
     override val useNewChapterEndpoint = true


### PR DESCRIPTION
Closes #9485

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
