### PR TITLE
Fix Elder Manga: HTTP 404 on reader

### DIFF
--- a/src/tr/eldermanga/build.gradle
+++ b/src/tr/eldermanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Elder Manga'
     extClass = '.ElderManga'
-    extVersionCode = 1
+    extVersionCode = 2
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/tr/eldermanga/src/eu/kanade/tachiyomi/extension/tr/eldermanga/ElderManga.kt
+++ b/src/tr/eldermanga/src/eu/kanade/tachiyomi/extension/tr/eldermanga/ElderManga.kt
@@ -28,7 +28,7 @@ class ElderManga : HttpSource() {
     override val baseUrl = "https://eldermanga.com"
 
     // CDN used for search API responses and images
-    private val CDN_URL = "https://cdn1.eldermanga.com"
+    private val CDN_URL = "https://manga3.efsaneler.can.re"
 
     override val lang = "tr"
 
@@ -153,7 +153,7 @@ class ElderManga : HttpSource() {
         val results = pageRegex.findAll(script).toList()
         return results.mapIndexed { index, result ->
             val url = result.groups.get(1)!!.value
-            Page(index, imageUrl = "$CDN_URL/upload/series/$url")
+            Page(index, imageUrl = "$CDN_URL/$url")
         }
     }
 


### PR DESCRIPTION
Closes #10518

Updated the CDN URL and image path construction.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
