### PR TITLE
Little Tyrant: Remove `www.` from baseUrl

### DIFF
--- a/src/pt/littletyrant/build.gradle
+++ b/src/pt/littletyrant/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.LittleTyrant'
     themePkg = 'madara'
     baseUrl = 'https://www.tiraninha.baby'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/pt/littletyrant/build.gradle
+++ b/src/pt/littletyrant/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Little Tyrant'
     extClass = '.LittleTyrant'
     themePkg = 'madara'
-    baseUrl = 'https://www.tiraninha.baby'
+    baseUrl = 'https://tiraninha.baby'
     overrideVersionCode = 1
     isNsfw = true
 }

--- a/src/pt/littletyrant/src/eu/kanade/tachiyomi/extension/pt/littletyrant/LittleTyrant.kt
+++ b/src/pt/littletyrant/src/eu/kanade/tachiyomi/extension/pt/littletyrant/LittleTyrant.kt
@@ -7,7 +7,7 @@ import java.util.Locale
 
 class LittleTyrant : Madara(
     "Little Tyrant",
-    "https://www.tiraninha.baby",
+    "https://tiraninha.baby",
     "pt-BR",
     dateFormat = SimpleDateFormat("MMM dd, yyyy", Locale("pt", "BR")),
 ) {


### PR DESCRIPTION
Closes #9714

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
