### PR TITLE
AnimeSama: Switch to New Endpoint and Direct AnimeSama Link Integration

### DIFF
--- a/src/fr/animesama/AndroidManifest.xml
+++ b/src/fr/animesama/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity
+            android:name=".fr.animesama.AnimeSamaUrlActivity"
+            android:excludeFromRecents="true"
+            android:exported="true"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="anime-sama.fr"
+                    android:pathPattern="/catalogue/..*"
+                    android:scheme="https" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/src/fr/animesama/build.gradle
+++ b/src/fr/animesama/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeSama'
     extClass = '.AnimeSama'
-    extVersionCode = 7
+    extVersionCode = 8
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/animesama/src/eu/kanade/tachiyomi/extension/fr/animesama/AnimeSama.kt
+++ b/src/fr/animesama/src/eu/kanade/tachiyomi/extension/fr/animesama/AnimeSama.kt
@@ -248,10 +248,10 @@ class AnimeSama : ParsedHttpSource() {
                         }
                     }
                     specialRegex.find(command) != null -> {
-                        val title = specialRegex.find(command)!!.groupValues[1]
+                        val chapterTitle = specialRegex.find(command)!!.groupValues[1]
                         parsedChapterList.add(
                             SChapter.create().apply {
-                                name = "Chapitre $title"
+                                name = "Chapitre $chapterTitle"
                                 setUrlWithoutDomain(chapterUrl.newBuilder().addQueryParameter("id", (parsedChapterList.size + 1).toString()).addQueryParameter("title", title).build().toString())
                                 scanlator = translationName
                             },

--- a/src/fr/animesama/src/eu/kanade/tachiyomi/extension/fr/animesama/AnimeSamaUrlActivity.kt
+++ b/src/fr/animesama/src/eu/kanade/tachiyomi/extension/fr/animesama/AnimeSamaUrlActivity.kt
@@ -1,0 +1,38 @@
+package eu.kanade.tachiyomi.extension.fr.animesama
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import kotlin.system.exitProcess
+
+/**
+ * Springboard that accepts https://anime-sama.fr/catalogue/xxxxxx/ intents and redirects them to
+ * the main Tachiyomi process.
+ */
+class AnimeSamaUrlActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val pathSegments = intent?.data?.pathSegments
+        if (pathSegments != null && pathSegments.size > 1) {
+            val id = pathSegments[1]
+            val mainIntent = Intent().apply {
+                action = "eu.kanade.tachiyomi.SEARCH"
+                putExtra("query", "ID:$id")
+                putExtra("filter", packageName)
+            }
+
+            try {
+                startActivity(mainIntent)
+            } catch (e: ActivityNotFoundException) {
+                Log.e("AnimeSamaUrlActivity", e.toString())
+            }
+        } else {
+            Log.e("AnimeSamaUrlActivity", "could not parse uri from intent $intent")
+        }
+
+        finish()
+        exitProcess(0)
+    }
+}


### PR DESCRIPTION
Changelog :  
- Change from the old “episode.js” route, which no longer contained new chapters, to the new endpoint “get_nb_chap_et_img.php”
- Interpretation of the query “ID:xxxx” to obtain a specific manga used to open AnimeSama links directly in the application.

Known bugs :  
- Not sure if it's a bug, but since the latest PR changes, my AnimeSama database contains 132 series outside the library. However, I only read one of them. If you think this is abnormal, I can try to check for a fix, but if you think it's normal, I'll leave it as is.

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
