### PR TITLE
Use `source().asResponseBody()` to fix MIME to avoid extra memory load

### DIFF
--- a/src/all/luscious/build.gradle
+++ b/src/all/luscious/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Luscious'
     extClass = '.LusciousFactory'
-    extVersionCode = 20
+    extVersionCode = 21
     isNsfw = true
 }
 

--- a/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/Luscious.kt
+++ b/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/Luscious.kt
@@ -31,11 +31,11 @@ import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
-import okhttp3.ResponseBody.Companion.toResponseBody
+import okhttp3.ResponseBody.Companion.asResponseBody
 import rx.Observable
 import uy.kohesive.injekt.injectLazy
 import java.util.Calendar
@@ -63,8 +63,8 @@ abstract class Luscious(
     private val rewriteOctetStream: Interceptor = Interceptor { chain ->
         val originalResponse: Response = chain.proceed(chain.request())
         if (originalResponse.headers("Content-Type").contains("application/octet-stream") && originalResponse.request.url.toString().contains(".webp")) {
-            val orgBody = originalResponse.body.bytes()
-            val newBody = orgBody.toResponseBody("image/webp".toMediaTypeOrNull())
+            val orgBody = originalResponse.body.source()
+            val newBody = orgBody.asResponseBody("image/webp".toMediaType())
             originalResponse.newBuilder()
                 .body(newBody)
                 .build()

--- a/src/all/tappytoon/build.gradle
+++ b/src/all/tappytoon/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Tappytoon'
     extClass = '.TappytoonFactory'
-    extVersionCode = 8
+    extVersionCode = 9
     isNsfw = true
 }
 

--- a/src/all/tappytoon/src/eu/kanade/tachiyomi/extension/all/tappytoon/Tappytoon.kt
+++ b/src/all/tappytoon/src/eu/kanade/tachiyomi/extension/all/tappytoon/Tappytoon.kt
@@ -41,8 +41,7 @@ class Tappytoon(override val lang: String) : HttpSource() {
             // Fix image content type
             val type = IMG_CONTENT_TYPE.toMediaType()
             val body = res.body.source().asResponseBody(type)
-            return@addInterceptor res.newBuilder().body(body)
-                .header("Content-Type", IMG_CONTENT_TYPE).build()
+            return@addInterceptor res.newBuilder().body(body).build()
         }
         // Throw JSON error if available
         if (mime == "application/json") {

--- a/src/all/tappytoon/src/eu/kanade/tachiyomi/extension/all/tappytoon/Tappytoon.kt
+++ b/src/all/tappytoon/src/eu/kanade/tachiyomi/extension/all/tappytoon/Tappytoon.kt
@@ -17,7 +17,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.Response
-import okhttp3.ResponseBody.Companion.toResponseBody
+import okhttp3.ResponseBody.Companion.asResponseBody
 import uy.kohesive.injekt.injectLazy
 import java.io.IOException
 import java.text.SimpleDateFormat
@@ -40,7 +40,7 @@ class Tappytoon(override val lang: String) : HttpSource() {
             }
             // Fix image content type
             val type = IMG_CONTENT_TYPE.toMediaType()
-            val body = res.body.bytes().toResponseBody(type)
+            val body = res.body.source().asResponseBody(type)
             return@addInterceptor res.newBuilder().body(body)
                 .header("Content-Type", IMG_CONTENT_TYPE).build()
         }

--- a/src/en/mangakatana/src/eu/kanade/tachiyomi/extension/en/mangakatana/MangaKatana.kt
+++ b/src/en/mangakatana/src/eu/kanade/tachiyomi/extension/en/mangakatana/MangaKatana.kt
@@ -15,11 +15,11 @@ import eu.kanade.tachiyomi.source.online.ParsedHttpSource
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferencesLazy
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
-import okhttp3.ResponseBody.Companion.toResponseBody
+import okhttp3.ResponseBody.Companion.asResponseBody
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
@@ -40,9 +40,9 @@ class MangaKatana : ConfigurableSource, ParsedHttpSource() {
     override val client: OkHttpClient = network.cloudflareClient.newBuilder().addNetworkInterceptor { chain ->
         val originalResponse = chain.proceed(chain.request())
         if (originalResponse.headers("Content-Type").contains("application/octet-stream")) {
-            val orgBody = originalResponse.body.bytes()
+            val orgBody = originalResponse.body.source()
             val extension = chain.request().url.toString().substringAfterLast(".")
-            val newBody = orgBody.toResponseBody("image/$extension".toMediaTypeOrNull())
+            val newBody = orgBody.asResponseBody("image/$extension".toMediaType())
             originalResponse.newBuilder()
                 .body(newBody)
                 .build()

--- a/src/en/tsumino/build.gradle
+++ b/src/en/tsumino/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Tsumino'
     extClass = '.Tsumino'
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = true
 }
 

--- a/src/en/tsumino/src/eu/kanade/tachiyomi/extension/en/tsumino/Tsumino.kt
+++ b/src/en/tsumino/src/eu/kanade/tachiyomi/extension/en/tsumino/Tsumino.kt
@@ -25,11 +25,11 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.FormBody
 import okhttp3.Interceptor
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
-import okhttp3.ResponseBody.Companion.toResponseBody
+import okhttp3.ResponseBody.Companion.asResponseBody
 import rx.Observable
 import uy.kohesive.injekt.injectLazy
 
@@ -49,8 +49,8 @@ class Tsumino : HttpSource() {
         if (originalResponse.headers("Content-Type").contains("application/octet-stream") &&
             originalResponse.request.url.pathSegments.any { it == "parts" }
         ) {
-            val orgBody = originalResponse.body.bytes()
-            val newBody = orgBody.toResponseBody("image/jpeg".toMediaTypeOrNull())
+            val orgBody = originalResponse.body.source()
+            val newBody = orgBody.asResponseBody("image/jpeg".toMediaType())
             originalResponse.newBuilder()
                 .body(newBody)
                 .build()

--- a/src/es/manhwalatino/build.gradle
+++ b/src/es/manhwalatino/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ManhwaLatino'
     themePkg = 'madara'
     baseUrl = 'https://manhwa-latino.com'
-    overrideVersionCode = 8
+    overrideVersionCode = 9
     isNsfw = true
 }
 

--- a/src/es/manhwalatino/src/eu/kanade/tachiyomi/extension/es/manhwalatino/ManhwaLatino.kt
+++ b/src/es/manhwalatino/src/eu/kanade/tachiyomi/extension/es/manhwalatino/ManhwaLatino.kt
@@ -6,10 +6,10 @@ import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.util.asJsoup
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Response
-import okhttp3.ResponseBody.Companion.toResponseBody
+import okhttp3.ResponseBody.Companion.asResponseBody
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -30,8 +30,8 @@ class ManhwaLatino : Madara(
                 .build()
             val response = chain.proceed(request.newBuilder().headers(headers).build())
             if (response.headers("Content-Type").contains("application/octet-stream") && response.request.url.toString().endsWith(".jpg")) {
-                val orgBody = response.body.bytes()
-                val newBody = orgBody.toResponseBody("image/jpeg".toMediaTypeOrNull())
+                val orgBody = response.body.source()
+                val newBody = orgBody.asResponseBody("image/jpeg".toMediaType())
                 response.newBuilder()
                     .body(newBody)
                     .build()

--- a/src/id/kiryuu/build.gradle
+++ b/src/id/kiryuu/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Kiryuu'
     themePkg = 'mangathemesia'
     baseUrl = 'https://kiryuu02.com'
-    overrideVersionCode = 11
+    overrideVersionCode = 12
     isNsfw = false
 }
 

--- a/src/id/kiryuu/src/eu/kanade/tachiyomi/extension/id/kiryuu/Kiryuu.kt
+++ b/src/id/kiryuu/src/eu/kanade/tachiyomi/extension/id/kiryuu/Kiryuu.kt
@@ -24,8 +24,7 @@ class Kiryuu : MangaThemesia("Kiryuu", "https://kiryuu02.com", "id", dateFormat 
                 // Fix image content type
                 val type = IMG_CONTENT_TYPE.toMediaType()
                 val body = response.body.source().asResponseBody(type)
-                return@addInterceptor response.newBuilder().body(body)
-                    .header("Content-Type", IMG_CONTENT_TYPE).build()
+                return@addInterceptor response.newBuilder().body(body).build()
             }
             response
         }

--- a/src/id/kiryuu/src/eu/kanade/tachiyomi/extension/id/kiryuu/Kiryuu.kt
+++ b/src/id/kiryuu/src/eu/kanade/tachiyomi/extension/id/kiryuu/Kiryuu.kt
@@ -4,7 +4,7 @@ import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
-import okhttp3.ResponseBody.Companion.toResponseBody
+import okhttp3.ResponseBody.Companion.asResponseBody
 import org.jsoup.nodes.Document
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -23,7 +23,7 @@ class Kiryuu : MangaThemesia("Kiryuu", "https://kiryuu02.com", "id", dateFormat 
                 }
                 // Fix image content type
                 val type = IMG_CONTENT_TYPE.toMediaType()
-                val body = response.body.bytes().toResponseBody(type)
+                val body = response.body.source().asResponseBody(type)
                 return@addInterceptor response.newBuilder().body(body)
                     .header("Content-Type", IMG_CONTENT_TYPE).build()
             }

--- a/src/id/komiktap/build.gradle
+++ b/src/id/komiktap/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Komiktap'
     themePkg = 'mangathemesia'
     baseUrl = 'https://komiktap.info'
-    overrideVersionCode = 3
+    overrideVersionCode = 4
     isNsfw = true
 }
 

--- a/src/id/komiktap/src/eu/kanade/tachiyomi/extension/id/komiktap/Komiktap.kt
+++ b/src/id/komiktap/src/eu/kanade/tachiyomi/extension/id/komiktap/Komiktap.kt
@@ -7,7 +7,7 @@ import okhttp3.Cookie
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Response
-import okhttp3.ResponseBody.Companion.toResponseBody
+import okhttp3.ResponseBody.Companion.asResponseBody
 import java.io.IOException
 
 class Komiktap : MangaThemesia("Komiktap", "https://komiktap.info", "id") {
@@ -23,7 +23,7 @@ class Komiktap : MangaThemesia("Komiktap", "https://komiktap.info", "id") {
                 }
                 // Fix image content type
                 val type = IMG_CONTENT_TYPE.toMediaType()
-                val body = response.body.bytes().toResponseBody(type)
+                val body = response.body.source().asResponseBody(type)
                 return@addInterceptor response.newBuilder().body(body)
                     .header("Content-Type", IMG_CONTENT_TYPE).build()
             }

--- a/src/id/komiktap/src/eu/kanade/tachiyomi/extension/id/komiktap/Komiktap.kt
+++ b/src/id/komiktap/src/eu/kanade/tachiyomi/extension/id/komiktap/Komiktap.kt
@@ -24,8 +24,7 @@ class Komiktap : MangaThemesia("Komiktap", "https://komiktap.info", "id") {
                 // Fix image content type
                 val type = IMG_CONTENT_TYPE.toMediaType()
                 val body = response.body.source().asResponseBody(type)
-                return@addInterceptor response.newBuilder().body(body)
-                    .header("Content-Type", IMG_CONTENT_TYPE).build()
+                return@addInterceptor response.newBuilder().body(body).build()
             }
             response
         }

--- a/src/pt/argoscomics/build.gradle
+++ b/src/pt/argoscomics/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ArgosComics'
     themePkg = 'madara'
     baseUrl = 'https://argoscomic.com'
-    overrideVersionCode = 5
+    overrideVersionCode = 6
     isNsfw = false
 }
 

--- a/src/pt/argoscomics/src/eu/kanade/tachiyomi/extension/pt/argoscomics/ArgosComics.kt
+++ b/src/pt/argoscomics/src/eu/kanade/tachiyomi/extension/pt/argoscomics/ArgosComics.kt
@@ -50,8 +50,7 @@ class ArgosComics : Madara(
                     // Fix image content type
                     val type = "image/jpeg".toMediaType()
                     val body = response.body.source().asResponseBody(type)
-                    return@addInterceptor response.newBuilder().body(body)
-                        .header("Content-Type", "image/jpeg").build()
+                    return@addInterceptor response.newBuilder().body(body).build()
                 }
             }
             response

