### PR TITLE
Update CI workflows and add security scanning

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -8,6 +8,8 @@ on:
       - '!.github/**'
       - '.github/workflows/build_pull_request.yml'
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -19,7 +21,7 @@ env:
 jobs:
   prepare:
     name: Prepare job
-    runs-on: 'ubuntu-24.04'
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.generate-matrices.outputs.matrix }}
       delete: ${{ steps.generate-matrices.outputs.delete }}
@@ -28,6 +30,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Java
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
@@ -48,13 +51,15 @@ jobs:
   build:
     name: Build extensions (${{ matrix.chunk.number }})
     needs: prepare
-    runs-on: 'ubuntu-24.04'
+    runs-on: ubuntu-latest
     if: ${{ toJson(fromJson(needs.prepare.outputs.matrix).chunk) != '[]' }}
     strategy:
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
       - name: Checkout PR
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Java
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
@@ -68,5 +73,7 @@ jobs:
           cache-read-only: true
 
       - name: Build extensions (${{ matrix.chunk.number }})
+        env:
+          MODULES: ${{ join(matrix.chunk.modules, ' ') }}
         run: |
-          ./gradlew $(echo '${{ toJson(matrix.chunk.modules) }}' | jq -r 'join(" ")')
+          ./gradlew $MODULES

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -22,6 +22,7 @@ jobs:
   prepare:
     name: Prepare job
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       matrix: ${{ steps.generate-matrices.outputs.matrix }}
       delete: ${{ steps.generate-matrices.outputs.delete }}
@@ -52,6 +53,7 @@ jobs:
     name: Build extensions (${{ matrix.chunk.number }})
     needs: prepare
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: ${{ toJson(fromJson(needs.prepare.outputs.matrix).chunk) != '[]' }}
     strategy:
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -11,6 +11,8 @@ on:
       - '.github/scripts/**'
       - '.github/workflows/build_push.yml'
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
@@ -22,7 +24,7 @@ env:
 jobs:
   prepare:
     name: Prepare job
-    runs-on: 'ubuntu-24.04'
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.generate-matrices.outputs.matrix }}
       delete: ${{ steps.generate-matrices.outputs.delete }}
@@ -31,6 +33,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Java
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
@@ -44,24 +47,27 @@ jobs:
           cache-read-only: true
 
       - name: Get last successful CI commit
-        id: last_successful_ci_commit
         uses: nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # v4.3.3
+        with:
+          fallback-sha: 4b825dc642cb6eb9a060e54bf8d69288fbee4904 # empty tree
 
       - id: generate-matrices
         name: Create output matrices
         run: |
-          python ./.github/scripts/generate-build-matrices.py ${{ steps.last_successful_ci_commit.outputs.base }} Release
+          python ./.github/scripts/generate-build-matrices.py "$NX_BASE" Release
 
   build:
     name: Build extensions (${{ matrix.chunk.number }})
     needs: prepare
-    runs-on: 'ubuntu-24.04'
+    runs-on: ubuntu-latest
     if: ${{ toJson(fromJson(needs.prepare.outputs.matrix).chunk) != '[]' }}
     strategy:
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
       - name: Checkout main branch
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Java
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
@@ -80,11 +86,12 @@ jobs:
 
       - name: Build extensions (${{ matrix.chunk.number }})
         env:
+          MODULES: ${{ join(matrix.chunk.modules, ' ') }}
           ALIAS: ${{ secrets.ALIAS }}
           KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
-          ./gradlew $(echo '${{ toJson(matrix.chunk.modules) }}' | jq -r 'join(" ")')
+          ./gradlew $MODULES
 
       - name: Upload APKs (${{ matrix.chunk.number }})
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -101,7 +108,7 @@ jobs:
     name: Publish extension repo
     needs: [prepare, build]
     if: "github.repository == 'keiyoushi/extensions-source'"
-    runs-on: 'ubuntu-24.04'
+    runs-on: ubuntu-latest
     steps:
       - name: Download APK artifacts
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
@@ -119,6 +126,7 @@ jobs:
         with:
           ref: main
           path: main
+          persist-credentials: false
 
       - name: Create repo artifacts
         run: |
@@ -136,9 +144,12 @@ jobs:
           token: ${{ secrets.BOT_PAT }}
           ref: repo
           path: repo
