### PR TITLE
Move MangaPlus Creators to new domain

### DIFF
--- a/src/all/mangapluscreators/AndroidManifest.xml
+++ b/src/all/mangapluscreators/AndroidManifest.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity
+            android:name=".all.mangapluscreators.MangaPlusCreatorsUrlActivity"
+            android:excludeFromRecents="true"
+            android:exported="true"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="mangaplus-creators.jp"
+                    android:pathPattern="/episodes/.+"
+                    android:scheme="https" />
+                <data
+                    android:host="mangaplus-creators.jp"
+                    android:pathPattern="/titles/.+"
+                    android:scheme="https" />
+                <data
+                    android:host="mangaplus-creators.jp"
+                    android:pathPattern="/authors/.+"
+                    android:scheme="https" />
+
+                <data
+                    android:host="medibang.com"
+                    android:pathPattern="/mpc/episodes/.+"
+                    android:scheme="https" />
+                <data
+                    android:host="medibang.com"
+                    android:pathPattern="/mpc/titles/.+"
+                    android:scheme="https" />
+                <data
+                    android:host="medibang.com"
+                    android:pathPattern="/mpc/authors/.+"
+                    android:scheme="https" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/src/all/mangapluscreators/AndroidManifest.xml
+++ b/src/all/mangapluscreators/AndroidManifest.xml
@@ -3,7 +3,7 @@
 
     <application>
         <activity
-            android:name=".all.mangapluscreators.MangaPlusCreatorsUrlActivity"
+            android:name=".all.mangapluscreators.MPCUrlActivity"
             android:excludeFromRecents="true"
             android:exported="true"
             android:theme="@android:style/Theme.NoDisplay">
@@ -15,28 +15,28 @@
 
                 <data
                     android:host="mangaplus-creators.jp"
-                    android:pathPattern="/episodes/.+"
+                    android:pathAdvancedPattern="/episodes/.+"
                     android:scheme="https" />
                 <data
                     android:host="mangaplus-creators.jp"
-                    android:pathPattern="/titles/.+"
+                    android:pathPattern="/titles/..*"
                     android:scheme="https" />
                 <data
                     android:host="mangaplus-creators.jp"
-                    android:pathPattern="/authors/.+"
+                    android:pathAdvancedPattern="/authors/.+"
                     android:scheme="https" />
 
                 <data
                     android:host="medibang.com"
-                    android:pathPattern="/mpc/episodes/.+"
+                    android:pathAdvancedPattern="/mpc/episodes/.+"
                     android:scheme="https" />
                 <data
                     android:host="medibang.com"
-                    android:pathPattern="/mpc/titles/.+"
+                    android:pathAdvancedPattern="/mpc/titles/..+"
                     android:scheme="https" />
                 <data
                     android:host="medibang.com"
-                    android:pathPattern="/mpc/authors/.+"
+                    android:pathAdvancedPattern="/mpc/authors/[0-9]+"
                     android:scheme="https" />
             </intent-filter>
         </activity>

--- a/src/all/mangapluscreators/build.gradle
+++ b/src/all/mangapluscreators/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MANGA Plus Creators by SHUEISHA'
     extClass = '.MangaPlusCreatorsFactory'