--- a/src/pt/argoscomics/src/eu/kanade/tachiyomi/extension/pt/argoscomics/ArgosComics.kt
+++ b/src/pt/argoscomics/src/eu/kanade/tachiyomi/extension/pt/argoscomics/ArgosComics.kt
@@ -5,7 +5,7 @@ import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
-import okhttp3.ResponseBody.Companion.toResponseBody
+import okhttp3.ResponseBody.Companion.asResponseBody
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import java.text.SimpleDateFormat
@@ -49,7 +49,7 @@ class ArgosComics : Madara(
                 if (mime == "application/octet-stream" || mime == null) {
                     // Fix image content type
                     val type = "image/jpeg".toMediaType()
-                    val body = response.body.bytes().toResponseBody(type)
+                    val body = response.body.source().asResponseBody(type)
                     return@addInterceptor response.newBuilder().body(body)
                         .header("Content-Type", "image/jpeg").build()
                 }

--- a/src/pt/arthurscan/build.gradle
+++ b/src/pt/arthurscan/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ArthurScan'
     themePkg = 'madara'
     baseUrl = 'https://arthurscan.xyz'
-    overrideVersionCode = 5
+    overrideVersionCode = 6
     isNsfw = false
 }
 

--- a/src/pt/arthurscan/src/eu/kanade/tachiyomi/extension/pt/arthurscan/ArthurScan.kt
+++ b/src/pt/arthurscan/src/eu/kanade/tachiyomi/extension/pt/arthurscan/ArthurScan.kt
@@ -25,8 +25,7 @@ class ArthurScan : Madara(
                 if (mime == "application/octet-stream" || mime == null) {
                     val type = "image/jpeg".toMediaType()
                     val body = response.body.source().asResponseBody(type)
-                    return@addInterceptor response.newBuilder().body(body)
-                        .header("Content-Type", "image/jpeg").build()
+                    return@addInterceptor response.newBuilder().body(body).build()
                 }
             }
             response

--- a/src/pt/arthurscan/src/eu/kanade/tachiyomi/extension/pt/arthurscan/ArthurScan.kt
+++ b/src/pt/arthurscan/src/eu/kanade/tachiyomi/extension/pt/arthurscan/ArthurScan.kt
@@ -4,7 +4,7 @@ import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
-import okhttp3.ResponseBody.Companion.toResponseBody
+import okhttp3.ResponseBody.Companion.asResponseBody
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.concurrent.TimeUnit
@@ -24,7 +24,7 @@ class ArthurScan : Madara(
             if (response.isSuccessful) {
                 if (mime == "application/octet-stream" || mime == null) {
                     val type = "image/jpeg".toMediaType()
-                    val body = response.body.bytes().toResponseBody(type)
+                    val body = response.body.source().asResponseBody(type)
                     return@addInterceptor response.newBuilder().body(body)
                         .header("Content-Type", "image/jpeg").build()
                 }


### PR DESCRIPTION
- Some of the code definitely looks like copy-pasted.
- Modifying the header is not necessary since the app only checks the response.
- Will try setting up a lint rule on this.
- Ikiru and Manhastro are not updated as they have ongoing rewrites that remove this code.
- MangaKatana is not bumped because it has recent server issues outstanding.
