### PR TITLE
Kemono: update Url

### DIFF
--- a/src/all/kemono/build.gradle
+++ b/src/all/kemono/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Kemono'
     extClass = '.Kemono'
     themePkg = 'kemono'
-    baseUrl = 'https://kemono.su'
-    overrideVersionCode = 0
+    baseUrl = 'https://kemono.cr'
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/all/kemono/src/eu/kanade/tachiyomi/extension/all/kemono/Kemono.kt
+++ b/src/all/kemono/src/eu/kanade/tachiyomi/extension/all/kemono/Kemono.kt
@@ -2,7 +2,7 @@ package eu.kanade.tachiyomi.extension.all.kemono
 
 import eu.kanade.tachiyomi.multisrc.kemono.Kemono
 
-class Kemono : Kemono("Kemono", "https://kemono.su", "all") {
+class Kemono : Kemono("Kemono", "https://kemono.cr", "all") {
     override val getTypes = listOf(
         "Patreon",
         "Pixiv Fanbox",


### PR DESCRIPTION
Closes #9935 

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
