### PR TITLE
Manga TV: decode image links, skip redirect

### DIFF
--- a/src/es/mangatv/build.gradle
+++ b/src/es/mangatv/build.gradle
@@ -2,9 +2,13 @@ ext {
     extName = 'Manga TV'
     extClass = '.MangaTV'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://www.mangatv.net'
-    overrideVersionCode = 0
+    baseUrl = 'https://mangatv.net'
+    overrideVersionCode = 1
     isNsfw = true
 }
 
 apply from: "$rootDir/common.gradle"
+
+dependencies {
+    implementation(project(':lib:unpacker'))
+}

--- a/src/es/mangatv/src/eu/kanade/tachiyomi/extension/es/mangatv/MangaTV.kt
+++ b/src/es/mangatv/src/eu/kanade/tachiyomi/extension/es/mangatv/MangaTV.kt
@@ -1,5 +1,7 @@
 package eu.kanade.tachiyomi.extension.es.mangatv
 
+import android.util.Base64
+import eu.kanade.tachiyomi.lib.unpacker.Unpacker
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import eu.kanade.tachiyomi.source.model.Page
 import kotlinx.serialization.json.jsonArray
@@ -10,7 +12,7 @@ import java.util.Locale
 
 class MangaTV : MangaThemesia(
     "Manga  TV",
-    "https://www.mangatv.net",
+    "https://mangatv.net",
     "es",
     mangaUrlDirectory = "/lista",
     dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.ROOT),
@@ -19,14 +21,19 @@ class MangaTV : MangaThemesia(
     override val seriesDescriptionSelector = "b:contains(Sinopsis) + span"
 
     override fun pageListParse(document: Document): List<Page> {
-        val imageListJson = JSON_IMAGE_LIST_REGEX.find(document.toString())?.destructured?.toList()?.get(0).orEmpty()
+        val unpackedScript = document.selectFirst("script:containsData(eval)")!!.data()
+            .let(Unpacker::unpack)
+
+        val imageListJson = JSON_IMAGE_LIST_REGEX.find(unpackedScript)?.destructured?.toList()?.get(0).orEmpty()
         val imageList = try {
             json.parseToJsonElement(imageListJson.replace(TRAILING_COMMA_REGEX, "]")).jsonArray
         } catch (_: IllegalArgumentException) {
             emptyList()
         }
         return imageList.mapIndexed { i, jsonEl ->
-            Page(i, imageUrl = "https:${jsonEl.jsonPrimitive.content}")
+            val encodedLink = jsonEl.jsonPrimitive.content
+            val decodedLink = String(Base64.decode(encodedLink, Base64.DEFAULT))
+            Page(i, imageUrl = "https:$decodedLink")
         }
     }
 

--- a/src/es/mangatv/src/eu/kanade/tachiyomi/extension/es/mangatv/MangaTV.kt
+++ b/src/es/mangatv/src/eu/kanade/tachiyomi/extension/es/mangatv/MangaTV.kt
@@ -3,9 +3,13 @@ package eu.kanade.tachiyomi.extension.es.mangatv
 import android.util.Base64
 import eu.kanade.tachiyomi.lib.unpacker.Unpacker
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.Page
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Request
 import org.jsoup.nodes.Document
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -36,6 +40,17 @@ class MangaTV : MangaThemesia(
             Page(i, imageUrl = "https:$decodedLink")
         }
     }
+
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+        val url = baseUrl.toHttpUrl().newBuilder()
+            .addPathSegment(mangaUrlDirectory.substring(1))
+            .addQueryParameter("s", query)
+            .addQueryParameter("page", page.toString())
+        return GET(url.build(), headers)
+    }
+
+    // TODO: add demografia, order, tipos, genre
+    override fun getFilterList() = FilterList()
 
     companion object {
         val TRAILING_COMMA_REGEX = """,\s+]""".toRegex()


### PR DESCRIPTION
Closes #8753

Old rejected PR: #8850

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
