### PR TITLE
MangaDistrict: fix search

### DIFF
--- a/src/en/mangadistrict/build.gradle
+++ b/src/en/mangadistrict/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaDistrict'
     themePkg = 'madara'
     baseUrl = 'https://mangadistrict.com'
-    overrideVersionCode = 11
+    overrideVersionCode = 12
     isNsfw = true
 }
 

--- a/src/en/mangadistrict/src/eu/kanade/tachiyomi/extension/en/mangadistrict/MangaDistrict.kt
+++ b/src/en/mangadistrict/src/eu/kanade/tachiyomi/extension/en/mangadistrict/MangaDistrict.kt
@@ -47,9 +47,19 @@ class MangaDistrict :
         } catch (_: Exception) {}
     }
 
+    override fun popularMangaFromElement(element: Element): SManga {
+        return super.popularMangaFromElement(element).cleanTitleIfNeeded()
+    }
+
     override fun popularMangaNextPageSelector() = "div[role=navigation] span.current + a.page"
 
-    private val titleVersion = Regex("\\(.*\\)")
+    override fun latestUpdatesFromElement(element: Element): SManga {
+        return super.latestUpdatesFromElement(element).cleanTitleIfNeeded()
+    }
+
+    override fun searchMangaSelector() = popularMangaSelector()
+    override fun searchMangaNextPageSelector() = popularMangaNextPageSelector()
+    override fun searchMangaFromElement(element: Element) = popularMangaFromElement(element)
 
     override fun mangaDetailsParse(document: Document): SManga {
         val tags = document.select(mangaDetailsSelectorTag).mapNotNull { element ->
@@ -58,11 +68,8 @@ class MangaDistrict :
         }
         tagList = tagList.plus(tags)
 
-        return super.mangaDetailsParse(document).apply {
-            if (isRemoveTitleVersion()) {
-                title = this.title.replace(titleVersion, "").trim()
-            }
-        }
+        return super.mangaDetailsParse(document)
+            .cleanTitleIfNeeded()
     }
 
     override fun chapterListParse(response: Response): List<SChapter> {
@@ -158,6 +165,14 @@ class MangaDistrict :
     private fun String.urlKey(): String {
         return toHttpUrl().pathSegments.let { path ->
             "${path[1]}/${path[2]}"
+        }
+    }
+
+    private val titleVersion = Regex("\\(.*\\)")
+
+    private fun SManga.cleanTitleIfNeeded() = apply {
+        if (isRemoveTitleVersion()) {
+            title = title.replace(titleVersion, "").trim()
         }
     }
 


### PR DESCRIPTION
and title cleanup on browse

closes #9529

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
