### PR TITLE
Update ww# subdomain, sync titles

### DIFF
--- a/src/en/mangafreak/build.gradle
+++ b/src/en/mangafreak/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'Mangafreak'
     extClass = '.Mangafreak'
-    extVersionCode = 10
+    extVersionCode = 11
+    isNsfw = true
 }
 
 

--- a/src/en/mangafreak/src/eu/kanade/tachiyomi/extension/en/mangafreak/Mangafreak.kt
+++ b/src/en/mangafreak/src/eu/kanade/tachiyomi/extension/en/mangafreak/Mangafreak.kt
@@ -22,7 +22,7 @@ class Mangafreak : ParsedHttpSource() {
 
     override val lang: String = "en"
 
-    override val baseUrl: String = "https://ww1.mangafreak.me"
+    override val baseUrl: String = "https://ww2.mangafreak.me"
 
     override val supportsLatest: Boolean = true
 

--- a/src/en/readattackontitanshingekinokyojinmanga/build.gradle
+++ b/src/en/readattackontitanshingekinokyojinmanga/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Read Attack on Titan Shingeki no Kyojin Manga'
     extClass = '.ReadAttackOnTitanShingekiNoKyojinManga'
     themePkg = 'mangacatalog'
-    baseUrl = 'https://ww9.readsnk.com'
-    overrideVersionCode = 5
+    baseUrl = 'https://ww11.readsnk.com'
+    overrideVersionCode = 6
     isNsfw = false
 }
 

--- a/src/en/readattackontitanshingekinokyojinmanga/src/eu/kanade/tachiyomi/extension/en/readattackontitanshingekinokyojinmanga/ReadAttackOnTitanShingekiNoKyojinManga.kt
+++ b/src/en/readattackontitanshingekinokyojinmanga/src/eu/kanade/tachiyomi/extension/en/readattackontitanshingekinokyojinmanga/ReadAttackOnTitanShingekiNoKyojinManga.kt
@@ -4,7 +4,7 @@ import eu.kanade.tachiyomi.multisrc.mangacatalog.MangaCatalog
 import eu.kanade.tachiyomi.source.model.SChapter
 import org.jsoup.nodes.Element
 
-class ReadAttackOnTitanShingekiNoKyojinManga : MangaCatalog("Read Attack on Titan Shingeki no Kyojin Manga", "https://ww9.readsnk.com", "en") {
+class ReadAttackOnTitanShingekiNoKyojinManga : MangaCatalog("Read Attack on Titan Shingeki no Kyojin Manga", "https://ww11.readsnk.com", "en") {
     override val sourceList = listOf(
         Pair("Shingeki No Kyojin", "$baseUrl/manga/shingeki-no-kyojin/"),
         Pair("Colored", "$baseUrl/manga/shingeki-no-kyojin-colored/"),
@@ -12,13 +12,15 @@ class ReadAttackOnTitanShingekiNoKyojinManga : MangaCatalog("Read Attack on Tita
         Pair("Lost Girls", "$baseUrl/manga/shingeki-no-kyojin-lost-girls/"),
         Pair("No Regrets", "$baseUrl/manga/attack-on-titan-no-regrets/"),
         Pair("Junior High", "$baseUrl/manga/attack-on-titan-junior-high/"),
+        Pair("Guidebook", "$baseUrl/manga/attack-on-titan-guidebook-inside-outside/"),
         Pair("Harsh Mistress", "$baseUrl/manga/attack-on-titan-harsh-mistress-of-the-city/"),
         Pair("Anthology", "$baseUrl/manga/attack-on-titan-anthology/"),
         Pair("Art Book", "$baseUrl/manga/attack-on-titan-exclusive-art-book/"),
         Pair("Spoof", "$baseUrl/manga/spoof-on-titan/"),
-        Pair("Guidebook", "$baseUrl/manga/attack-on-titan-guidebook-inside-outside/"),
         Pair("No Regrets Colored", "$baseUrl/manga/attack-on-titan-no-regrets-colored/"),
-    ).sortedBy { it.first }.distinctBy { it.second }
+        Pair("BTF Light Novel", "$baseUrl/manga/attack-on-titan-before-the-fall-light-novel/"),
+        Pair("Best of SNK", "$baseUrl/manga/the-best-of-attack-on-titan-in-color/"),
+    )
 
     override fun chapterListSelector(): String = "div.w-full div.grid div.col-span-4"
 

--- a/src/en/readberserkmanga/build.gradle
+++ b/src/en/readberserkmanga/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ReadBerserkManga'
     themePkg = 'mangacatalog'
     baseUrl = 'https://readberserk.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = false
 }
 

--- a/src/en/readberserkmanga/src/eu/kanade/tachiyomi/extension/en/readberserkmanga/ReadBerserkManga.kt
+++ b/src/en/readberserkmanga/src/eu/kanade/tachiyomi/extension/en/readberserkmanga/ReadBerserkManga.kt
@@ -14,11 +14,12 @@ class ReadBerserkManga : MangaCatalog("Read Berserk Manga", "https://readberserk
         Pair("Berserk", "$baseUrl/manga/berserk/"),
         Pair("Guidebook", "$baseUrl/manga/berserk-official-guidebook/"),
         Pair("Colored", "$baseUrl/manga/berserk-colored/"),
-        Pair("Motion Comic", "$baseUrl/manga/berserk-the-motion-comic/"),
+        // Pair("Motion Comic", "$baseUrl/manga/berserk-the-motion-comic/"), // Video
         Pair("Duranki", "$baseUrl/manga/duranki/"),
         Pair("Gigantomakhia", "$baseUrl/manga/gigantomakhia/"),
+        Pair("Futatabi", "$baseUrl/manga/futatabi/"),
         Pair("Berserk Spoilers & RAW", "$baseUrl/manga/berserk-spoilers-raw/"),
-    ).sortedBy { it.first }.distinctBy { it.second }
+    )
 
     override fun mangaDetailsParse(document: Document): SManga = SManga.create().apply {
         description = document.select("div.card-body > p").text()

--- a/src/en/readblackclovermangaonline/build.gradle
+++ b/src/en/readblackclovermangaonline/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Read Black Clover Manga Online'
     extClass = '.ReadBlackCloverMangaOnline'
     themePkg = 'mangacatalog'
-    baseUrl = 'https://ww7.readblackclover.com'
-    overrideVersionCode = 0
+    baseUrl = 'https://ww10.readblackclover.com'
+    overrideVersionCode = 1
     isNsfw = false
 }
 

--- a/src/en/readblackclovermangaonline/src/eu/kanade/tachiyomi/extension/en/readblackclovermangaonline/ReadBlackCloverMangaOnline.kt
+++ b/src/en/readblackclovermangaonline/src/eu/kanade/tachiyomi/extension/en/readblackclovermangaonline/ReadBlackCloverMangaOnline.kt
@@ -2,11 +2,11 @@ package eu.kanade.tachiyomi.extension.en.readblackclovermangaonline
 
 import eu.kanade.tachiyomi.multisrc.mangacatalog.MangaCatalog
 
