### PR TITLE
ManhuaTop: Fix Browse

### DIFF
--- a/src/en/manhuatop/build.gradle
+++ b/src/en/manhuatop/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ManhuaTop'
     themePkg = 'madara'
     baseUrl = 'https://manhuatop.org'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/en/manhuatop/src/eu/kanade/tachiyomi/extension/en/manhuatop/ManhuaTop.kt
+++ b/src/en/manhuatop/src/eu/kanade/tachiyomi/extension/en/manhuatop/ManhuaTop.kt
@@ -11,6 +11,8 @@ class ManhuaTop : Madara(
     dateFormat = SimpleDateFormat("MM/dd/yyyy", Locale.ROOT),
 ) {
     override val useLoadMoreRequest = LoadMoreStrategy.Never
+    override fun popularMangaSelector() = ".comic_post__item"
+    override val popularMangaUrlSelector = ".comic_post__title a"
     override val useNewChapterEndpoint = true
 
     override val mangaSubString = "manhua"

--- a/src/en/manhuatop/src/eu/kanade/tachiyomi/extension/en/manhuatop/ManhuaTop.kt
+++ b/src/en/manhuatop/src/eu/kanade/tachiyomi/extension/en/manhuatop/ManhuaTop.kt
@@ -11,7 +11,7 @@ class ManhuaTop : Madara(
     dateFormat = SimpleDateFormat("MM/dd/yyyy", Locale.ROOT),
 ) {
     override val useLoadMoreRequest = LoadMoreStrategy.Never
-    override val useNewChapterEndpoint = false
+    override val useNewChapterEndpoint = true
 
     override val mangaSubString = "manhua"
     override val filterNonMangaItems = false


### PR DESCRIPTION
Closes #10558
* Set `useNewChapterEndpoint` to true (as of writing this, the source borked its chapter list, but trust)
* Updated popularManga selectors to fix Latest/Popular pages (with help from Secozzi)

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
