### PR TITLE
fix yanmaga1.4.2 not show chapter list problem

### DIFF
--- a/src/ja/yanmaga/build.gradle
+++ b/src/ja/yanmaga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = "Weekly Young Magazine"
     extClass = ".YanmagaFactory"
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/ja/yanmaga/src/eu/kanade/tachiyomi/extension/ja/yanmaga/Yanmaga.kt
+++ b/src/ja/yanmaga/src/eu/kanade/tachiyomi/extension/ja/yanmaga/Yanmaga.kt
@@ -79,10 +79,10 @@ abstract class Yanmaga(
 
         val chapterUrl = response.request.url.toString()
         val firstChapterList = document
-            .select("ul.mod-episode-list:first-of-type > li.mod-episode-item")
+            .select("ul.mod-episode-list:first-of-type > li.mod-episode-item:has(.mod-episode-title)")
             .map { chapterFromElement(it) }
         val lastChapterList = document
-            .select("ul.mod-episode-list:last-of-type > li.mod-episode-item")
+            .select("ul.mod-episode-list:last-of-type > li.mod-episode-item:has(.mod-episode-title)")
             .map { chapterFromElement(it) }
         val totalChapterCount = document
             .selectFirst("#contents")
@@ -132,7 +132,7 @@ abstract class Yanmaga(
             .filter { it.url.isNotEmpty() }
     }
 
-    override fun chapterListSelector() = "ul.mod-episode-list > li.mod-episode-item"
+    override fun chapterListSelector() = "ul.mod-episode-list > li.mod-episode-item:has(.mod-episode-title)"
 
     override fun chapterFromElement(element: Element) = SChapter.create().apply {
         // The first chapter sometimes is a fake one. However, this still count towards the total


### PR DESCRIPTION
Closes #11028 
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
