### PR TITLE
Bilimanga: fixed some chapter page response encoding parsing errors

### DIFF
--- a/src/zh/bilimanga/build.gradle
+++ b/src/zh/bilimanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'BiliManga'
     extClass = '.BiliManga'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/zh/bilimanga/src/eu/kanade/tachiyomi/extension/zh/bilimanga/BiliManga.kt
+++ b/src/zh/bilimanga/src/eu/kanade/tachiyomi/extension/zh/bilimanga/BiliManga.kt
@@ -117,7 +117,7 @@ class BiliManga : HttpSource(), ConfigurableSource {
     override fun mangaDetailsParse(response: Response) = SManga.create().apply {
         val doc = response.asJsoup()
         val meta = doc.selectFirst(".book-meta")!!.text().split("|")
-        val extra = meta.filterNot(META_REGEX::containsMatchIn) // •
+        val extra = meta.filterNot(META_REGEX::containsMatchIn)
         val backupname = doc.selectFirst(".backupname")?.let {
             "\n\n漫畫別名：\n• ${it.text().split("、").joinToString("\n• ")}"
         }
@@ -164,7 +164,7 @@ class BiliManga : HttpSource(), ConfigurableSource {
         val images = it.select(".imagecontent")
         check(images.size > 0) {
             it.selectFirst("#acontentz")?.let { e ->
-                if ("電腦端" in e.text()) "章節不支持桌面電腦端瀏覽器顯示" else "漫畫可能已下架或需要登錄查看"
+                if ("電腦端" in e.text()) "不支持電腦端查看，請在高級設置中更換移動端UA標識" else "漫畫可能已下架或需要登錄查看"
             } ?: "章节鏈接错误"
         }
         images.mapIndexed { i, image ->

--- a/src/zh/bilimanga/src/eu/kanade/tachiyomi/extension/zh/bilimanga/MangaInterceptor.kt
+++ b/src/zh/bilimanga/src/eu/kanade/tachiyomi/extension/zh/bilimanga/MangaInterceptor.kt
@@ -28,13 +28,13 @@ class MangaInterceptor : Interceptor {
             "/read/${groups?.get(1)?.value}/${groups?.get(2)?.value?.toInt()?.minus(1)}.html"
         }
         else -> "/read/0/0.html"
-    } + "?predict"
+    }
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val origin = chain.request()
         regexOf(origin.url.fragment)?.let {
             val response = chain.proceed(origin.newBuilder().removeHeader("Accept-Encoding").build())
-            val url = it.find(response.body.string())?.groups?.get(1)?.value?.plus("?match")
+            val url = it.find(response.body.string())?.groups?.get(1)?.value
             return response.newBuilder().code(302)
                 .header("Location", url ?: predictUrlByContext(origin.url)).build()
         }

--- a/src/zh/bilimanga/src/eu/kanade/tachiyomi/extension/zh/bilimanga/MangaInterceptor.kt
+++ b/src/zh/bilimanga/src/eu/kanade/tachiyomi/extension/zh/bilimanga/MangaInterceptor.kt
@@ -3,8 +3,6 @@ package eu.kanade.tachiyomi.extension.zh.bilimanga
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.Response
-import okio.GzipSource
-import okio.buffer
 
 class MangaInterceptor : Interceptor {
 
@@ -35,9 +33,8 @@ class MangaInterceptor : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val origin = chain.request()
         regexOf(origin.url.fragment)?.let {
-            val response = chain.proceed(origin)
-            val html = GzipSource(response.body.source()).buffer().readUtf8()
-            val url = it.find(html)?.groups?.get(1)?.value?.plus("?match")
+            val response = chain.proceed(origin.newBuilder().removeHeader("Accept-Encoding").build())
+            val url = it.find(response.body.string())?.groups?.get(1)?.value?.plus("?match")
             return response.newBuilder().code(302)
                 .header("Location", url ?: predictUrlByContext(origin.url)).build()
         }

--- a/src/zh/bilimanga/src/eu/kanade/tachiyomi/extension/zh/bilimanga/Preferences.kt
+++ b/src/zh/bilimanga/src/eu/kanade/tachiyomi/extension/zh/bilimanga/Preferences.kt
@@ -11,17 +11,17 @@ fun preferencesInternal(context: Context) = arrayOf(
         title = "熱門漫畫顯示内容"
         summary = "%s"
         entries = arrayOf(
-            "月点击榜",
-            "周点击榜",
-            "月推荐榜",
-            "周推荐榜",
-            "月鲜花榜",
-            "周鲜花榜",
-            "月鸡蛋榜",
-            "周鸡蛋榜",
-            "最新入库",
+            "月點擊榜",
+            "周點擊榜",
+            "月推薦榜",
+            "周推薦榜",
+            "月鮮花榜",
+            "周鮮花榜",
+            "月雞蛋榜",
+            "周雞蛋榜",
+            "最新入庫",
             "收藏榜",
-            "新书榜",
+            "新書榜",
         )
         entryValues = arrayOf(
             "/top/monthvisit/%d.html",


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
