### PR TITLE
Mangabox: Fix Selectors

### DIFF
--- a/lib-multisrc/mangabox/build.gradle.kts
+++ b/lib-multisrc/mangabox/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 7
+baseVersionCode = 8

--- a/lib-multisrc/mangabox/src/eu/kanade/tachiyomi/multisrc/mangabox/MangaBox.kt
+++ b/lib-multisrc/mangabox/src/eu/kanade/tachiyomi/multisrc/mangabox/MangaBox.kt
@@ -155,7 +155,7 @@ abstract class MangaBox(
 
     open val simpleQueryPath = "search/story/"
 
-    override fun popularMangaSelector() = "div.truyen-list > div.list-truyen-item-wrap"
+    override fun popularMangaSelector() = "div.truyen-list > div.list-truyen-item-wrap, div.comic-list > .list-comic-item-wrap"
 
     override fun popularMangaRequest(page: Int): Request {
         return GET("$baseUrl/$popularUrlPath$page", headers)
@@ -211,7 +211,7 @@ abstract class MangaBox(
         }
     }
 
-    override fun searchMangaSelector() = ".panel_story_list .story_item, div.list-truyen-item-wrap"
+    override fun searchMangaSelector() = ".panel_story_list .story_item, div.list-truyen-item-wrap, .list-comic-item-wrap .list-story-item"
 
     override fun searchMangaFromElement(element: Element) = mangaFromElement(element)
 


### PR DESCRIPTION
Closes #10696

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
