### PR TITLE
Add workaround buttons for The Blank Scanlation

### DIFF
--- a/src/en/theblank/build.gradle
+++ b/src/en/theblank/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.TheBlank'
     themePkg = 'madara'
     baseUrl = 'https://theblank.net'
-    overrideVersionCode = 3
+    overrideVersionCode = 4
     isNsfw = true
 }
 

--- a/src/en/theblank/src/eu/kanade/tachiyomi/extension/en/theblank/TheBlank.kt
+++ b/src/en/theblank/src/eu/kanade/tachiyomi/extension/en/theblank/TheBlank.kt
@@ -68,7 +68,6 @@ class TheBlank :
 
             setOnPreferenceChangeListener { _, _ ->
                 val intent = Intent("com.android.webview.SHOW_DEV_UI").apply {
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
                     putExtra("fragment-id", 2)
                 }
                 startActivity(intent)
@@ -87,7 +86,6 @@ class TheBlank :
                 val intent = Intent(Intent.ACTION_VIEW).apply {
                     data = Uri.parse("market://details?id=com.google.android.webview")
                     setPackage("com.android.vending")
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
                 }
                 startActivity(intent)
                 false
@@ -98,6 +96,7 @@ class TheBlank :
 }
 
 private fun startActivity(intent: Intent) {
+    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
     val app = Injekt.get<Application>()
     try {
         app.startActivity(intent)

--- a/src/en/theblank/src/eu/kanade/tachiyomi/extension/en/theblank/TheBlank.kt
+++ b/src/en/theblank/src/eu/kanade/tachiyomi/extension/en/theblank/TheBlank.kt
@@ -60,11 +60,13 @@ class TheBlank :
         addRandomUAPreferenceToScreen(screen)
 
         SwitchPreferenceCompat(screen.context).run {
-            title = "Open WebView flags"
-            summary = "To work around website restrictions, tap this to open WebView flags, " +
-                "search for “XReq” in the new screen, " +
-                "set “WebViewXRequestedWithHeaderControl” to “Enabled”, then restart the app. " +
-                "If it fails to open or there’s no such flag, try the steps below."
+            title = "[Workaround] Open WebView flags"
+            summary = "To work around website restrictions:\n" +
+                "1. Tap this to open WebView flags.\n" +
+                "2. Search for “XReq” in the new screen.\n" +
+                "3. Set this flag to “Enabled”: “WebViewXRequestedWithHeaderControl”.\n" +
+                "4. Restart the app.\n" +
+                "If the screen fails to open or there’s no such flag, try the steps below."
 
             setOnPreferenceChangeListener { _, _ ->
                 val intent = Intent("com.android.webview.SHOW_DEV_UI").apply {

--- a/src/en/theblank/src/eu/kanade/tachiyomi/extension/en/theblank/TheBlank.kt
+++ b/src/en/theblank/src/eu/kanade/tachiyomi/extension/en/theblank/TheBlank.kt
@@ -1,6 +1,12 @@
 package eu.kanade.tachiyomi.extension.en.theblank
 
+import android.app.Application
+import android.content.Intent
+import android.net.Uri
+import android.util.Log
+import android.widget.Toast
 import androidx.preference.PreferenceScreen
+import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.lib.randomua.addRandomUAPreferenceToScreen
 import eu.kanade.tachiyomi.lib.randomua.getPrefCustomUA
 import eu.kanade.tachiyomi.lib.randomua.getPrefUAType
@@ -9,6 +15,10 @@ import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import keiyoushi.utils.getPreferences
+import okhttp3.Interceptor
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -29,6 +39,17 @@ class TheBlank :
             preferences.getPrefUAType(),
             preferences.getPrefCustomUA(),
         )
+        .apply {
+            val interceptor = Interceptor { chain ->
+                try {
+                    chain.proceed(chain.request())
+                } catch (e: IOException) {
+                    val message = "${e.message} - try the workaround in extension settings"
+                    throw IOException(message, e)
+                }
+            }
+            interceptors().add(0, interceptor)
+        }
         .build()
 
     override val useNewChapterEndpoint = true
@@ -37,5 +58,51 @@ class TheBlank :
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         addRandomUAPreferenceToScreen(screen)
+
+        SwitchPreferenceCompat(screen.context).run {
+            title = "Open WebView flags"
+            summary = "To work around website restrictions, tap this to open WebView flags, " +
+                "search for “XReq” in the new screen, " +
+                "set “WebViewXRequestedWithHeaderControl” to “Enabled”, then restart the app. " +
+                "If it fails to open or there’s no such flag, try the steps below."
+
+            setOnPreferenceChangeListener { _, _ ->
+                val intent = Intent("com.android.webview.SHOW_DEV_UI").apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                    putExtra("fragment-id", 2)
+                }
+                startActivity(intent)
+                false
+            }
+            screen.addPreference(this)
+        }
+
+        SwitchPreferenceCompat(screen.context).run {
+            title = "Open “Android System WebView” in Play Store"
+            summary = "Tap this and try updating Android System WebView in the Play Store. " +
+                "If the flags screen still doesn’t open, tap this, enroll into the beta program " +
+                "and update again."
+
+            setOnPreferenceChangeListener { _, _ ->
+                val intent = Intent(Intent.ACTION_VIEW).apply {
+                    data = Uri.parse("market://details?id=com.google.android.webview")
+                    setPackage("com.android.vending")
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                }
+                startActivity(intent)
+                false
+            }
+            screen.addPreference(this)
+        }
+    }
+}
+
+private fun startActivity(intent: Intent) {
+    val app = Injekt.get<Application>()
+    try {
+        app.startActivity(intent)
+    } catch (e: Throwable) {
+        Log.e("TheBlank", "failed to start activity", e)
+        Toast.makeText(app, e.message, Toast.LENGTH_LONG).show()
     }
 }


### PR DESCRIPTION
Closes #9892

We'll ship this solution since having the package spoof fixed or getting WebView to remove the header NEITHER come soon.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
