### PR TITLE
Mangacrab : Fix thumbnail and images

### DIFF
--- a/lib-multisrc/madara/build.gradle.kts
+++ b/lib-multisrc/madara/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 42
+baseVersionCode = 43
 
 dependencies {
     api(project(":lib:cryptoaes"))

--- a/lib-multisrc/madara/build.gradle.kts
+++ b/lib-multisrc/madara/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 43
+baseVersionCode = 42
 
 dependencies {
     api(project(":lib:cryptoaes"))

--- a/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
+++ b/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
@@ -163,6 +163,7 @@ abstract class Madara(
     override fun popularMangaSelector() = "div.page-item-detail:not(:has(a[href*='bilibilicomics.com']))$mangaEntrySelector , .manga__item"
 
     open val popularMangaUrlSelector = "div.post-title a"
+    open val popularMangaUrlSelectorImg = "img"
 
     override fun popularMangaFromElement(element: Element): SManga {
         val manga = SManga.create()
@@ -173,7 +174,7 @@ abstract class Madara(
                 manga.title = it.ownText()
             }
 
-            selectFirst("img")?.let {
+            selectFirst(popularMangaUrlSelectorImg)?.let {
                 manga.thumbnail_url = imageFromElement(it)
             }
         }

--- a/src/es/mangacrab/build.gradle
+++ b/src/es/mangacrab/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaCrab'
     themePkg = 'madara'
     baseUrl = 'https://mangacrab.topmanhuas.org'
-    overrideVersionCode = 13
+    overrideVersionCode = 14
     isNsfw = false
 }
 

--- a/src/es/mangacrab/src/eu/kanade/tachiyomi/extension/es/mangacrab/MangaCrab.kt
+++ b/src/es/mangacrab/src/eu/kanade/tachiyomi/extension/es/mangacrab/MangaCrab.kt
@@ -38,6 +38,7 @@ class MangaCrab :
 
     override fun popularMangaSelector() = "div.manga__item"
     override val popularMangaUrlSelector = "div.post-title a"
+    override val popularMangaUrlSelectorImg = "div.manga__thumb_item img"
     override fun chapterListSelector() = "div.listing-chapters_wrap > ul > li"
     override val mangaDetailsSelectorTitle = "h1.post-title"
     override val mangaDetailsSelectorDescription = "div.c-page__content div.modal-contenido"
@@ -49,12 +50,15 @@ class MangaCrab :
     override val pageListParseSelector = "div.page-break:not([style*='display:none'])"
 
     override fun imageFromElement(element: Element): String? {
+        val imageAbsUrl = element.attributes().find { it.key.startsWith("data-img-") }?.value
+
         return when {
             element.hasAttr("data-src") -> element.attr("abs:data-src")
             element.hasAttr("data-lazy-src") -> element.attr("abs:data-lazy-src")
             element.hasAttr("srcset") -> element.attr("abs:srcset").getSrcSetImage()
             element.hasAttr("data-cfsrc") -> element.attr("abs:data-cfsrc")
             element.hasAttr("data-src-base64") -> element.attr("abs:data-src-base64")
+            imageAbsUrl != null -> imageAbsUrl
             else -> element.attr("abs:src")
         }
     }


### PR DESCRIPTION
Closes  #9978

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
