### PR TITLE
Move ColaManga to single source

### DIFF
--- a/lib-multisrc/colamanga/build.gradle.kts
+++ b/lib-multisrc/colamanga/build.gradle.kts
@@ -1,9 +1,0 @@
-plugins {
-    id("lib-multisrc")
-}
-
-baseVersionCode = 9
-
-dependencies {
-    api(project(":lib:synchrony"))
-}

--- a/src/zh/onemanhua/AndroidManifest.xml
+++ b/src/zh/onemanhua/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
         <activity
-            android:name="eu.kanade.tachiyomi.multisrc.colamanga.ColaMangaUrlActivity"
+            android:name="eu.kanade.tachiyomi.extension.zh.onemanhua.ColaMangaUrlActivity"
             android:excludeFromRecents="true"
             android:exported="true"
             android:theme="@android:style/Theme.NoDisplay">
@@ -12,8 +12,8 @@
                 <category android:name="android.intent.category.BROWSABLE"/>
 
                 <data
-                    android:host="${SOURCEHOST}"
-                    android:scheme="${SOURCESCHEME}"
+                    android:host="www.colamanga.com"
+                    android:scheme="https"
                     android:pathPattern="/manga-..*/" />
             </intent-filter>
         </activity>

--- a/src/zh/onemanhua/build.gradle
+++ b/src/zh/onemanhua/build.gradle
@@ -1,10 +1,12 @@
 ext {
     extName = 'COLAMANGA'
     extClass = '.Onemanhua'
-    themePkg = 'colamanga'
-    baseUrl = 'https://www.colamanga.com'
-    overrideVersionCode = 15
+    extVersionCode = 24
     isNsfw = true
 }
 
 apply from: "$rootDir/common.gradle"
+
+dependencies {
+    implementation(project(":lib:synchrony"))
+}

--- a/src/zh/onemanhua/src/eu/kanade/tachiyomi/extension/zh/onemanhua/ColaManga.kt
+++ b/src/zh/onemanhua/src/eu/kanade/tachiyomi/extension/zh/onemanhua/ColaManga.kt
@@ -1,4 +1,4 @@
-package eu.kanade.tachiyomi.multisrc.colamanga
+package eu.kanade.tachiyomi.extension.zh.onemanhua
 
 import android.annotation.SuppressLint
 import android.app.Application

--- a/src/zh/onemanhua/src/eu/kanade/tachiyomi/extension/zh/onemanhua/ColaMangaFilters.kt
+++ b/src/zh/onemanhua/src/eu/kanade/tachiyomi/extension/zh/onemanhua/ColaMangaFilters.kt
@@ -1,4 +1,4 @@
-package eu.kanade.tachiyomi.multisrc.colamanga
+package eu.kanade.tachiyomi.extension.zh.onemanhua
 
 import eu.kanade.tachiyomi.source.model.Filter
 import okhttp3.HttpUrl

--- a/src/zh/onemanhua/src/eu/kanade/tachiyomi/extension/zh/onemanhua/ColaMangaImageInterceptor.kt
+++ b/src/zh/onemanhua/src/eu/kanade/tachiyomi/extension/zh/onemanhua/ColaMangaImageInterceptor.kt
@@ -1,4 +1,4 @@
-package eu.kanade.tachiyomi.multisrc.colamanga
+package eu.kanade.tachiyomi.extension.zh.onemanhua
 
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType

--- a/src/zh/onemanhua/src/eu/kanade/tachiyomi/extension/zh/onemanhua/ColaMangaIntl.kt
+++ b/src/zh/onemanhua/src/eu/kanade/tachiyomi/extension/zh/onemanhua/ColaMangaIntl.kt
@@ -1,4 +1,4 @@
-package eu.kanade.tachiyomi.multisrc.colamanga
+package eu.kanade.tachiyomi.extension.zh.onemanhua
 
 class ColaMangaIntl(private val lang: String) {
 

--- a/src/zh/onemanhua/src/eu/kanade/tachiyomi/extension/zh/onemanhua/ColaMangaUrlActivity.kt
+++ b/src/zh/onemanhua/src/eu/kanade/tachiyomi/extension/zh/onemanhua/ColaMangaUrlActivity.kt
@@ -1,4 +1,4 @@
-package eu.kanade.tachiyomi.multisrc.colamanga
+package eu.kanade.tachiyomi.extension.zh.onemanhua
 
 import android.app.Activity
 import android.content.ActivityNotFoundException
@@ -13,7 +13,7 @@ class ColaMangaUrlActivity : Activity() {
 
         val pathSegments = intent?.data?.pathSegments
 
-        if (pathSegments != null && pathSegments.size > 0) {
+        if (pathSegments != null && pathSegments.isNotEmpty()) {
             val intent = Intent().apply {
                 action = "eu.kanade.tachiyomi.SEARCH"
                 putExtra("query", "${ColaManga.PREFIX_SLUG_SEARCH}${pathSegments[0]}")

--- a/src/zh/onemanhua/src/eu/kanade/tachiyomi/extension/zh/onemanhua/Onemanhua.kt
+++ b/src/zh/onemanhua/src/eu/kanade/tachiyomi/extension/zh/onemanhua/Onemanhua.kt
@@ -1,7 +1,5 @@
 package eu.kanade.tachiyomi.extension.zh.onemanhua
 
-import eu.kanade.tachiyomi.multisrc.colamanga.ColaManga
-import eu.kanade.tachiyomi.multisrc.colamanga.UriPartFilter
 import eu.kanade.tachiyomi.source.model.FilterList
 
 class Onemanhua : ColaManga("COLAMANGA", "https://www.colamanga.com", "zh") {


### PR DESCRIPTION
The other override, MangaDig, for which this multisrc was created, was removed in #5319.

The extension stays broken and the version code is not bumped.
