### PR TITLE
InmortalScan / Raijin Scans Url Updates

### DIFF
--- a/src/es/inmortalscan/build.gradle
+++ b/src/es/inmortalscan/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Inmortal Scan'
     extClass = '.InmortalScan'
     themePkg = 'madara'
-    baseUrl = 'https://scaninmortal.com'
-    overrideVersionCode = 2
+    baseUrl = 'https://scanimnortal.com'
+    overrideVersionCode = 3
     isNsfw = false
 }
 

--- a/src/es/inmortalscan/src/eu/kanade/tachiyomi/extension/es/inmortalscan/InmortalScan.kt
+++ b/src/es/inmortalscan/src/eu/kanade/tachiyomi/extension/es/inmortalscan/InmortalScan.kt
@@ -6,7 +6,7 @@ import java.util.Locale
 
 class InmortalScan : Madara(
     "Inmortal Scan",
-    "https://scaninmortal.com",
+    "https://scanimnortal.com",
     "es",
     SimpleDateFormat("MMM dd, yyyy", Locale("es")),
 ) {

--- a/src/fr/raijinscans/build.gradle
+++ b/src/fr/raijinscans/build.gradle
@@ -1,8 +1,8 @@
 ext {
     extName = 'Raijin Scans'
     extClass = '.RaijinScans'
-    baseUrl = 'https://raijinscan.co'
-    extVersionCode = 48
+    baseUrl = 'https://raijin-scans.fr'
+    extVersionCode = 49
     isNsfw = false
 }
 

--- a/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
+++ b/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
@@ -24,7 +24,7 @@ import java.util.Locale
 class RaijinScans : HttpSource() {
 
     override val name = "Raijin Scans"
-    override val baseUrl = "https://raijinscan.co"
+    override val baseUrl = "https://raijin-scans.fr"
     override val lang = "fr"
     override val supportsLatest = true
 


### PR DESCRIPTION
closes #11205   The publication says that the old domain is not being updated.

closes #11212

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
