### PR TITLE
Fix Uzay Manga: HTTP 404 on reader

### DIFF
--- a/src/tr/uzaymanga/build.gradle
+++ b/src/tr/uzaymanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Uzay Manga'
     extClass = '.UzayManga'
-    extVersionCode = 38
+    extVersionCode = 39
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/tr/uzaymanga/src/eu/kanade/tachiyomi/extension/tr/uzaymanga/UzayManga.kt
+++ b/src/tr/uzaymanga/src/eu/kanade/tachiyomi/extension/tr/uzaymanga/UzayManga.kt
@@ -139,7 +139,7 @@ class UzayManga : ParsedHttpSource() {
 
         return pageRegex.findAll(script).mapIndexed { index, result ->
             val url = result.groups.get(1)!!.value
-            Page(index, document.location(), "$CDN_URL/upload/series/$url")
+            Page(index, document.location(), "$CDN_URL/$url")
         }.toList()
     }
 
@@ -155,7 +155,7 @@ class UzayManga : ParsedHttpSource() {
         fragment.any { trim().contains(it, ignoreCase = true) }
 
     companion object {
-        const val CDN_URL = "https://cdn1.uzaymanga.com"
+        const val CDN_URL = "https://manga2.efsaneler.can.re"
         const val URL_SEARCH_PREFIX = "slug:"
         val dateFormat = SimpleDateFormat("MMM d ,yyyy", Locale("tr"))
         val pageRegex = """\\"path\\":\\"([^"]+)\\""".trimIndent().toRegex()


### PR DESCRIPTION
Closes #10324

Updated the CDN URL and image path construction.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
