### PR TITLE
Bato.to: randomize auto mirror better

### DIFF
--- a/src/all/batoto/build.gradle
+++ b/src/all/batoto/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Bato.to'
     extClass = '.BatoToFactory'
-    extVersionCode = 51
+    extVersionCode = 52
     isNsfw = true
 }
 

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
@@ -43,7 +43,6 @@ import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
-import kotlin.math.abs
 import kotlin.random.Random
 
 open class BatoTo(
@@ -121,11 +120,7 @@ open class BatoTo(
                     BuildConfig.VERSION_NAME.hashCode().toLong()
                 }
 
-                val prng = Random(seed)
-                val randomValue = abs(prng.nextInt())
-                val index = 1 + (randomValue % (MIRROR_PREF_ENTRIES.size - 1))
-
-                MIRROR_PREF_ENTRY_VALUES[index]
+                MIRROR_PREF_ENTRY_VALUES.drop(1).random(Random(seed))
             }
     }
 

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
@@ -43,6 +43,8 @@ import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
+import kotlin.math.abs
+import kotlin.random.Random
 
 open class BatoTo(
     final override val lang: String,
@@ -107,14 +109,23 @@ open class BatoTo(
         return preferences.getString("${MIRROR_PREF_KEY}_$lang", MIRROR_PREF_DEFAULT_VALUE)
             ?.takeUnless { it == MIRROR_PREF_DEFAULT_VALUE }
             ?: let {
+                /* Semi-sticky mirror:
+                 * - Don't randomize on boot
+                 * - Don't randomize per language
+                 * - Fallback for non-Android platform
+                 */
                 val seed = runCatching {
                     val pm = Injekt.get<Application>().packageManager
                     pm.getPackageInfo(BuildConfig.APPLICATION_ID, 0).lastUpdateTime
                 }.getOrElse {
                     BuildConfig.VERSION_NAME.hashCode().toLong()
-                }.coerceAtLeast(0)
+                }
 
-                MIRROR_PREF_ENTRY_VALUES[1 + (seed % (MIRROR_PREF_ENTRIES.size - 1)).toInt()]
+                val prng = Random(seed)
+                val randomValue = abs(prng.nextInt())
+                val index = 1 + (randomValue % (MIRROR_PREF_ENTRIES.size - 1))
+
+                MIRROR_PREF_ENTRY_VALUES[index]
             }
     }
 


### PR DESCRIPTION
- #9767 made it always pick the 2nd mirror if the seed was negative, this has been fixed by using `abs()` instead of `.coerceAtLeast(0)`.
- `.hashCode()` was also unexpectedly sequential, amplifying the first issue. Fixed by passing the seed to `Random`.
- Added a short code comment outlining goals.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
