### PR TITLE
Fix "restart tachiyomi" message when making changes to komga [ettings

### DIFF
--- a/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/KomgaUtils.kt
+++ b/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/KomgaUtils.kt
@@ -81,7 +81,7 @@ fun PreferenceScreen.addEditTextPreference(
                 val result = text.isBlank() || validate?.invoke(text) ?: true
 
                 if (restartRequired && result) {
-                    Toast.makeText(context, "Restart Tachiyomi to apply new setting.", Toast.LENGTH_LONG).show()
+                    Toast.makeText(context, "Restart the app to apply new setting.", Toast.LENGTH_LONG).show()
                 }
 
                 result


### PR DESCRIPTION
Removing "tachiyomi" from the "apply settings" message