### PR TITLE
Comick: separate small thumbnail rate limit, tweak parse cover

### DIFF
--- a/src/all/comickfun/build.gradle
+++ b/src/all/comickfun/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comick'
     extClass = '.ComickFactory'
-    extVersionCode = 59
+    extVersionCode = 60
     isNsfw = true
 }
 

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Helpers.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/Helpers.kt
@@ -47,7 +47,7 @@ enum class CoverQuality {
 
 internal fun parseCover(thumbnailUrl: String?, mdCovers: List<MDcovers>, coverQuality: CoverQuality = CoverQuality.WebDefault): String? {
     fun addOrReplaceCoverQualitySuffix(url: String, qualitySuffix: String): String {
-        return url.substringBeforeLast('.').replace(Regex("-(m|s)$"), "") +
+        return url.substringBeforeLast('#').substringBeforeLast('.').replace(Regex("-(m|s)$"), "") +
             "$qualitySuffix.jpg#${url.substringAfter('#', "")}"
     }
 


### PR DESCRIPTION
now that the thumbnail images on browse is using the small version we can make it use lower rate limit and separate from ch image rate limit

tweaking the parse cover to do better at handling "." after "#" in the thumbnail url

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
