### PR TITLE
Keyoapp: tweak selector; Asmodeus Scans: filter novel,fix info

### DIFF
--- a/lib-multisrc/keyoapp/build.gradle.kts
+++ b/lib-multisrc/keyoapp/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 17
+baseVersionCode = 18
 
 dependencies {
     api(project(":lib:i18n"))

--- a/lib-multisrc/keyoapp/src/eu/kanade/tachiyomi/multisrc/keyoapp/Keyoapp.kt
+++ b/lib-multisrc/keyoapp/src/eu/kanade/tachiyomi/multisrc/keyoapp/Keyoapp.kt
@@ -231,7 +231,7 @@ abstract class Keyoapp(
             document.selectFirst(typeSelector)?.text()?.replaceFirstChar {
                 if (it.isLowerCase()) {
                     it.titlecase(
-                        Locale.getDefault(),
+                        Locale.ENGLISH,
                     )
                 } else {
                     it.toString()

--- a/lib-multisrc/keyoapp/src/eu/kanade/tachiyomi/multisrc/keyoapp/Keyoapp.kt
+++ b/lib-multisrc/keyoapp/src/eu/kanade/tachiyomi/multisrc/keyoapp/Keyoapp.kt
@@ -215,7 +215,9 @@ abstract class Keyoapp(
     protected open val statusSelector: String = "div:has(span:containsOwn(Status)) ~ div"
     protected open val authorSelector: String = "div:has(span:containsOwn(Author)) ~ div"
     protected open val artistSelector: String = "div:has(span:containsOwn(Artist)) ~ div"
-    protected open val genreSelector: String = "div:has(span:containsOwn(Type)) ~ div"
+    protected open val genreSelector: String = "div.grid:has(>h1) > div > a:not([title='Status'])"
+
+    protected open val typeSelector: String = "div:has(span:containsOwn(Type)) ~ div"
     protected open val dateSelector: String = ".text-xs"
 
     override fun mangaDetailsParse(document: Document): SManga = SManga.create().apply {
@@ -226,7 +228,7 @@ abstract class Keyoapp(
         author = document.selectFirst(authorSelector)?.text()
         artist = document.selectFirst(artistSelector)?.text()
         genre = buildList {
-            document.selectFirst(genreSelector)?.text()?.replaceFirstChar {
+            document.selectFirst(typeSelector)?.text()?.replaceFirstChar {
                 if (it.isLowerCase()) {
                     it.titlecase(
                         Locale.getDefault(),
@@ -235,7 +237,7 @@ abstract class Keyoapp(
                     it.toString()
                 }
             }.let(::add)
-            document.select("div.grid:has(>h1) > div > a").forEach { add(it.text()) }
+            document.select(genreSelector).forEach { add(it.text()) }
         }.joinToString()
     }
 

--- a/src/en/aeinscans/src/eu/kanade/tachiyomi/extension/en/aeinscans/AeinScans.kt
+++ b/src/en/aeinscans/src/eu/kanade/tachiyomi/extension/en/aeinscans/AeinScans.kt
@@ -11,5 +11,5 @@ class AeinScans : Keyoapp(
     override val statusSelector: String = "div[alt=Status]"
     override val authorSelector: String = "div[alt=Author]"
     override val artistSelector: String = "div[alt=Artist]"
-    override val genreSelector: String = "div[alt='Series Type']"
+    override val typeSelector: String = "div[alt='Series Type']"
 }

--- a/src/en/artlapsa/src/eu/kanade/tachiyomi/extension/en/artlapsa/ArtLapsa.kt
+++ b/src/en/artlapsa/src/eu/kanade/tachiyomi/extension/en/artlapsa/ArtLapsa.kt
@@ -66,7 +66,7 @@ class ArtLapsa : Keyoapp("Art Lapsa", "https://artlapsa.com", "en") {
 
     override val descriptionSelector = "#expand_content"
     override val statusSelector = "[alt=Status]"
-    override val genreSelector = "[alt=Type]"
+    override val typeSelector = "[alt=Type]"
 
     override fun chapterListSelector(): String {
         if (!preferences.showPaidChapters) {

--- a/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/Asmotoon.kt
+++ b/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/Asmotoon.kt
@@ -17,13 +17,13 @@ class Asmotoon : Keyoapp(
 
     override val genreSelector: String = ".gap-3 .gap-1 a"
 
-    override fun mangaDetailsParse(document: Document): SManga = SManga.create().apply {
+    override fun mangaDetailsParse(document: Document): SManga {
         return super.mangaDetailsParse(document).apply {
             genre = buildList {
                 document.selectFirst(typeSelector)?.text()?.replaceFirstChar {
                     if (it.isLowerCase()) {
                         it.titlecase(
-                            Locale.getDefault(),
+                            Locale.ENGLISH,
                         )
                     } else {
                         it.toString()

--- a/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/Asmotoon.kt
+++ b/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/Asmotoon.kt
@@ -1,9 +1,36 @@
 package eu.kanade.tachiyomi.extension.en.asmotoon
 
 import eu.kanade.tachiyomi.multisrc.keyoapp.Keyoapp
+import eu.kanade.tachiyomi.source.model.SManga
+import org.jsoup.nodes.Document
+import java.util.Locale
 
 class Asmotoon : Keyoapp(
     "Asmodeus Scans",
     "https://asmotoon.com",
     "en",
-)
+) {
+    // filtering novel entries
+    override fun popularMangaSelector() = "div:contains(Trending) + div .group.overflow-hidden.grid:not(:has(.capitalize:contains(Novel)))"
+    override fun latestUpdatesSelector() = "div.grid > div.group:not(:has(.capitalize:contains(Novel)))"
+    override fun searchMangaSelector() = "#searched_series_page > button:not(:has(.capitalize:contains(Novel)))"
+
+    override val genreSelector: String = ".gap-3 .gap-1 a"
+
+    override fun mangaDetailsParse(document: Document): SManga = SManga.create().apply {
+        return super.mangaDetailsParse(document).apply {
+            genre = buildList {
+                document.selectFirst(typeSelector)?.text()?.replaceFirstChar {
+                    if (it.isLowerCase()) {
+                        it.titlecase(
+                            Locale.getDefault(),
+                        )
+                    } else {
+                        it.toString()
+                    }
+                }.let(::add)
+                document.select(genreSelector).forEach { add(it.text().removeSuffix(",")) }
+            }.joinToString()
+        }
+    }
+}

--- a/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/Asmotoon.kt
+++ b/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/Asmotoon.kt
@@ -15,6 +15,7 @@ class Asmotoon : Keyoapp(
     override fun latestUpdatesSelector() = "div.grid > div.group:not(:has(.capitalize:contains(Novel)))"
     override fun searchMangaSelector() = "#searched_series_page > button:not(:has(.capitalize:contains(Novel)))"
 
+    override val descriptionSelector: String = "#expand_content"
     override val genreSelector: String = ".gap-3 .gap-1 a"
 
     override fun mangaDetailsParse(document: Document): SManga {

--- a/src/en/casacomic/src/eu/kanade/tachiyomi/extension/en/casacomic/CasaComic.kt
+++ b/src/en/casacomic/src/eu/kanade/tachiyomi/extension/en/casacomic/CasaComic.kt
@@ -11,5 +11,5 @@ class CasaComic : Keyoapp(
     override val statusSelector: String = "div[alt=Status]"
     override val authorSelector: String = "div[alt=Author]"
     override val artistSelector: String = "div[alt=Artist]"
-    override val genreSelector: String = "div[alt='Series Type']"
+    override val typeSelector: String = "div[alt='Series Type']"
 }

--- a/src/en/kaynscans/src/eu/kanade/tachiyomi/extension/en/kaynscans/KaynScans.kt
+++ b/src/en/kaynscans/src/eu/kanade/tachiyomi/extension/en/kaynscans/KaynScans.kt
@@ -11,5 +11,5 @@ class KaynScans : Keyoapp(
     override val statusSelector: String = "div[alt=Status]"
     override val authorSelector: String = "div[alt=Author]"
     override val artistSelector: String = "div[alt=Artist]"
-    override val genreSelector: String = "div[alt='Series Type']"
+    override val typeSelector: String = "div[alt='Series Type']"
 }

--- a/src/en/msytoon/src/eu/kanade/tachiyomi/extension/en/msytoon/MSYToon.kt
+++ b/src/en/msytoon/src/eu/kanade/tachiyomi/extension/en/msytoon/MSYToon.kt
@@ -11,5 +11,5 @@ class MSYToon : Keyoapp(
     override val statusSelector: String = "div[alt=Status]"
     override val authorSelector: String = "div[alt=Author]"
     override val artistSelector: String = "div[alt=Artist]"
-    override val genreSelector: String = "div[alt='Series Type']"
+    override val typeSelector: String = "div[alt='Series Type']"
 }

--- a/src/en/nyanukafe/src/eu/kanade/tachiyomi/extension/en/nyanukafe/NyanuKafe.kt
+++ b/src/en/nyanukafe/src/eu/kanade/tachiyomi/extension/en/nyanukafe/NyanuKafe.kt
@@ -11,5 +11,5 @@ class NyanuKafe : Keyoapp(
     override val statusSelector: String = "div[alt=Status]"
     override val authorSelector: String = "div[alt=Author]"
     override val artistSelector: String = "div[alt=Artist]"
-    override val genreSelector: String = "div[alt='Series Type']"
+    override val typeSelector: String = "div[alt='Series Type']"
 }

--- a/src/en/ritharscans/src/eu/kanade/tachiyomi/extension/en/ritharscans/RitharScans.kt
+++ b/src/en/ritharscans/src/eu/kanade/tachiyomi/extension/en/ritharscans/RitharScans.kt
@@ -66,7 +66,7 @@ class RitharScans : Keyoapp("RitharScans", "https://ritharscans.com", "en") {
 
     override val descriptionSelector = "#expand_content"
     override val statusSelector = "[alt=Status]"
-    override val genreSelector = "[alt=Type]"
+    override val typeSelector = "[alt=Type]"
 
     override fun pageListParse(document: Document): List<Page> {
         val (pages, baseLink) = document.selectFirst("[x-data*=pages]")!!.attr("x-data")

--- a/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
+++ b/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
@@ -11,5 +11,5 @@ class ValirScans : Keyoapp(
     override val statusSelector: String = "div[alt=Status]"
     override val authorSelector: String = "div[alt=Author]"
     override val artistSelector: String = "div[alt=Artist]"
-    override val genreSelector: String = "div[alt='Series Type']"
+    override val typeSelector: String = "div[alt='Series Type']"
 }


### PR DESCRIPTION
Asmodeus Scans: filter novel, add/fix genres, clean description - Closes #9471

Keyoapp:
- previous type selector was mistakenly named genre
- make genre selector val
- tweak the genre selector to exclude manga status from genre

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
