### PR TITLE
HentaiRead: Add `Western` category support

### DIFF
--- a/src/en/hentairead/build.gradle
+++ b/src/en/hentairead/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Hentairead'
     themePkg = 'madara'
     baseUrl = 'https://hentairead.com'
-    overrideVersionCode = 9
+    overrideVersionCode = 10
     isNsfw = true
 }
 

--- a/src/en/hentairead/src/eu/kanade/tachiyomi/extension/en/hentairead/HentaiReadFilters.kt
+++ b/src/en/hentairead/src/eu/kanade/tachiyomi/extension/en/hentairead/HentaiReadFilters.kt
@@ -41,6 +41,7 @@ internal class TypeFilter(name: String) :
             "Doujinshi" to "4",
             "Manga" to "52",
             "Artist CG" to "4798",
+            "Western" to "36278",
         ).map { CheckBoxFilter(it.first, it.second, true) },
     )
 internal open class CheckBoxFilter(name: String, val value: String, state: Boolean) : Filter.CheckBox(name, state)


### PR DESCRIPTION
Closes #8961

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
