### PR TITLE
fix(Madara): preserve the capitalization of tags and genres

### DIFF
--- a/lib-multisrc/madara/build.gradle.kts
+++ b/lib-multisrc/madara/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 42
+baseVersionCode = 43
 
 dependencies {
     api(project(":lib:cryptoaes"))

--- a/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
+++ b/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
@@ -702,12 +702,11 @@ abstract class Madara(
                 }
             }
             val genres = select(mangaDetailsSelectorGenre)
-                .map { element -> element.text().lowercase(Locale.ROOT) }
-                .toMutableSet()
+                .mapTo(ArrayList()) { element -> element.text() }
 
             if (mangaDetailsSelectorTag.isNotEmpty()) {
                 select(mangaDetailsSelectorTag).forEach { element ->
-                    if (genres.contains(element.text()).not() &&
+                    if (
                         element.text().length <= 25 &&
                         element.text().contains("read", true).not() &&
                         element.text().contains(name, true).not() &&
@@ -715,29 +714,19 @@ abstract class Madara(
                         element.text().contains(manga.title, true).not() &&
                         element.text().contains(altName, true).not()
                     ) {
-                        genres.add(element.text().lowercase(Locale.ROOT))
+                        genres.add(element.text())
                     }
                 }
             }
 
             // add manga/manhwa/manhua thinggy to genre
             document.selectFirst(seriesTypeSelector)?.ownText()?.let {
-                if (it.isEmpty().not() && it.notUpdating() && it != "-" && genres.contains(it).not()) {
-                    genres.add(it.lowercase(Locale.ROOT))
+                if (it.isEmpty().not() && it.notUpdating() && it != "-") {
+                    genres.add(it)
                 }
             }
 
-            manga.genre = genres.toList().joinToString { genre ->
-                genre.replaceFirstChar {
-                    if (it.isLowerCase()) {
-                        it.titlecase(
-                            Locale.ROOT,
-                        )
-                    } else {
-                        it.toString()
-                    }
-                }
-            }
+            manga.genre = genres.distinctBy(String::lowercase).joinToString()
 
             // add alternative name to manga description
             document.selectFirst(altNameSelector)?.ownText()?.let {


### PR DESCRIPTION
Fixed the capitalization of tags and genres by manually lowercasing strings and comparing with `any` + predicate.  

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
