### PR TITLE
Manga Demon: filter ads, loosen & separate thumbnail ratelimit

### DIFF
--- a/src/en/mangademon/build.gradle
+++ b/src/en/mangademon/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Manga Demon'
     extClass = '.MangaDemon'
-    extVersionCode = 16
+    extVersionCode = 17
     isNsfw = false
 }
 

--- a/src/en/mangademon/src/eu/kanade/tachiyomi/extension/en/mangademon/MangaDemon.kt
+++ b/src/en/mangademon/src/eu/kanade/tachiyomi/extension/en/mangademon/MangaDemon.kt
@@ -30,7 +30,7 @@ class MangaDemon : ParsedHttpSource() {
     override val baseUrl = "https://demonicscans.org"
 
     override val client = network.cloudflareClient.newBuilder()
-        .rateLimit(1)
+        .rateLimit(2)
         .build()
 
     override fun headersBuilder() = super.headersBuilder()
@@ -56,7 +56,7 @@ class MangaDemon : ParsedHttpSource() {
 
     override fun latestUpdatesNextPageSelector() = popularMangaNextPageSelector()
 
-    override fun latestUpdatesSelector() = "div#updates-container > div.updates-element"
+    override fun latestUpdatesSelector() = "div#updates-container > div.updates-element:not(:has(.toffee-badge))"
 
     override fun latestUpdatesFromElement(element: Element) = SManga.create().apply {
         with(element.selectFirst("div.updates-element-info")!!) {


### PR DESCRIPTION
Closes #11129

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
