### PR TITLE
AllManga: Allow nullable image url

### DIFF
--- a/src/en/allanime/build.gradle
+++ b/src/en/allanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AllManga'
     extClass = '.AllManga'
-    extVersionCode = 9
+    extVersionCode = 10
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/Dto.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/Dto.kt
@@ -146,5 +146,5 @@ class Servers(
 
 @Serializable
 class PageUrl(
-    val url: String,
+    val url: String?,
 )


### PR DESCRIPTION
Users will be able to read the other pages, but the download won’t work. I’m not sure if the broken images should be filtered, currently it shows a 404 error

Closes #10841

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
