### PR TITLE
Manga Pro: Use API URL

### DIFF
--- a/src/ar/mangapro/build.gradle
+++ b/src/ar/mangapro/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaPro'
     themePkg = 'iken'
     baseUrl = 'https://promanga.net'
-    overrideVersionCode = 29
+    overrideVersionCode = 30
     isNsfw = false
 }
 

--- a/src/ar/mangapro/src/eu/kanade/tachiyomi/extension/ar/mangapro/MangaPro.kt
+++ b/src/ar/mangapro/src/eu/kanade/tachiyomi/extension/ar/mangapro/MangaPro.kt
@@ -6,6 +6,7 @@ class MangaPro : Iken(
     "Manga Pro",
     "ar",
     "https://promanga.net",
+    "https:/api.promanga.net",
 ) {
     override val versionId = 4
 }


### PR DESCRIPTION
Closes #10119, supercedes draft PR #10323
* Some chapters in entries appear "missing" even though it's available on the site, this is most likely their own API/labeling issue (forgetting to unmark previously paid chapters in their API/data)
* Users should enable "Show locked chapters" in the extension's settings to see/read those missing but free chapters available on the site. It works fine despite showing the lock emoji in the chapter list.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
