### PR TITLE
Jiangzaitoon: update domain, fix blurry thumbnails

### DIFF
--- a/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
+++ b/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
@@ -788,7 +788,7 @@ abstract class Madara(
     /**
      *  Get the best image quality available from srcset
      */
-    protected fun String.getSrcSetImage(): String? {
+    protected open fun String.getSrcSetImage(): String? {
         return this.split(" ")
             .filter(URL_REGEX::matches)
             .maxOfOrNull(String::toString)

--- a/src/tr/jiangzaitoon/build.gradle
+++ b/src/tr/jiangzaitoon/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Jiangzaitoon'
     extClass = '.Jiangzaitoon'
     themePkg = 'madara'
-    baseUrl = 'https://jiangzaitoon.wtf'
-    overrideVersionCode = 11
+    baseUrl = 'https://jiangzaitoon.lgbt'
+    overrideVersionCode = 12
     isNsfw = true
 }
 

--- a/src/tr/jiangzaitoon/src/eu/kanade/tachiyomi/extension/tr/jiangzaitoon/Jiangzaitoon.kt
+++ b/src/tr/jiangzaitoon/src/eu/kanade/tachiyomi/extension/tr/jiangzaitoon/Jiangzaitoon.kt
@@ -29,7 +29,6 @@ class Jiangzaitoon : Madara(
          */
         return this
             .split(",")
-            .map(String::trim)
             .mapNotNull { candidate ->
                 candidate
                     .trim()

--- a/src/tr/jiangzaitoon/src/eu/kanade/tachiyomi/extension/tr/jiangzaitoon/Jiangzaitoon.kt
+++ b/src/tr/jiangzaitoon/src/eu/kanade/tachiyomi/extension/tr/jiangzaitoon/Jiangzaitoon.kt
@@ -31,12 +31,17 @@ class Jiangzaitoon : Madara(
             .split(",")
             .map(String::trim)
             .mapNotNull { candidate ->
-                val (url, desc) = candidate.split(" ")
-                desc
-                    .takeIf { it.endsWith("w") }
-                    ?.removeSuffix("w")
-                    ?.toIntOrNull()
-                    ?.let { size -> url to size }
+                candidate
+                    .trim()
+                    .split(" ", limit = 2)
+                    .takeIf { it.size == 2 }
+                    ?.let { (url, desc) ->
+                        desc
+                            .takeIf { it.endsWith("w") }
+                            ?.removeSuffix("w")
+                            ?.toIntOrNull()
+                            ?.let { size -> url to size }
+                    }
             }
             .maxByOrNull { it.second }
             ?.first

--- a/src/tr/jiangzaitoon/src/eu/kanade/tachiyomi/extension/tr/jiangzaitoon/Jiangzaitoon.kt
+++ b/src/tr/jiangzaitoon/src/eu/kanade/tachiyomi/extension/tr/jiangzaitoon/Jiangzaitoon.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit
 
 class Jiangzaitoon : Madara(
     "Jiangzaitoon",
-    "https://jiangzaitoon.wtf",
+    "https://jiangzaitoon.lgbt",
     "tr",
     SimpleDateFormat("d MMM yyy", Locale("tr")),
 ) {
@@ -22,4 +22,23 @@ class Jiangzaitoon : Madara(
     }
 
     override val chapterUrlSelector = "> a"
+
+    override fun String.getSrcSetImage(): String? {
+        /* Assumption: URL is absolute
+         * Assumption: descriptor is always in width
+         */
+        return this
+            .split(",")
+            .map(String::trim)
+            .mapNotNull { candidate ->
+                val (url, desc) = candidate.split(" ")
+                desc
+                    .takeIf { it.endsWith("w") }
+                    ?.removeSuffix("w")
+                    ?.toIntOrNull()
+                    ?.let { size -> url to size }
+            }
+            .maxByOrNull { it.second }
+            ?.first
+    }
 }


### PR DESCRIPTION
Madara was also updated to allow overriding `String.getSrcSetImage()`, not bumping the multisrc.

Closes #8771

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
