### PR TITLE
MangaPlus: use alternative api endpoint that contains all latest updates

### DIFF
--- a/src/all/mangaplus/build.gradle
+++ b/src/all/mangaplus/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MANGA Plus by SHUEISHA'
     extClass = '.MangaPlusFactory'
-    extVersionCode = 55
+    extVersionCode = 56
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlus.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlus.kt
@@ -123,8 +123,7 @@ class MangaPlus(
         }
     }
 
-    override fun latestUpdatesRequest(page: Int) =
-        GET("$API_URL/web/web_homeV4?lang=$internalLang&clang=$internalLang&format=json", headers)
+    override fun latestUpdatesRequest(page: Int) = GET("$API_URL/home_v4?lang=$internalLang&clang=$internalLang&format=json", headers)
 
     override fun latestUpdatesParse(response: Response): MangasPage {
         val result = response.asMangaPlusResponse()
@@ -133,26 +132,16 @@ class MangaPlus(
             result.error!!.langPopup(langCode)?.body ?: intl["unknown_error"]
         }
 
-        directory = result.success.webHomeViewV4!!.groups
-            .flatMap(UpdatedTitleV2Group::titleGroups)
-            .flatMap(OriginalTitleGroup::titles)
-            .map(UpdatedTitle::title)
-            .filter { it.language == langCode }
-            .distinctBy(Title::titleId)
+        directory =
+            result.success.homeViewV3!!
+                .groups
+                .flatMap(UpdatedTitleV2Group::titleGroups)
+                .flatMap(OriginalTitleGroup::titles)
+                .map(UpdatedTitle::title)
+                .filter { it.language == langCode }
+                .distinctBy(Title::titleId)
 
         titleCache.putAll(directory.associateBy(Title::titleId))
-        titleCache.putAll(
-            result.success.webHomeViewV4.rankedTitles
-                .flatMap(RankedTitle::titles)
-                .filter { it.language == langCode }
-                .associateBy(Title::titleId),
-        )
-        titleCache.putAll(
-            result.success.webHomeViewV4.featuredTitleLists
-                .flatMap(FeaturedTitleList::featuredTitles)
-                .filter { it.language == langCode }
-                .associateBy(Title::titleId),
-        )
 
         return parseDirectory(1)
     }

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusDto.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusDto.kt
@@ -34,6 +34,7 @@ class SuccessResult(
     val mangaViewer: MangaViewer? = null,
     val allTitlesViewV2: AllTitlesViewV2? = null,
     val webHomeViewV4: WebHomeViewV4? = null,
+    val homeViewV3: HomeViewV3? = null,
 )
 
 @Serializable
@@ -60,6 +61,11 @@ class WebHomeViewV4(
     val groups: List<UpdatedTitleV2Group> = emptyList(),
     val rankedTitles: List<RankedTitle> = emptyList(),
     val featuredTitleLists: List<FeaturedTitleList> = emptyList(),
+)
+
+@Serializable
+class HomeViewV3(
+    val groups: List<UpdatedTitleV2Group> = emptyList(),
 )
 
 @Serializable


### PR DESCRIPTION
icymi mangaplus updated their web ui. This unfortunately has meant that 1 (one) manga among recently updated manga gets put in a banner and doesn't show up in latest updates api endpoint (For eg: [today](https://jumpg-webapi.tokyo-cdn.com/api/home_v4?lang=eng&clang=eng&format=json) it is ["War of Adults"](https://jumpg-webapi.tokyo-cdn.com/api/web/web_homeV4?lang=eng&clang=eng&format=json), yesterday "Bateren Tales", day before "Kami Kill", before that I wasn't checking was anyone?). While this doesn't affect title updates, it feels wrong that a new chapter may exist for a manga but may not show up in latest section. Fortunately, the app still shows all latest updates (for [now](https://jumpg-webapi.tokyo-cdn.com/api/home_v5?lang=eng&clang=eng&format=json), anyways - imo its kinda icky to have to check for multiple `titleGroup` even if simple to do)

Note that it does show up in the API response after like 12hours or so and moreover, may just be a temporary solution until the app also updates to a new web UI (at which point, we might have to include the banner contents and make sure to de-duplicate). Just to account for geographical changes, I'd appreciate more people testing the extension if possible.

If you'd like me to lint/refactor some other portion of this extension in this update, leave a review comment and I'll get to it. If there's someone who wants to convert the icon into an svg for fun using the [favicon](https://mangaplus.shueisha.co.jp/favicon.ico), please send it here to be added.

PS. Linting seems strange because I was playing with [kotlinx-datetime](https://github.com/Kotlin/kotlinx-datetime) and had to update kotlinter, gradle etc and ktlint has newer android studio specific kotlin styling now /shrug. That said, datetime looks cool (perhaps something for #9164? or ext-lib idk. note to self: ktlint v spotless)

PPS. yes, I've seen #5056. My personal solution has been to just add the date into the chapter name but I don't think that's a good solution for GA. There looks to be progress on the app side, so maybe the issue can just be closed once app updates.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
