### PR TITLE
Kagane: Fix search and chapters index

### DIFF
--- a/src/en/kagane/build.gradle
+++ b/src/en/kagane/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Kagane'
     extClass = '.Kagane'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = true
 }
 

--- a/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Dto.kt
+++ b/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Dto.kt
@@ -84,10 +84,11 @@ class ChapterDto(
         @SerialName("pages_count")
         val pagesCount: Int,
     ) {
-        fun toSChapter(): SChapter = SChapter.create().apply {
+        fun toSChapter(index: Int): SChapter = SChapter.create().apply {
             url = "$seriesId;$id;$pagesCount"
             name = title
             date_upload = dateFormat.tryParse(releaseDate)
+            chapter_number = index.toFloat()
         }
     }
 

--- a/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Kagane.kt
+++ b/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Kagane.kt
@@ -138,7 +138,9 @@ class Kagane : HttpSource(), ConfigurableSource {
 
     // ============================== Popular ===============================
 
-    override fun popularMangaRequest(page: Int) = searchMangaRequest(page, "", FilterList(SortFilter(0)))
+    override fun popularMangaRequest(page: Int) =
+        searchMangaRequest(page, "", FilterList(SortFilter(1)))
+
     override fun popularMangaParse(response: Response) = searchMangaParse(response)
 
     // =============================== Latest ===============================
@@ -203,7 +205,7 @@ class Kagane : HttpSource(), ConfigurableSource {
 
     override fun chapterListParse(response: Response): List<SChapter> {
         val dto = response.parseAs<ChapterDto>()
-        return dto.content.map { it.toSChapter() }.reversed()
+        return dto.content.mapIndexed { i, it -> it.toSChapter(i) }.reversed()
     }
 
     override fun chapterListRequest(manga: SManga): Request {
@@ -351,11 +353,12 @@ class Kagane : HttpSource(), ConfigurableSource {
             throw Exception("Failed to get drm challenge")
         }
 
-        val challengeUrl = "$apiUrl/api/v1/books/$seriesId/file/$chapterId".toHttpUrl().newBuilder().apply {
-            if (preferences.dataSaver) {
-                addQueryParameter("datasaver", true.toString())
-            }
-        }.build()
+        val challengeUrl =
+            "$apiUrl/api/v1/books/$seriesId/file/$chapterId".toHttpUrl().newBuilder().apply {
+                if (preferences.dataSaver) {
+                    addQueryParameter("datasaver", true.toString())
+                }
+            }.build()
         val challengeBody = buildJsonObject {
             put("challenge", jsInterface.challenge)
         }.toJsonString().toRequestBody("application/json".toMediaType())
@@ -441,7 +444,8 @@ class Kagane : HttpSource(), ConfigurableSource {
     class SortFilter(state: Int = 0) : UriPartFilter(
         "Sort By",
         arrayOf(
-            Pair("Relevance", "avg_views,desc"),
+            Pair("Relevance", ""),
+            Pair("Popular", "avg_views,desc"),
             Pair("Latest", "updated_at"),
             Pair("Latest Descending", "updated_at,desc"),
             Pair("By Name", "series_name"),

--- a/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Kagane.kt
+++ b/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Kagane.kt
@@ -205,7 +205,7 @@ class Kagane : HttpSource(), ConfigurableSource {
 
     override fun chapterListParse(response: Response): List<SChapter> {
         val dto = response.parseAs<ChapterDto>()
-        return dto.content.mapIndexed { i, it -> it.toSChapter(i) }.reversed()
+        return dto.content.mapIndexed { i, it -> it.toSChapter(i + 1) }.reversed()
     }
 
     override fun chapterListRequest(manga: SManga): Request {


### PR DESCRIPTION
Closes #11003 - Force the chapters to follow the correct order
Closes #11008 - This was a filter issue, now should works like the website

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
