### PR TITLE
LeitorDeManga: Bypass jschallenge

### DIFF
--- a/src/en/yakshascans/build.gradle
+++ b/src/en/yakshascans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.YakshaScans'
     themePkg = 'madara'
     baseUrl = 'https://yakshascans.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/en/yakshascans/src/eu/kanade/tachiyomi/extension/en/yakshascans/YakshaScans.kt
+++ b/src/en/yakshascans/src/eu/kanade/tachiyomi/extension/en/yakshascans/YakshaScans.kt
@@ -36,11 +36,13 @@ class YakshaScans : Madara(
             .add("challenge", token)
             .build()
 
-        chain.proceed(POST("$baseUrl/hcdn-cgi/jschallenge-validate", headers, body)).use {
-            if (it.isSuccessful.not()) {
-                throw IOException("Failed to bypass js challenge!")
+        chain.proceed(POST("$baseUrl/hcdn-cgi/jschallenge-validate", headers, body))
+            .apply(Response::close)
+            .run {
+                if (!isSuccessful) {
+                    throw IOException("Failed to bypass js challenge!")
+                }
             }
-        }
         return chain.proceed(chain.request())
     }
 

--- a/src/en/yakshascans/src/eu/kanade/tachiyomi/extension/en/yakshascans/YakshaScans.kt
+++ b/src/en/yakshascans/src/eu/kanade/tachiyomi/extension/en/yakshascans/YakshaScans.kt
@@ -22,33 +22,36 @@ class YakshaScans : Madara(
         .addInterceptor(::jsChallengeInterceptor)
         .build()
 
+    // Linked to src/pt/leitordemanga
     private fun jsChallengeInterceptor(chain: Interceptor.Chain): Response {
-        val request = chain.request()
-        val origRes = chain.proceed(request)
-        if (origRes.code != 403) return origRes
-        origRes.close()
+        val response = chain.proceed(chain.request())
+        if (response.code != 403) {
+            return response
+        }
+        response.close()
 
-        // Same delay as the source
         Thread.sleep(3000L)
         val token = fetchToken(chain).sha256()
+        val body = FormBody.Builder()
+            .add("challenge", token)
+            .build()
 
-        val body = FormBody.Builder().add("challenge", token).build()
-        val challengeReq = POST("$baseUrl/hcdn-cgi/jschallenge-validate", headers, body = body)
-
-        val challengeResponse = chain.proceed(challengeReq)
-        challengeResponse.close()
-        if (challengeResponse.code != 200) throw IOException("Failed to bypass js challenge!")
-
-        return chain.proceed(request)
+        chain.proceed(POST("$baseUrl/hcdn-cgi/jschallenge-validate", headers, body)).use {
+            if (it.isSuccessful.not()) {
+                throw IOException("Failed to bypass js challenge!")
+            }
+        }
+        return chain.proceed(chain.request())
     }
 
-    private tailrec fun fetchToken(chain: Interceptor.Chain, attempt: Int = 0): String {
-        if (attempt > 5) throw IOException("Failed to fetch challenge token!")
-        val request = GET("$baseUrl/hcdn-cgi/jschallenge", headers)
-        val res = chain.proceed(request).body.string()
-
-        return res.substringAfter("cjs = '").substringBefore("'")
-            .takeUnless { it == "nil" } ?: fetchToken(chain, attempt + 1)
+    private fun fetchToken(chain: Interceptor.Chain, attempt: Int = 0): String {
+        if (attempt > MAX_ATTEMPT) {
+            throw IOException("Failed to fetch challenge token!")
+        }
+        return chain.proceed(GET("$baseUrl/hcdn-cgi/jschallenge", headers)).let {
+            TOKEN_REGEX.find(it.body.string())?.groups?.get(1)?.value
+                ?.takeUnless { it == "nil" } ?: fetchToken(chain, attempt.plus(1))
+        }
     }
 
     private fun String.sha256(): String {
@@ -62,4 +65,9 @@ class YakshaScans : Madara(
 
     override val mangaDetailsSelectorDescription: String =
         "div.description-summary div.summary__content h3 + p, div.description-summary div.summary__content:not(:has(h3)), div.summary_content div.post-content_item > h5 + div, div.summary_content div.manga-excerpt"
+
+    companion object {
+        private const val MAX_ATTEMPT = 5
+        private val TOKEN_REGEX = """cjs[^']+'([^']+)""".toRegex()
+    }
 }

--- a/src/pt/leitordemanga/build.gradle
+++ b/src/pt/leitordemanga/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.LeitorDeManga'
     themePkg = 'madara'
     baseUrl = 'https://leitordemanga.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = false
 }
 

--- a/src/pt/leitordemanga/src/eu/kanade/tachiyomi/extension/pt/leitordemanga/LeitorDeManga.kt
+++ b/src/pt/leitordemanga/src/eu/kanade/tachiyomi/extension/pt/leitordemanga/LeitorDeManga.kt
@@ -1,8 +1,15 @@
 package eu.kanade.tachiyomi.extension.pt.leitordemanga
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import okhttp3.FormBody
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
+import okhttp3.Response
+import java.io.IOException
+import java.security.MessageDigest
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.concurrent.TimeUnit
@@ -17,5 +24,50 @@ class LeitorDeManga : Madara(
 
     override val client: OkHttpClient = super.client.newBuilder()
         .rateLimit(1, 2, TimeUnit.SECONDS)
+        .addInterceptor(::jsChallengeInterceptor)
         .build()
+
+    // Linked to src/en/yakshascans
+    private fun jsChallengeInterceptor(chain: Interceptor.Chain): Response {
+        val response = chain.proceed(chain.request())
+        if (response.code != 403) {
+            return response
+        }
+        response.close()
+
+        Thread.sleep(3000L)
+        val token = fetchToken(chain).sha256()
+        val body = FormBody.Builder()
+            .add("challenge", token)
+            .build()
+
+        chain.proceed(POST("$baseUrl/hcdn-cgi/jschallenge-validate", headers, body)).use {
+            if (it.isSuccessful.not()) {
+                throw IOException("Failed to bypass js challenge!")
+            }
+        }
+        return chain.proceed(chain.request())
+    }
+
+    private fun fetchToken(chain: Interceptor.Chain, attempt: Int = 0): String {
+        if (attempt > MAX_ATTEMPT) {
+            throw IOException("Failed to fetch challenge token!")
+        }
+        return chain.proceed(GET("$baseUrl/hcdn-cgi/jschallenge", headers)).let {
+            TOKEN_REGEX.find(it.body.string())?.groups?.get(1)?.value
+                ?.takeUnless { it == "nil" } ?: fetchToken(chain, attempt.plus(1))
+        }
+    }
+
+    private fun String.sha256(): String {
+        return MessageDigest
+            .getInstance("SHA-256")
+            .digest(toByteArray())
+            .fold("", { str, it -> str + "%02x".format(it) })
+    }
+
+    companion object {
+        private const val MAX_ATTEMPT = 5
+        private val TOKEN_REGEX = """cjs[^']+'([^']+)""".toRegex()
+    }
 }

--- a/src/pt/leitordemanga/src/eu/kanade/tachiyomi/extension/pt/leitordemanga/LeitorDeManga.kt
+++ b/src/pt/leitordemanga/src/eu/kanade/tachiyomi/extension/pt/leitordemanga/LeitorDeManga.kt
@@ -41,11 +41,13 @@ class LeitorDeManga : Madara(
             .add("challenge", token)
             .build()
 
-        chain.proceed(POST("$baseUrl/hcdn-cgi/jschallenge-validate", headers, body)).use {
-            if (it.isSuccessful.not()) {
-                throw IOException("Failed to bypass js challenge!")
+        chain.proceed(POST("$baseUrl/hcdn-cgi/jschallenge-validate", headers, body))
+            .apply(Response::close)
+            .run {
+                if (!isSuccessful) {
+                    throw IOException("Failed to bypass js challenge!")
+                }
             }
-        }
         return chain.proceed(chain.request())
     }
 

--- a/src/pt/leitordemanga/src/eu/kanade/tachiyomi/extension/pt/leitordemanga/LeitorDeManga.kt
+++ b/src/pt/leitordemanga/src/eu/kanade/tachiyomi/extension/pt/leitordemanga/LeitorDeManga.kt
@@ -49,13 +49,18 @@ class LeitorDeManga : Madara(
         return chain.proceed(chain.request())
     }
 
-    private fun fetchToken(chain: Interceptor.Chain, attempt: Int = 0): String {
+    private tailrec fun fetchToken(chain: Interceptor.Chain, attempt: Int = 0): String {
         if (attempt > MAX_ATTEMPT) {
             throw IOException("Failed to fetch challenge token!")
         }
-        return chain.proceed(GET("$baseUrl/hcdn-cgi/jschallenge", headers)).let {
-            TOKEN_REGEX.find(it.body.string())?.groups?.get(1)?.value
-                ?.takeUnless { it == "nil" } ?: fetchToken(chain, attempt.plus(1))
+
+        val response = chain.proceed(GET("$baseUrl/hcdn-cgi/jschallenge", headers))
+        val token = TOKEN_REGEX.find(response.body.string())?.groups?.get(1)?.value
+
+        return if (token != null && token != "nil") {
+            token
+        } else {
+            fetchToken(chain, attempt + 1)
         }
     }
 


### PR DESCRIPTION
Closes #9764

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