-class ReadBlackCloverMangaOnline : MangaCatalog("Read Black Clover Manga Online", "https://ww7.readblackclover.com", "en") {
+class ReadBlackCloverMangaOnline : MangaCatalog("Read Black Clover Manga Online", "https://ww10.readblackclover.com", "en") {
     override val sourceList = listOf(
-        Pair("Black Clover", "$baseUrl/manga/black-clover"),
-        Pair("Black Clover Gainden Quartet Knights", "$baseUrl/manga/black-clover-gaiden-quartet-knights"),
-        Pair("Fan Colored", "$baseUrl/manga/black-clover-colored"),
-        Pair("Hungry Joker", "$baseUrl/manga/hungry-joker"),
+        Pair("Black Clover", "$baseUrl/manga/black-clover/"),
+        Pair("Fan Colored", "$baseUrl/manga/black-clover-colored/"),
+        Pair("Hungry Joker", "$baseUrl/manga/hungry-joker/"),
+        Pair("Gaiden", "$baseUrl/manga/black-clover-gaiden-quartet-knights/"),
     )
 }

--- a/src/en/readbokunoheroacademiamyheroacademiamanga/build.gradle
+++ b/src/en/readbokunoheroacademiamyheroacademiamanga/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Read Boku no Hero Academia My Hero Academia Manga'
     extClass = '.ReadBokuNoHeroAcademiaMyHeroAcademiaManga'
     themePkg = 'mangacatalog'
-    baseUrl = 'https://ww6.readmha.com'
-    overrideVersionCode = 2
+    baseUrl = 'https://ww10.readmha.com'
+    overrideVersionCode = 3
     isNsfw = false
 }
 

--- a/src/en/readbokunoheroacademiamyheroacademiamanga/src/eu/kanade/tachiyomi/extension/en/readbokunoheroacademiamyheroacademiamanga/ReadBokuNoHeroAcademiaMyHeroAcademiaManga.kt
+++ b/src/en/readbokunoheroacademiamyheroacademiamanga/src/eu/kanade/tachiyomi/extension/en/readbokunoheroacademiamyheroacademiamanga/ReadBokuNoHeroAcademiaMyHeroAcademiaManga.kt
@@ -2,16 +2,17 @@ package eu.kanade.tachiyomi.extension.en.readbokunoheroacademiamyheroacademiaman
 
 import eu.kanade.tachiyomi.multisrc.mangacatalog.MangaCatalog
 
-class ReadBokuNoHeroAcademiaMyHeroAcademiaManga : MangaCatalog("Read Boku no Hero Academia My Hero Academia Manga", "https://ww6.readmha.com", "en") {
+class ReadBokuNoHeroAcademiaMyHeroAcademiaManga : MangaCatalog("Read Boku no Hero Academia My Hero Academia Manga", "https://ww10.readmha.com", "en") {
     override val sourceList = listOf(
         Pair("Boku no Hero Academia", "$baseUrl/manga/boku-no-hero-academia/"),
         Pair("Vigilante", "$baseUrl/manga/vigilante-boku-no-hero-academia-illegals/"),
         Pair("Team Up", "$baseUrl/manga/my-hero-academia-team-up-mission/"),
         Pair("MHA Smash", "$baseUrl/manga/boku-no-hero-academia-smash/"),
-        Pair("MHA: School Brief", "$baseUrl/manga/my-hero-academia-school-briefs/"),
+        Pair("School Brief", "$baseUrl/manga/my-hero-academia-school-briefs/"),
         Pair("Rising", "$baseUrl/manga/deku-bakugo-rising/"),
         Pair("Colored", "$baseUrl/manga/boku-no-hero-academia-colored/"),
         Pair("Oumagadoki Zoo", "$baseUrl/manga/oumagadoki-zoo/"),
         Pair("Sensei no Bulge", "$baseUrl/manga/sensei-no-bulge/"),
-    ).sortedBy { it.first }.distinctBy { it.second }
+        Pair("Ultra Analysis", "$baseUrl/manga/my-hero-academia-ultra-analysis/"),
+    )
 }

--- a/src/en/readchainsawmanmangaonline/build.gradle
+++ b/src/en/readchainsawmanmangaonline/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Read Chainsaw Man Manga Online'
     extClass = '.ReadChainsawManMangaOnline'
     themePkg = 'mangacatalog'
-    baseUrl = 'https://ww4.readchainsawman.com'
-    overrideVersionCode = 1
+    baseUrl = 'https://ww5.readchainsawman.com'
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/en/readchainsawmanmangaonline/src/eu/kanade/tachiyomi/extension/en/readchainsawmanmangaonline/ReadChainsawManMangaOnline.kt
+++ b/src/en/readchainsawmanmangaonline/src/eu/kanade/tachiyomi/extension/en/readchainsawmanmangaonline/ReadChainsawManMangaOnline.kt
@@ -2,22 +2,19 @@ package eu.kanade.tachiyomi.extension.en.readchainsawmanmangaonline
 
 import eu.kanade.tachiyomi.multisrc.mangacatalog.MangaCatalog
 
-class ReadChainsawManMangaOnline : MangaCatalog("Read Chainsaw Man Manga Online", "https://ww4.readchainsawman.com", "en") {
+class ReadChainsawManMangaOnline : MangaCatalog("Read Chainsaw Man Manga Online", "https://ww5.readchainsawman.com", "en") {
     override val sourceList = listOf(
-        // Chainsaw Man
         Pair("Chainsaw Man", "$baseUrl/manga/chainsaw-man/"),
+        Pair("17-21", "$baseUrl/manga/17-21-fujimoto-tatsuki-tanpenshuu/"),
+        Pair("Fire Punch", "$baseUrl/manga/fire-punch/"),
+        Pair("Nayuta", "$baseUrl/manga/yogen-no-nayuta/"),
+        Pair("Look Back", "$baseUrl/manga/look-back/"),
+        Pair("Light Novel", "$baseUrl/manga/chainsaw-man-buddy-stories/"),
+        Pair("Colored", "$baseUrl/manga/chainsaw-man-colored/"),
+        Pair("Listen to Song", "$baseUrl/manga/futsuu-ni-kiite-kure/"),
+        Pair("Goodbye, Eri", "$baseUrl/manga/sayonara-eri-goodbye-eri/"),
+        Pair("22-26", "$baseUrl/manga/22-26-fujimoto-tatsuki-tanpenshuu/"),
         Pair("Chainsaw Man Colored", "$baseUrl/manga/chainsaw-man-colored/"),
         Pair("Chainsaw Man: Buddy Stories", "$baseUrl/manga/chainsaw-man-buddy-stories/"),
-
-        // Other titles
-        Pair("Fire Punch", "$baseUrl/manga/fire-punch/"),
-        Pair("Yogen no Nayuta", "$baseUrl/manga/yogen-no-nayuta/"),
-        Pair("Look Back", "$baseUrl/manga/look-back/"),
-        Pair("Just Listen to the Song", "$baseUrl/manga/futsuu-ni-kiite-kure/"),
-        Pair("Sayonara Eri (Goodbye, Eri)", "$baseUrl/manga/sayonara-eri-goodbye-eri/"),
-
-        // Storybooks
-        Pair("Tatsuki Fujimoto Before Chainsaw Man: 17-21", "$baseUrl/manga/17-21-fujimoto-tatsuki-tanpenshuu/"),
-        Pair("Tatsuki Fujimoto Before Chainsaw Man: 22-26", "$baseUrl/manga/22-26-fujimoto-tatsuki-tanpenshuu/"),
-    ).sortedBy { it.first }.distinctBy { it.second }
+    )
 }

