### PR TITLE
BigSolo : Fix extension #11226

### DIFF
--- a/src/fr/bigsolo/AndroidManifest.xml
+++ b/src/fr/bigsolo/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity
+            android:name=".fr.bigsolo.BigSoloUrlActivity"
+            android:excludeFromRecents="true"
+            android:exported="true"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="bigsolo.org"
+                    android:pathPattern="/..*"
+                    android:scheme="https" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/src/fr/bigsolo/AndroidManifest.xml
+++ b/src/fr/bigsolo/AndroidManifest.xml
@@ -17,6 +17,10 @@
                     android:host="bigsolo.org"
                     android:pathPattern="/..*"
                     android:scheme="https" />
+                <data
+                    android:host="www.bigsolo.org"
+                    android:pathPattern="/..*"
+                    android:scheme="https" />
             </intent-filter>
         </activity>
     </application>

--- a/src/fr/bigsolo/build.gradle
+++ b/src/fr/bigsolo/build.gradle
@@ -1,9 +1,7 @@
 ext {
     extName = 'BigSolo'
     extClass = '.BigSolo'
-    themePkg = 'scanr'
-    baseUrl = 'https://www.bigsolo.org'
-    overrideVersionCode = 1
+    extVersionCode = 3
     isNsfw = false
 }
 

--- a/src/fr/bigsolo/src/eu/kanade/tachiyomi/extension/fr/bigsolo/BigSolo.kt
+++ b/src/fr/bigsolo/src/eu/kanade/tachiyomi/extension/fr/bigsolo/BigSolo.kt
@@ -19,10 +19,11 @@ class BigSolo : HttpSource() {
         private const val SERIES_DATA_SELECTOR = "#series-data-placeholder"
     }
 
-    override val name = "Big Solo"
+    override val name = "BigSolo"
     override val baseUrl = "https://bigsolo.org"
     override val lang = "fr"
     override val supportsLatest = true
