### PR TITLE
Manga Pro: Fix API URL typo

### DIFF
--- a/src/ar/mangapro/build.gradle
+++ b/src/ar/mangapro/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaPro'
     themePkg = 'iken'
     baseUrl = 'https://promanga.net'
-    overrideVersionCode = 30
+    overrideVersionCode = 31
     isNsfw = false
 }
 

--- a/src/ar/mangapro/src/eu/kanade/tachiyomi/extension/ar/mangapro/MangaPro.kt
+++ b/src/ar/mangapro/src/eu/kanade/tachiyomi/extension/ar/mangapro/MangaPro.kt
@@ -6,7 +6,7 @@ class MangaPro : Iken(
     "Manga Pro",
     "ar",
     "https://promanga.net",
-    "https:/api.promanga.net",
+    "https://api.promanga.net",
 ) {
     override val versionId = 4
 }


### PR DESCRIPTION
Not sure how it fixed the issue before/made the extension work again with said typo, but this fixes/makes the extension actually pull the right Latest entries data now.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
