### PR TITLE
fix(es-manhuaonline): update domain to samuraiscan.com

### DIFF
--- a/src/es/manhuaonline/build.gradle
+++ b/src/es/manhuaonline/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'SamuraiScan'
     extClass = '.SamuraiScan'
     themePkg = 'madara'
-    baseUrl = 'https://samurai.rzword.xyz'
-    overrideVersionCode = 14
+    baseUrl = 'https://samuraiscan.com'
+    overrideVersionCode = 15
     isNsfw = false
 }
 

--- a/src/es/manhuaonline/src/eu/kanade/tachiyomi/extension/es/manhuaonline/SamuraiScan.kt
+++ b/src/es/manhuaonline/src/eu/kanade/tachiyomi/extension/es/manhuaonline/SamuraiScan.kt
@@ -11,7 +11,7 @@ import java.util.Locale
 
 class SamuraiScan : Madara(
     "SamuraiScan",
-    "https://samurai.rzword.xyz",
+    "https://samuraiscan.com",
     "es",
     SimpleDateFormat("dd MMMM, yyyy", Locale("es")),
 ) {


### PR DESCRIPTION
**What**
- Update `baseUrl` from `https://samurai.rzword.xyz` to `https://samuraiscan.com`
- Bump `overrideVersionCode` (+1) for the multisrc extension

**Why**
Old domain is dead/redirecting; new canonical domain is `samuraiscan.com`.

**Notes**
- No source name changes
- `id` kept as original
- Built and tested locally (assembleDebug + install)

Closes #10351

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #10351")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