+    override val id = 4410528266393104437
 
     // Popular
     override fun popularMangaRequest(page: Int): Request {

--- a/src/fr/bigsolo/src/eu/kanade/tachiyomi/extension/fr/bigsolo/BigSolo.kt
+++ b/src/fr/bigsolo/src/eu/kanade/tachiyomi/extension/fr/bigsolo/BigSolo.kt
@@ -1,10 +1,178 @@
 package eu.kanade.tachiyomi.extension.fr.bigsolo
 
-import eu.kanade.tachiyomi.multisrc.scanr.ScanR
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.parseAs
+import okhttp3.Request
+import okhttp3.Response
+import org.jsoup.nodes.Document
 
-class BigSolo : ScanR(
-    name = "Big Solo",
-    baseUrl = "https://bigsolo.org",
-    lang = "fr",
-    useHighLowQualityCover = true,
-)
+class BigSolo : HttpSource() {
+
+    companion object {
+        private const val SERIES_DATA_SELECTOR = "#series-data-placeholder"
+    }
+
+    override val name = "BigSolo"
+    override val baseUrl = "https://bigsolo.org"
+    override val lang = "fr"
+    override val supportsLatest = false
+
+    private val seriesDataCache = mutableMapOf<String, SeriesData>()
+
+    // Popular
+    override fun popularMangaRequest(page: Int): Request {
+        return GET("$baseUrl/data/config.json", headers)
+    }
+
+    override fun popularMangaParse(response: Response): MangasPage {
+        return searchMangaParse(response)
+    }
+
+    // Latest
+    override fun latestUpdatesRequest(page: Int): Request {
+        throw UnsupportedOperationException()
+    }
+
+    override fun latestUpdatesParse(response: Response): MangasPage {
+        throw UnsupportedOperationException()
+    }
+
+    // Search
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+        val url = if (query.isNotBlank()) {
+            "$baseUrl/data/config.json#$query"
+        } else {
+            "$baseUrl/data/config.json"
+        }
+        return GET(url, headers)
+    }
+
+    override fun searchMangaParse(response: Response): MangasPage {
+        val config = response.parseAs<ConfigResponse>()
+        val mangaList = mutableListOf<SManga>()
+
+        val fragment = response.request.url.fragment
+        val searchQuery = fragment ?: ""
+
+        for (fileName in config.localSeriesFiles) {
+            val seriesData = fetchSeriesData(fileName)
+
+            if (searchQuery.isBlank() || seriesData.title.contains(
+                    searchQuery,
+                    ignoreCase = true,
+                )
+            ) {
+                mangaList.add(seriesData.toSManga())
+            }
+        }
+
+        return MangasPage(mangaList, false)
+    }
+
+    // Details
+    override fun mangaDetailsParse(response: Response): SManga {
+        val document = response.asJsoup()
+        val jsonData = document.selectFirst(SERIES_DATA_SELECTOR)!!.html()
+
+        val seriesData = jsonData.parseAs<SeriesData>()
+        return seriesData.toDetailedSManga()
+    }
+
+    override fun pageListParse(response: Response): List<Page> {
+        val document = response.asJsoup()
+        val chapterNumber = document.location().substringAfterLast("/")
+        val chapterId = extractChapterId(document, chapterNumber)
+        return fetchChapterPages(chapterId)
+    }
+
+    override fun imageUrlParse(response: Response): String {
+        throw UnsupportedOperationException()
+    }
+
+    // Chapters
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val document = response.asJsoup()
+        val jsonData = document.selectFirst(SERIES_DATA_SELECTOR)!!.html()
+
+        val seriesData = jsonData.parseAs<SeriesData>()
+        return buildChapterList(seriesData)
+    }
+
+    private fun fetchSeriesData(fileName: String): SeriesData {
+        val cachedData = seriesDataCache[fileName]
+        if (cachedData != null) {
+            return cachedData
+        }
+
+        val fileUrl = "$baseUrl/data/series/$fileName"
+        val response = client.newCall(GET(fileUrl, headers)).execute()
+        val seriesData = response.parseAs<SeriesData>()
+
+        seriesDataCache[fileName] = seriesData
+
+        return seriesData
+    }
+
+    private fun extractChapterId(document: Document, chapterNumber: String): String {
+        val jsonData = document.selectFirst("#reader-data-placeholder")!!.html()
+
+        val readerData = jsonData.parseAs<ReaderData>()
+        return readerData.series.chapters
+            ?.get(chapterNumber)
+            ?.groups
+            ?.values
+            ?.firstOrNull()
+            ?.substringAfterLast("/")
+            ?: throw NoSuchElementException("Chapter data not found for chapter $chapterNumber")
+    }
+
+    private fun buildChapterList(seriesData: SeriesData): List<SChapter> {
+        val chapters = seriesData.chapters ?: return emptyList()
+        val chapterList = mutableListOf<SChapter>()
+        val multipleChapters = chapters.size > 1
+
+        for ((chapterNumber, chapterData) in chapters) {
+            if (chapterData.licencied) continue
+
+            val title = chapterData.title ?: ""
+            val volumeNumber = chapterData.volume ?: ""
+
+            val baseName = if (multipleChapters) {
+                buildString {
+                    if (volumeNumber.isNotBlank()) append("Vol. $volumeNumber ")
+                    append("Ch. $chapterNumber")
+                    if (title.isNotBlank()) append(" – $title")
+                }
+            } else {
+                if (title.isNotBlank()) "One Shot – $title" else "One Shot"
+            }
+
+            val chapter = SChapter.create().apply {
+                name = baseName
+                url = "/${toSlug(seriesData.title)}/$chapterNumber"
+                chapter_number = chapterNumber.toFloatOrNull() ?: -1f
+                date_upload = (chapterData.lastUpdated ?: 0) * 1000L
+            }
+            chapterList.add(chapter)
+        }
+
+        return chapterList.sortedByDescending { it.chapter_number }
+    }
+
+    private fun fetchChapterPages(chapterId: String): List<Page> {
+        val pagesResponse =
+            client.newCall(GET("$baseUrl/api/imgchest-chapter-pages?id=$chapterId", headers))
+                .execute()
+        val pages = pagesResponse.parseAs<List<PageData>>()
+        return pages.mapIndexed { index, pageData ->
+            Page(index, imageUrl = pageData.link)
+        }
+    }
+}

