### PR TITLE
MMLook: Fix search of Dumanwu

### DIFF
--- a/lib-multisrc/mmlook/build.gradle.kts
+++ b/lib-multisrc/mmlook/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 1
+baseVersionCode = 2
 
 dependencies {
     implementation(project(":lib:unpacker"))

--- a/lib-multisrc/mmlook/src/eu/kanade/tachiyomi/multisrc/mmlook/MMLook.kt
+++ b/lib-multisrc/mmlook/src/eu/kanade/tachiyomi/multisrc/mmlook/MMLook.kt
@@ -95,10 +95,10 @@ open class MMLook(
     override fun searchMangaParse(response: Response): MangasPage {
         if (response.request.method == "GET") return popularMangaParse(response)
 
-        val entries = response.asJsoup().select(".col-auto").map { element ->
+        val entries = response.asJsoup().select(".item-data > div").map { element ->
             SManga.create().apply {
                 url = element.selectFirst("a")!!.attr("href").mustRemoveSurrounding("/", "/")
-                title = element.selectFirst(".e-title")!!.text()
+                title = element.selectFirst(".e-title, .title")!!.text()
                 author = element.selectFirst(".tip")!!.text()
                 thumbnail_url = element.selectFirst("img")!!.attr("data-src")
             }.formatUrl()


### PR DESCRIPTION
Closes #10005 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
