### PR TITLE
zh/boylove: fix unscrambler/filter selectors, Add VIP manga filter

### DIFF
--- a/src/zh/boylove/build.gradle
+++ b/src/zh/boylove/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'BoyLove'
     extClass = '.BoyLove'
-    extVersionCode = 14
+    extVersionCode = 15
     isNsfw = true
 }
 

--- a/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLove.kt
+++ b/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLove.kt
@@ -137,9 +137,9 @@ class BoyLove : HttpSource(), ConfigurableSource {
         }
 
     private fun Document.getPartsCount(): Int? {
-        return selectFirst("script:containsData(do_mergeImg):containsData(context0 =)")?.data()?.run {
-            substringBefore("canvas0.width")
-                .substringAfterLast("var ")
+        return selectFirst("script:containsData(firstMergeImg):containsData(imageData)")?.data()?.run {
+            substringBefore("var scrollTop")
+                .substringAfterLast("var randomClass = ")
                 .substringBefore(';')
                 .trim()
                 .substringAfterLast(" ")
@@ -169,6 +169,8 @@ class BoyLove : HttpSource(), ConfigurableSource {
             StatusFilter(),
             TypeFilter(),
             genreFilter,
+            Filter.Header("若要观看VIP漫画，请先在Webview中登录网站，并确认您的账户已达到Lv3"),
+            VipFilter(),
             // SortFilter(), // useless
         )
     }
@@ -179,7 +181,7 @@ class BoyLove : HttpSource(), ConfigurableSource {
             try {
                 val request = client.newCall(GET("$baseUrl/home/book/cate.html", headers))
                 val document = request.execute().asJsoup()
-                genres = document.select("ul[data-str=tag] > li[class] > a")
+                genres = document.select("div[data-str=tag] > a.button")
                     .map { it.ownText() }.toTypedArray()
             } catch (e: Throwable) {
                 isFetchingGenres = false

--- a/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLoveFilters.kt
+++ b/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLoveFilters.kt
@@ -12,23 +12,25 @@ import eu.kanade.tachiyomi.source.model.FilterList
  * [4] page, index from 1
  * [5] type, 0=all, 1=清水, 2=有肉
  * [6] 1=manga, 2=novel, else=manga
- * [7] vip, 0=default, useless
+ * [7] vip, 2=all, 0=without, 1=hasvip
  */
 internal fun parseFilters(page: Int, filters: FilterList): String {
     var status = '2'
     var type = '0'
     var genre = "0"
     var sort = '1'
+    var vip = '2'
     for (filter in filters) {
         when (filter) {
             is StatusFilter -> status = STATUS_KEYS[filter.state]
             is TypeFilter -> type = TYPE_KEYS[filter.state]
             is GenreFilter -> if (filter.state > 0) genre = filter.values[filter.state]
             is SortFilter -> sort = SORT_KEYS[filter.state]
+            is VipFilter -> vip = VIP_KEYS[filter.state]
             else -> {}
         }
     }
-    return "1-$genre-$status-$sort-$page-$type-1-0"
+    return "1-$genre-$status-$sort-$page-$type-1-$vip"
 }
 
 internal class StatusFilter : Filter.Select<String>("状态", STATUS_NAMES)
@@ -47,3 +49,8 @@ internal class SortFilter : Filter.Select<String>("排序", SORT_NAMES)
 
 private val SORT_NAMES = arrayOf("顺序", "类似排行榜")
 private val SORT_KEYS = arrayOf('1', '2')
+
+internal class VipFilter : Filter.Select<String>("漫画权限", VIP_NAMES)
+
+private val VIP_NAMES = arrayOf("全部", "非会员可观看", "VIP 漫画")
+private val VIP_KEYS = arrayOf('2', '0', '1')


### PR DESCRIPTION
Close #9914 

This PR fixed the related css selectors for the unscrambler in BoyLove. The site introduced a random number into its image-scrambling process after the end-of-July update. The number of parts into which the source images are sliced now varies for each manga (currently the uploads after 2024). The PR has added a new selector to make the unscrambler work again.

It also fixed the CSS selectors for the search filter and genres, which changed in the new responsive theme.  

Now that the VIP manga restrictions on the website have also taken effect, this PR adds a separate filter entry to help users find those mangas. Users with accounts at level 3 or above can login the site in Webview, then continue viewing these mangas using the extension.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