--- a/src/en/readdragonballsuperchoumangaonline/build.gradle
+++ b/src/en/readdragonballsuperchoumangaonline/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Read Dragon Ball Super Chou Manga Online'
     extClass = '.ReadDragonBallSuperChouMangaOnline'
     themePkg = 'mangacatalog'
-    baseUrl = 'https://ww6.dbsmanga.com'
-    overrideVersionCode = 1
+    baseUrl = 'https://ww10.dbsmanga.com'
+    overrideVersionCode = 2
     isNsfw = false
 }
 

--- a/src/en/readdragonballsuperchoumangaonline/src/eu/kanade/tachiyomi/extension/en/readdragonballsuperchoumangaonline/ReadDragonBallSuperChouMangaOnline.kt
+++ b/src/en/readdragonballsuperchoumangaonline/src/eu/kanade/tachiyomi/extension/en/readdragonballsuperchoumangaonline/ReadDragonBallSuperChouMangaOnline.kt
@@ -2,7 +2,7 @@ package eu.kanade.tachiyomi.extension.en.readdragonballsuperchoumangaonline
 
 import eu.kanade.tachiyomi.multisrc.mangacatalog.MangaCatalog
 
-class ReadDragonBallSuperChouMangaOnline : MangaCatalog("Read Dragon Ball Super Chou Manga Online", "https://ww6.dbsmanga.com", "en") {
+class ReadDragonBallSuperChouMangaOnline : MangaCatalog("Read Dragon Ball Super Chou Manga Online", "https://ww10.dbsmanga.com", "en") {
     override val sourceList = listOf(
         Pair("Dragon Ball Super", "$baseUrl/manga/dragon-ball-super/"),
         Pair("Dragon Ball", "$baseUrl/manga/dragon-ball/"),
@@ -16,7 +16,11 @@ class ReadDragonBallSuperChouMangaOnline : MangaCatalog("Read Dragon Ball Super 
         Pair("Universe Mission", "$baseUrl/manga/super-dragon-ball-heroes-universe-mission/"),
         Pair("Colored: Saiyan Arc", "$baseUrl/manga/dragon-ball-full-color-saiyan-arc/"),
         Pair("Colored: Freeza Arc", "$baseUrl/manga/dragon-ball-full-color-freeza-arc/"),
-        Pair("Big Bang Mission!", "$baseUrl/manga/super-dragon-ball-heroes-big-bang-mission/"),
+        Pair("Big Bang", "$baseUrl/manga/super-dragon-ball-heroes-big-bang-mission/"),
         Pair("DBS Colored", "$baseUrl/manga/dragon-ball-super-colored/"),
-    ).sortedBy { it.first }.distinctBy { it.second }
+        Pair("Ultra God Mission", "$baseUrl/manga/super-dragon-ball-heroes-ultra-god-mission/"),
+        Pair("Neko Majin", "$baseUrl/manga/neko-majin/"),
+        Pair("Sand Land", "$baseUrl/manga/sand-land/"),
+        Pair("Sand Land Colored", "$baseUrl/manga/sand-land-digital-colored-comics/"),
+    )
 }

--- a/src/en/readdrstonemangaonline/build.gradle
+++ b/src/en/readdrstonemangaonline/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Read Dr. Stone Manga Online'
     extClass = '.ReadDrStoneMangaOnline'
     themePkg = 'mangacatalog'
-    baseUrl = 'https://ww3.readdrstone.com'
-    overrideVersionCode = 0
+    baseUrl = 'https://ww7.readdrstone.com'
+    overrideVersionCode = 1
     isNsfw = false
 }
 

--- a/src/en/readdrstonemangaonline/src/eu/kanade/tachiyomi/extension/en/readdrstonemangaonline/ReadDrStoneMangaOnline.kt
+++ b/src/en/readdrstonemangaonline/src/eu/kanade/tachiyomi/extension/en/readdrstonemangaonline/ReadDrStoneMangaOnline.kt
@@ -2,12 +2,20 @@ package eu.kanade.tachiyomi.extension.en.readdrstonemangaonline
 
 import eu.kanade.tachiyomi.multisrc.mangacatalog.MangaCatalog
 
-class ReadDrStoneMangaOnline : MangaCatalog("Read Dr. Stone Manga Online", "https://ww3.readdrstone.com", "en") {
+class ReadDrStoneMangaOnline : MangaCatalog("Read Dr. Stone Manga Online", "https://ww7.readdrstone.com", "en") {
     override val sourceList = listOf(
         Pair("Dr. Stone", "$baseUrl/manga/dr-stone/"),
-        Pair("Dr. Stone: Reboot", "$baseUrl/manga/dr-stone-reboot-byakuya/"),
+        Pair("Dr Stone: Reboot", "$baseUrl/manga/dr-stone-reboot-byakuya/"),
         Pair("Sun-ken Rock", "$baseUrl/manga/sun-ken-rock/"),
+        Pair("One Shots", "$baseUrl/manga/oneshot-by-boichi/"),
+        Pair("Hotel", "$baseUrl/manga/hotel/"),
         Pair("Origin", "$baseUrl/manga/origin/"),
         Pair("Raqiya", "$baseUrl/manga/raqiya/"),
-    ).sortedBy { it.first }.distinctBy { it.second }
+        Pair("Isekai Kenbunroku", "$baseUrl/manga/super-string-isekai-kenbunroku/"),
+        Pair("Feed Yumin", "$baseUrl/manga/i-want-to-feed-yumin/"),
+        Pair("Space Chef", "$baseUrl/manga/space-chef-caisar/"),
+        Pair("Wallman", "$baseUrl/manga/wallman/"),
+        Pair("Trillion Game", "$baseUrl/manga/trillion-game/"),
+        Pair("The Marshal King", "$baseUrl/manga/the-marshal-king/"),
+    )
 }

--- a/src/en/readfairytailedenszeromangaonline/build.gradle
+++ b/src/en/readfairytailedenszeromangaonline/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Read Fairy Tail & Edens Zero Manga Online'
     extClass = '.ReadFairyTailEdensZeroMangaOnline'
     themePkg = 'mangacatalog'
