### PR TITLE
AnimeSama - Fix manga with trailing spaces

### DIFF
--- a/src/fr/animesama/build.gradle
+++ b/src/fr/animesama/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeSama'
     extClass = '.AnimeSama'
-    extVersionCode = 8
+    extVersionCode = 9
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/animesama/src/eu/kanade/tachiyomi/extension/fr/animesama/AnimeSama.kt
+++ b/src/fr/animesama/src/eu/kanade/tachiyomi/extension/fr/animesama/AnimeSama.kt
@@ -212,7 +212,7 @@ class AnimeSama : ParsedHttpSource() {
     private fun parseChapterFromResponse(response: Response, translationName: String): List<SChapter> {
         val document = response.asJsoup()
 
-        val title = document.select("#titreOeuvre").text()
+        val title = document.select("#titreOeuvre").textNodes()[0]?.wholeText
         val chapterUrl = "$baseUrl/s2/scans/get_nb_chap_et_img.php".toHttpUrl()
             .newBuilder()
             .addQueryParameter("oeuvre", title)
@@ -313,7 +313,7 @@ class AnimeSama : ParsedHttpSource() {
     override fun pageListParse(document: Document): List<Page> {
         val url = document.baseUri().toHttpUrl()
 
-        val title = url.queryParameter("title")
+        val title = url.queryParameter("oeuvre")
         val chapter = url.queryParameter("id")
 
         val chapterUrl = "$baseUrl/s2/scans/get_nb_chap_et_img.php".toHttpUrl()


### PR DESCRIPTION
Fix mangas with trailing spaces that break listing and downloads (ex Tower of God)



Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
