### PR TITLE
fix(BuonDua): resolve issue with loading more than 9 galleries

### DIFF
--- a/src/all/buondua/build.gradle
+++ b/src/all/buondua/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Buon Dua'
     extClass = '.BuonDua'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/all/buondua/src/eu/kanade/tachiyomi/extension/all/buondua/BuonDua.kt
+++ b/src/all/buondua/src/eu/kanade/tachiyomi/extension/all/buondua/BuonDua.kt
@@ -93,7 +93,11 @@ class BuonDua() : ParsedHttpSource() {
         val doc = response.asJsoup()
         val dateUploadStr = doc.selectFirst(".article-info > small")?.text()
         val dateUpload = DATE_FORMAT.tryParse(dateUploadStr)
-        val maxPage = doc.select("nav.pagination:first-of-type a.pagination-link").last()?.text()?.toInt() ?: 1
+        // /xiuren-no-10051---10065-1127-photos-467c89d5b3e204eebe33ddbc54d905b1-47452?page=57
+        val maxPage = doc.select("nav.pagination:first-of-type a.pagination-next").last()
+            ?.absUrl("href")
+            ?.toHttpUrl()
+            ?.queryParameter("page")?.toInt() ?: 1
         val basePageUrl = response.request.url
         return (maxPage downTo 1).map { page ->
             SChapter.create().apply {


### PR DESCRIPTION
- Use URL of the last page to determine maximum page count

#Closes: #9139

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