-    extVersionCode = 1
+    extVersionCode = 2
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MPCUrlActivity.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MPCUrlActivity.kt
@@ -1,0 +1,54 @@
+package eu.kanade.tachiyomi.extension.all.mangapluscreators
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import kotlin.system.exitProcess
+
+class MPCUrlActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val pathSegments = intent?.data?.pathSegments
+        if (pathSegments != null && pathSegments.size > 1) {
+            // {medibang.com/mpc,mangaplus-creators.jp}/{episodes,titles,authors}
+            val pathIndex = if (intent?.data?.host?.startsWith("medibang") == true) 1 else 0
+            val idIndex = pathIndex + 1
+            val query = when {
+                pathSegments[pathIndex].equals("episodes") -> {
+                    MangaPlusCreators.PREFIX_EPISODE_ID_SEARCH + pathSegments[idIndex]
+                }
+                pathSegments[pathIndex].equals("authors") -> {
+                    MangaPlusCreators.PREFIX_AUTHOR_ID_SEARCH + pathSegments[idIndex]
+                }
+                pathSegments[pathIndex].equals("titles") -> {
+                    MangaPlusCreators.PREFIX_TITLE_ID_SEARCH + pathSegments[idIndex]
+                }
+                else -> null // TODO: is this required?
+            }
+
+            if (query != null) {
+                val mainIntent = Intent().setAction("eu.kanade.tachiyomi.SEARCH").apply {
+                    putExtra("query", query)
+                    putExtra("filter", packageName)
+                }
+
+                try {
+                    startActivity(mainIntent)
+                } catch (e: ActivityNotFoundException) {
+                    Log.e("MPCUrlActivity", e.toString())
+                }
+            } else {
+                Log.e("MPCUrlActivity", "Missing alphanumeric ID from the URL")
+            }
+        } else {
+            Log.e("MPCUrlActivity", "Could not parse URI from intent $intent")
+        }
+
+        finish()
+        exitProcess(0)
+    }
+}

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MPCUrlActivity.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MPCUrlActivity.kt
@@ -15,7 +15,14 @@ class MPCUrlActivity : Activity() {
         val pathSegments = intent?.data?.pathSegments
         if (pathSegments != null && pathSegments.size > 1) {
             // {medibang.com/mpc,mangaplus-creators.jp}/{episodes,titles,authors}
-            val pathIndex = if (intent?.data?.host?.startsWith("medibang") == true) 1 else 0
+            // TODO: val pathIndex = if (intent?.data?.host?.startsWith("medibang") == true) 1 else 0
+            val host = intent?.data?.host ?: ""
+            val pathIndex = with(host) {
+                when {
+                    equals("medibang.com") -> 1
+                    else -> 0
+                }
+            }
             val idIndex = pathIndex + 1
             val query = when {
                 pathSegments[pathIndex].equals("episodes") -> {
@@ -31,7 +38,9 @@ class MPCUrlActivity : Activity() {
             }
 
             if (query != null) {
-                val mainIntent = Intent().setAction("eu.kanade.tachiyomi.SEARCH").apply {
+                // TODO: val mainIntent = Intent().setAction("eu.kanade.tachiyomi.SEARCH").apply {
+                val mainIntent = Intent().apply {
+                    setAction("eu.kanade.tachiyomi.SEARCH")
                     putExtra("query", query)
                     putExtra("filter", packageName)
                 }

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -294,7 +294,8 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         val dataPages = readerElement.attr("data-pages")
         val refererUrl = response.request.url.toString()
         return dataPages.parseAs<MpcReaderDataPages>().pc.map {
-            (pageNo, imageUrl) -> Page(pageNo, refererUrl, imageUrl)
+                (pageNo, imageUrl) ->
+            Page(pageNo, refererUrl, imageUrl)
         }
     }
 

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -104,7 +104,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         if (query.startsWith(PREFIX_TITLE_ID_SEARCH)) {
             val titleContentId = query.removePrefix(PREFIX_TITLE_ID_SEARCH)
             val titleUrl = "$baseUrl/titles/$titleContentId"
-            return client.newCall(GET(titleUrl))
+            return client.newCall(GET(titleUrl, headers))
                 .asObservableSuccess()
                 .map { response ->
                     val result = response.asJsoup()
@@ -119,7 +119,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         }
         if (query.startsWith(PREFIX_EPISODE_ID_SEARCH)) {
             val episodeId = query.removePrefix(PREFIX_EPISODE_ID_SEARCH)
-            return client.newCall(GET("$baseUrl/episodes/$episodeId"))
+            return client.newCall(GET("$baseUrl/episodes/$episodeId", headers))
                 .asObservableSuccess().map { response ->
                     val result = response.asJsoup()
                     val readerElement = result.select("div[react=viewer]")
@@ -131,7 +131,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         }
         if (query.startsWith(PREFIX_AUTHOR_ID_SEARCH)) {
             val authorId = query.removePrefix(PREFIX_AUTHOR_ID_SEARCH)
-            return client.newCall(GET("$baseUrl/authors/$authorId"))
+            return client.newCall(GET("$baseUrl/authors/$authorId", headers))
                 .asObservableSuccess()
                 .map { response ->
                     val result = response.asJsoup()
@@ -171,7 +171,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
                 }
             }.toString()
 
-        return client.newCall(GET(genreUrl))
+        return client.newCall(GET(genreUrl, headers))
             .asObservableSuccess()
             .map { response ->
                 popularMangaParse(response)
@@ -231,7 +231,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
     }
 
     fun chapterListPageRequest(page: Int, titleContentId: String): Request {
-        return GET("$baseUrl/titles/$titleContentId/?page=$page")
+        return GET("$baseUrl/titles/$titleContentId/?page=$page", headers)
     }
 
     override fun chapterListParse(response: Response): List<SChapter> {

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -37,13 +37,9 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
 
     // POPULAR Section
     override fun popularMangaRequest(page: Int): Request {
-        val newHeaders = headersBuilder()
-            .set("Referer", "$baseUrl/titles/popular/?p=m")
-            .build()
-
         val popularUrl = "$baseUrl/titles/popular/?p=m&l=$lang".toHttpUrl().toString()
 
-        return GET(popularUrl, newHeaders)
+        return GET(popularUrl, headers)
     }
 
     override fun popularMangaParse(response: Response): MangasPage = parseMangasPageFromElement(
@@ -73,17 +69,13 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
 
     // LATEST Section
     override fun latestUpdatesRequest(page: Int): Request {
-        val newHeaders = headersBuilder()
-            .set("Referer", "$baseUrl/titles/recent/?t=episode")
-            .build()
-
         val apiUrl = "$apiUrl/titles/recent/".toHttpUrl().newBuilder()
             .addQueryParameter("page", page.toString())
             .addQueryParameter("l", lang)
             .addQueryParameter("t", "episode")
             .toString()
 
-        return GET(apiUrl, newHeaders)
+        return GET(apiUrl, headers)
     }
 
     override fun latestUpdatesParse(response: Response): MangasPage {

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -21,12 +21,12 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
 
     override val name = "MANGA Plus Creators by SHUEISHA"
 
-    override val baseUrl = "https://medibang.com/mpc"
+    override val baseUrl = BASE_URL
 
     override val supportsLatest = true
 
     override fun headersBuilder(): Headers.Builder = Headers.Builder()
-        .add("Origin", baseUrl.substringBeforeLast("/"))
+//        .add("Origin", baseUrl.substringBeforeLast("/"))
         .add("Referer", baseUrl)
         .add("User-Agent", USER_AGENT)
 
@@ -35,19 +35,11 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
     override fun popularMangaRequest(page: Int): Request {
         val newHeaders = headersBuilder()
             .set("Referer", "$baseUrl/titles/popular/?p=m")
-            .add("X-Requested-With", "XMLHttpRequest")
             .build()
 
-        val apiUrl = "$API_URL/titles/popular/list".toHttpUrl().newBuilder()
-            .addQueryParameter("page", page.toString())
-            .addQueryParameter("pageSize", POPULAR_PAGE_SIZE)
-            .addQueryParameter("l", lang)
-            .addQueryParameter("p", "m")
-            .addQueryParameter("isWebview", "false")
-            .addQueryParameter("_", System.currentTimeMillis().toString())
-            .toString()
+        val popularUrl = "$baseUrl/titles/popular/?p=m&l=$lang".toHttpUrl().toString()
 
-        return GET(apiUrl, newHeaders)
+        return GET(popularUrl, newHeaders)
     }
 
     override fun popularMangaParse(response: Response): MangasPage {
@@ -63,16 +55,12 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
     override fun latestUpdatesRequest(page: Int): Request {
         val newHeaders = headersBuilder()
             .set("Referer", "$baseUrl/titles/recent/?t=episode")
-            .add("X-Requested-With", "XMLHttpRequest")
             .build()
 
-        val apiUrl = "$API_URL/titles/recent/list".toHttpUrl().newBuilder()
-            .addQueryParameter("page", page.toString())
-            .addQueryParameter("pageSize", POPULAR_PAGE_SIZE)
+        val apiUrl = "$API_URL/titles/recent/".toHttpUrl().newBuilder()
+            .addQueryParameter("page", testLastPage)
             .addQueryParameter("l", lang)
-            .addQueryParameter("c", "episode")
-            .addQueryParameter("isWebview", "false")
-            .addQueryParameter("_", System.currentTimeMillis().toString())
+            .addQueryParameter("t", "episode")
             .toString()
 
         return GET(apiUrl, newHeaders)
@@ -90,16 +78,14 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
             .add("X-Requested-With", "XMLHttpRequest")
             .build()
 
-        val apiUrl = "$API_URL/search/titles".toHttpUrl().newBuilder()
-            .addQueryParameter("keyword", query)
-            .addQueryParameter("page", page.toString())
-            .addQueryParameter("pageSize", POPULAR_PAGE_SIZE)
-            .addQueryParameter("sort", "newly")
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+        val searchUrl = "$baseUrl/keywords".toHttpUrl().newBuilder()
+            .addQueryParameter("q", query)
+            .addQueryParameter("s", "date")
             .addQueryParameter("lang", lang)
-            .addQueryParameter("_", System.currentTimeMillis().toString())
             .toString()
 
-        return GET(apiUrl, newHeaders)
+        return GET(searchUrl, headers)
     }
 
     override fun searchMangaParse(response: Response): MangasPage = popularMangaParse(response)
@@ -125,20 +111,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
     }
 
     override fun chapterListRequest(manga: SManga): Request {
-        val titleId = manga.url.substringAfterLast("/")
-
-        val newHeaders = headersBuilder()
-            .set("Referer", baseUrl + manga.url)
-            .add("X-Requested-With", "XMLHttpRequest")
-            .build()
-
-        val apiUrl = "$API_URL/titles/$titleId/episodes/".toHttpUrl().newBuilder()
-            .addQueryParameter("page", "1")
-            .addQueryParameter("pageSize", CHAPTER_PAGE_SIZE)
-            .addQueryParameter("_", System.currentTimeMillis().toString())
-            .toString()
-
-        return GET(apiUrl, newHeaders)
+        return GET("${manga.url}/?page=1")
     }
 
     override fun chapterListParse(response: Response): List<SChapter> {
@@ -152,18 +125,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
     }
 
     override fun pageListRequest(chapter: SChapter): Request {
-        val chapterId = chapter.url.substringAfterLast("/")
-
-        val newHeaders = headersBuilder()
-            .set("Referer", baseUrl + chapter.url)
-            .add("X-Requested-With", "XMLHttpRequest")
-            .build()
-
-        val apiUrl = "$API_URL/episodes/pageList/$chapterId/".toHttpUrl().newBuilder()
-            .addQueryParameter("_", System.currentTimeMillis().toString())
-            .toString()
-
-        return GET(apiUrl, newHeaders)
+        return GET(chapter.url)
     }
 
     override fun pageListParse(response: Response): List<Page> {
@@ -196,7 +158,8 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
     }
 
     companion object {
-        private const val API_URL = "https://medibang.com/api/mpc"
+        private const val BASE_URL = "https://mangaplus-creators.jp"
+        private const val API_URL = "$BASE_URL/api"
         private const val USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
             "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36"
 

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -57,10 +57,10 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
     }
 
     private fun popularElementToSManga(element: Element): SManga {
-        val titleThumbnailUrl = element.select(".image-area img").attr("src")
+        val titleThumbnailUrl = element.selectFirst(".image-area img")!!.attr("src")
         val titleContentId = titleThumbnailUrl.toHttpUrl().pathSegments[2]
         return SManga.create().apply {
-            title = element.select(".title-area .title").text().toString()
+            title = element.selectFirst(".title-area .title")!!.text().toString()
             thumbnail_url = titleThumbnailUrl
             setUrlWithoutDomain("/titles/$titleContentId")
         }
@@ -121,7 +121,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
             return client.newCall(GET("$baseUrl/episodes/$episodeId", headers))
                 .asObservableSuccess().map { response ->
                     val result = response.asJsoup()
-                    val readerElement = result.select("div[react=viewer]")
+                    val readerElement = result.selectFirst("div[react=viewer]")!!
                     val dataTitle = readerElement.attr("data-title")
                     val dataTitleResult = dataTitle.parseAs<MpcReaderDataTitle>()
                     val episodeAsSManga = dataTitleResult.toSManga()
@@ -136,10 +136,10 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
                     val result = response.asJsoup()
                     val elements = result.select("#works .manga-list li .md\\:block")
                     val smangas = elements.map { element ->
-                        val titleThumbnailUrl = element.select(".image-area img").attr("src")
+                        val titleThumbnailUrl = element.selectFirst(".image-area img")!!.attr("src")
                         val titleContentId = titleThumbnailUrl.toHttpUrl().pathSegments[2]
                         SManga.create().apply {
-                            title = element.select("p.text-white").text().toString()
+                            title = element.selectFirst("p.text-white")!!.text().toString()
                             thumbnail_url = titleThumbnailUrl
                             setUrlWithoutDomain("/titles/$titleContentId")
                         }
@@ -272,8 +272,8 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
 
     private fun chapterElementToSChapter(element: Element): SChapter {
         val episode = element.attr("href").substringAfterLast("/")
-        val latestUpdatedDate = element.select(".first-update").text()
-        val chapterNumberElement = element.select(".number").text()
+        val latestUpdatedDate = element.selectFirst(".first-update")!!.text()
+        val chapterNumberElement = element.selectFirst(".number")!!.text()
         val chapterNumber = chapterNumberElement.substringAfter("#").toFloatOrNull()
         return SChapter.create().apply {
             setUrlWithoutDomain("/episodes/$episode")
@@ -290,7 +290,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
     // PAGES & IMAGES Section
     override fun pageListParse(response: Response): List<Page> {
         val result = response.asJsoup()
-        val readerElement = result.select("div[react=viewer]")
+        val readerElement = result.selectFirst("div[react=viewer]")!!
         val dataPages = readerElement.attr("data-pages")
         val refererUrl = response.request.url.toString()
         return dataPages.parseAs<MpcReaderDataPages>().pc.map {

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -240,18 +240,16 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         var hasNextPage = chapterListResponse.hasNextPage
         val titleContentId = response.request.url.pathSegments[1]
         var page = 1
-        run breaking@{
-            while (hasNextPage) {
+        while (hasNextPage) {
                 page += 1
                 val nextPageRequest = chapterListPageRequest(page, titleContentId)
                 val nextPageResponse = client.newCall(nextPageRequest).execute()
                 val nextPageResult = chapterListPageParse(nextPageResponse)
                 if (nextPageResult.chapters.isEmpty()) {
-                    return@breaking
+                    break
                 }
                 chapterListResult.addAll(nextPageResult.chapters)
                 hasNextPage = nextPageResult.hasNextPage
-            }
         }
 
         return chapterListResult.asReversed()

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -87,10 +87,12 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
 
         val titles = result.titles.orEmpty().map(MpcTitle::toSManga)
 
+        // TODO: handle last page of latest
         return MangasPage(titles, result.status != "error")
     }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+        // TODO: maybe this needn't be a new builder and just similar to `popularUrl` above?
         val searchUrl = "$baseUrl/keywords".toHttpUrl().newBuilder()
             .addQueryParameter("q", query)
             .addQueryParameter("s", "date")

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -241,15 +241,15 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         val titleContentId = response.request.url.pathSegments[1]
         var page = 1
         while (hasNextPage) {
-                page += 1
-                val nextPageRequest = chapterListPageRequest(page, titleContentId)
-                val nextPageResponse = client.newCall(nextPageRequest).execute()
-                val nextPageResult = chapterListPageParse(nextPageResponse)
-                if (nextPageResult.chapters.isEmpty()) {
-                    break
-                }
-                chapterListResult.addAll(nextPageResult.chapters)
-                hasNextPage = nextPageResult.hasNextPage
+            page += 1
+            val nextPageRequest = chapterListPageRequest(page, titleContentId)
+            val nextPageResponse = client.newCall(nextPageRequest).execute()
+            val nextPageResult = chapterListPageParse(nextPageResponse)
+            if (nextPageResult.chapters.isEmpty()) {
+                break
+            }
+            chapterListResult.addAll(nextPageResult.chapters)
+            hasNextPage = nextPageResult.hasNextPage
         }
 
         return chapterListResult.asReversed()

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -46,7 +46,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         "div.item-recent",
     )
 
-    fun parseMangasPageFromElement(response: Response, selector: String): MangasPage {
+    private fun parseMangasPageFromElement(response: Response, selector: String): MangasPage {
         val result = response.asJsoup()
 
         val mangas = result.select(selector).map { element ->
@@ -56,7 +56,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         return MangasPage(mangas, false)
     }
 
-    fun popularElementToSManga(element: Element): SManga {
+    private fun popularElementToSManga(element: Element): SManga {
         val titleThumbnailUrl = element.select(".image-area img").attr("src")
         val titleContentId = titleThumbnailUrl.toHttpUrl().pathSegments[2]
         return SManga.create().apply {
@@ -86,7 +86,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         return MangasPage(titles, result.status != "error")
     }
 
-    fun MpcTitle.toSManga(): SManga {
+    private fun MpcTitle.toSManga(): SManga {
         val mTitle = this.title
         val mAuthor = this.author.name // TODO: maybe not required
         return SManga.create().apply {
@@ -177,7 +177,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
             }
     }
 
-    fun MpcReaderDataTitle.toSManga(): SManga {
+    private fun MpcReaderDataTitle.toSManga(): SManga {
         val mTitle = title
         return SManga.create().apply {
             title = mTitle
@@ -229,7 +229,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         return chapterListPageRequest(1, titleContentId)
     }
 
-    fun chapterListPageRequest(page: Int, titleContentId: String): Request {
+    private fun chapterListPageRequest(page: Int, titleContentId: String): Request {
         return GET("$baseUrl/titles/$titleContentId/?page=$page", headers)
     }
 
@@ -257,7 +257,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         return chapterListResult.asReversed()
     }
 
-    fun chapterListPageParse(response: Response): ChaptersPage {
+    private fun chapterListPageParse(response: Response): ChaptersPage {
         val result = response.asJsoup()
         val chapters = result.select(".mod-item-series").map {
                 element ->
@@ -270,7 +270,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         )
     }
 
-    fun chapterElementToSChapter(element: Element): SChapter {
+    private fun chapterElementToSChapter(element: Element): SChapter {
         val episode = element.attr("href").substringAfterLast("/")
         val latestUpdatedDate = element.select(".first-update").text()
         val chapterNumberElement = element.select(".number").text()

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -280,7 +280,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
             chapter_number = if (chapterNumberElement == "One-shot") {
                 0F
             } else {
-                chapterNumber ?: 1F
+                chapterNumber ?: -1F
             }
         }
     }

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -35,6 +35,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
 
     private val json: Json by injectLazy()
 
+    // POPULAR Section
     override fun popularMangaRequest(page: Int): Request {
         val newHeaders = headersBuilder()
             .set("Referer", "$baseUrl/titles/popular/?p=m")
@@ -70,6 +71,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         }
     }
 
+    // LATEST Section
     override fun latestUpdatesRequest(page: Int): Request {
         val newHeaders = headersBuilder()
             .set("Referer", "$baseUrl/titles/recent/?t=episode")
@@ -104,6 +106,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         }
     }
 
+    // SEARCH Section
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
         // TODO: HTTPSource::fetchSearchManga is deprecated? super.getSearchManga
         if (query.startsWith(PREFIX_TITLE_ID_SEARCH)) {
@@ -208,6 +211,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         "div.item-search",
     )
 
+    // MANGA Section
     override fun mangaDetailsParse(response: Response): SManga {
         val result = response.asJsoup()
         val bookBox = result.selectFirst(".book-box")!!
@@ -228,6 +232,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         }
     }
 
+    // CHAPTER Section
     override fun chapterListRequest(manga: SManga): Request {
         val titleContentId = (baseUrl + manga.url).toHttpUrl().pathSegments[1]
         return chapterListPageRequest(1, titleContentId)
@@ -291,6 +296,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         }
     }
 
+    // PAGES & IMAGES Section
     override fun pageListParse(response: Response): List<Page> {
         val result = response.asJsoup()
         val readerElement = result.select("div[react=viewer]")
@@ -315,11 +321,6 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         return GET(page.imageUrl!!, newHeaders)
     }
 
-    private fun parseChapterDate(dateStr: String): Long {
-        return runCatching { CHAPTER_DATE_FORMAT.parse(dateStr)?.time }
-            .getOrNull() ?: 0L
-    }
-
     companion object {
         private val CHAPTER_DATE_FORMAT by lazy {
             SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH)
@@ -333,6 +334,12 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         const val PREFIX_AUTHOR_ID_SEARCH = "author:"
     }
 
+    private fun parseChapterDate(dateStr: String): Long {
+        return runCatching { CHAPTER_DATE_FORMAT.parse(dateStr)?.time }
+            .getOrNull() ?: 0L
+    }
+
+    // FILTERS Section
     override fun getFilterList() = FilterList(
         Filter.Separator(),
         Filter.Header("NOTE: Ignored if using text search!"),

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -28,7 +28,6 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
     override val supportsLatest = true
 
     override fun headersBuilder(): Headers.Builder = Headers.Builder()
-//        .add("Origin", baseUrl.substringBeforeLast("/"))
         .add("Referer", baseUrl)
         .add("User-Agent", USER_AGENT)
 
@@ -74,14 +73,8 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
             .set("Referer", "$baseUrl/titles/recent/?t=episode")
             .build()
 
-        val testLastPage = when (lang) {
-//            "en" -> 100
-            "es" -> 79 + page
-            else -> page
-        }
-
         val apiUrl = "$API_URL/titles/recent/".toHttpUrl().newBuilder()
-            .addQueryParameter("page", page)
+            .addQueryParameter("page", page.toString())
             .addQueryParameter("l", lang)
             .addQueryParameter("t", "episode")
             .toString()
@@ -195,10 +188,6 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         }
     }
 
-    override fun pageListRequest(chapter: SChapter): Request {
-        return GET(baseUrl + chapter.url)
-    }
-
     override fun pageListParse(response: Response): List<Page> {
         val result = response.asJsoup()
         val readerElement = result.select("div[react=viewer]")
@@ -232,15 +221,9 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         private val CHAPTER_DATE_FORMAT by lazy {
             SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH)
         }
-        private const val LTAG = "MPCCC"
         private const val BASE_URL = "https://mangaplus-creators.jp"
         private const val API_URL = "$BASE_URL/api"
         private const val USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
             "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36"
-
-        private const val POPULAR_PAGE_SIZE = "30"
-        private const val CHAPTER_PAGE_SIZE = "200"
-
-        private const val EMPTY_RESPONSE_ERROR = "Empty response from the API. Try again later."
     }
 }

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -332,7 +332,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         Filter.Separator(),
     )
 
-    class SortFilter() : SelectFilter(
+    private class SortFilter() : SelectFilter(
         "Sort",
         listOf(
             SelectFilterOption("Popularity", ""),
@@ -342,7 +342,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         0,
     )
 
-    class GenreFilter() : SelectFilter(
+    private class GenreFilter() : SelectFilter(
         "Genres",
         listOf(
             SelectFilterOption("Fantasy", "fantasy"),
@@ -359,7 +359,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         0,
     )
 
-    abstract class SelectFilter(
+    private abstract class SelectFilter(
         name: String,
         private val options: List<SelectFilterOption>,
         default: Int = 0,
@@ -372,5 +372,5 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
             get() = options[state].value
     }
 
-    data class SelectFilterOption(val name: String, val value: String)
+    private data class SelectFilterOption(val name: String, val value: String)
 }

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -60,7 +60,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         val titleThumbnailUrl = element.selectFirst(".image-area img")!!.attr("src")
         val titleContentId = titleThumbnailUrl.toHttpUrl().pathSegments[2]
         return SManga.create().apply {
-            title = element.selectFirst(".title-area .title")!!.text().toString()
+            title = element.selectFirst(".title-area .title")!!.text()
             thumbnail_url = titleThumbnailUrl
             setUrlWithoutDomain("/titles/$titleContentId")
         }

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -37,8 +37,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
 
     // POPULAR Section
     override fun popularMangaRequest(page: Int): Request {
-        val popularUrl = "$baseUrl/titles/popular/?p=m&l=$lang".toHttpUrl().toString()
-
+        val popularUrl = "$baseUrl/titles/popular/?p=m&l=$lang".toHttpUrl()
         return GET(popularUrl, headers)
     }
 
@@ -73,7 +72,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
             .addQueryParameter("page", page.toString())
             .addQueryParameter("l", lang)
             .addQueryParameter("t", "episode")
-            .toString()
+            .build()
 
         return GET(apiUrl, headers)
     }
@@ -169,7 +168,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
                         else -> { /* Nothing else is supported for now */ }
                     }
                 }
-            }.toString()
+            }.build()
 
         return client.newCall(GET(genreUrl, headers))
             .asObservableSuccess()
@@ -193,7 +192,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
             .addQueryParameter("q", query)
             .addQueryParameter("s", "date")
             .addQueryParameter("lang", lang)
-            .toString()
+            .build()
 
         return GET(searchUrl, headers)
     }

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -25,7 +25,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
 
     override val name = "MANGA Plus Creators by SHUEISHA"
 
-    override val baseUrl = BASE_URL
+    override val baseUrl = "https://mangaplus-creators.jp"
 
     override val supportsLatest = true
 
@@ -322,7 +322,6 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         private val CHAPTER_DATE_FORMAT by lazy {
             SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH)
         }
-        private const val BASE_URL = "https://mangaplus-creators.jp"
         private const val API_URL = "$BASE_URL/api"
         private const val USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
             "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36"

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -294,8 +294,8 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         val dataPages = readerElement.attr("data-pages")
         val refererUrl = response.request.url.toString()
         return dataPages.parseAs<MpcReaderDataPages>().pc.map {
-                (pageNo, imageUrl) ->
-            Page(pageNo, refererUrl, imageUrl)
+                page ->
+            Page(page.pageNo, refererUrl, page.imageUrl)
         }
     }
 
@@ -373,5 +373,5 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
             get() = options[state].value
     }
 
-    private data class SelectFilterOption(val name: String, val value: String)
+    private class SelectFilterOption(val name: String, val value: String)
 }

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -113,7 +113,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
                 else -> SManga.UNKNOWN
             }
             genre = bookBox.select("div.genre-area div.tag-genre")
-                .joinToString { it.text() }
+                .joinToString(", ") { it.text() }
             thumbnail_url = bookBox.selectFirst("div.cover img")!!.attr("data-src")
         }
     }

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -27,6 +27,8 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
 
     override val baseUrl = "https://mangaplus-creators.jp"
 
+    private val apiUrl = "$baseUrl/api"
+
     override val supportsLatest = true
 
     override fun headersBuilder(): Headers.Builder = Headers.Builder()
@@ -75,7 +77,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
             .set("Referer", "$baseUrl/titles/recent/?t=episode")
             .build()
 
-        val apiUrl = "$API_URL/titles/recent/".toHttpUrl().newBuilder()
+        val apiUrl = "$apiUrl/titles/recent/".toHttpUrl().newBuilder()
             .addQueryParameter("page", page.toString())
             .addQueryParameter("l", lang)
             .addQueryParameter("t", "episode")
@@ -322,7 +324,6 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         private val CHAPTER_DATE_FORMAT by lazy {
             SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH)
         }
-        private const val API_URL = "$BASE_URL/api"
         private const val USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
             "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36"
         const val PREFIX_TITLE_ID_SEARCH = "title:"

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -42,7 +42,11 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         return GET(popularUrl, newHeaders)
     }
 
-    override fun popularMangaParse(response: Response): MangasPage {
+    override fun popularMangaParse(response: Response): MangasPage = parseMangasPageFromElement(
+        response, "div.item-recent"
+    )
+
+    fun parseMangasPageFromElement(response: Response, selector: String): MangasPage {
         val result = response.asJsoup()
 
         val mangas = result.select("div.item-recent").map { element ->
@@ -96,7 +100,9 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         return GET(searchUrl, headers)
     }
 
-    override fun searchMangaParse(response: Response): MangasPage = popularMangaParse(response)
+    override fun searchMangaParse(response: Response): MangasPage = parseMangasPageFromElement(
+        response, "item-search"
+    )
 
     override fun mangaDetailsParse(response: Response): SManga {
         val result = response.asJsoup()

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -148,16 +148,18 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         var hasNextPage = chapterListResponse.hasNextPage
         val titleContentId = response.request.url.pathSegments[1]
         var page = 1
-        while (hasNextPage) {
+        run breaking@{
+            while (hasNextPage) {
                 page += 1
                 val nextPageRequest = chapterListPageRequest(page, titleContentId)
                 val nextPageResponse = client.newCall(nextPageRequest).execute()
                 val nextPageResult = chapterListPageParse(nextPageResponse)
                 if (nextPageResult.chapters.isEmpty()) {
-                    break
+                    return@breaking
                 }
                 chapterListResult.addAll(nextPageResult.chapters)
                 hasNextPage = nextPageResult.hasNextPage
+            }
         }
 
         return chapterListResult.asReversed()

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -16,6 +16,7 @@ import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
+import org.jsoup.nodes.Element
 import rx.Observable
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -58,7 +59,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         return MangasPage(mangas, false)
     }
 
-    fun popularElementToSManga(element: org.jsoup.nodes.Element): SManga {
+    fun popularElementToSManga(element: Element): SManga {
         val titleThumbnailUrl = element.select(".image-area img").attr("src")
         val titleContentId = titleThumbnailUrl.toHttpUrl().pathSegments[2]
         return SManga.create().apply {
@@ -276,7 +277,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
         )
     }
 
-    fun chapterElementToSChapter(element: org.jsoup.nodes.Element): SChapter {
+    fun chapterElementToSChapter(element: Element): SChapter {
         val episode = element.attr("href").substringAfterLast("/")
         val latestUpdatedDate = element.select(".first-update").text()
         val chapterNumberElement = element.select(".number").text()

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -92,9 +92,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
     override fun latestUpdatesParse(response: Response): MangasPage {
         val result = json.decodeFromString<MpcResponse>(response.body.string())
 
-        checkNotNull(result.titles) { EMPTY_RESPONSE_ERROR }
-
-        val titles = result.titles.titleList.orEmpty().map(MpcTitle::toSManga)
+        val titles = result.titles.orEmpty().map(MpcTitle::toSManga)
 
         return MangasPage(titles, result.status != "error")
     }
@@ -167,7 +165,7 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
     }
 
     override fun pageListRequest(chapter: SChapter): Request {
-        return GET(chapter.url)
+        return GET(baseUrl + chapter.url)
     }
 
     override fun pageListParse(response: Response): List<Page> {

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -43,13 +43,14 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
     }
 
     override fun popularMangaParse(response: Response): MangasPage = parseMangasPageFromElement(
-        response, "div.item-recent"
+        response,
+        "div.item-recent",
     )
 
     fun parseMangasPageFromElement(response: Response, selector: String): MangasPage {
         val result = response.asJsoup()
 
-        val mangas = result.select("div.item-recent").map { element ->
+        val mangas = result.select(selector).map { element ->
             popularElementToSManga(element)
         }
 
@@ -101,7 +102,8 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
     }
 
     override fun searchMangaParse(response: Response): MangasPage = parseMangasPageFromElement(
-        response, "item-search"
+        response,
+        "div.item-search",
     )
 
     override fun mangaDetailsParse(response: Response): SManga {

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreatorsDto.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreatorsDto.kt
@@ -1,7 +1,6 @@
 package eu.kanade.tachiyomi.extension.all.mangapluscreators
 
 import eu.kanade.tachiyomi.source.model.SChapter
-import eu.kanade.tachiyomi.source.model.SManga
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -18,15 +17,7 @@ data class MpcTitle(
     @SerialName("is_one_shot") val isOneShot: Boolean,
     val author: MpcAuthorDto,
     @SerialName("latest_episode") val latestEpisode: MpcLatestEpisode,
-) {
-
-    fun toSManga(): SManga = SManga.create().apply {
-        title = this@MpcTitle.title
-        thumbnail_url = thumbnail
-        url = "/titles/${latestEpisode.titleConnectId}"
-        author = this@MpcTitle.author.name
-    }
-}
+)
 
 @Serializable
 data class MpcAuthorDto(

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreatorsDto.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreatorsDto.kt
@@ -44,7 +44,7 @@ data class MpcReaderPage(
 data class MpcReaderDataTitle(
     val title: String,
     val thumbnail: String,
-    @SerialName("is_one_shot") val isOneShot: Boolean,
+    @SerialName("is_oneshot") val isOneShot: Boolean,
     @SerialName("contents_id") val contentsId: String,
 )
 

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreatorsDto.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreatorsDto.kt
@@ -7,46 +7,42 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class MpcResponse(
-    @SerialName("mpcEpisodesDto") val episodes: MpcEpisodesDto? = null,
+    val status: String,
     @SerialName("mpcTitlesDto") val titles: MpcTitlesDto? = null,
-    val pageList: List<MpcPage>? = emptyList(),
-)
-
-@Serializable
-data class MpcEpisodesDto(
-    val pagination: MpcPagination? = null,
-    val episodeList: List<MpcEpisode>? = emptyList(),
 )
 
 @Serializable
 data class MpcTitlesDto(
-    val pagination: MpcPagination? = null,
     val titleList: List<MpcTitle>? = emptyList(),
 )
-
-@Serializable
-data class MpcPagination(
-    val page: Int,
-    val maxPage: Int,
-) {
-
-    val hasNextPage: Boolean
-        get() = page < maxPage
-}
 
 @Serializable
 data class MpcTitle(
     @SerialName("titleId") val id: String,
     val title: String,
-    val thumbnailUrl: String,
-) {
+    val thumbnail: String,
+    @SerialName("is_one_shot") val isOneShot: Boolean,
+    val author: MpcAuthorDto,
+    @SerialName("latest_episode") val latestEpisode: MpcLatestEpisode,
+    ) {
 
     fun toSManga(): SManga = SManga.create().apply {
         title = this@MpcTitle.title
-        thumbnail_url = thumbnailUrl
-        url = "/titles/$id"
+        thumbnail_url = thumbnail
+        url = "/titles/${latestEpisode.titleConnectId}"
+        author = this@MpcTitle.author.name
     }
 }
+
+@Serializable
+data class MpcAuthorDto(
+    val name: String,
+)
+
+@Serializable
+data class MpcLatestEpisode(
+    @SerialName("title_connect_id") val titleConnectId: String,
+)
 
 @Serializable
 data class MpcEpisode(

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreatorsDto.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreatorsDto.kt
@@ -5,13 +5,13 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class MpcResponse(
+class MpcResponse(
     val status: String,
     val titles: List<MpcTitle>? = null,
 )
 
 @Serializable
-data class MpcTitle(
+class MpcTitle(
     val title: String,
     val thumbnail: String,
     @SerialName("is_one_shot") val isOneShot: Boolean,
@@ -20,32 +20,32 @@ data class MpcTitle(
 )
 
 @Serializable
-data class MpcAuthorDto(
+class MpcAuthorDto(
     val name: String,
 )
 
 @Serializable
-data class MpcLatestEpisode(
+class MpcLatestEpisode(
     @SerialName("title_connect_id") val titleConnectId: String,
 )
 
 @Serializable
-data class MpcReaderDataPages(
+class MpcReaderDataPages(
     val pc: List<MpcReaderPage>,
 )
 
 @Serializable
-data class MpcReaderPage(
+class MpcReaderPage(
     @SerialName("page_no") val pageNo: Int,
     @SerialName("image_url") val imageUrl: String,
 )
 
 @Serializable
-data class MpcReaderDataTitle(
+class MpcReaderDataTitle(
     val title: String,
     val thumbnail: String,
     @SerialName("is_oneshot") val isOneShot: Boolean,
     @SerialName("contents_id") val contentsId: String,
 )
 
-data class ChaptersPage(val chapters: List<SChapter>, val hasNextPage: Boolean)
+class ChaptersPage(val chapters: List<SChapter>, val hasNextPage: Boolean)

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreatorsDto.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreatorsDto.kt
@@ -49,4 +49,12 @@ data class MpcReaderPage(
     @SerialName("image_url") val imageUrl: String,
 )
 
+@Serializable
+data class MpcReaderDataTitle(
+    val title: String,
+    val thumbnail: String,
+    @SerialName("is_one_shot") val isOneShot: Boolean,
+    @SerialName("contents_id") val contentsId: String,
+)
+
 data class ChaptersPage(val chapters: List<SChapter>, val hasNextPage: Boolean)

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreatorsDto.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreatorsDto.kt
@@ -71,3 +71,5 @@ data class MpcReaderPage(
     @SerialName("page_no") val pageNo: Int,
     @SerialName("image_url") val imageUrl: String,
 )
+
+data class ChaptersPage(val chapters: List<SChapter>, val hasNextPage: Boolean)

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreatorsDto.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreatorsDto.kt
@@ -39,32 +39,9 @@ data class MpcLatestEpisode(
 )
 
 @Serializable
-data class MpcEpisode(
-    @SerialName("episodeId") val id: String,
-    @SerialName("episodeTitle") val title: String,
-    val numbering: Int,
-    val oneshot: Boolean = false,
-    val publishDate: Long,
-) {
-
-    fun toSChapter(): SChapter = SChapter.create().apply {
-        name = if (oneshot) "One-shot" else title
-        date_upload = publishDate
-        url = "/episodes/$id"
-    }
-}
-
-@Serializable
-data class MpcPage(val publicBgImage: String)
-
-@Serializable
 data class MpcReaderDataPages(
     val pc: List<MpcReaderPage>,
-) {
-    fun getPages(): List<MpcReaderPage> {
-        return pc.sortedBy { (pageNo, _) -> pageNo }
-    }
-}
+)
 
 @Serializable
 data class MpcReaderPage(

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreatorsDto.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreatorsDto.kt
@@ -8,23 +8,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class MpcResponse(
     val status: String,
-    @SerialName("mpcTitlesDto") val titles: MpcTitlesDto? = null,
-)
-
-@Serializable
-data class MpcTitlesDto(
-    val titleList: List<MpcTitle>? = emptyList(),
+    val titles: List<MpcTitle>? = null,
 )
 
 @Serializable
 data class MpcTitle(
-    @SerialName("titleId") val id: String,
     val title: String,
     val thumbnail: String,
     @SerialName("is_one_shot") val isOneShot: Boolean,
     val author: MpcAuthorDto,
     @SerialName("latest_episode") val latestEpisode: MpcLatestEpisode,
-    ) {
+) {
 
     fun toSManga(): SManga = SManga.create().apply {
         title = this@MpcTitle.title
@@ -62,3 +56,18 @@ data class MpcEpisode(
 
 @Serializable
 data class MpcPage(val publicBgImage: String)
+
+@Serializable
+data class MpcReaderDataPages(
+    val pc: List<MpcReaderPage>,
+) {
+    fun getPages(): List<MpcReaderPage> {
+        return pc.sortedBy { (pageNo, _) -> pageNo }
+    }
+}
+
+@Serializable
+data class MpcReaderPage(
+    @SerialName("page_no") val pageNo: Int,
+    @SerialName("image_url") val imageUrl: String,
+)


### PR DESCRIPTION
Closes #9614 

Ship of Theseus moment. This is such a hodgepodge, I'll welcome any and all suggestions (or forgotten API endpoints; only latest for now) - also please help with the TODOs or they'll stay there until the next poor soul

I don't know what's the latest in referrals and origins and in my testing (emulator and phone) it didn't seem to have much issues - there is an endpoint with query is_webview=false but that seems to be mostly for the embedded webview within the mangaplus app for notifications/announcements and such /shrug

Also, shoutout to intents for being almost impossible to debug on an emulator. (I refuse to believe that there's no way to trigger an intent within android studio to an emulator - maybe its because I chose aosp for storage & lolz)

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
