### PR TITLE
Zerobyw: Support login in settings

### DIFF
--- a/src/zh/zerobyw/build.gradle
+++ b/src/zh/zerobyw/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Zerobyw'
     extClass = '.Zerobyw'
-    extVersionCode = 19
+    extVersionCode = 20
 }
 
 apply from: "$rootDir/common.gradle"


### PR DESCRIPTION
Closes #8934. Tested on Mihon 0.18.0 and Suwayomi 2.0.1826.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
