### PR TITLE
Iqiyi/Tencent/Dongman: set desktop UA, move to zh-Hans

### DIFF
--- a/src/zh/dongmanmanhua/build.gradle
+++ b/src/zh/dongmanmanhua/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Dongman Manhua'
     extClass = '.DongmanManhua'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = false
 }
 

--- a/src/zh/dongmanmanhua/src/eu/kanade/tachiyomi/extension/zh/dongmanmanhua/DongmanManhua.kt
+++ b/src/zh/dongmanmanhua/src/eu/kanade/tachiyomi/extension/zh/dongmanmanhua/DongmanManhua.kt
@@ -19,7 +19,8 @@ import java.util.Locale
 
 class DongmanManhua : HttpSource() {
     override val name = "Dongman Manhua"
-    override val lang = "zh"
+    override val lang get() = "zh-Hans"
+    override val id get() = 4222375517460530289
     override val baseUrl = "https://www.dongmanmanhua.cn"
     override val supportsLatest = true
 

--- a/src/zh/iqiyi/build.gradle
+++ b/src/zh/iqiyi/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Iqiyi'
     extClass = '.Iqiyi'
-    extVersionCode = 2
+    extVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/zh/iqiyi/src/eu/kanade/tachiyomi/extension/zh/iqiyi/Iqiyi.kt
+++ b/src/zh/iqiyi/src/eu/kanade/tachiyomi/extension/zh/iqiyi/Iqiyi.kt
@@ -25,6 +25,9 @@ class Iqiyi : ParsedHttpSource() {
     override val baseUrl: String = "https://www.iqiyi.com/manhua"
     private val json: Json by injectLazy()
 
+    override fun headersBuilder() = super.headersBuilder()
+        .set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36")
+
     // Popular
 
     override fun popularMangaRequest(page: Int) = GET("$baseUrl/category/全部_-1_-1_9_$page/", headers)

--- a/src/zh/iqiyi/src/eu/kanade/tachiyomi/extension/zh/iqiyi/Iqiyi.kt
+++ b/src/zh/iqiyi/src/eu/kanade/tachiyomi/extension/zh/iqiyi/Iqiyi.kt
@@ -20,7 +20,8 @@ import uy.kohesive.injekt.injectLazy
 
 class Iqiyi : ParsedHttpSource() {
     override val name: String = "爱奇艺叭嗒"
-    override val lang: String = "zh"
+    override val lang get() = "zh-Hans"
+    override val id get() = 2198877009406729694
     override val supportsLatest: Boolean = true
     override val baseUrl: String = "https://www.iqiyi.com/manhua"
     private val json: Json by injectLazy()

--- a/src/zh/tencentcomics/build.gradle
+++ b/src/zh/tencentcomics/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Tencent Comics (ac.qq.com)'
     extClass = '.TencentComics'
-    extVersionCode = 7
+    extVersionCode = 8
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/zh/tencentcomics/src/eu/kanade/tachiyomi/extension/zh/tencentcomics/TencentComics.kt
+++ b/src/zh/tencentcomics/src/eu/kanade/tachiyomi/extension/zh/tencentcomics/TencentComics.kt
@@ -34,7 +34,7 @@ class TencentComics : ParsedHttpSource() {
 
     private val desktopUrl = "https://ac.qq.com"
 
-    override val lang = "zh"
+    override val lang = "zh-Hans"
 
     override val supportsLatest = true
 
@@ -43,6 +43,9 @@ class TencentComics : ParsedHttpSource() {
     override val client: OkHttpClient = network.cloudflareClient
 
     private val json: Json by injectLazy()
+
+    override fun headersBuilder() = super.headersBuilder()
+        .set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36")
 
     override fun chapterListRequest(manga: SManga): Request {
         return GET("$desktopUrl/Comic/comicInfo/" + manga.url.substringAfter("/index/"), headers)


### PR DESCRIPTION
Apps are using mobile UA by default.

- See #1474
- Closes #2168
- Closes #2170
- Closes #6953

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
