### PR TITLE
LectorTmo: include book type to genre

### DIFF
--- a/src/es/lectortmo/build.gradle
+++ b/src/es/lectortmo/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'TuMangaOnline'
     extClass = '.LectorTmo'
-    extVersionCode = 8
+    extVersionCode = 9
     isNsfw = true
 }
 

--- a/src/es/lectortmo/src/eu/kanade/tachiyomi/extension/es/lectortmo/LectorTmo.kt
+++ b/src/es/lectortmo/src/eu/kanade/tachiyomi/extension/es/lectortmo/LectorTmo.kt
@@ -239,7 +239,10 @@ class LectorTmo : ParsedHttpSource(), ConfigurableSource {
             author = it.first()?.attr("title")?.substringAfter(", ")
             artist = it.last()?.attr("title")?.substringAfter(", ")
         }
-        genre = (document.select("a.py-2").map { it.text() } + document.selectFirst("h1.book-type")?.text()?.capitalize()).filterNotNull().joinToString(", ")
+        genre = buildList {
+            addAll(document.select("a.py-2").eachText())
+            document.selectFirst("h1.book-type")?.text()?.capitalize()?.also(::add)
+        }.joinToString()
         description = document.select("p.element-description").text()
         status = parseStatus(document.select("span.book-status").text())
         thumbnail_url = document.select(".book-thumbnail").attr("src")

--- a/src/es/lectortmo/src/eu/kanade/tachiyomi/extension/es/lectortmo/LectorTmo.kt
+++ b/src/es/lectortmo/src/eu/kanade/tachiyomi/extension/es/lectortmo/LectorTmo.kt
@@ -239,9 +239,7 @@ class LectorTmo : ParsedHttpSource(), ConfigurableSource {
             author = it.first()?.attr("title")?.substringAfter(", ")
             artist = it.last()?.attr("title")?.substringAfter(", ")
         }
-        genre = document.select("a.py-2").joinToString(", ") {
-            it.text()
-        }
+        genre = (document.select("a.py-2").map { it.text() } + document.selectFirst("h1.book-type")?.text()?.capitalize()).filterNotNull().joinToString(", ")
         description = document.select("p.element-description").text()
         status = parseStatus(document.select("span.book-status").text())
         thumbnail_url = document.select(".book-thumbnail").attr("src")


### PR DESCRIPTION
Refactor genre extraction to include book type

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
