### PR TITLE
Cubari: simplify url handling and search

### DIFF
--- a/src/all/cubari/AndroidManifest.xml
+++ b/src/all/cubari/AndroidManifest.xml
@@ -32,19 +32,6 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:host="*.guya.moe" />
-                <data android:host="guya.moe" />
-
-                <data
-                    android:pathPattern="/proxy/..*"
-                    android:scheme="https" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
                 <data android:host="*.imgur.com" />
                 <data android:host="imgur.com" />
 

--- a/src/all/cubari/README.md
+++ b/src/all/cubari/README.md
@@ -20,6 +20,6 @@ If you've setup the Remote Storage via WebView the Recent tab shows your recent,
 You can visit the [Cubari](https://cubari.moe/) website for for more information.
 
 ### How do I add a gallery to Cubari?
-You can directly open a imgur or Cubari link in the extension.
+You can directly open a imgur or Cubari link in the extension or paste the url in cubari browse
 
 [Uncomment this if needed]: <> (## Guides)

--- a/src/all/cubari/build.gradle
+++ b/src/all/cubari/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Cubari'
     extClass = '.CubariFactory'
-    extVersionCode = 25
+    extVersionCode = 26
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/cubari/src/eu/kanade/tachiyomi/extension/all/cubari/Cubari.kt
+++ b/src/all/cubari/src/eu/kanade/tachiyomi/extension/all/cubari/Cubari.kt
@@ -48,8 +48,8 @@ class Cubari(override val lang: String) : HttpSource() {
             "User-Agent",
             "(Android ${Build.VERSION.RELEASE}; " +
                 "${Build.MANUFACTURER} ${Build.MODEL}) " +
-                "Tachiyomi/Mihon/${AppInfo.getVersionName()} (Keiyoushi) " +
-                Build.ID,
+                "Tachiyomi/${AppInfo.getVersionName()} ${Build.ID} " +
+                "Keiyoushi"
         ).build()
 
     override fun latestUpdatesRequest(page: Int): Request {

--- a/src/all/cubari/src/eu/kanade/tachiyomi/extension/all/cubari/Cubari.kt
+++ b/src/all/cubari/src/eu/kanade/tachiyomi/extension/all/cubari/Cubari.kt
@@ -49,7 +49,7 @@ class Cubari(override val lang: String) : HttpSource() {
             "(Android ${Build.VERSION.RELEASE}; " +
                 "${Build.MANUFACTURER} ${Build.MODEL}) " +
                 "Tachiyomi/${AppInfo.getVersionName()} ${Build.ID} " +
-                "Keiyoushi"
+                "Keiyoushi",
         ).build()
 
     override fun latestUpdatesRequest(page: Int): Request {

--- a/src/all/cubari/src/eu/kanade/tachiyomi/extension/all/cubari/Cubari.kt
+++ b/src/all/cubari/src/eu/kanade/tachiyomi/extension/all/cubari/Cubari.kt
@@ -48,7 +48,7 @@ class Cubari(override val lang: String) : HttpSource() {
             "User-Agent",
             "(Android ${Build.VERSION.RELEASE}; " +
                 "${Build.MANUFACTURER} ${Build.MODEL}) " +
-                "Tachiyomi/Mihon/${AppInfo.getVersionName()} (Keiyoushi)" +
+                "Tachiyomi/Mihon/${AppInfo.getVersionName()} (Keiyoushi) " +
                 Build.ID,
         ).build()
 
@@ -235,7 +235,7 @@ class Cubari(override val lang: String) : HttpSource() {
                     .map { response ->
                         val result = response.parseAs<JsonObject>()
                         val manga = SManga.create().apply {
-                            url = "/read/$source/$slug/"
+                            url = "/read/$source/$slug"
                         }
                         val mangaList = listOf(parseManga(result, manga))
 

--- a/src/all/cubari/src/eu/kanade/tachiyomi/extension/all/cubari/Cubari.kt
+++ b/src/all/cubari/src/eu/kanade/tachiyomi/extension/all/cubari/Cubari.kt
@@ -44,7 +44,7 @@ class Cubari(override val lang: String) : HttpSource() {
         .build()
 
     private val cubariHeaders = super.headersBuilder()
-        .add(
+        .set(
             "User-Agent",
             "(Android ${Build.VERSION.RELEASE}; " +
                 "${Build.MANUFACTURER} ${Build.MODEL}) " +

--- a/src/all/cubari/src/eu/kanade/tachiyomi/extension/all/cubari/CubariUrlActivity.kt
+++ b/src/all/cubari/src/eu/kanade/tachiyomi/extension/all/cubari/CubariUrlActivity.kt
@@ -11,59 +11,20 @@ class CubariUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val host = intent?.data?.host
-        val pathSegments = intent?.data?.pathSegments
 
-        if (host != null && pathSegments != null) {
-            val query = with(host) {
-                when {
-                    equals("m.imgur.com") || equals("imgur.com") -> fromSource("imgur", pathSegments)
-                    equals("m.reddit.com") || equals("reddit.com") || equals("www.reddit.com") -> fromSource("reddit", pathSegments)
-                    equals("imgchest.com") -> fromSource("imgchest", pathSegments)
-                    equals("catbox.moe") || equals("www.catbox.moe") -> fromSource("catbox", pathSegments)
-                    else -> fromCubari(pathSegments)
-                }
-            }
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-            if (query == null) {
-                Log.e("CubariUrlActivity", "Unable to parse URI from intent $intent")
-                finish()
-                exitProcess(1)
-            }
-
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", query)
-                putExtra("filter", packageName)
-            }
-
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("CubariUrlActivity", e.toString())
-            }
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("CubariUrlActivity", "Unable to find activity", e)
         }
 
         finish()
         exitProcess(0)
-    }
-
-    private fun fromSource(source: String, pathSegments: List<String>): String? {
-        if (pathSegments.size >= 2) {
-            val id = pathSegments[1]
-
-            return "${Cubari.PROXY_PREFIX}$source/$id"
-        }
-        return null
-    }
-
-    private fun fromCubari(pathSegments: MutableList<String>): String? {
-        return if (pathSegments.size >= 3) {
-            val source = pathSegments[1]
-            val slug = pathSegments[2]
-            "${Cubari.PROXY_PREFIX}$source/$slug"
-        } else {
-            null
-        }
     }
 }


### PR DESCRIPTION
Simplify searching in Cubari extension. Now users can paste in a cubari url directly in search and it will work. old `cubari:source/slug` format is also still supported.

some other changes:
 - remove `guya.moe` from intent filter, it redirects to `guya.cubari.moe`
 - use `parseAs` instead of `json.decode...`
 - set custom useragent only for cubari requests

<details>

<summary>Screenshots</summary>
<img width="528" height="455" alt="Screenshot From 2025-10-23 16-59-23" src="https://github.com/user-attachments/assets/4b24028e-74bb-4492-884c-27e942bdab84" />
<img width="528" height="455" alt="Screenshot From 2025-10-23 17-00-05" src="https://github.com/user-attachments/assets/555faee2-d12b-47e5-9c4e-3c85e319cf9e" />
<img width="528" height="455" alt="Screenshot From 2025-10-23 17-01-42" src="https://github.com/user-attachments/assets/ae7547b9-7a07-48d3-825e-df97b4d679fb" />
<img width="528" height="455" alt="Screenshot From 2025-10-23 17-02-08" src="https://github.com/user-attachments/assets/0071bf1a-8ccf-4776-a4f4-b1e972593498" />
<img width="528" height="455" alt="Screenshot From 2025-10-23 17-02-29" src="https://github.com/user-attachments/assets/18fbad02-9772-4fff-80f0-b4977d91ab9b" />
<img width="667" height="493" alt="Screenshot From 2025-10-23 17-03-08" src="https://github.com/user-attachments/assets/da5ecebb-6ce3-4c1a-9015-446d62a6d75d" />
<img width="570" height="490" alt="Screenshot From 2025-10-23 17-03-49" src="https://github.com/user-attachments/assets/a19663e0-73a5-446f-89a2-0d0c9307b79f" />
</details> 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
