### PR TITLE
DoujinHentai: Fix HTTP 404

### DIFF
--- a/src/es/doujinhentai/build.gradle
+++ b/src/es/doujinhentai/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.DoujinHentai'
     themePkg = 'madara'
     baseUrl = 'https://doujinhentai.net'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = true
 }
 


### PR DESCRIPTION
Closes #9690

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
