### PR TITLE
Batoto: Custom regex for cleaning title & fix duplicate manga

### DIFF
--- a/src/all/batoto/build.gradle
+++ b/src/all/batoto/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Bato.to'
     extClass = '.BatoToFactory'
-    extVersionCode = 55
+    extVersionCode = 56
     isNsfw = true
 }
 

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
@@ -2,6 +2,9 @@ package eu.kanade.tachiyomi.extension.all.batoto
 
 import android.app.Application
 import android.content.SharedPreferences
+import android.text.Editable
+import android.text.TextWatcher
+import android.widget.Button
 import android.widget.Toast
 import androidx.preference.CheckBoxPreference
 import androidx.preference.EditTextPreference
@@ -94,12 +97,38 @@ open class BatoTo(
             title = "Custom regex to be removed from title"
             summary = customRemoveTitle()
             setDefaultValue("")
+
+            val validate = { str: String ->
+                runCatching { Regex(str) }
+                    .map { true to "" }
+                    .getOrElse { false to it.message }
+            }
+
+            setOnBindEditTextListener { editText ->
+                editText.addTextChangedListener(
+                    object : TextWatcher {
+                        override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+                        override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+
+                        override fun afterTextChanged(editable: Editable?) {
+                            editable ?: return
+                            val text = editable.toString()
+                            val valid = validate(text)
+                            editText.error = if (!valid.first) valid.second else null
+                            editText.rootView.findViewById<Button>(android.R.id.button1)?.isEnabled = editText.error == null
+                        }
+                    },
+                )
+            }
+
             setOnPreferenceChangeListener { _, newValue ->
-                runCatching {
-                    Regex(newValue as String)
-                }.onFailure {
-                    Toast.makeText(screen.context, it.message, Toast.LENGTH_LONG).show()
-                }.isSuccess
+                val (isValid, message) = validate(newValue as String)
+                if (isValid) {
+                    summary = newValue
+                } else {
+                    Toast.makeText(screen.context, message, Toast.LENGTH_LONG).show()
+                }
+                isValid
             }
         }
         screen.addPreference(mirrorPref)

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
@@ -196,7 +196,7 @@ open class BatoTo(
         val manga = SManga.create()
         val item = element.select("a.item-cover")
         val imgurl = item.select("img").attr("abs:src")
-        manga.setUrlWithoutDomain(item.attr("href"))
+        manga.setUrlWithoutDomain(stripSeriesUrl(item.attr("href")))
         manga.title = element.select("a.item-title").text().removeEntities()
             .cleanTitleIfNeeded()
         manga.thumbnail_url = imgurl
@@ -326,7 +326,7 @@ open class BatoTo(
             .cleanTitleIfNeeded()
         manga.thumbnail_url = document.select("div.attr-cover img")
             .attr("abs:src")
-        manga.setUrlWithoutDomain(infoElement.select("h3 a").attr("abs:href"))
+        manga.setUrlWithoutDomain(stripSeriesUrl(infoElement.select("h3 a").attr("abs:href")))
         return MangasPage(listOf(manga), false)
     }
 
@@ -357,7 +357,7 @@ open class BatoTo(
 
     private fun searchUtilsFromElement(element: Element): SManga {
         val manga = SManga.create()
-        manga.setUrlWithoutDomain(element.select("td a").attr("href"))
+        manga.setUrlWithoutDomain(stripSeriesUrl(element.select("td a").attr("href")))
         manga.title = element.select("td a").text()
             .cleanTitleIfNeeded()
         manga.thumbnail_url = element.select("img").attr("abs:src")
@@ -366,7 +366,7 @@ open class BatoTo(
 
     private fun searchHistoryFromElement(element: Element): SManga {
         val manga = SManga.create()
-        manga.setUrlWithoutDomain(element.select(".position-relative a").attr("href"))
+        manga.setUrlWithoutDomain(stripSeriesUrl(element.select(".position-relative a").attr("href")))
         manga.title = element.select(".position-relative a").text()
             .cleanTitleIfNeeded()
         manga.thumbnail_url = element.select("img").attr("abs:src")
@@ -473,9 +473,9 @@ open class BatoTo(
     }
 
     override fun chapterListRequest(manga: SManga): Request {
-        return if (getAltChapterListPref()) {
-            val id = manga.url.substringBeforeLast("/").substringAfterLast("/").trim()
-
+        val id = seriesIdRegex.find(manga.url)
+            ?.groups?.get(1)?.value?.trim()
+        return if (getAltChapterListPref() && !id.isNullOrBlank()) {
             GET("$baseUrl/rss/series/$id.xml", headers)
         } else if (manga.url.startsWith("http")) {
             // Check if trying to use a deprecated mirror, force current mirror
@@ -1088,7 +1088,14 @@ open class BatoTo(
         CheckboxFilterOption("pt-PT", "Portuguese (Portugal)"),
     ).filterNot { it.value == siteLang }
 
+    private fun stripSeriesUrl(url: String): String {
+        val matchResult = seriesUrlRegex.find(url)
+        return matchResult?.groups?.get(1)?.value ?: url
+    }
+
     companion object {
+        private val seriesUrlRegex = Regex("""(.*/series/\d+)/.*""")
+        private val seriesIdRegex = Regex("""series/(\d+)""")
         private const val MIRROR_PREF_KEY = "MIRROR"
         private const val MIRROR_PREF_TITLE = "Mirror"
         private const val REMOVE_TITLE_VERSION_PREF = "REMOVE_TITLE_VERSION"

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
@@ -379,17 +379,28 @@ open class BatoTo(
             }
         }.trim()
 
-        val cleanedTitle = originalTitle
-            .replace(Regex(customRemoveTitle()), "")
-            .replace(if (isRemoveTitleVersion()) titleRegex else Regex(""), "")
-            .trim()
+        val cleanedTitle = originalTitle.let {
+            var tempTitle = it
+            if (customRemoveTitle().isNotEmpty()) {
+                tempTitle = tempTitle.replace(Regex(customRemoveTitle()), "")
+            }
+            if (isRemoveTitleVersion()) {
+                tempTitle = tempTitle.replace(titleRegex, "")
+            }
+            tempTitle.trim()
+        }
 
         manga.title = cleanedTitle
         manga.author = infoElement.select("div.attr-item:contains(author) span").text()
         manga.artist = infoElement.select("div.attr-item:contains(artist) span").text()
         manga.status = parseStatus(workStatus, uploadStatus)
         manga.genre = infoElement.select(".attr-item b:contains(genres) + span ").joinToString { it.text() }
-        manga.description = description
+        manga.description = if (originalTitle.trim() != cleanedTitle) {
+            listOf(originalTitle, description)
+                .joinToString("\n\n")
+        } else {
+            description
+        }
         manga.thumbnail_url = document.select("div.attr-cover img").attr("abs:src")
         return manga
     }


### PR DESCRIPTION
- Add custom regex for cleaning title
- Also cleaning title while browsing/searching
- Add original (un-cleaned) title to description
- Fix duplicate magna due to name changed (Close #11037)
(need to migrate old manga)

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
