### PR TITLE
flamecomics: fix altTitles not parsing correctly

### DIFF
--- a/src/en/flamecomics/build.gradle
+++ b/src/en/flamecomics/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Flame Comics'
     extClass = '.FlameComics'
-    extVersionCode = 43
+    extVersionCode = 44
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComics.kt
+++ b/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComics.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.graphics.Rect
+import android.util.Log
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.source.model.FilterList
@@ -91,7 +92,7 @@ class FlameComics : HttpSource() {
             seriesList.filter { series ->
                 val titles = mutableListOf(series.title)
                 if (series.altTitles != null) {
-                    titles += json.decodeFromString<List<String>>(series.altTitles)
+                    titles += series.altTitles
                 }
                 titles.any { title ->
                     removeSpecialCharsRegex.replace(
@@ -177,6 +178,7 @@ class FlameComics : HttpSource() {
     override fun mangaDetailsParse(response: Response): SManga = SManga.create().apply {
         val seriesData =
             json.decodeFromString<MangaPageData>(response.body.string()).pageProps.series
+        Log.d("flame-mangaDetailsParse", "seriesData, $seriesData")
         title = seriesData.title
         thumbnail_url = thumbnailUrl(seriesData)
         description = Jsoup.parseBodyFragment(seriesData.description).wholeText()
@@ -198,6 +200,7 @@ class FlameComics : HttpSource() {
 
     override fun chapterListParse(response: Response): List<SChapter> {
         val mangaPageData = json.decodeFromString<MangaPageData>(response.body.string())
+        Log.d("flame- chapterListParse", "mangaPageData, $mangaPageData")
         return mangaPageData.pageProps.chapters.map { chapter ->
             SChapter.create().apply {
                 setUrlWithoutDomain(

--- a/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComics.kt
+++ b/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComics.kt
@@ -4,7 +4,6 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.graphics.Rect
-import android.util.Log
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.source.model.FilterList
@@ -178,7 +177,6 @@ class FlameComics : HttpSource() {
     override fun mangaDetailsParse(response: Response): SManga = SManga.create().apply {
         val seriesData =
             json.decodeFromString<MangaPageData>(response.body.string()).pageProps.series
-        Log.d("flame-mangaDetailsParse", "seriesData, $seriesData")
         title = seriesData.title
         thumbnail_url = thumbnailUrl(seriesData)
         description = Jsoup.parseBodyFragment(seriesData.description).wholeText()
@@ -200,7 +198,6 @@ class FlameComics : HttpSource() {
 
     override fun chapterListParse(response: Response): List<SChapter> {
         val mangaPageData = json.decodeFromString<MangaPageData>(response.body.string())
-        Log.d("flame- chapterListParse", "mangaPageData, $mangaPageData")
         return mangaPageData.pageProps.chapters.map { chapter ->
             SChapter.create().apply {
                 setUrlWithoutDomain(

--- a/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComicsDto.kt
+++ b/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComicsDto.kt
@@ -67,7 +67,7 @@ class ChapterPageData(
 @Serializable
 class Series(
     val title: String,
-    val altTitles: String?,
+    val altTitles: List<String>?,
     val description: String,
     val cover: String,
     val type: String,


### PR DESCRIPTION
Closes #10502 & #10506

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
