### PR TITLE
Arcanescans: fix browse, site changing theme

### DIFF
--- a/src/en/arcanescans/build.gradle
+++ b/src/en/arcanescans/build.gradle
@@ -1,9 +1,9 @@
 ext {
     extName = 'Arcanescans'
     extClass = '.Arcanescans'
-    themePkg = 'madara'
+    themePkg = 'mangathemesia'
     baseUrl = 'https://arcanescans.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 15
     isNsfw = false
 }
 

--- a/src/en/arcanescans/src/eu/kanade/tachiyomi/extension/en/arcanescans/Arcanescans.kt
+++ b/src/en/arcanescans/src/eu/kanade/tachiyomi/extension/en/arcanescans/Arcanescans.kt
@@ -1,5 +1,5 @@
 package eu.kanade.tachiyomi.extension.en.arcanescans
 
-import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 
-class Arcanescans : Madara("Arcanescans", "https://arcanescans.com", "en")
+class Arcanescans : MangaThemesia("Arcanescans", "https://arcanescans.com", "en")


### PR DESCRIPTION
manga url same as previous theme
Closes #10738

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
