### PR TITLE
When the cover is damaged, refresh to get the latest cover

### DIFF
--- a/src/zh/picacomic/build.gradle
+++ b/src/zh/picacomic/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Picacomic'
     extClass = '.Picacomic'
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = true
 }
 

--- a/src/zh/picacomic/src/eu/kanade/tachiyomi/extension/zh/picacomic/Picacomic.kt
+++ b/src/zh/picacomic/src/eu/kanade/tachiyomi/extension/zh/picacomic/Picacomic.kt
@@ -284,6 +284,7 @@ class Picacomic : HttpSource(), ConfigurableSource {
                 .distinct()
                 .joinToString(", ")
             status = if (comic.finished) SManga.COMPLETED else SManga.ONGOING
+            thumbnail_url = comic.thumb.let { "${it.fileServer}/static/${it.path}" }
         }
     }
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
