### PR TITLE
Astratoons: fix chapters pages not found

### DIFF
--- a/src/pt/astratoons/build.gradle
+++ b/src/pt/astratoons/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Astratoons'
     extClass = '.Astratoons'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = false
 }
 

--- a/src/pt/astratoons/src/eu/kanade/tachiyomi/extension/pt/astratoons/Astratoons.kt
+++ b/src/pt/astratoons/src/eu/kanade/tachiyomi/extension/pt/astratoons/Astratoons.kt
@@ -119,8 +119,8 @@ class Astratoons : ParsedHttpSource() {
     // ======================== Pages ===========================
 
     override fun pageListParse(document: Document): List<Page> {
-        return document.select(".chapter-image-canvas").mapIndexed { index, element ->
-            Page(index, imageUrl = element.absUrl("data-src-url"))
+        return document.select("img.chapter-image").mapIndexed { index, element ->
+            Page(index, imageUrl = element.absUrl("src"))
         }
     }
 


### PR DESCRIPTION
Closes #9625
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
