### PR TITLE
Zaimanhua: Support search by ID & proactively acquire token

### DIFF
--- a/src/zh/zaimanhua/build.gradle
+++ b/src/zh/zaimanhua/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Zaimanhua'
     extClass = '.Zaimanhua'
-    extVersionCode = 14
+    extVersionCode = 15
     isNsfw = false
 }
 

--- a/src/zh/zaimanhua/src/eu/kanade/tachiyomi/extension/zh/zaimanhua/Filter.kt
+++ b/src/zh/zaimanhua/src/eu/kanade/tachiyomi/extension/zh/zaimanhua/Filter.kt
@@ -3,6 +3,8 @@ package eu.kanade.tachiyomi.extension.zh.zaimanhua
 import eu.kanade.tachiyomi.source.model.Filter
 import okhttp3.HttpUrl
 
+class SearchByIdFilter : Filter.CheckBox("启用ID跳转（搜索纯数字时）")
+
 open class QueryFilter(name: String, private val key: String, private val params: Array<Pair<String, String>>) :
     Filter.Select<String>(name, params.map { it.first }.toTypedArray()) {
     fun addQuery(builder: HttpUrl.Builder) {
@@ -13,7 +15,7 @@ open class QueryFilter(name: String, private val key: String, private val params
     }
 }
 class RankingGroup : Filter.Group<Filter<*>>(
-    "排行榜（搜索文本时无效）",
+    "排行榜（搜索时无效）",
     listOf<Filter<*>>(
         TimeFilter(),
         SortFilter(),


### PR DESCRIPTION
Add the ability to directly open a manga by searching for its ID. A new filter option is added to allow searching for numbers instead of jumping to the manga page.

Close #10898

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
