### PR TITLE
Zaimanhua: Fix get mangaDetails failed for some manga, add reason for restricted manga

### DIFF
--- a/src/zh/zaimanhua/build.gradle
+++ b/src/zh/zaimanhua/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Zaimanhua'
     extClass = '.Zaimanhua'
-    extVersionCode = 9
+    extVersionCode = 10
     isNsfw = false
 }
 

--- a/src/zh/zaimanhua/src/eu/kanade/tachiyomi/extension/zh/zaimanhua/Zaimanhua.kt
+++ b/src/zh/zaimanhua/src/eu/kanade/tachiyomi/extension/zh/zaimanhua/Zaimanhua.kt
@@ -132,7 +132,7 @@ class Zaimanhua : HttpSource(), ConfigurableSource {
 
     // path: "/comic/detail/mangaId"
     override fun mangaDetailsRequest(manga: SManga): Request =
-        GET("$apiUrl/comic/detail/${manga.url}?channel=android&_v=2.2.5", apiHeaders)
+        GET("$apiUrl/comic/detail/${manga.url}?_v=2.2.5", apiHeaders)
 
     override fun mangaDetailsParse(response: Response): SManga {
         val result = response.parseAs<ResponseDto<DataWrapperDto<MangaDto>>>()

--- a/src/zh/zaimanhua/src/eu/kanade/tachiyomi/extension/zh/zaimanhua/Zaimanhua.kt
+++ b/src/zh/zaimanhua/src/eu/kanade/tachiyomi/extension/zh/zaimanhua/Zaimanhua.kt
@@ -132,7 +132,7 @@ class Zaimanhua : HttpSource(), ConfigurableSource {
 
     // path: "/comic/detail/mangaId"
     override fun mangaDetailsRequest(manga: SManga): Request =
-        GET("$apiUrl/comic/detail/${manga.url}?channel=android", apiHeaders)
+        GET("$apiUrl/comic/detail/${manga.url}?channel=android&_v=2.2.5", apiHeaders)
 
     override fun mangaDetailsParse(response: Response): SManga {
         val result = response.parseAs<ResponseDto<DataWrapperDto<MangaDto>>>()
@@ -163,7 +163,7 @@ class Zaimanhua : HttpSource(), ConfigurableSource {
 
     // path: "/comic/chapter/mangaId/chapterId"
     private fun pageListApiRequest(path: String): Request =
-        GET("$apiUrl/comic/chapter/$path", apiHeaders, USE_CACHE)
+        GET("$apiUrl/comic/chapter/$path?_v=2.2.5", apiHeaders, USE_CACHE)
 
     override fun pageListParse(response: Response): List<Page> = throw UnsupportedOperationException()
 
@@ -173,8 +173,11 @@ class Zaimanhua : HttpSource(), ConfigurableSource {
         if (result.errmsg.isNotBlank()) {
             throw Exception(result.errmsg)
         } else {
+            if (!result.data.data!!.canRead) {
+                throw Exception("用户权限不足，请提升用户等级")
+            }
             return Observable.just(
-                result.data.data!!.images.mapIndexed { index, it ->
+                result.data.data.images.mapIndexed { index, it ->
                     val fragment = json.encodeToString(ImageRetryParamsDto(chapter.url, index))
                     Page(index, imageUrl = "$it#$fragment")
                 },
@@ -266,6 +269,7 @@ class Zaimanhua : HttpSource(), ConfigurableSource {
     companion object {
         val USE_CACHE = CacheControl.Builder().maxStale(170, TimeUnit.SECONDS).build()
     }
+
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         ListPreference(screen.context).apply {
             EditTextPreference(screen.context).apply {

--- a/src/zh/zaimanhua/src/eu/kanade/tachiyomi/extension/zh/zaimanhua/ZaimanhuaDto.kt
+++ b/src/zh/zaimanhua/src/eu/kanade/tachiyomi/extension/zh/zaimanhua/ZaimanhuaDto.kt
@@ -93,6 +93,7 @@ class ChapterDto(
 class ChapterImagesDto(
     @SerialName("page_url_hd")
     val images: List<String>,
+    val canRead: Boolean,
 )
 
 @Serializable


### PR DESCRIPTION
When getting manga details for restricted comics through the API, the APP version needs to be specified.
The restricted comics on this site require binding the mobile phone number using the official app to increase the level from 0 to 1.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
