### PR TITLE
CatharsisWorld Add Url Editor

### DIFF
--- a/src/es/catharsisworld/build.gradle
+++ b/src/es/catharsisworld/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.CatharsisWorld'
     themePkg = 'madara'
     baseUrl = 'https://catharsisworld.dig-it.info'
-    overrideVersionCode = 7
+    overrideVersionCode = 8
     isNsfw = true
 }
 

--- a/src/es/catharsisworld/src/eu/kanade/tachiyomi/extension/es/catharsisworld/CatharsisWorld.kt
+++ b/src/es/catharsisworld/src/eu/kanade/tachiyomi/extension/es/catharsisworld/CatharsisWorld.kt
@@ -21,12 +21,7 @@ class CatharsisWorld :
     ),
     ConfigurableSource {
 
-    private val isCi = System.getenv("CI") == "true"
-
-    override val baseUrl get() = when {
-        isCi -> super.baseUrl
-        else -> preferences.prefBaseUrl
-    }
+    reemplazar  val  baseUrl get()  =  preferencias.prefBaseUrl 
 
     override val versionId = 2
 

--- a/src/es/catharsisworld/src/eu/kanade/tachiyomi/extension/es/catharsisworld/CatharsisWorld.kt
+++ b/src/es/catharsisworld/src/eu/kanade/tachiyomi/extension/es/catharsisworld/CatharsisWorld.kt
@@ -21,7 +21,7 @@ class CatharsisWorld :
     ),
     ConfigurableSource {
 
-    val  baseUrl get()  =  preferencias.prefBaseUrl 
+    override val baseUrl get() = preferences.prefBaseUrl
 
     override val versionId = 2
 

--- a/src/es/catharsisworld/src/eu/kanade/tachiyomi/extension/es/catharsisworld/CatharsisWorld.kt
+++ b/src/es/catharsisworld/src/eu/kanade/tachiyomi/extension/es/catharsisworld/CatharsisWorld.kt
@@ -90,9 +90,15 @@ class CatharsisWorld :
             dialogTitle = "Editar URL de la fuente"
             dialogMessage = "URL por defecto:\n${super.baseUrl}"
             setDefaultValue(super.baseUrl)
-            setOnPreferenceChangeListener { _, _ ->
-                Toast.makeText(screen.context, "Reinicie la aplicación para aplicar los cambios", Toast.LENGTH_LONG).show()
-                true
+            setOnPreferenceChangeListener { _, newVal ->
+                val url = newVal as String
+                try {
+                    val httpurl = url.toHttpUrl()
+                    preferences.prefBaseUrl = "https://${httpurl.host}"
+                } catch (_: Throwable) {
+                    Toast.makeText(screen.context, "Invalid Url", Toast.LENGTH_LONG).show()
+                }
+                false
             }
         }.also { screen.addPreference(it) }
     }

--- a/src/es/catharsisworld/src/eu/kanade/tachiyomi/extension/es/catharsisworld/CatharsisWorld.kt
+++ b/src/es/catharsisworld/src/eu/kanade/tachiyomi/extension/es/catharsisworld/CatharsisWorld.kt
@@ -1,26 +1,55 @@
 package eu.kanade.tachiyomi.extension.es.catharsisworld
 
+import android.content.SharedPreferences
+import android.widget.Toast
+import androidx.preference.EditTextPreference
+import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
+import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
+import keiyoushi.utils.getPreferences
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.jsoup.nodes.Element
 
-class CatharsisWorld : Madara(
-    "Catharsis World",
-    "https://catharsisworld.dig-it.info",
-    "es",
-) {
+class CatharsisWorld :
+    Madara(
+        "Catharsis World",
+        "https://catharsisworld.dig-it.info",
+        "es",
+    ),
+    ConfigurableSource {
+
+    private val isCi = System.getenv("CI") == "true"
+
+    override val baseUrl get() = when {
+        isCi -> super.baseUrl
+        else -> preferences.prefBaseUrl
+    }
+
     override val versionId = 2
 
     override val mangaSubString = "serie"
 
     override val useLoadMoreRequest = LoadMoreStrategy.Always
 
-    override val client = super.client.newBuilder()
-        .rateLimitHost(baseUrl.toHttpUrl(), 3, 1)
-        .build()
+    override val client by lazy {
+        super.client.newBuilder()
+            .rateLimitHost(baseUrl.toHttpUrl(), 3, 1)
+            .build()
+    }
+
+    private val preferences = getPreferences {
+        this.getString(DEFAULT_BASE_URL_PREF, null).let { domain ->
+            if (domain != super.baseUrl) {
+                this.edit()
+                    .putString(BASE_URL_PREF, super.baseUrl)
+                    .putString(DEFAULT_BASE_URL_PREF, super.baseUrl)
+                    .apply()
+            }
+        }
+    }
 
     override fun popularMangaSelector() = "div.latest-poster"
 
@@ -56,5 +85,38 @@ class CatharsisWorld : Madara(
 
     private fun Element.imageFromStyle(): String {
         return this.attr("style").substringAfter("url(").substringBefore(")")
+    }
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        EditTextPreference(screen.context).apply {
+            key = BASE_URL_PREF
+            title = "Editar URL de la fuente"
+            summary = "Para uso temporal, si la extensión se actualiza se perderá el cambio."
+            dialogTitle = "Editar URL de la fuente"
+            dialogMessage = "URL por defecto:\n${super.baseUrl}"
+            setDefaultValue(super.baseUrl)
+            setOnPreferenceChangeListener { _, _ ->
+                Toast.makeText(screen.context, "Reinicie la aplicación para aplicar los cambios", Toast.LENGTH_LONG).show()
+                true
+            }
+        }.also { screen.addPreference(it) }
+    }
+
+    private var _cachedBaseUrl: String? = null
+    private var SharedPreferences.prefBaseUrl: String
+        get() {
+            if (_cachedBaseUrl == null) {
+                _cachedBaseUrl = getString(BASE_URL_PREF, super.baseUrl)!!
+            }
+            return _cachedBaseUrl!!
+        }
+        set(value) {
+            _cachedBaseUrl = value
+            edit().putString(BASE_URL_PREF, value).apply()
+        }
+
+    companion object {
+        private const val BASE_URL_PREF = "overrideBaseUrl"
+        private const val DEFAULT_BASE_URL_PREF = "defaultBaseUrl"
     }
 }

--- a/src/es/catharsisworld/src/eu/kanade/tachiyomi/extension/es/catharsisworld/CatharsisWorld.kt
+++ b/src/es/catharsisworld/src/eu/kanade/tachiyomi/extension/es/catharsisworld/CatharsisWorld.kt
@@ -21,7 +21,7 @@ class CatharsisWorld :
     ),
     ConfigurableSource {
 
-    reemplazar  val  baseUrl get()  =  preferencias.prefBaseUrl 
+    val  baseUrl get()  =  preferencias.prefBaseUrl 
 
     override val versionId = 2
 


### PR DESCRIPTION
I was working on implementing the URL Editor feature in this extension. I know it's a temporary solution until someone updates the extension's domain.

_P.S. This was a personal project, but I wanted to publish it since it has already been tested._

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
