### PR TITLE
SeitaCelestial: Theme changed

### DIFF
--- a/src/pt/prismascans/build.gradle
+++ b/src/pt/prismascans/build.gradle
@@ -1,9 +1,9 @@
 ext {
     extName = 'Seita Celestial'
     extClass = '.SeitaCelestial'
-    themePkg = 'mangathemesia'
+    themePkg = 'madara'
     baseUrl = 'https://seitacelestial.com'
-    overrideVersionCode = 18
+    overrideVersionCode = 5
     isNsfw = false
 }
 

--- a/src/pt/prismascans/src/eu/kanade/tachiyomi/extension/pt/prismascans/SeitaCelestial.kt
+++ b/src/pt/prismascans/src/eu/kanade/tachiyomi/extension/pt/prismascans/SeitaCelestial.kt
@@ -1,44 +1,25 @@
 package eu.kanade.tachiyomi.extension.pt.prismascans
 
-import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
-import eu.kanade.tachiyomi.network.asObservable
+import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
-import eu.kanade.tachiyomi.source.model.SChapter
-import eu.kanade.tachiyomi.source.model.SManga
 import okhttp3.OkHttpClient
-import rx.Observable
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
-class SeitaCelestial : MangaThemesia(
+class SeitaCelestial : Madara(
     "Seita Celestial",
     "https://seitacelestial.com",
     "pt-BR",
-    mangaUrlDirectory = "/comics",
     dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("pt", "BR")),
 ) {
-
-    // They changed their name from Prisma Scans to Demon Sect and now to Celestial Sect.
     override val id: Long = 8168108118738519332
 
     override val client: OkHttpClient = super.client.newBuilder()
         .rateLimit(1, 2, TimeUnit.SECONDS)
         .build()
 
-    override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> {
-        return client.newCall(chapterListRequest(manga))
-            .asObservable()
-            .map { response ->
-                if (!response.isSuccessful) {
-                    throw Exception(
-                        """
-                            Obra não encontrada.
-                            Realize a migração do título para atualizar.
-                        """.trimIndent(),
-                    )
-                }
-                chapterListParse(response)
-            }
-    }
+    override val useNewChapterEndpoint = true
+
+    override val useLoadMoreRequest = LoadMoreStrategy.Never
 }


### PR DESCRIPTION
Closes #10710

Migrated to Madara, and some entries are compatible, while other entries may need to be migrated to the extension itself

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
