### PR TITLE
fix(buondua): handle single-page URL parsing case

### DIFF
--- a/src/all/buondua/build.gradle
+++ b/src/all/buondua/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Buon Dua'
     extClass = '.BuonDua'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = true
 }
 

--- a/src/all/buondua/src/eu/kanade/tachiyomi/extension/all/buondua/BuonDua.kt
+++ b/src/all/buondua/src/eu/kanade/tachiyomi/extension/all/buondua/BuonDua.kt
@@ -96,6 +96,7 @@ class BuonDua() : ParsedHttpSource() {
         // /xiuren-no-10051---10065-1127-photos-467c89d5b3e204eebe33ddbc54d905b1-47452?page=57
         val maxPage = doc.select("nav.pagination:first-of-type a.pagination-next").last()
             ?.absUrl("href")
+            ?.takeIf { it.startsWith("http") }
             ?.toHttpUrl()
             ?.queryParameter("page")?.toInt() ?: 1
         val basePageUrl = response.request.url


### PR DESCRIPTION
- Fix URL extraction when only one page exists

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
