### PR TITLE
ManhwaWeb: Fix incorrect slug

### DIFF
--- a/src/es/manhwaweb/build.gradle
+++ b/src/es/manhwaweb/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ManhwaWeb'
     extClass = '.ManhwaWeb'
-    extVersionCode = 8
+    extVersionCode = 9
     isNsfw = true
 }
 

--- a/src/es/manhwaweb/src/eu/kanade/tachiyomi/extension/es/manhwaweb/ManhwaWebDto.kt
+++ b/src/es/manhwaweb/src/eu/kanade/tachiyomi/extension/es/manhwaweb/ManhwaWebDto.kt
@@ -25,7 +25,7 @@ class PopularComicDto(
     fun toSManga() = SManga.create().apply {
         title = name
         thumbnail_url = thumbnail
-        url = slug.removePrefix("/")
+        url = slug.removePrefix("/").replace("manga/", "manhwa/")
     }
 }
 
@@ -44,16 +44,14 @@ class LatestDto(
 @Serializable
 class LatestComicDto(
     @SerialName("create") val latestChapterDate: Long,
-    @SerialName("id_manhwa") val slug: String,
-    @SerialName("_plataforma") val platform: String,
+    @SerialName("id_rel") val slug: String,
     @SerialName("name_manhwa") private val name: String,
     @SerialName("img") private val thumbnail: String,
 ) {
     fun toSManga() = SManga.create().apply {
         title = name
         thumbnail_url = thumbnail
-        val type = if (platform == "toptoon" || platform == "lezhin") "manhwa" else "manga"
-        url = "$type/$slug"
+        url = "manhwa/$slug"
     }
 }
 
@@ -65,16 +63,14 @@ class PayloadSearchDto(
 
 @Serializable
 class SearchComicDto(
-    @SerialName("_id") val slug: String,
-    @SerialName("_plataforma") val platform: String,
+    @SerialName("real_id") val slug: String,
     @SerialName("the_real_name") private val name: String,
     @SerialName("_imagen") private val thumbnail: String,
 ) {
     fun toSManga() = SManga.create().apply {
         title = name
         thumbnail_url = thumbnail
-        val type = if (platform == "toptoon" || platform == "lezhin") "manhwa" else "manga"
-        url = "$type/$slug"
+        url = "manhwa/$slug"
     }
 }
 


### PR DESCRIPTION
Closes #11073

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