--- a/src/fr/bigsolo/src/eu/kanade/tachiyomi/extension/fr/bigsolo/BigSolo.kt
+++ b/src/fr/bigsolo/src/eu/kanade/tachiyomi/extension/fr/bigsolo/BigSolo.kt
@@ -15,10 +15,6 @@ import java.net.URI
 
 class BigSolo : HttpSource() {
 
-    companion object {
-        private const val SERIES_DATA_SELECTOR = "#series-data-placeholder"
-    }
-
     override val name = "BigSolo"
     override val baseUrl = "https://bigsolo.org"
     override val lang = "fr"

--- a/src/fr/bigsolo/src/eu/kanade/tachiyomi/extension/fr/bigsolo/BigSoloDto.kt
+++ b/src/fr/bigsolo/src/eu/kanade/tachiyomi/extension/fr/bigsolo/BigSoloDto.kt
@@ -9,31 +9,24 @@ import kotlinx.serialization.Serializable
  */
 
 @Serializable
-data class SeriesResponse(
+class SeriesResponse(
     val series: List<Serie>,
     val os: List<Serie>,
     val reco: List<Serie>,
 )
 
 @Serializable
-data class Serie(
+class Serie(
     val slug: String = "",
     val title: String,
     val description: String,
     val artist: String,
     val author: String,
-    val demographic: String,
-    val magazine: String,
-    @SerialName("release_year")
-    val releaseYear: Int,
     val tags: List<String>,
     @SerialName("ja_title")
     val jaTitle: String,
     @SerialName("alternative_titles")
     val alternativeTitles: List<String>,
-    val teams: List<Teams>,
-    @SerialName("imgchest_username")
-    val imgchestUsername: String,
     val status: String,
     val cover: Cover? = null,
     val chapters: Map<String, Chapter>,
@@ -42,48 +35,29 @@ data class Serie(
 )
 
 @Serializable
-data class lastChapter(
-    val number: Int,
-    val title: String,
-    val volume: String = "",
+class lastChapter(
     val timestamp: Int,
-    val teams: List<String>,
 )
 
 @Serializable
-data class Chapter(
+class Chapter(
     val title: String,
     val volume: String = "",
     val timestamp: Int,
     val teams: List<String>,
-    val source: Source? = null,
     @SerialName("licensed")
     val licencied: Boolean = false,
 )
 
 @Serializable
-data class ChapterDetails(
+class ChapterDetails(
     val images: List<String>,
 )
 
 @Serializable
-data class Source(
-    val service: String,
-    val id: String,
-)
-
-@Serializable
-data class Cover(
+class Cover(
     @SerialName("url_hq")
     val urlHq: String,
-    @SerialName("url_lq")
-    val urlLq: String,
-)
-
-@Serializable
-data class Teams(
-    val id: String,
-    val active: Boolean,
 )
 
 // DTO to SManga extension functions
@@ -92,7 +66,7 @@ fun Serie.toDetailedSManga(): SManga = SManga.create().apply {
     description = this@toDetailedSManga.description
     artist = this@toDetailedSManga.artist
     author = this@toDetailedSManga.author
-    genre = this@toDetailedSManga.tags.joinToString(", ")
+    genre = this@toDetailedSManga.tags.joinToString()
     status = when (this@toDetailedSManga.status) {
         "En cours" -> SManga.ONGOING
         "Finis", "Fini" -> SManga.COMPLETED

--- a/src/fr/bigsolo/src/eu/kanade/tachiyomi/extension/fr/bigsolo/BigSoloDto.kt
+++ b/src/fr/bigsolo/src/eu/kanade/tachiyomi/extension/fr/bigsolo/BigSoloDto.kt
@@ -9,91 +9,95 @@ import kotlinx.serialization.Serializable
  */
 
 @Serializable
-data class ConfigResponse(
-    @SerialName("LOCAL_SERIES_FILES")
-    val localSeriesFiles: List<String>,
+data class SeriesResponse(
+    val series: List<Serie>,
+    val os: List<Serie>,
+    val reco: List<Serie>,
 )
 
 @Serializable
-data class SeriesData(
+data class Serie(
+    val slug: String = "",
     val title: String,
-    val description: String?,
-    val artist: String?,
-    val author: String?,
-    @SerialName("cover_low")
-    val coverLow: String?,
-    @SerialName("cover_hq")
-    val coverHq: String?,
-    val tags: List<String>?,
-    @SerialName("release_status")
-    val releaseStatus: String?,
-    val chapters: Map<String, ChapterData>?,
+    val description: String,
+    val artist: String,
+    val author: String,
+    val demographic: String,
+    val magazine: String,
+    @SerialName("release_year")
+    val releaseYear: Int,
+    val tags: List<String>,
+    @SerialName("ja_title")
+    val jaTitle: String,
+    @SerialName("alternative_titles")
+    val alternativeTitles: List<String>,
+    val teams: List<Teams>,
+    @SerialName("imgchest_username")
+    val imgchestUsername: String,
+    val status: String,
+    val cover: Cover? = null,
+    val chapters: Map<String, Chapter>,
+    @SerialName("last_chapter")
+    val lastChapter: lastChapter? = null,
 )
 
 @Serializable
-data class ReaderData(
-    val series: SeriesData,
+data class lastChapter(
+    val number: Int,
+    val title: String,
+    val volume: String = "",
+    val timestamp: Int,
+    val teams: List<String>,
 )
 
 @Serializable
-data class ChapterData(
-    val title: String?,
-    val volume: String?,
-    @SerialName("last_updated")
-    val lastUpdated: Long?,
+data class Chapter(
+    val title: String,
+    val volume: String = "",
+    val timestamp: Int,
+    val teams: List<String>,
+    val source: Source? = null,
+    @SerialName("licensed")
     val licencied: Boolean = false,
-    val groups: Map<String, String>?,
 )
 
 @Serializable
-data class PageData(
-    val link: String,
+data class ChapterDetails(
+    val images: List<String>,
+)
+
+@Serializable
+data class Source(
+    val service: String,
+    val id: String,
+)
+
+@Serializable
+data class Cover(
+    @SerialName("url_hq")
+    val urlHq: String,
+    @SerialName("url_lq")
+    val urlLq: String,
+)
+
+@Serializable
+data class Teams(
+    val id: String,
+    val active: Boolean,
 )
 
 // DTO to SManga extension functions
-fun SeriesData.toSManga(): SManga = SManga.create().apply {
-    title = this@toSManga.title
-    artist = this@toSManga.artist
-    author = this@toSManga.author
-    thumbnail_url = this@toSManga.coverLow
-    url = "/${toSlug(this@toSManga.title)}"
-}
-
-fun SeriesData.toDetailedSManga(): SManga = SManga.create().apply {
+fun Serie.toDetailedSManga(): SManga = SManga.create().apply {
     title = this@toDetailedSManga.title
     description = this@toDetailedSManga.description
     artist = this@toDetailedSManga.artist
     author = this@toDetailedSManga.author
-    genre = this@toDetailedSManga.tags?.joinToString(", ") ?: ""
-    status = when (this@toDetailedSManga.releaseStatus) {
+    genre = this@toDetailedSManga.tags.joinToString(", ")
+    status = when (this@toDetailedSManga.status) {
         "En cours" -> SManga.ONGOING
         "Finis", "Fini" -> SManga.COMPLETED
         else -> SManga.UNKNOWN
     }
-    thumbnail_url = this@toDetailedSManga.coverHq
-    url = "/${toSlug(this@toDetailedSManga.title)}"
-}
-
-// Utility function for slug generation
-// URLs are manually calculated using a slugify function
-fun toSlug(input: String?): String {
-    if (input == null) return ""
-
-    val accentsMap = mapOf(
-        'à' to 'a', 'á' to 'a', 'â' to 'a', 'ä' to 'a', 'ã' to 'a',
-        'è' to 'e', 'é' to 'e', 'ê' to 'e', 'ë' to 'e',
-        'ì' to 'i', 'í' to 'i', 'î' to 'i', 'ï' to 'i',
-        'ò' to 'o', 'ó' to 'o', 'ô' to 'o', 'ö' to 'o', 'õ' to 'o',
-        'ù' to 'u', 'ú' to 'u', 'û' to 'u', 'ü' to 'u',
-        'ç' to 'c', 'ñ' to 'n',
-    )
-
-    return input
-        .lowercase()
-        .map { accentsMap[it] ?: it }
-        .joinToString("")
-        .replace("[^a-z0-9\\s-]".toRegex(), "")
-        .replace("\\s+".toRegex(), "-")
-        .replace("-+".toRegex(), "-")
-        .trim('-')
+    thumbnail_url = this@toDetailedSManga.cover?.urlHq
+    url = "/${this@toDetailedSManga.slug}"
 }

--- a/src/fr/bigsolo/src/eu/kanade/tachiyomi/extension/fr/bigsolo/BigSoloDto.kt
+++ b/src/fr/bigsolo/src/eu/kanade/tachiyomi/extension/fr/bigsolo/BigSoloDto.kt
@@ -1,0 +1,99 @@
+package eu.kanade.tachiyomi.extension.fr.bigsolo
+
+import eu.kanade.tachiyomi.source.model.SManga
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Data Transfer Objects for BigSolo extension
+ */
+
+@Serializable
+data class ConfigResponse(
+    @SerialName("LOCAL_SERIES_FILES")
+    val localSeriesFiles: List<String>,
+)
+
+@Serializable
+data class SeriesData(
+    val title: String,
+    val description: String?,
+    val artist: String?,
+    val author: String?,
+    @SerialName("cover_low")
+    val coverLow: String?,
+    @SerialName("cover_hq")
+    val coverHq: String?,
+    val tags: List<String>?,
+    @SerialName("release_status")
+    val releaseStatus: String?,
+    val chapters: Map<String, ChapterData>?,
+)
+
+@Serializable
+data class ReaderData(
+    val series: SeriesData,
+)
+
+@Serializable
+data class ChapterData(
+    val title: String?,
+    val volume: String?,
+    @SerialName("last_updated")
+    val lastUpdated: Long?,
+    val licencied: Boolean = false,
+    val groups: Map<String, String>?,
+)
+
+@Serializable
+data class PageData(
+    val link: String,
+)
+
+// DTO to SManga extension functions
+fun SeriesData.toSManga(): SManga = SManga.create().apply {
+    title = this@toSManga.title
+    artist = this@toSManga.artist
+    author = this@toSManga.author
+    thumbnail_url = this@toSManga.coverLow
+    url = "/${toSlug(this@toSManga.title)}"
+}
+
+fun SeriesData.toDetailedSManga(): SManga = SManga.create().apply {
+    title = this@toDetailedSManga.title
+    description = this@toDetailedSManga.description
+    artist = this@toDetailedSManga.artist
+    author = this@toDetailedSManga.author
+    genre = this@toDetailedSManga.tags?.joinToString(", ") ?: ""
+    status = when (this@toDetailedSManga.releaseStatus) {
+        "En cours" -> SManga.ONGOING
+        "Finis", "Fini" -> SManga.COMPLETED
+        else -> SManga.UNKNOWN
+    }
+    thumbnail_url = this@toDetailedSManga.coverHq
+    url = "/${toSlug(this@toDetailedSManga.title)}"
+}
+
+// Utility function for slug generation
+// URLs are manually calculated using a slugify function
+fun toSlug(input: String?): String {
+    if (input == null) return ""
+
+    val accentsMap = mapOf(
+        'à' to 'a', 'á' to 'a', 'â' to 'a', 'ä' to 'a', 'ã' to 'a',
+        'è' to 'e', 'é' to 'e', 'ê' to 'e', 'ë' to 'e',
+        'ì' to 'i', 'í' to 'i', 'î' to 'i', 'ï' to 'i',
+        'ò' to 'o', 'ó' to 'o', 'ô' to 'o', 'ö' to 'o', 'õ' to 'o',
+        'ù' to 'u', 'ú' to 'u', 'û' to 'u', 'ü' to 'u',
+        'ç' to 'c', 'ñ' to 'n',
+    )
+
+    return input
+        .lowercase()
+        .map { accentsMap[it] ?: it }
+        .joinToString("")
+        .replace("[^a-z0-9\\s-]".toRegex(), "")
+        .replace("\\s+".toRegex(), "-")
+        .replace("-+".toRegex(), "-")
+        .trim('-')
+}

--- a/src/fr/bigsolo/src/eu/kanade/tachiyomi/extension/fr/bigsolo/BigSoloUrlActivity.kt
+++ b/src/fr/bigsolo/src/eu/kanade/tachiyomi/extension/fr/bigsolo/BigSoloUrlActivity.kt
@@ -1,0 +1,38 @@
+package eu.kanade.tachiyomi.extension.fr.bigsolo
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import kotlin.system.exitProcess
+
+/**
+ * Springboard that accepts https://bigsolo.org/xxxxxx intents and redirects them to
+ * the main Tachiyomi process.
+ */
+class BigSoloUrlActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val pathSegments = intent?.data?.pathSegments
+        if (pathSegments != null && pathSegments.size >= 1) {
+            val slug = pathSegments[0]
+            val mainIntent = Intent().apply {
+                action = "eu.kanade.tachiyomi.SEARCH"
+                putExtra("query", "SLUG:$slug")
+                putExtra("filter", packageName)
+            }
+
+            try {
+                startActivity(mainIntent)
+            } catch (e: ActivityNotFoundException) {
+                Log.e("BigSoloUrlActivity", e.toString())
+            }
+        } else {
+            Log.e("BigSoloUrlActivity", "could not parse uri from intent $intent")
+        }
+
+        finish()
+        exitProcess(0)
+    }
+}


### PR DESCRIPTION
Closes #11226 

Reversal of changes made by PR #11156, as BigSolo is no longer based on “ScanR” and corrects changes made to the backend.
Source name from "Big Solo" to "BigSolo" (this revert name change from PR #11156)

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [X] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
