### PR TITLE
Fix PoseidonScans missing premium chapters and volume detection

### DIFF
--- a/src/fr/poseidonscans/build.gradle
+++ b/src/fr/poseidonscans/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Poseidon Scans'
     extClass = '.PoseidonScans'
-    extVersionCode = 45
+    extVersionCode = 46
     isNsfw = false
 }
 

--- a/src/fr/poseidonscans/src/eu/kanade/tachiyomi/extension/fr/poseidonscans/PoseidonScans.kt
+++ b/src/fr/poseidonscans/src/eu/kanade/tachiyomi/extension/fr/poseidonscans/PoseidonScans.kt
@@ -418,7 +418,7 @@ class PoseidonScans : HttpSource() {
                 val chapterNumberString = ch.number.toString().removeSuffix(".0")
                 SChapter.create().apply {
                     val isVolume = ch.isVolume == true || (
-                            ch.number == ch.number.toInt().toFloat() &&
+                        ch.number == ch.number.toInt().toFloat() &&
                             ch.title?.lowercase()?.contains("volume") == true
                         )
 

--- a/src/fr/poseidonscans/src/eu/kanade/tachiyomi/extension/fr/poseidonscans/PoseidonScansDto.kt
+++ b/src/fr/poseidonscans/src/eu/kanade/tachiyomi/extension/fr/poseidonscans/PoseidonScansDto.kt
@@ -41,6 +41,8 @@ class ChapterData(
     val title: String? = null,
     val createdAt: String,
     val isPremium: Boolean? = false,
+    val premiumUntil: String? = null,
+    val isVolume: Boolean? = false,
 )
 
 @Serializable


### PR DESCRIPTION
Fixed missing chapters with expired premium status and added automatic volume detection to display "Volume X" instead of "Chapitre X" for volume entries.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
