### PR TITLE
fix: changed mangaworld it domain

### DIFF
--- a/src/it/mangaworld/build.gradle
+++ b/src/it/mangaworld/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Mangaworld'
     themePkg = 'mangaworld'
     baseUrl = 'https://www.mangaworld.ac'
-    overrideVersionCode = 8
+    overrideVersionCode = 9
     isNsfw = false
 }
 

--- a/src/it/mangaworld/build.gradle
+++ b/src/it/mangaworld/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Mangaworld'
     extClass = '.Mangaworld'
     themePkg = 'mangaworld'
-    baseUrl = 'https://www.mangaworld.cx'
+    baseUrl = 'https://www.mangaworld.ac'
     overrideVersionCode = 8
     isNsfw = false
 }

--- a/src/it/mangaworld/src/eu/kanade/tachiyomi/extension/it/mangaworld/Mangaworld.kt
+++ b/src/it/mangaworld/src/eu/kanade/tachiyomi/extension/it/mangaworld/Mangaworld.kt
@@ -4,6 +4,6 @@ import eu.kanade.tachiyomi.multisrc.mangaworld.MangaWorld
 
 class Mangaworld : MangaWorld(
     "Mangaworld",
-    "https://www.mangaworld.cx",
+    "https://www.mangaworld.ac",
     "it",
 )


### PR DESCRIPTION
Closes #10383

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
