### PR TITLE
Fix StarboundScans image loading by using data-src attribute

### DIFF
--- a/src/fr/starboundscans/build.gradle
+++ b/src/fr/starboundscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.StarboundScans'
     themePkg = 'madara'
     baseUrl = 'https://starboundscans.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = false
 }
 

--- a/src/fr/starboundscans/src/eu/kanade/tachiyomi/extension/fr/starboundscans/StarboundScans.kt
+++ b/src/fr/starboundscans/src/eu/kanade/tachiyomi/extension/fr/starboundscans/StarboundScans.kt
@@ -65,7 +65,7 @@ class StarboundScans : Madara(
 
     override fun pageListParse(document: Document): List<Page> {
         return document.select("img.wp-manga-chapter-img").mapIndexed { index, element ->
-            val imageUrl = element.attr("abs:src")
+            val imageUrl = element.attr("abs:data-src")
             Page(index, url = document.location(), imageUrl = imageUrl)
         }
     }


### PR DESCRIPTION
Update pageListParse to use data-src instead of src attribute

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
