### PR TITLE
Fix StarboundScans revert to old loading by using src attribute 

### DIFF
--- a/src/fr/starboundscans/build.gradle
+++ b/src/fr/starboundscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.StarboundScans'
     themePkg = 'madara'
     baseUrl = 'https://starboundscans.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
 }
 

--- a/src/fr/starboundscans/src/eu/kanade/tachiyomi/extension/fr/starboundscans/StarboundScans.kt
+++ b/src/fr/starboundscans/src/eu/kanade/tachiyomi/extension/fr/starboundscans/StarboundScans.kt
@@ -8,6 +8,7 @@ import keiyoushi.utils.tryParse
 import okhttp3.Headers
 import okhttp3.Response
 import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -63,9 +64,16 @@ class StarboundScans : Madara(
         }
     }
 
+    private fun Element.imgAttr(): String {
+        return when {
+            hasAttr("data-src") -> attr("abs:data-src")
+            else -> attr("abs:src")
+        }
+    }
+
     override fun pageListParse(document: Document): List<Page> {
         return document.select("img.wp-manga-chapter-img").mapIndexed { index, element ->
-            val imageUrl = element.attr("abs:src")
+            val imageUrl = element.imgAttr()
             Page(index, url = document.location(), imageUrl = imageUrl)
         }
     }

--- a/src/fr/starboundscans/src/eu/kanade/tachiyomi/extension/fr/starboundscans/StarboundScans.kt
+++ b/src/fr/starboundscans/src/eu/kanade/tachiyomi/extension/fr/starboundscans/StarboundScans.kt
@@ -65,7 +65,7 @@ class StarboundScans : Madara(
 
     override fun pageListParse(document: Document): List<Page> {
         return document.select("img.wp-manga-chapter-img").mapIndexed { index, element ->
-            val imageUrl = element.attr("abs:data-src")
+            val imageUrl = element.attr("abs:src")
             Page(index, url = document.location(), imageUrl = imageUrl)
         }
     }


### PR DESCRIPTION
Update pageListParse to use src instead of data-src attribute
Yeah the site just use data-src for 4 days and just revert.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
