### PR TITLE
Vortex Scans: Fix `HTTP 500` error appearing on certain entries

### DIFF
--- a/src/en/arvenscans/build.gradle
+++ b/src/en/arvenscans/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Vortex Scans'
     extClass = '.VortexScans'
     themePkg = 'iken'
-    overrideVersionCode = 38
+    overrideVersionCode = 39
     isNsfw = false
 }
 

--- a/src/en/arvenscans/src/eu/kanade/tachiyomi/extension/en/arvenscans/VortexScans.kt
+++ b/src/en/arvenscans/src/eu/kanade/tachiyomi/extension/en/arvenscans/VortexScans.kt
@@ -2,9 +2,13 @@ package eu.kanade.tachiyomi.extension.en.arvenscans
 
 import eu.kanade.tachiyomi.multisrc.iken.Iken
 import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.asObservable
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
+import rx.Observable
 
 class VortexScans : Iken(
     "Vortex Scans",
@@ -35,4 +39,16 @@ class VortexScans : Iken(
     }
     override fun popularMangaParse(response: Response) = searchMangaParse(response)
     val perPage = 18
+
+    override fun fetchMangaDetails(manga: SManga): Observable<SManga> {
+        return client.newCall(mangaDetailsRequest(manga))
+            .asObservable()
+            .map(::mangaDetailsParse)
+    }
+
+    override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> {
+        return client.newCall(chapterListRequest(manga))
+            .asObservable()
+            .map(::chapterListParse)
+    }
 }

--- a/src/en/arvenscans/src/eu/kanade/tachiyomi/extension/en/arvenscans/VortexScans.kt
+++ b/src/en/arvenscans/src/eu/kanade/tachiyomi/extension/en/arvenscans/VortexScans.kt
@@ -40,12 +40,6 @@ class VortexScans : Iken(
     override fun popularMangaParse(response: Response) = searchMangaParse(response)
     val perPage = 18
 
-    override fun fetchMangaDetails(manga: SManga): Observable<SManga> {
-        return client.newCall(mangaDetailsRequest(manga))
-            .asObservable()
-            .map(::mangaDetailsParse)
-    }
-
     override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> {
         return client.newCall(chapterListRequest(manga))
             .asObservable()


### PR DESCRIPTION
Closes #10991

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
