### PR TITLE
Fixed YakshaComics 403 error

### DIFF
--- a/src/en/yakshacomics/build.gradle
+++ b/src/en/yakshacomics/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.YakshaComics'
     themePkg = 'madara'
     baseUrl = 'https://yakshacomics.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = false
 }
 

--- a/src/en/yakshacomics/src/eu/kanade/tachiyomi/extension/en/yakshacomics/YakshaComics.kt
+++ b/src/en/yakshacomics/src/eu/kanade/tachiyomi/extension/en/yakshacomics/YakshaComics.kt
@@ -1,6 +1,15 @@
 package eu.kanade.tachiyomi.extension.en.yakshacomics
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import okhttp3.FormBody
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.Response
+import java.io.IOException
+import java.security.MessageDigest
 
 class YakshaComics : Madara(
     "YakshaComics",
@@ -8,4 +17,62 @@ class YakshaComics : Madara(
     "en",
 ) {
     override val useNewChapterEndpoint = true
+
+    // Adapted from src/en/yakshascans
+    override val client: OkHttpClient = super.client.newBuilder()
+        .rateLimit(1)
+        .addInterceptor(::jsChallengeInterceptor)
+        .build()
+
+    private fun jsChallengeInterceptor(chain: Interceptor.Chain): Response {
+        val response = chain.proceed(chain.request())
+        if (response.code != 403) {
+            return response
+        }
+        response.close()
+
+        Thread.sleep(3000L)
+        val token = fetchToken(chain).sha256()
+        val body = FormBody.Builder()
+            .add("challenge", token)
+            .build()
+
+        val validateResponse = chain.proceed(POST("$baseUrl/hcdn-cgi/jschallenge-validate", headers, body))
+        validateResponse.use {
+            if (!it.isSuccessful) {
+                throw IOException("Failed to bypass js challenge!")
+            }
+        }
+        return chain.proceed(chain.request())
+    }
+
+    private tailrec fun fetchToken(chain: Interceptor.Chain, attempt: Int = 0): String {
+        if (attempt > MAX_ATTEMPT) {
+            throw IOException("Failed to fetch challenge token!")
+        }
+
+        val response = chain.proceed(GET("$baseUrl/hcdn-cgi/jschallenge", headers))
+        val token = TOKEN_REGEX.find(response.body.string())?.groups?.get(1)?.value
+
+        return if (!token.isNullOrEmpty() && token != "nil") {
+            token
+        } else {
+            fetchToken(chain, attempt + 1)
+        }
+    }
+
+    private fun String.sha256(): String {
+        return MessageDigest
+            .getInstance("SHA-256")
+            .digest(toByteArray())
+            .fold("", { str, it -> str + "%02x".format(it) })
+    }
+
+    override val mangaDetailsSelectorDescription: String =
+        "div.description-summary div.summary__content h3 + p, div.description-summary div.summary__content:not(:has(h3)), div.summary_content div.post-content_item > h5 + div, div.summary_content div.manga-excerpt"
+
+    companion object {
+        private const val MAX_ATTEMPT = 5
+        private val TOKEN_REGEX = """cjs[^']+'([^']+)""".toRegex()
+    }
 }


### PR DESCRIPTION
Adapted code from src/en/yakshascans with slight changes to fix 403 error when fetching mangas for yakshacomics

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
