### PR TITLE
Mangagun: Fix thumbnail url selector

### DIFF
--- a/src/ja/mangagun/build.gradle
+++ b/src/ja/mangagun/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaGun'
     themePkg = 'fmreader'
     baseUrl = 'https://mangagun.net'
-    overrideVersionCode = 3
+    overrideVersionCode = 4
     isNsfw = true
 }
 

--- a/src/ja/mangagun/src/eu/kanade/tachiyomi/extension/ja/mangagun/MangaGun.kt
+++ b/src/ja/mangagun/src/eu/kanade/tachiyomi/extension/ja/mangagun/MangaGun.kt
@@ -31,6 +31,17 @@ class MangaGun : FMReader("MangaGun", "https://$DOMAIN", "ja") {
 
     override fun popularMangaRequest(page: Int): Request = mangaRequest("views", page)
 
+    override fun popularMangaFromElement(element: Element): SManga {
+        return SManga.create().apply {
+            element.select(headerSelector).let {
+                setUrlWithoutDomain(it.attr("abs:href"))
+                title = it.text()
+            }
+            thumbnail_url = element.select("img, .thumb-wrapper .img-in-ratio").attr("style")
+                .substringAfter("background-image:url(").substringBefore(")")
+        }
+    }
+
     override fun latestUpdatesRequest(page: Int): Request = mangaRequest("last_update", page)
 
     override fun getImgAttr(element: Element?): String? {


### PR DESCRIPTION
Closes #9844

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
