### PR TITLE
Japscan fix

### DIFF
--- a/src/fr/japscan/build.gradle
+++ b/src/fr/japscan/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Japscan'
     extClass = '.Japscan'
-    extVersionCode = 51
+    extVersionCode = 52
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -227,13 +227,16 @@ class Japscan : ConfigurableSource, ParsedHttpSource() {
     // Those have a span.badge "SPOILER" or "RAW". The additional pseudo selector makes sure to exclude these from the chapter list.
 
     override fun chapterFromElement(element: Element): SChapter {
-        val urlElement = element.selectFirst("*[href~=manga]")!!
+        val urlElement = element.selectFirst("*[href~=manga|manhua|manhwa]")
+        if (urlElement == null) {
+            throw Exception("Impossible de trouver l'URL du chapitre")
+        }
 
         val chapter = SChapter.create()
         chapter.setUrlWithoutDomain(urlElement.attr("href"))
         chapter.name = urlElement.ownText()
-        // Using ownText() doesn't include childs' text, like "VUS" or "RAW" badges, in the chapter name.
-        chapter.date_upload = element.selectFirst("span")!!.text().trim().let { parseChapterDate(it) }
+        // Using ownText() doesn't include child's text, like "VUS" or "RAW" badges, in the chapter name.
+        chapter.date_upload = element.selectFirst("span")?.text()?.trim()?.let { parseChapterDate(it) } ?: 0L
         return chapter
     }
 


### PR DESCRIPTION
Japscan: 9357388ebe9437cf2730e4752aa99c276195133f
 - fix manhua & manhwa url (closes #10276)
 - better error management

---

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [X] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [X] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [X] Have removed `web_hi_res_512.png` when adding a new extension
