### PR TITLE
Sagrado Império da Britannia: fix search

### DIFF
--- a/src/pt/imperiodabritannia/build.gradle
+++ b/src/pt/imperiodabritannia/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ImperioDaBritannia'
     themePkg = 'madara'
     baseUrl = 'https://imperiodabritannia.com'
-    overrideVersionCode = 6
+    overrideVersionCode = 7
     isNsfw = false
 }
 

--- a/src/pt/imperiodabritannia/src/eu/kanade/tachiyomi/extension/pt/imperiodabritannia/ImperioDaBritannia.kt
+++ b/src/pt/imperiodabritannia/src/eu/kanade/tachiyomi/extension/pt/imperiodabritannia/ImperioDaBritannia.kt
@@ -22,7 +22,7 @@ class ImperioDaBritannia : Madara(
 
     override val useNewChapterEndpoint = true
 
-    override val useLoadMoreRequest = LoadMoreStrategy.Never
+    override val useLoadMoreRequest = LoadMoreStrategy.Always
 
     override val mangaDetailsSelectorTag = ""
 


### PR DESCRIPTION
Closes #10371

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
