### PR TITLE
fix: update Mangaworld domain to .cx

### DIFF
--- a/src/it/mangaworld/src/eu/kanade/tachiyomi/extension/it/mangaworld/Mangaworld.kt
+++ b/src/it/mangaworld/src/eu/kanade/tachiyomi/extension/it/mangaworld/Mangaworld.kt
@@ -4,6 +4,6 @@ import eu.kanade.tachiyomi.multisrc.mangaworld.MangaWorld
 
 class Mangaworld : MangaWorld(
     "Mangaworld",
-    "https://www.mangaworld.nz",
+    "https://www.mangaworld.cx",
     "it",
 )


### PR DESCRIPTION
The previous MangaWorld domain (`mangaworld.nz`) is no longer active and has been replaced by `mangaworld.cx`.

This pull request updates the `BASE_URL` in `MangaWorld.kt` to reflect the new working domain and restore the extension’s functionality.

**Note:** I was not able to test the extension locally, but the change is minimal and only affects the base URL.  

Related issue: #9860 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
