### PR TITLE
Fix Android Manifest hack for new AGP versions

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -17,7 +17,7 @@ android {
     namespace "eu.kanade.tachiyomi.extension"
     sourceSets {
         main {
-            manifest.srcFile "AndroidManifest.xml"
+            manifest.srcFile layout.buildDirectory.file("tempAndroidManifest.xml")
             java.srcDirs = ['src']
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']
@@ -105,17 +105,20 @@ dependencies {
     compileOnly(libs.bundles.common)
 }
 
+tasks.register("copyManifestFile", Copy) {
+    from 'AndroidManifest.xml'
+    rename { 'tempAndroidManifest.xml' }
+    into layout.buildDirectory
+}
+
 tasks.register("writeManifestFile") {
+    dependsOn(copyManifestFile)
     doLast {
-        def manifest = android.sourceSets.getByName("main").manifest
-        if (!manifest.srcFile.exists()) {
-            File tempFile = layout.buildDirectory.get().file("tempAndroidManifest.xml").getAsFile()
-            if (!tempFile.exists()) {
-                tempFile.withWriter {
-                    it.write('<?xml version="1.0" encoding="utf-8"?>\n<manifest />\n')
-                }
+        File manifest = android.sourceSets.getByName("main").manifest.srcFile
+        if (!manifest.exists()) {
+            manifest.withWriter {
+                it.write('<?xml version="1.0" encoding="utf-8"?>\n<manifest />\n')
             }
-            manifest.srcFile(tempFile.path)
         }
     }
 }

--- a/common.gradle
+++ b/common.gradle
@@ -17,7 +17,7 @@ android {
     namespace "eu.kanade.tachiyomi.extension"
     sourceSets {
         main {
-            manifest.srcFile layout.buildDirectory.file("tempAndroidManifest.xml")
+            manifest.srcFile layout.buildDirectory.file('tempAndroidManifest.xml')
             java.srcDirs = ['src']
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']
@@ -114,9 +114,9 @@ tasks.register("copyManifestFile", Copy) {
 tasks.register("writeManifestFile") {
     dependsOn(copyManifestFile)
     doLast {
-        File manifest = android.sourceSets.getByName("main").manifest.srcFile
-        if (!manifest.exists()) {
-            manifest.withWriter {
+        File tempFile = android.sourceSets.getByName('main').manifest.srcFile
+        if (!tempFile.exists()) {
+            tempFile.withWriter {
                 it.write('<?xml version="1.0" encoding="utf-8"?>\n<manifest />\n')
             }
         }


### PR DESCRIPTION
The old hack breaks with AGP 8.10.1 and 8.12.0 (#10071).
