### PR TITLE
Update Japscan extension to improve chapter URL extraction after the new obfuscation techniques

### DIFF
--- a/src/fr/japscan/build.gradle
+++ b/src/fr/japscan/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Japscan'
     extClass = '.Japscan'
-    extVersionCode = 52
+    extVersionCode = 53
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -245,8 +245,10 @@ class Japscan : ConfigurableSource, ParsedHttpSource() {
                 }
             }
             .distinctBy { it.second }
-            .sortedWith(compareByDescending<Triple<String, String, Boolean>> { it.third }
-            .thenBy { it.second.length }) // Prefer non-href first, then shorter URLs
+            .sortedWith(
+                compareByDescending<Triple<String, String, Boolean>> { it.third }
+                    .thenBy { it.second.length },
+            ) // Prefer non-href first, then shorter URLs
             .map { Pair(it.first, it.second) }
 
         var foundPair: Pair<String, String>? = urlPairs.firstOrNull()

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -227,15 +227,48 @@ class Japscan : ConfigurableSource, ParsedHttpSource() {
     // Those have a span.badge "SPOILER" or "RAW". The additional pseudo selector makes sure to exclude these from the chapter list.
 
     override fun chapterFromElement(element: Element): SChapter {
-        val urlElement = element.selectFirst("*[href~=manga|manhua|manhwa]")
-        if (urlElement == null) {
+        // Only search for a tag with any attribute containing manga/manhua/manhwa
+        val urlPairs = element.getElementsByTag("a")
+            .mapNotNull { el ->
+                // Find the first attribute whose value matches the chapter URL pattern
+                val attrMatch = el.attributes().asList().firstOrNull { attr ->
+                    val value = attr.value
+                    value.startsWith("/manga/") || value.startsWith("/manhua/") || value.startsWith("/manhwa/")
+                }
+                if (attrMatch != null) {
+                    val name = el.ownText().ifBlank { el.text() }
+                    // Mark if the attribute is not "href"
+                    val isNonHref = attrMatch.key != "href"
+                    Triple(name, attrMatch.value, isNonHref)
+                } else {
+                    null
+                }
+            }
+            .distinctBy { it.second }
+            .sortedWith(compareByDescending<Triple<String, String, Boolean>> { it.third }
+            .thenBy { it.second.length }) // Prefer non-href first, then shorter URLs
+            .map { Pair(it.first, it.second) }
+
+        var foundPair: Pair<String, String>? = urlPairs.firstOrNull()
+        // var log = urlPairs.size.toString() + " URLs found:\n"
+        // for ((name, url) in urlPairs) {
+        //     val testUrl = internalBaseUrl + url
+        //     val response = client.newCall(GET(testUrl, headers)).execute()
+        //     log += "$name: $testUrl => ${response}\n"
+        //     if (response.isSuccessful) {
+        //         foundPair = Pair(name, url)
+        //         response.close()
+        //         break
+        //     }
+        //     response.close()
+        // }
+        if (foundPair == null) {
             throw Exception("Impossible de trouver l'URL du chapitre")
         }
 
         val chapter = SChapter.create()
-        chapter.setUrlWithoutDomain(urlElement.attr("href"))
-        chapter.name = urlElement.ownText()
-        // Using ownText() doesn't include child's text, like "VUS" or "RAW" badges, in the chapter name.
+        chapter.setUrlWithoutDomain(foundPair.second)
+        chapter.name = foundPair.first
         chapter.date_upload = element.selectFirst("span")?.text()?.trim()?.let { parseChapterDate(it) } ?: 0L
         return chapter
     }
@@ -299,7 +332,7 @@ class Japscan : ConfigurableSource, ParsedHttpSource() {
         handler.post { webView?.destroy() }
 
         if (latch.count == 1L) {
-            throw Exception("Timed out decrypting image links")
+            throw Exception("Erreur lors de la récupération des pages")
         }
 
         val baseUrlHost = internalBaseUrl.toHttpUrl().host.substringAfter("www.")


### PR DESCRIPTION
Update Japscan extension to improve chapter URL extraction after the new obfuscation techniques

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