-    baseUrl = 'https://ww4.readfairytail.com'
-    overrideVersionCode = 1
+    baseUrl = 'https://ww8.readfairytail.com'
+    overrideVersionCode = 2
     isNsfw = false
 }
 

--- a/src/en/readfairytailedenszeromangaonline/src/eu/kanade/tachiyomi/extension/en/readfairytailedenszeromangaonline/ReadFairyTailEdensZeroMangaOnline.kt
+++ b/src/en/readfairytailedenszeromangaonline/src/eu/kanade/tachiyomi/extension/en/readfairytailedenszeromangaonline/ReadFairyTailEdensZeroMangaOnline.kt
@@ -2,23 +2,27 @@ package eu.kanade.tachiyomi.extension.en.readfairytailedenszeromangaonline
 
 import eu.kanade.tachiyomi.multisrc.mangacatalog.MangaCatalog
 
-class ReadFairyTailEdensZeroMangaOnline : MangaCatalog("Read Fairy Tail & Edens Zero Manga Online", "https://ww4.readfairytail.com", "en") {
+class ReadFairyTailEdensZeroMangaOnline : MangaCatalog("Read Fairy Tail & Edens Zero Manga Online", "https://ww8.readfairytail.com", "en") {
     override val sourceList = listOf(
         Pair("Eden's Zero", "$baseUrl/manga/edens-zero/"),
         Pair("Fairy Tail", "$baseUrl/manga/fairy-tail/"),
         Pair("FT Zero", "$baseUrl/manga/fairy-tail-zero/"),
-        Pair("FT City Hero", "$baseUrl/manga/fairy-tail-zero/"),
+        Pair("FT City Hero", "$baseUrl/manga/fairy-tail-city-hero/"),
         Pair("Hero’s", "$baseUrl/manga/heros/"),
         Pair("FT Happy Adv", "$baseUrl/manga/fairy-tail-happys-grand-adventure/"),
         Pair("FT 100 Year", "$baseUrl/manga/fairy-tail-100-years-quest/"),
         Pair("FT Ice Trail", "$baseUrl/manga/fairy-tail-ice-trail/"),
         Pair("FT x Taizai", "$baseUrl/manga/fairy-tail-x-nanatsu-no-taizai-christmas-special/"),
         Pair("Parasyte x FT", "$baseUrl/manga/parasyte-x-fairy-tail/"),
+        Pair("Gaiden 1", "$baseUrl/manga/fairy-tail-gaiden-raigo-issen/"),
+        Pair("FT x Rave", "$baseUrl/manga/fairy-tail-x-rave/"),
         Pair("Monster Hunter", "$baseUrl/manga/monster-hunter-orage/"),
         Pair("Rave Master", "$baseUrl/manga/rave-master/"),
-        Pair("Fairy Tail x Rave", "$baseUrl/manga/fairy-tail-x-rave/"),
-        Pair("Fairy Tail Gaiden – Raigo Issen", "$baseUrl/manga/fairy-tail-gaiden-raigo-issen/"),
-        Pair("Fairy Tail Gaiden – Kengami no Souryuu", "$baseUrl/manga/fairy-tail-gaiden-kengami-no-souryuu/"),
-        Pair("Fairy Tail Gaiden – Road Knight", "$baseUrl/manga/fairy-tail-gaiden-road-knight/"),
-    ).sortedBy { it.first }.distinctBy { it.second }
+        Pair("Dead Rock", "$baseUrl/manga/dead-rock/"),
+        Pair("Fairy Girls", "$baseUrl/manga/fairy-girls/"),
+        Pair("Gaiden 4", "$baseUrl/manga/fairy-tail-gaiden-raigo-issen/"),
+        Pair("Gaiden 2", "$baseUrl/manga/fairy-tail-gaiden-kengami-no-souryuu/"),
+        Pair("Gaiden 3", "$baseUrl/manga/fairy-tail-gaiden-road-knight/"),
+        Pair("FT x 7DS", "$baseUrl/manga/fairy-tail-x-nanatsu-no-taizai-christmas-special/"),
+    )
 }

--- a/src/en/readhaikyuumangaonline/build.gradle
+++ b/src/en/readhaikyuumangaonline/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Read Haikyuu!! Manga Online'
     extClass = '.ReadHaikyuuMangaOnline'
     themePkg = 'mangacatalog'
-    baseUrl = 'https://ww6.readhaikyuu.com'
-    overrideVersionCode = 0
+    baseUrl = 'https://ww9.readhaikyuu.com'
+    overrideVersionCode = 1
     isNsfw = false
 }
 

--- a/src/en/readhaikyuumangaonline/src/eu/kanade/tachiyomi/extension/en/readhaikyuumangaonline/ReadHaikyuuMangaOnline.kt
+++ b/src/en/readhaikyuumangaonline/src/eu/kanade/tachiyomi/extension/en/readhaikyuumangaonline/ReadHaikyuuMangaOnline.kt
@@ -2,11 +2,12 @@ package eu.kanade.tachiyomi.extension.en.readhaikyuumangaonline
 
 import eu.kanade.tachiyomi.multisrc.mangacatalog.MangaCatalog
 
-class ReadHaikyuuMangaOnline : MangaCatalog("Read Haikyuu!! Manga Online", "https://ww6.readhaikyuu.com", "en") {
+class ReadHaikyuuMangaOnline : MangaCatalog("Read Haikyuu!! Manga Online", "https://ww9.readhaikyuu.com", "en") {
     override val sourceList = listOf(
         Pair("Haikyuu", "$baseUrl/manga/haikyuu/"),
         Pair("Haikyuu-bu!!", "$baseUrl/manga/haikyuu-bu/"),
         Pair("Haikyuu! x Nisekoi", "$baseUrl/manga/haikyuu-x-nisekoi/"),
         Pair("Let’s! Haikyu!?", "$baseUrl/manga/lets-haikyu/"),
-    ).sortedBy { it.first }.distinctBy { it.second }
+        Pair("Colored", "$baseUrl/manga/haikyu-digital-colored-comics/"),
+    )
 }

--- a/src/en/readhunterxhuntermangaonline/build.gradle
+++ b/src/en/readhunterxhuntermangaonline/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Read Hunter x Hunter Manga Online'
     extClass = '.ReadHunterxHunterMangaOnline'
     themePkg = 'mangacatalog'
-    baseUrl = 'https://ww2.readhxh.com'
-    overrideVersionCode = 1
+    baseUrl = 'https://ww6.readhxh.com'
+    overrideVersionCode = 2
     isNsfw = false
 }
 

--- a/src/en/readhunterxhuntermangaonline/src/eu/kanade/tachiyomi/extension/en/readhunterxhuntermangaonline/ReadHunterxHunterMangaOnline.kt
+++ b/src/en/readhunterxhuntermangaonline/src/eu/kanade/tachiyomi/extension/en/readhunterxhuntermangaonline/ReadHunterxHunterMangaOnline.kt
@@ -2,11 +2,12 @@ package eu.kanade.tachiyomi.extension.en.readhunterxhuntermangaonline
 
 import eu.kanade.tachiyomi.multisrc.mangacatalog.MangaCatalog
 
