### PR TITLE
IkigaiMangas: Fix nsfw cookie value

### DIFF
--- a/src/es/ikigaimangas/build.gradle
+++ b/src/es/ikigaimangas/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Ikigai Mangas'
     extClass = '.IkigaiMangas'
-    extVersionCode = 24
+    extVersionCode = 25
     isNsfw = true
 }
 

--- a/src/es/ikigaimangas/src/eu/kanade/tachiyomi/extension/es/ikigaimangas/IkigaiMangas.kt
+++ b/src/es/ikigaimangas/src/eu/kanade/tachiyomi/extension/es/ikigaimangas/IkigaiMangas.kt
@@ -70,8 +70,7 @@ class IkigaiMangas : HttpSource(), ConfigurableSource {
     private val cookieInterceptor = CookieInterceptor(
         "",
         listOf(
-            "data-saving" to "0",
-            "nsfw-mode" to "1",
+            "nsfw-mode" to "true",
         ),
     )
 


### PR DESCRIPTION
Closes #9666 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
