### PR TITLE
Webtoon Hatti: update domain, date format

### DIFF
--- a/src/tr/webtoonhatti/build.gradle
+++ b/src/tr/webtoonhatti/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Webtoon Hatti'
     extClass = '.WebtoonHatti'
     themePkg = 'madara'
-    baseUrl = 'https://webtoonhatti.me'
-    overrideVersionCode = 6
+    baseUrl = 'https://webtoonhatti.club'
+    overrideVersionCode = 7
     isNsfw = false
 }
 

--- a/src/tr/webtoonhatti/src/eu/kanade/tachiyomi/extension/tr/webtoonhatti/WebtoonHatti.kt
+++ b/src/tr/webtoonhatti/src/eu/kanade/tachiyomi/extension/tr/webtoonhatti/WebtoonHatti.kt
@@ -6,9 +6,9 @@ import java.util.Locale
 
 class WebtoonHatti : Madara(
     "Webtoon Hatti",
-    "https://webtoonhatti.me",
+    "https://webtoonhatti.club",
     "tr",
-    dateFormat = SimpleDateFormat("dd MMMM", Locale("tr")),
+    dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.ROOT),
 ) {
     override val useNewChapterEndpoint = false
 


### PR DESCRIPTION
Closes #8915 
Closes #9654


Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
