### PR TITLE
GigaViewer: fix scrambled image detection

### DIFF
--- a/lib-multisrc/gigaviewer/build.gradle.kts
+++ b/lib-multisrc/gigaviewer/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 7
+baseVersionCode = 8

--- a/lib-multisrc/gigaviewer/src/eu/kanade/tachiyomi/multisrc/gigaviewer/GigaViewerDto.kt
+++ b/lib-multisrc/gigaviewer/src/eu/kanade/tachiyomi/multisrc/gigaviewer/GigaViewerDto.kt
@@ -23,6 +23,7 @@ data class GigaViewerReadableProduct(
 @Serializable
 data class GigaViewerPageStructure(
     val pages: List<GigaViewerPage> = emptyList(),
+    val choJuGiga: String,
 )
 
 @Serializable


### PR DESCRIPTION
Closes #10318 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