-class ReadHunterxHunterMangaOnline : MangaCatalog("Read Hunter x Hunter Manga Online", "https://ww2.readhxh.com", "en") {
+class ReadHunterxHunterMangaOnline : MangaCatalog("Read Hunter x Hunter Manga Online", "https://ww6.readhxh.com", "en") {
     override val sourceList = listOf(
         Pair("Hunter x Hunter", "$baseUrl/manga/hunter-x-hunter/"),
-        Pair("Colored", "$baseUrl/manga/hunter-x-hunter-colored/"),
-        Pair("Level E", "$baseUrl/manga/level-e/"),
+        Pair("HxH Colored", "$baseUrl/manga/hunter-x-hunter-colored/"),
         Pair("Yu Yu Hakusho", "$baseUrl/manga/yu-yu-hakusho/"),
-    ).sortedBy { it.first }.distinctBy { it.second }
+        Pair("Level E", "$baseUrl/manga/level-e/"),
+        Pair("Kurapika Spinoff", "$baseUrl/manga/hunter-x-hunter-kurapika-tsuioku-hen/"),
+    )
 }

--- a/src/en/readjujutsukaisenmangaonline/build.gradle
+++ b/src/en/readjujutsukaisenmangaonline/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Read Jujutsu Kaisen Manga Online'
     extClass = '.ReadJujutsuKaisenMangaOnline'
     themePkg = 'mangacatalog'
-    baseUrl = 'https://ww1.readjujutsukaisen.com'
-    overrideVersionCode = 1
+    baseUrl = 'https://ww5.readjujutsukaisen.com'
+    overrideVersionCode = 2
     isNsfw = false
 }
 

--- a/src/en/readjujutsukaisenmangaonline/src/eu/kanade/tachiyomi/extension/en/readjujutsukaisenmangaonline/ReadJujutsuKaisenMangaOnline.kt
+++ b/src/en/readjujutsukaisenmangaonline/src/eu/kanade/tachiyomi/extension/en/readjujutsukaisenmangaonline/ReadJujutsuKaisenMangaOnline.kt
@@ -2,13 +2,15 @@ package eu.kanade.tachiyomi.extension.en.readjujutsukaisenmangaonline
 
 import eu.kanade.tachiyomi.multisrc.mangacatalog.MangaCatalog
 
-class ReadJujutsuKaisenMangaOnline : MangaCatalog("Read Jujutsu Kaisen Manga Online", "https://ww1.readjujutsukaisen.com", "en") {
+class ReadJujutsuKaisenMangaOnline : MangaCatalog("Read Jujutsu Kaisen Manga Online", "https://ww5.readjujutsukaisen.com", "en") {
     override val sourceList = listOf(
         Pair("Jujutsu Kaisen", "$baseUrl/manga/jujutsu-kaisen/"),
         Pair("Jujutsu Kaisen 0", "$baseUrl/manga/jujutsu-kaisen-0/"),
-        Pair("JJK Light Novel", "$baseUrl/manga/jujutsu-kaisen-first-light-novel/"),
-        Pair("No.9", "$baseUrl/manga/no-9/"),
         Pair("JJK Colored", "$baseUrl/manga/jujutsu-kaisen-colored/"),
+        Pair("Fan Scan", "$baseUrl/manga/jujutsu-kaisen-fan-scan/"),
+        Pair("JJK Light Novel", "$baseUrl/manga/jujutsu-kaisen-first-light-novel/"),
+        Pair("2nd Light Novel", "$baseUrl/manga/jujutsu-kaisen-second-light-novel/"),
+        Pair("No.9", "$baseUrl/manga/no-9/"),
         Pair("Fanbook", "$baseUrl/manga/jujutsu-kaisen-official-fanbook/"),
-    ).sortedBy { it.first }.distinctBy { it.second }
+    )
 }

--- a/src/en/readkaguyasamamangaonline/build.gradle
+++ b/src/en/readkaguyasamamangaonline/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Read Kaguya-sama Manga Online'
     extClass = '.ReadKaguyaSamaMangaOnline'
     themePkg = 'mangacatalog'
-    baseUrl = 'https://ww1.readkaguyasama.com'
-    overrideVersionCode = 1
+    baseUrl = 'https://ww4.readkaguyasama.com'
+    overrideVersionCode = 2
     isNsfw = false
 }
 

--- a/src/en/readkaguyasamamangaonline/src/eu/kanade/tachiyomi/extension/en/readkaguyasamamangaonline/ReadKaguyaSamaMangaOnline.kt
+++ b/src/en/readkaguyasamamangaonline/src/eu/kanade/tachiyomi/extension/en/readkaguyasamamangaonline/ReadKaguyaSamaMangaOnline.kt
@@ -2,15 +2,18 @@ package eu.kanade.tachiyomi.extension.en.readkaguyasamamangaonline
 
 import eu.kanade.tachiyomi.multisrc.mangacatalog.MangaCatalog
 
-class ReadKaguyaSamaMangaOnline : MangaCatalog("Read Kaguya-sama Manga Online", "https://ww1.readkaguyasama.com", "en") {
+class ReadKaguyaSamaMangaOnline : MangaCatalog("Read Kaguya-sama Manga Online", "https://ww4.readkaguyasama.com", "en") {
     override val sourceList = listOf(
         Pair("Kaguya-sama: Love is War", "$baseUrl/manga/kaguya-sama-love-is-war/"),
         Pair("Official Doujin", "$baseUrl/manga/kaguya-wants-to-be-confessed-to-official-doujin/"),
         Pair("Spin off", "$baseUrl/manga/we-want-to-talk-about-kaguya/"),
-        Pair("Light Novel", "$baseUrl/manga/kaguya-sama-light-novel/"),
+        // Pair("Light Novel", "$baseUrl/manga/kaguya-sama-light-novel/"), // Text
         Pair("Instant Bullet", "$baseUrl/manga/ib-instant-bullet/"),
-        Pair("Oshi no Ko", "$baseUrl/manga/oshi-no-ko/"),
-        Pair("Sayonara Piano Sonata", "$baseUrl/manga/sayonara-piano-sonata/"),
         Pair("Original Hinatazaka", "$baseUrl/manga/original-hinatazaka/"),
-    ).sortedBy { it.first }.distinctBy { it.second }
+        Pair("Oshi no Ko", "$baseUrl/manga/oshi-no-ko/"),
+        Pair("Piano Sonata", "$baseUrl/manga/sayonara-piano-sonata/"),
+        Pair("Colored", "$baseUrl/manga/kaguya-sama-love-is-war-digital-colored-comics/"),
+        Pair("Kaguya Sama", "$baseUrl/manga/kaguya-sama-love-is-war/"),
+        Pair("Marchen Crown", "$baseUrl/manga/marchen-crown/"),
+    )
 }

