### PR TITLE
MiMiHentai: Update search support exclude tag and remove 'yaoi' tag from Latest/Popular page

### DIFF
--- a/src/vi/mimihentai/build.gradle
+++ b/src/vi/mimihentai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = "MiMiHentai"
     extClass = ".MiMiHentai"
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 apply from: "$rootDir/common.gradle"

--- a/src/vi/mimihentai/src/eu/kanade/tachiyomi/extension/vi/mimihentai/Dto.kt
+++ b/src/vi/mimihentai/src/eu/kanade/tachiyomi/extension/vi/mimihentai/Dto.kt
@@ -60,7 +60,13 @@ private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS", Locale
 
 @Serializable
 class PageListDto(
-    val pages: List<String>,
+    val pages: List<ListPages>,
+)
+
+@Serializable
+class ListPages(
+    val imageUrl: String,
+    val drm: String? = null,
 )
 
 @Serializable

--- a/src/vi/mimihentai/src/eu/kanade/tachiyomi/extension/vi/mimihentai/MiMiHentai.kt
+++ b/src/vi/mimihentai/src/eu/kanade/tachiyomi/extension/vi/mimihentai/MiMiHentai.kt
@@ -44,6 +44,7 @@ class MiMiHentai : HttpSource() {
             addPathSegments("tatcatruyen")
             addQueryParameter("page", (page - 1).toString())
             addQueryParameter("sort", "updated_at")
+            addQueryParameter("ex", "196")
         }.build(),
         headers,
     )
@@ -112,6 +113,7 @@ class MiMiHentai : HttpSource() {
             addPathSegments("tatcatruyen")
             addQueryParameter("page", (page - 1).toString())
             addQueryParameter("sort", "views")
+            addQueryParameter("ex", "196")
         }.build(),
         headers,
     )
@@ -156,8 +158,11 @@ class MiMiHentai : HttpSource() {
                             val sort = getSortByList()[filters.state]
                             addQueryParameter("sort", sort.id)
                         }
-                    is GenreList -> {
-                        filters.state.forEach { genre -> if (genre.state) addQueryParameter("genre", genre.id) }
+                    is GenreList -> filters.state.forEach {
+                        when (it.state) {
+                            Filter.TriState.STATE_INCLUDE -> addQueryParameter("genre", it.id)
+                            Filter.TriState.STATE_EXCLUDE -> addQueryParameter("ex", it.id)
+                        }
                     }
                     is TextField -> setQueryParameter(filters.key, filters.state)
                     else -> {}
@@ -197,7 +202,7 @@ class MiMiHentai : HttpSource() {
     private class GenreList(name: String, pairs: List<Pair<Long, String>>) : GenresFilter(name, pairs)
     private open class GenresFilter(title: String, pairs: List<Pair<Long, String>>) :
         Filter.Group<GenreCheckBox>(title, pairs.map { GenreCheckBox(it.second, it.first.toString()) })
-    class GenreCheckBox(name: String, val id: String = name) : Filter.CheckBox(name)
+    class GenreCheckBox(name: String, val id: String = name) : Filter.TriState(name)
 
     private class SortByList(sort: Array<SortBy>) : Filter.Select<SortBy>("Sắp xếp", sort)
     private class SortBy(name: String, val id: String) : Filter.CheckBox(name) {

--- a/src/vi/mimihentai/src/eu/kanade/tachiyomi/extension/vi/mimihentai/MiMiHentai.kt
+++ b/src/vi/mimihentai/src/eu/kanade/tachiyomi/extension/vi/mimihentai/MiMiHentai.kt
@@ -102,7 +102,7 @@ class MiMiHentai : HttpSource() {
     override fun pageListParse(response: Response): List<Page> {
         val res = response.parseAs<PageListDto>()
         return res.pages.mapIndexed { index, url ->
-            Page(index, imageUrl = url)
+            Page(index, imageUrl = url.imageUrl)
         }
     }
 


### PR DESCRIPTION
Many mimihentai users suggested removing the 'yaoi' tag from the Latest/Popular page 
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
