### PR TITLE
NineManga: Update EN domain

### DIFF
--- a/src/all/ninemanga/build.gradle
+++ b/src/all/ninemanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'NineManga'
     extClass = '.NineMangaFactory'
-    extVersionCode = 21
+    extVersionCode = 22
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/ninemanga/src/eu/kanade/tachiyomi/extension/all/ninemanga/NineMangaFactory.kt
+++ b/src/all/ninemanga/src/eu/kanade/tachiyomi/extension/all/ninemanga/NineMangaFactory.kt
@@ -23,7 +23,7 @@ class NineMangaFactory : SourceFactory {
     )
 }
 
-class NineMangaEn : NineManga("NineMangaEn", "https://en.ninemanga.com", "en") {
+class NineMangaEn : NineManga("NineMangaEn", "https://ninemanga.com", "en") {
     override fun latestUpdatesFromElement(element: Element) = SManga.create().apply {
         element.select("a.bookname").let {
             url = it.attr("abs:href").substringAfter("ninemanga.com")


### PR DESCRIPTION
Closes #8874

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
