### PR TITLE
MangaTaro: fix chapter name

### DIFF
--- a/src/en/mangataro/build.gradle
+++ b/src/en/mangataro/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaTaro'
     extClass = '.MangaTaro'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = false
 }
 

--- a/src/en/mangataro/src/eu/kanade/tachiyomi/extension/en/mangataro/MangaTaro.kt
+++ b/src/en/mangataro/src/eu/kanade/tachiyomi/extension/en/mangataro/MangaTaro.kt
@@ -249,14 +249,14 @@ class MangaTaro : HttpSource() {
                 setUrlWithoutDomain(it.absUrl("href"))
                 val details = it.select("> div + div > div")
                 name = buildString {
-                    append(details[0].selectFirst("span")!!.ownText())
+                    append(it.attr("title"))
                     details[1].text().also { title ->
                         if (title !in placeholders) {
                             append(": ", title)
                         }
                     }
                 }
-                details[2].text().let { group ->
+                it.attr("data-group-name").let { group ->
                     if (group !in placeholders) {
                         scanlator = group
                         hasScanlator = true


### PR DESCRIPTION
closes #11230

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
