### PR TITLE
zh/boylove: add manga region filter

### DIFF
--- a/src/zh/boylove/build.gradle
+++ b/src/zh/boylove/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'BoyLove'
     extClass = '.BoyLove'
-    extVersionCode = 15
+    extVersionCode = 16
     isNsfw = true
 }
 

--- a/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLove.kt
+++ b/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLove.kt
@@ -168,6 +168,7 @@ class BoyLove : HttpSource(), ConfigurableSource {
             Filter.Header("分类筛选（搜索文本时无效）"),
             StatusFilter(),
             TypeFilter(),
+            RegionFilter(),
             genreFilter,
             Filter.Header("若要观看VIP漫画，请先在Webview中登录网站，并确认您的账户已达到Lv3"),
             VipFilter(),

--- a/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLoveFilters.kt
+++ b/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLoveFilters.kt
@@ -6,7 +6,7 @@ import eu.kanade.tachiyomi.source.model.FilterList
 /*
  * 1-0-2-1-1-0-1-0
  * [0] cate, useless
- * [1] tag(genre), 0=all
+ * [1] tag(genre and region), 0=all
  * [2] done(status), 2=all, 0=ongoing, 1=completed
  * [3] order(sort), 1=normal
  * [4] page, index from 1
@@ -17,6 +17,7 @@ import eu.kanade.tachiyomi.source.model.FilterList
 internal fun parseFilters(page: Int, filters: FilterList): String {
     var status = '2'
     var type = '0'
+    var region = "0"
     var genre = "0"
     var sort = '1'
     var vip = '2'
@@ -24,13 +25,22 @@ internal fun parseFilters(page: Int, filters: FilterList): String {
         when (filter) {
             is StatusFilter -> status = STATUS_KEYS[filter.state]
             is TypeFilter -> type = TYPE_KEYS[filter.state]
+            is RegionFilter -> region = REGION_KEYS[filter.state]
             is GenreFilter -> if (filter.state > 0) genre = filter.values[filter.state]
             is SortFilter -> sort = SORT_KEYS[filter.state]
             is VipFilter -> vip = VIP_KEYS[filter.state]
             else -> {}
         }
     }
-    return "1-$genre-$status-$sort-$page-$type-1-$vip"
+
+    val tags = when {
+        region == "0" && genre == "0" -> "0"
+        region == "0" && genre != "0" -> genre
+        region != "0" && genre == "0" -> region
+        else -> region + "+" + genre
+    }
+
+    return "1-$tags-$status-$sort-$page-$type-1-$vip"
 }
 
 internal class StatusFilter : Filter.Select<String>("状态", STATUS_NAMES)
@@ -42,6 +52,11 @@ internal class TypeFilter : Filter.Select<String>("类型", TYPE_NAMES)
 
 private val TYPE_NAMES = arrayOf("全部", "清水", "有肉")
 private val TYPE_KEYS = arrayOf('0', '1', '2')
+
+internal class RegionFilter : Filter.Select<String>("地区", REGION_NAMES)
+
+private val REGION_NAMES = arrayOf("全部", "日漫", "韩漫", "国漫", "台漫")
+private val REGION_KEYS = arrayOf("0", "日漫", "韩漫", "国漫", "台漫")
 
 internal class GenreFilter(names: Array<String>) : Filter.Select<String>("标签", names)
 

--- a/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLoveFilters.kt
+++ b/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLoveFilters.kt
@@ -33,7 +33,7 @@ internal fun parseFilters(page: Int, filters: FilterList): String {
         }
     }
 
-    val tags = when {
+    var tags = when {
         region == "0" && genre == "0" -> "0"
         region == "0" && genre != "0" -> genre
         region != "0" && genre == "0" -> region

--- a/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLoveFilters.kt
+++ b/src/zh/boylove/src/eu/kanade/tachiyomi/extension/zh/boylove/BoyLoveFilters.kt
@@ -33,7 +33,7 @@ internal fun parseFilters(page: Int, filters: FilterList): String {
         }
     }
 
-    var tags = when {
+    val tags = when {
         region == "0" && genre == "0" -> "0"
         region == "0" && genre != "0" -> genre
         region != "0" && genre == "0" -> region


### PR DESCRIPTION
This PR adds a dedicated filter by manga source region for BoyLove, since the site split the region tags into a dedicated bar earlier this week. This meant that users could no longer query manga by region from the genre list as before.

Since the API supports multi-tag queries (by adding tags together using "+"), this PR has made the necessary changes to enable users to query two tags (region and genre) simultaneously.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
