### PR TITLE
MangaPlus: add new label DX

### DIFF
--- a/src/all/mangaplus/build.gradle
+++ b/src/all/mangaplus/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MANGA Plus by SHUEISHA'
     extClass = '.MangaPlusFactory'
-    extVersionCode = 54
+    extVersionCode = 55
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusDto.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusDto.kt
@@ -204,6 +204,7 @@ class Label(val label: LabelCode? = LabelCode.WEEKLY_SHOUNEN_JUMP) {
             LabelCode.MANGA_PLUS_CREATORS -> "MANGA Plus Creators"
             LabelCode.SAIKYOU_JUMP -> "Saikyou Jump"
             LabelCode.ULTRA_JUMP -> "Ultra Jump"
+            LabelCode.DX -> "Dash X Comic"
             else -> null
         }
 }
@@ -243,6 +244,9 @@ enum class LabelCode {
 
     @SerialName("UJ")
     ULTRA_JUMP,
+
+    @SerialName("DX")
+    DX,
 }
 
 @Serializable


### PR DESCRIPTION
Closes #9895 

DX expanded to Dash X Comic as per [MangaUpdates](https://www.mangaupdates.com/series/053qpoc/jimi-na-ojisan-jitsu-wa-eiyu-datta-jikaku-ga-nai-mama-muso-shitetara-mei-no-dungeon-haishin-de-sarasareteta-yo-desu)

`@JsonIgnoreUnknownKeys` :soontm: https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-json/kotlinx.serialization.json/-json-ignore-unknown-keys/

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
