### PR TITLE
[skip ci] Taiyō: use correct domain in UrlActivity comments

### DIFF
--- a/src/pt/taiyo/src/eu/kanade/tachiyomi/extension/pt/taiyo/TaiyoUrlActivity.kt
+++ b/src/pt/taiyo/src/eu/kanade/tachiyomi/extension/pt/taiyo/TaiyoUrlActivity.kt
@@ -8,7 +8,7 @@ import android.util.Log
 import kotlin.system.exitProcess
 
 /**
- * Springboard that accepts https://www.taiyo.moe/media/<item> intents
+ * Springboard that accepts https://taiyo.moe/media/<item> intents
  * and redirects them to the main Tachiyomi process.
  */
 class TaiyoUrlActivity : Activity() {


### PR DESCRIPTION
For easier grep-ability when looking for old domains.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
