### PR TITLE
[Iken] Add lock prefix only if not accessible

### DIFF
--- a/lib-multisrc/iken/build.gradle.kts
+++ b/lib-multisrc/iken/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 10
+baseVersionCode = 11

--- a/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Dto.kt
+++ b/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Dto.kt
@@ -107,7 +107,7 @@ class Chapter(
     fun isLocked() = (isLocked == true) || (isTimeLocked == true)
 
     fun toSChapter(mangaSlug: String?) = SChapter.create().apply {
-        val prefix = if (isLocked()) "🔒 " else ""
+        val prefix = if (!isAccessible()) "🔒 " else ""
         val seriesSlug = mangaSlug ?: mangaPost.slug
         url = "/series/$seriesSlug/$slug#$id"
         name = "${prefix}Chapter $number"

--- a/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Iken.kt
+++ b/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Iken.kt
@@ -171,7 +171,7 @@ abstract class Iken(
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         SwitchPreferenceCompat(screen.context).apply {
             key = showLockedChapterPrefKey
-            title = "Show locked chapters"
+            title = "Show inaccessible chapters"
             setDefaultValue(false)
         }.also(screen::addPreference)
     }


### PR DESCRIPTION
A chapter can still be considered "locked" even if the user has already purchased it. What we really care about is whether a chapter is _accesible_.

Adding a lock to the chapter name when it has already been paid for by the user is confusing, and it has the disadvantage that downloads will have that lock as part of the filename, meaning after the chapter is no longer locked on the site then existing downloads will not be found anymore. (This is not a problem for non-accesible chapters since they by definition can't be downloaded).

TODO: Build and test. I made this edit on my phone since it's so small, might be a bit before I have my laptop to test it.

Checklist:

- [x] N/A Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] N/A Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] N/A Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- N/A Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [x] N/A Have removed `web_hi_res_512.png` when adding a new extension