--- a/src/en/readkingdommangaonline/build.gradle
+++ b/src/en/readkingdommangaonline/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Read Kingdom Manga Online'
     extClass = '.ReadKingdomMangaOnline'
     themePkg = 'mangacatalog'
-    baseUrl = 'https://ww2.readkingdom.com'
-    overrideVersionCode = 0
+    baseUrl = 'https://ww5.readkingdom.com'
+    overrideVersionCode = 1
     isNsfw = false
 }
 

--- a/src/en/readkingdommangaonline/src/eu/kanade/tachiyomi/extension/en/readkingdommangaonline/ReadKingdomMangaOnline.kt
+++ b/src/en/readkingdommangaonline/src/eu/kanade/tachiyomi/extension/en/readkingdommangaonline/ReadKingdomMangaOnline.kt
@@ -2,10 +2,11 @@ package eu.kanade.tachiyomi.extension.en.readkingdommangaonline
 
 import eu.kanade.tachiyomi.multisrc.mangacatalog.MangaCatalog
 
-class ReadKingdomMangaOnline : MangaCatalog("Read Kingdom Manga Online", "https://ww2.readkingdom.com", "en") {
+class ReadKingdomMangaOnline : MangaCatalog("Read Kingdom Manga Online", "https://ww5.readkingdom.com", "en") {
     override val sourceList = listOf(
         Pair("Kingdom", "$baseUrl/manga/kingdom/"),
         Pair("Li Mu", "$baseUrl/manga/li-mu/"),
         Pair("Meng Wu & Chu Zi", "$baseUrl/manga/meng-wu-and-chu-zi-one-shot/"),
-    ).sortedBy { it.first }.distinctBy { it.second }
+        // Pair("History Spoilers", "$baseUrl/manga/kingdom-history-spoilers/"), // PDF
+    )
 }

--- a/src/en/readnanatsunotaizai7deadlysinsmangaonline/build.gradle
+++ b/src/en/readnanatsunotaizai7deadlysinsmangaonline/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Read Nanatsu no Taizai 7 Deadly Sins Manga Online'
     extClass = '.ReadNanatsuNoTaizai7DeadlySinsMangaOnline'
     themePkg = 'mangacatalog'
-    baseUrl = 'https://ww3.read7deadlysins.com'
-    overrideVersionCode = 2
+    baseUrl = 'https://ww7.read7deadlysins.com'
+    overrideVersionCode = 3
     isNsfw = false
 }
 

--- a/src/en/readnanatsunotaizai7deadlysinsmangaonline/src/eu/kanade/tachiyomi/extension/en/readnanatsunotaizai7deadlysinsmangaonline/ReadNanatsuNoTaizai7DeadlySinsMangaOnline.kt
+++ b/src/en/readnanatsunotaizai7deadlysinsmangaonline/src/eu/kanade/tachiyomi/extension/en/readnanatsunotaizai7deadlysinsmangaonline/ReadNanatsuNoTaizai7DeadlySinsMangaOnline.kt
@@ -2,17 +2,18 @@ package eu.kanade.tachiyomi.extension.en.readnanatsunotaizai7deadlysinsmangaonli
 
 import eu.kanade.tachiyomi.multisrc.mangacatalog.MangaCatalog
 
-class ReadNanatsuNoTaizai7DeadlySinsMangaOnline : MangaCatalog("Read Nanatsu no Taizai 7 Deadly Sins Manga Online", "https://ww3.read7deadlysins.com", "en") {
+class ReadNanatsuNoTaizai7DeadlySinsMangaOnline : MangaCatalog("Read Nanatsu no Taizai 7 Deadly Sins Manga Online", "https://ww7.read7deadlysins.com", "en") {
     override val sourceList = listOf(
-        Pair("Mokushiroku no Yonkishi", "$baseUrl/manga/four-horsemen-of-the-apocalypse/"),
+        Pair("Four Horsemen of the Apocalypse", "$baseUrl/manga/four-horsemen-of-the-apocalypse/"),
         Pair("7DS: School", "$baseUrl/manga/mayoe-nanatsu-no-taizai-gakuen/"),
         Pair("7DS:7 Days", "$baseUrl/manga/nanatsu-no-taizai-seven-days/"),
         Pair("7DS:Vampires", "$baseUrl/manga/nanatsu-no-taizai-vampires-of-edinburgh/"),
         Pair("Queen of Altar", "$baseUrl/manga/the-queen-of-the-altar/"),
         Pair("7DS: 7 Colors", "$baseUrl/manga/nanatsu-no-taizai-nanairo-no-tsuioku/"),
         Pair("7DS x FT", "$baseUrl/manga/fairy-tail-x-nanatsu-no-taizai-christmas-special/"),
-        Pair("7 Deadly Sins", "$baseUrl/manga/nanatsu-no-taizai/"),
-        Pair("7DS:7 Scars", "$baseUrl/manga/nanatsu-no-taizai-the-seven-scars-which-they-left-behind/"),
         Pair("Kongou Banchou", "$baseUrl/manga/kongou-banchou/"),
-    ).sortedBy { it.first }.distinctBy { it.second }
+        Pair("7DS:7 Scars", "$baseUrl/manga/nanatsu-no-taizai-the-seven-scars-which-they-left-behind/"),
+        Pair("7 Deadly Sins", "$baseUrl/manga/nanatsu-no-taizai/"),
+        Pair("Mokushiroku no Yonkishi", "$baseUrl/manga/four-horsemen-of-the-apocalypse/"),
+    )
 }

--- a/src/en/readnarutoborutosamurai8mangaonline/build.gradle
+++ b/src/en/readnarutoborutosamurai8mangaonline/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Read Naruto Boruto Samurai 8 Manga Online'
     extClass = '.ReadNarutoBorutoSamurai8MangaOnline'
     themePkg = 'mangacatalog'
-    baseUrl = 'https://ww7.readnaruto.com'
-    overrideVersionCode = 1
+    baseUrl = 'https://ww11.readnaruto.com'
+    overrideVersionCode = 2
     isNsfw = false
 }
 

--- a/src/en/readnarutoborutosamurai8mangaonline/src/eu/kanade/tachiyomi/extension/en/readnarutoborutosamurai8mangaonline/ReadNarutoBorutoSamurai8MangaOnline.kt
+++ b/src/en/readnarutoborutosamurai8mangaonline/src/eu/kanade/tachiyomi/extension/en/readnarutoborutosamurai8mangaonline/ReadNarutoBorutoSamurai8MangaOnline.kt
@@ -2,12 +2,16 @@ package eu.kanade.tachiyomi.extension.en.readnarutoborutosamurai8mangaonline
 
 import eu.kanade.tachiyomi.multisrc.mangacatalog.MangaCatalog
 