+          persist-credentials: true
 
       - name: Merge and deploy repo
+        env:
+          DELETE: ${{ needs.prepare.outputs.delete }}
         run: |
           cd repo
-          python ../main/.github/scripts/merge-repo.py '${{ needs.prepare.outputs.delete }}'
+          python ../main/.github/scripts/merge-repo.py "$DELETE"
           ../main/.github/scripts/commit-repo.sh

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -25,6 +25,7 @@ jobs:
   prepare:
     name: Prepare job
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       matrix: ${{ steps.generate-matrices.outputs.matrix }}
       delete: ${{ steps.generate-matrices.outputs.delete }}
@@ -60,6 +61,7 @@ jobs:
     name: Build extensions (${{ matrix.chunk.number }})
     needs: prepare
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: ${{ toJson(fromJson(needs.prepare.outputs.matrix).chunk) != '[]' }}
     strategy:
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
@@ -109,6 +111,7 @@ jobs:
     needs: [prepare, build]
     if: "github.repository == 'keiyoushi/extensions-source'"
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Download APK artifacts
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0

--- a/.github/workflows/codeberg_mirror.yml
+++ b/.github/workflows/codeberg_mirror.yml
@@ -8,6 +8,8 @@ on:
   schedule:
     - cron: "0 */8 * * *"
 
+permissions: {}
+
 jobs:
   codeberg:
     if: "github.repository == 'keiyoushi/extensions-source'"
@@ -16,6 +18,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: pixta-dev/repository-mirroring-action@674e65a7d483ca28dafaacba0d07351bdcc8bd75 # v1.1.1
         with:
           target_repo_url: "git@codeberg.org:keiyoushi/extensions-source.git"

--- a/.github/workflows/codeberg_mirror.yml
+++ b/.github/workflows/codeberg_mirror.yml
@@ -14,6 +14,7 @@ jobs:
   codeberg:
     if: "github.repository == 'keiyoushi/extensions-source'"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:

--- a/.github/workflows/issue_moderator.yml
+++ b/.github/workflows/issue_moderator.yml
@@ -6,6 +6,9 @@ on:
   issue_comment:
     types: [ created ]
 
+permissions:
+  issues: write
+
 jobs:
   autoclose:
     runs-on: ubuntu-latest
@@ -13,7 +16,8 @@ jobs:
       - name: Moderate issues
         uses: keiyoushi/issue-moderator-action@c1bae1cf6fd33c272b88505c8bfa0a97b7761eb3
         with:
-          repo-token: ${{ secrets.ISSUE_MODERATOR_PAT }}
+          repo-token: ${{ github.token }}
+          member-token: ${{ secrets.MEMBER_TOKEN }}
           duplicate-label: Duplicate
 
           blurbs: |

--- a/.github/workflows/issue_moderator.yml
+++ b/.github/workflows/issue_moderator.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   autoclose:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Moderate issues
         uses: keiyoushi/issue-moderator-action@c1bae1cf6fd33c272b88505c8bfa0a97b7761eb3

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -6,8 +6,10 @@ on:
     - cron: '0 0 * * *'
   # Manual trigger
   workflow_dispatch:
-    inputs:
 
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   lock:
@@ -15,6 +17,6 @@ jobs:
     steps:
       - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5.0.1
         with:
-          github-token: ${{ github.token }}
           issue-inactive-days: '2'
           pr-inactive-days: '2'
+          process-only: 'issues, prs'

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   lock:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5.0.1
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: GitHub Actions Security Analysis
+
+on:
+  push:
+    paths:
+      - .github/workflows/**
+  pull_request:
+    paths:
+      - .github/workflows/**
+
+permissions:
+  security-events: write
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5ca5fc7a4779c5263a3ffa0e1f693009994446d1 # v0.1.2

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   zizmor:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
- Add zizmor scanning and fixed reported issues
- Does NOT target #10110; that will be done when refactoring CI code
- The zizmor workflow has path filters and won't be enforced in PRs in the future like the PR build check; the scanning feature will add comments on violation, should be easy to spot
- Only used `permissions` at top level because our workflows are simple; didn't go the pedantic way (use `{}` at top level and add permissions in specific jobs)
- Uses GitHub Actions token for issue moderator; membership check through a special member token