### PR TITLE
Manhastro: Fix auth cookie duplicated

### DIFF
--- a/src/pt/manhastro/build.gradle
+++ b/src/pt/manhastro/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Manhastro'
     themePkg = 'madara'
     baseUrl = 'https://manhastro.net'
-    overrideVersionCode = 8
+    overrideVersionCode = 9
     isNsfw = true
 }
 

--- a/src/pt/manhastro/src/eu/kanade/tachiyomi/extension/pt/manhastro/Manhastro.kt
+++ b/src/pt/manhastro/src/eu/kanade/tachiyomi/extension/pt/manhastro/Manhastro.kt
@@ -58,10 +58,8 @@ class Manhastro :
     private var showWarning: Boolean = true
 
     private val authCookie: Cookie by lazy {
-        handler.post {
-            cookieManager.removeAllCookies { }
-            cookieManager.flush()
-        }
+        cookieManager.removeAllCookies(null)
+        cookieManager.flush()
 
         val cookieJson = preferences.getString(COOKIE_STORAGE_PREF, "") as String
         if (cookieJson.isBlank()) {

--- a/src/pt/manhastro/src/eu/kanade/tachiyomi/extension/pt/manhastro/Manhastro.kt
+++ b/src/pt/manhastro/src/eu/kanade/tachiyomi/extension/pt/manhastro/Manhastro.kt
@@ -6,6 +6,7 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Base64
 import android.util.Log
+import android.webkit.CookieManager
 import android.widget.Toast
 import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen
@@ -52,9 +53,16 @@ class Manhastro :
 
     private val application: Application by lazy { Injekt.get<Application>() }
 
+    private val cookieManager by lazy { CookieManager.getInstance() }
+
     private var showWarning: Boolean = true
 
     private val authCookie: Cookie by lazy {
+        handler.post {
+            cookieManager.removeAllCookies { }
+            cookieManager.flush()
+        }
+
         val cookieJson = preferences.getString(COOKIE_STORAGE_PREF, "") as String
         if (cookieJson.isBlank()) {
             return@lazy doAuth().also(::upsetCookie)


### PR DESCRIPTION
This change fixes the request error when the expired cookie is sent with the new auth cookie. 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
