### PR TITLE
Strip all AGP version data from APKs

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -80,11 +80,6 @@ android {
         resources.excludes.add("kotlin-tooling-metadata.json")
     }
 
-    // https://stackoverflow.com/a/77745844
-    tasks.withType(com.android.build.gradle.tasks.PackageAndroidArtifact).configureEach {
-        doFirst { appMetadata.asFile.getOrNull()?.write('') }
-    }
-
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
@@ -123,6 +118,15 @@ tasks.register("writeManifestFile") {
         if (!tempFile.exists()) {
             tempFile.write('<?xml version="1.0" encoding="utf-8"?>\n<manifest />\n')
         }
+    }
+}
+
+afterEvaluate {
+    tasks.withType(com.android.build.gradle.tasks.PackageAndroidArtifact).configureEach {
+        // need to be in afterEvaluate to overwrite default value
+        createdBy = ""
+        // https://stackoverflow.com/a/77745844
+        doFirst { appMetadata.asFile.getOrNull()?.write('') }
     }
 }
 


### PR DESCRIPTION
Follow up of #10131

This further strips `Android Gradle X.XX.X` values from `Created-By` fields in the signature manifests (`META-INF/CERT.SF` and `META-INF/MANIFEST.MF`).

If AGP updates to freeze that value, we can strip the values by signing the APKs manually.