### PR TITLE
Dm5: Fix chapter list not loading

### DIFF
--- a/src/zh/dm5/build.gradle
+++ b/src/zh/dm5/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Dm5'
     extClass = '.Dm5'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/zh/dm5/src/eu/kanade/tachiyomi/extension/zh/dm5/Dm5.kt
+++ b/src/zh/dm5/src/eu/kanade/tachiyomi/extension/zh/dm5/Dm5.kt
@@ -82,8 +82,7 @@ class Dm5 : ParsedHttpSource(), ConfigurableSource {
     override fun chapterListParse(response: Response): List<SChapter> {
         val document = response.asJsoup()
         // May need to click button on website to read
-        document.selectFirst("ul#detail-list-select-1")?.attr("class")
-            ?: throw Exception("請到webview確認")
+        document.selectFirst("div#chapterlistload") ?: throw Exception("請到webview確認")
         val li = document.select("div#chapterlistload li > a").map {
             SChapter.create().apply {
                 url = it.attr("href")


### PR DESCRIPTION
Some mangas don't have "ul#detail-list-select-1" (probably 连载), and show "請到webview確認" exception, but nothing can be done in webview.
There is no related issue.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
