### PR TITLE
Hitomi: fix animated webp & potential oom

### DIFF
--- a/src/all/hitomi/build.gradle
+++ b/src/all/hitomi/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hitomi'
     extClass = '.HitomiFactory'
-    extVersionCode = 40
+    extVersionCode = 41
     isNsfw = true
 }
 

--- a/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Hitomi.kt
+++ b/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Hitomi.kt
@@ -32,6 +32,7 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.security.MessageDigest
 import java.text.SimpleDateFormat
+import java.util.LinkedHashSet
 import java.util.LinkedList
 import java.util.Locale
 import kotlin.math.min
@@ -325,7 +326,7 @@ class Hitomi(
         }
 
         // we know total number so avoid internal resize overhead
-        val galleryIDs = LinkedHashSet<Int>(initialCapacity = numberOfGalleryIDs, loadFactor = 1.0f)
+        val galleryIDs = LinkedHashSet<Int>(numberOfGalleryIDs, 1.0f)
 
         for (i in 0.until(numberOfGalleryIDs))
             galleryIDs.add(buffer.int)
@@ -413,7 +414,7 @@ class Hitomi(
         val size = arrayBuffer.remaining() / Int.SIZE_BYTES
 
         // we know total number so avoid internal resize overhead
-        val nozomi = LinkedHashSet<Int>(initialCapacity = size, loadFactor = 1.0f)
+        val nozomi = LinkedHashSet<Int>(size, 1.0f)
 
         while (arrayBuffer.hasRemaining())
             nozomi.add(arrayBuffer.int)

--- a/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Hitomi.kt
+++ b/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/Hitomi.kt
@@ -308,8 +308,6 @@ class Hitomi(
 
         val inbuf = getRangedResponse(url, offset.until(offset + length))
 
-        val galleryIDs = mutableSetOf<Int>()
-
         val buffer =
             ByteBuffer
                 .wrap(inbuf)
@@ -325,6 +323,9 @@ class Hitomi(
         require(inbuf.size == expectedLength) {
             "inbuf.byteLength ${inbuf.size} != expected_length $expectedLength"
         }
+
+        // we know total number so avoid internal resize overhead
+        val galleryIDs = LinkedHashSet<Int>(initialCapacity = numberOfGalleryIDs, loadFactor = 1.0f)
 
         for (i in 0.until(numberOfGalleryIDs))
             galleryIDs.add(buffer.int)
@@ -404,11 +405,15 @@ class Hitomi(
         }
 
         val bytes = getRangedResponse(nozomiAddress, range)
-        val nozomi = mutableSetOf<Int>()
 
         val arrayBuffer = ByteBuffer
             .wrap(bytes)
             .order(ByteOrder.BIG_ENDIAN)
+
+        val size = arrayBuffer.remaining() / Int.SIZE_BYTES
+
+        // we know total number so avoid internal resize overhead
+        val nozomi = LinkedHashSet<Int>(initialCapacity = size, loadFactor = 1.0f)
 
         while (arrayBuffer.hasRemaining())
             nozomi.add(arrayBuffer.int)

--- a/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/HitomiDto.kt
+++ b/src/all/hitomi/src/eu/kanade/tachiyomi/extension/all/hitomi/HitomiDto.kt
@@ -24,7 +24,7 @@ class ImageFile(
     val hash: String,
     private val name: String,
 ) {
-    val isGif get() = name.endsWith(".gif")
+    val isGif get() = name.endsWith(".gif") || name.endsWith(".webp")
 }
 
 @Serializable


### PR DESCRIPTION
closes #9554

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