-class ReadNarutoBorutoSamurai8MangaOnline : MangaCatalog("Read Naruto Boruto Samurai 8 Manga Online", "https://ww7.readnaruto.com", "en") {
+class ReadNarutoBorutoSamurai8MangaOnline : MangaCatalog("Read Naruto Boruto Samurai 8 Manga Online", "https://ww11.readnaruto.com", "en") {
     override val sourceList = listOf(
-        Pair("Boruto", "$baseUrl/manga/boruto-naruto-next-generations/"),
+        Pair("Boruto - Two Blue Vortex", "$baseUrl/manga/boruto-two-blue-vortex/"),
         Pair("Naruto", "$baseUrl/manga/naruto/"),
-        Pair("Colored", "$baseUrl/manga/naruto-digital-colored-comics/"),
+        Pair("Naruto Colored", "$baseUrl/manga/naruto-digital-colored-comics/"),
         Pair("Naruto Gaiden", "$baseUrl/manga/naruto-gaiden-the-seventh-hokage/"),
+        Pair("Boruto", "$baseUrl/manga/boruto-naruto-next-generations/"),
         Pair("Samurai 8", "$baseUrl/manga/samurai-8-hachimaru-den/"),
-    ).sortedBy { it.first }.distinctBy { it.second }
+        Pair("Rock Lee SpinOff", "$baseUrl/manga/rock-lee-no-seishun-full-power-ninden/"),
+        Pair("Chibi Sasuke", "$baseUrl/manga/uchiha-sasuke-no-sharingan-den/"),
+        Pair("Sasuke Story", "$baseUrl/manga/naruto-sasuke-retsuden-uchiha-no-matsuei-to-tenkyuu-no-hoshikuzu/"),
+    )
 }

--- a/src/en/readonepiecemangaonline/build.gradle
+++ b/src/en/readonepiecemangaonline/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Read One Piece Manga Online'
     extClass = '.ReadOnePieceMangaOnline'
     themePkg = 'mangacatalog'
-    baseUrl = 'https://ww8.readonepiece.com'
-    overrideVersionCode = 0
+    baseUrl = 'https://ww12.readonepiece.com'
+    overrideVersionCode = 1
     isNsfw = false
 }
 

--- a/src/en/readonepiecemangaonline/src/eu/kanade/tachiyomi/extension/en/readonepiecemangaonline/ReadOnePieceMangaOnline.kt
+++ b/src/en/readonepiecemangaonline/src/eu/kanade/tachiyomi/extension/en/readonepiecemangaonline/ReadOnePieceMangaOnline.kt
@@ -2,7 +2,7 @@ package eu.kanade.tachiyomi.extension.en.readonepiecemangaonline
 
 import eu.kanade.tachiyomi.multisrc.mangacatalog.MangaCatalog
 
-class ReadOnePieceMangaOnline : MangaCatalog("Read One Piece Manga Online", "https://ww8.readonepiece.com", "en") {
+class ReadOnePieceMangaOnline : MangaCatalog("Read One Piece Manga Online", "https://ww12.readonepiece.com", "en") {
     override val sourceList = listOf(
         Pair("One Piece", "$baseUrl/manga/one-piece/"),
         Pair("Colored", "$baseUrl/manga/one-piece-digital-colored-comics/"),
@@ -14,7 +14,13 @@ class ReadOnePieceMangaOnline : MangaCatalog("Read One Piece Manga Online", "htt
         Pair("Ace's Story", "$baseUrl/manga/one-piece-ace-s-story/"),
         Pair("Omake", "$baseUrl/manga/one-piece-omake/"),
         Pair("Vivre Card", "$baseUrl/manga/vivre-card-databook/"),
+        Pair("Pirate Recipes", "$baseUrl/manga/one-piece-pirate-recipes/"),
         Pair("Databook", "$baseUrl/manga/one-piece-databook/"),
         Pair("Ace's Story Manga", "$baseUrl/manga/one-piece-ace-story-manga/"),
-    ).sortedBy { it.first }.distinctBy { it.second }
+        Pair("OP Academy", "$baseUrl/manga/one-piece-academy/"),
+        Pair("MONSTERS", "$baseUrl/manga/monsters/"),
+        Pair("Zoro Novel", "$baseUrl/manga/one-piece-novel-zoro/"),
+        Pair("OP in Love", "$baseUrl/manga/one-piece-in-love/"),
+        Pair("Heroines", "$baseUrl/manga/one-piece-novel-heroines/"),
+    )
 }

--- a/src/en/readsololevelingmangamanhwaonline/build.gradle
+++ b/src/en/readsololevelingmangamanhwaonline/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Read Solo Leveling Manga Manhwa Online'
     extClass = '.ReadSoloLevelingMangaManhwaOnline'
     themePkg = 'mangacatalog'
-    baseUrl = 'https://readsololeveling.org'
-    overrideVersionCode = 2
+    baseUrl = 'https://ww3.readsololeveling.org'
+    overrideVersionCode = 3
     isNsfw = false
 }
 

--- a/src/en/readsololevelingmangamanhwaonline/src/eu/kanade/tachiyomi/extension/en/readsololevelingmangamanhwaonline/ReadSoloLevelingMangaManhwaOnline.kt
+++ b/src/en/readsololevelingmangamanhwaonline/src/eu/kanade/tachiyomi/extension/en/readsololevelingmangamanhwaonline/ReadSoloLevelingMangaManhwaOnline.kt
@@ -2,9 +2,12 @@ package eu.kanade.tachiyomi.extension.en.readsololevelingmangamanhwaonline
 
 import eu.kanade.tachiyomi.multisrc.mangacatalog.MangaCatalog
 
-class ReadSoloLevelingMangaManhwaOnline : MangaCatalog("Read Solo Leveling Manga Manhwa Online", "https://readsololeveling.org", "en") {
+class ReadSoloLevelingMangaManhwaOnline : MangaCatalog("Read Solo Leveling Manga Manhwa Online", "https://ww3.readsololeveling.org", "en") {
     override val sourceList = listOf(
-        Pair("Solo Leveling", "$baseUrl/manga/solo-leveling/"),
-        Pair("Light Novel", "$baseUrl/manga/solo-leveling-novel/"),
-    ).sortedBy { it.first }.distinctBy { it.second }
+        Pair("Solo Leveling Manhwa", "$baseUrl/manga/solo-leveling/"),
+        Pair("Solo Leveling Light Novel", "$baseUrl/manga/solo-leveling-light-novel/"),
+        // Pair("Audio book", "$baseUrl/manga/solo-leveling-audiobook/"), // Audio
+        Pair("Solo Leveling : Ragnarok", "$baseUrl/manga/solo-leveling-ragnarok/"),
+        Pair("SL: Ragnarok Novel", "$baseUrl/manga/solo-leveling-ragnarok-novel/"),
+    )
 }

--- a/src/en/readthepromisedneverlandmangaonline/build.gradle
+++ b/src/en/readthepromisedneverlandmangaonline/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Read The Promised Neverland Manga Online'
     extClass = '.ReadThePromisedNeverlandMangaOnline'
     themePkg = 'mangacatalog'
