### PR TITLE
Fix weebcentral filter search showing duplicates

### DIFF
--- a/src/en/weebcentral/build.gradle
+++ b/src/en/weebcentral/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Weeb Central'
     extClass = '.WeebCentral'
-    extVersionCode = 15
+    extVersionCode = 16
     isNsfw = true
 }
 

--- a/src/en/weebcentral/src/eu/kanade/tachiyomi/extension/en/weebcentral/WeebCentral.kt
+++ b/src/en/weebcentral/src/eu/kanade/tachiyomi/extension/en/weebcentral/WeebCentral.kt
@@ -246,7 +246,7 @@ class WeebCentral : ParsedHttpSource() {
     )
 
     companion object {
-        const val FETCH_LIMIT = 24
+        const val FETCH_LIMIT = 32
         const val URL_SEARCH_PREFIX = "id:"
     }
 }

--- a/src/en/weebcentral/src/eu/kanade/tachiyomi/extension/en/weebcentral/WeebCentral.kt
+++ b/src/en/weebcentral/src/eu/kanade/tachiyomi/extension/en/weebcentral/WeebCentral.kt
@@ -246,6 +246,8 @@ class WeebCentral : ParsedHttpSource() {
     )
 
     companion object {
+        // The related "&limit=" query parameter of the api is currently non functional
+        // and always returns 32 entries per request
         const val FETCH_LIMIT = 32
         const val URL_SEARCH_PREFIX = "id:"
     }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension

When using filter search with weebcentral there was an issue of there being duplicate entries being shown. Every 32 entries there were 8 duplicates.

<img width="768" height="564" alt="image" src="https://github.com/user-attachments/assets/1644a0f1-6fb6-4627-b3d9-7df947eb19cc" />

This appears to be a bug with their api, if you use limit=24 you still get 32 entries.
You can reproduce this by opening dev tools in https://weebcentral.com/search/data?limit=24&offset=32&sort=Latest+Updates&order=Descending&official=Any&anime=Any&adult=Any&included_tag=Action&display_mode=Full+Display and typing `document.querySelectorAll("body > article")`.

An easy fix is to set `FETCH_LIMIT` to 32.