### PR TITLE
Truyenhentai18: Fix popularMangaNextPageSelector

### DIFF
--- a/src/vi/truyenhentai18/build.gradle
+++ b/src/vi/truyenhentai18/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = "Truyen Hentai 18+"
     extClass = ".TruyenHentai18"
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/vi/truyenhentai18/src/eu/kanade/tachiyomi/extension/vi/truyenhentai18/TruyenHentai18.kt
+++ b/src/vi/truyenhentai18/src/eu/kanade/tachiyomi/extension/vi/truyenhentai18/TruyenHentai18.kt
@@ -51,7 +51,7 @@ class TruyenHentai18 : ParsedHttpSource() {
         thumbnail_url = element.selectFirst("img")?.absUrl("src")
     }
 
-    override fun popularMangaNextPageSelector() = "ul.pagination li.page-item.active:not(:last-child)"
+    override fun popularMangaNextPageSelector() = "div.overflow-x-scroll div button"
 
     // ============================== Latest ======================================
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