-    baseUrl = 'https://ww3.readneverland.com'
-    overrideVersionCode = 1
+    baseUrl = 'https://ww7.readneverland.com'
+    overrideVersionCode = 2
     isNsfw = false
 }
 

--- a/src/en/readthepromisedneverlandmangaonline/src/eu/kanade/tachiyomi/extension/en/readthepromisedneverlandmangaonline/ReadThePromisedNeverlandMangaOnline.kt
+++ b/src/en/readthepromisedneverlandmangaonline/src/eu/kanade/tachiyomi/extension/en/readthepromisedneverlandmangaonline/ReadThePromisedNeverlandMangaOnline.kt
@@ -2,7 +2,7 @@ package eu.kanade.tachiyomi.extension.en.readthepromisedneverlandmangaonline
 
 import eu.kanade.tachiyomi.multisrc.mangacatalog.MangaCatalog
 
-class ReadThePromisedNeverlandMangaOnline : MangaCatalog("Read The Promised Neverland Manga Online", "https://ww3.readneverland.com", "en") {
+class ReadThePromisedNeverlandMangaOnline : MangaCatalog("Read The Promised Neverland Manga Online", "https://ww7.readneverland.com", "en") {
     override val sourceList = listOf(
         Pair("The Promised Neverland", "$baseUrl/manga/the-promised-neverland/"),
         Pair("Parody", "$baseUrl/manga/the-parodied-jokeland/"),
@@ -10,5 +10,5 @@ class ReadThePromisedNeverlandMangaOnline : MangaCatalog("Read The Promised Neve
         Pair("Poppy no Negai", "$baseUrl/manga/poppy-no-negai/"),
         Pair("Author's One shot", "$baseUrl/manga/shinrei-shashinshi-kouno-saburou/"),
         Pair("Ashley Goeth", "$baseUrl/manga/ashley-goeth-no-yukue/"),
-    ).sortedBy { it.first }.distinctBy { it.second }
+    )
 }

--- a/src/en/readtokyoghoulretokyoghoulmangaonline/build.gradle
+++ b/src/en/readtokyoghoulretokyoghoulmangaonline/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ReadTokyoGhoulReTokyoGhoulMangaOnline'
     themePkg = 'mangacatalog'
     baseUrl = 'https://ww11.tokyoghoulre.com'
-    overrideVersionCode = 3
+    overrideVersionCode = 4
     isNsfw = false
 }
 

--- a/src/en/readtokyoghoulretokyoghoulmangaonline/src/eu/kanade/tachiyomi/extension/en/readtokyoghoulretokyoghoulmangaonline/ReadTokyoGhoulReTokyoGhoulMangaOnline.kt
+++ b/src/en/readtokyoghoulretokyoghoulmangaonline/src/eu/kanade/tachiyomi/extension/en/readtokyoghoulretokyoghoulmangaonline/ReadTokyoGhoulReTokyoGhoulMangaOnline.kt
@@ -5,12 +5,12 @@ import eu.kanade.tachiyomi.multisrc.mangacatalog.MangaCatalog
 class ReadTokyoGhoulReTokyoGhoulMangaOnline : MangaCatalog("Read Tokyo Ghoul Re & Tokyo Ghoul Manga Online", "https://ww11.tokyoghoulre.com", "en") {
     override val sourceList = listOf(
         Pair("Tokyo Ghoul", "$baseUrl/manga/tokyo-ghoul/"),
-        Pair("Tokyo Ghoul:re", "$baseUrl/manga/tokyo-ghoulre/"),
-        Pair("TG Jack", "$baseUrl/manga/tokyo-ghoul-jack/"),
-        Pair("TGre Colored", "$baseUrl/manga/tokyo-ghoulre-colored/"),
+        Pair("Tokyo Ghoul Jack", "$baseUrl/manga/tokyo-ghoul-jack/"),
+        Pair("Tokyo Ghoul: re Colored", "$baseUrl/manga/tokyo-ghoulre-colored/"),
         Pair("Gorilla", "$baseUrl/manga/this-gorilla-will-die-in-1-day/"),
-        Pair("ArtBook", "$baseUrl/manga/tokyo-ghoul-zakki/"),
-        Pair("TG Light Novel", "$baseUrl/manga/tokyo-ghoul-re-light-novels/"),
+        Pair("Zakki", "$baseUrl/manga/tokyo-ghoul-zakki/"),
+        Pair("Light Novel", "$baseUrl/manga/tokyo-ghoul-re-light-novels/"),
         Pair("Choujin X", "$baseUrl/manga/choujin-x/"),
-    ).sortedBy { it.first }.distinctBy { it.second }
+        Pair("Tokyo Ghoul re", "$baseUrl/manga/tokyo-ghoulre/"),
+    )
 }

--- a/src/en/readvinlandsagamangaonline/build.gradle
+++ b/src/en/readvinlandsagamangaonline/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Read Vinland Saga Manga Online'
     extClass = '.ReadVinlandSagaMangaOnline'
     themePkg = 'mangacatalog'
-    baseUrl = 'https://ww1.readvinlandsaga.com'
-    overrideVersionCode = 0
+    baseUrl = 'https://ww5.readvinlandsaga.com'
+    overrideVersionCode = 1
     isNsfw = false
 }
 

--- a/src/en/readvinlandsagamangaonline/src/eu/kanade/tachiyomi/extension/en/readvinlandsagamangaonline/ReadVinlandSagaMangaOnline.kt
+++ b/src/en/readvinlandsagamangaonline/src/eu/kanade/tachiyomi/extension/en/readvinlandsagamangaonline/ReadVinlandSagaMangaOnline.kt
@@ -2,10 +2,11 @@ package eu.kanade.tachiyomi.extension.en.readvinlandsagamangaonline
 
 import eu.kanade.tachiyomi.multisrc.mangacatalog.MangaCatalog
 
-class ReadVinlandSagaMangaOnline : MangaCatalog("Read Vinland Saga Manga Online", "https://ww1.readvinlandsaga.com", "en") {
+class ReadVinlandSagaMangaOnline : MangaCatalog("Read Vinland Saga Manga Online", "https://ww5.readvinlandsaga.com", "en") {
     override val sourceList = listOf(
         Pair("Vinland Saga", "$baseUrl/manga/vinland-saga/"),
+        Pair("Sayonara ga Chikai no de", "$baseUrl/manga/sayonara-ga-chikai-no-de/"),
         Pair("Fan Colored", "$baseUrl/manga/vinland-saga-colored/"),
         Pair("Planetes", "$baseUrl/manga/planetes/"),
-    ).sortedBy { it.first }.distinctBy { it.second }
+    )
 }


### PR DESCRIPTION
MangaCatalog sites are now up to date with what is present in each site's nav bar, with the same order. Unsupported content (video, text, pdf, audio) has been commented out. All entries were checked.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
  (Only looked for issues with 'Read' in the title)
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
