### PR TITLE
Kagane: use site's chapter numbers & cache filters in network cache

### DIFF
--- a/src/en/kagane/build.gradle
+++ b/src/en/kagane/build.gradle
@@ -6,3 +6,7 @@ ext {
 }
 
 apply from: "$rootDir/common.gradle"
+
+dependencies {
+    compileOnly("com.squareup.okhttp3:okhttp-brotli:5.0.0-alpha.11")
+}

--- a/src/en/kagane/build.gradle
+++ b/src/en/kagane/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Kagane'
     extClass = '.Kagane'
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = true
 }
 

--- a/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Dto.kt
+++ b/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Dto.kt
@@ -83,12 +83,14 @@ class ChapterDto(
         val releaseDate: String?,
         @SerialName("pages_count")
         val pagesCount: Int,
+        @SerialName("number_sort")
+        val number: Float,
     ) {
-        fun toSChapter(index: Int): SChapter = SChapter.create().apply {
+        fun toSChapter(): SChapter = SChapter.create().apply {
             url = "$seriesId;$id;$pagesCount"
             name = title
             date_upload = dateFormat.tryParse(releaseDate)
-            chapter_number = index.toFloat()
+            chapter_number = number
         }
     }
 

--- a/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Kagane.kt
+++ b/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Kagane.kt
@@ -202,7 +202,7 @@ class Kagane : HttpSource(), ConfigurableSource {
 
     override fun chapterListParse(response: Response): List<SChapter> {
         val dto = response.parseAs<ChapterDto>()
-        return dto.content.mapIndexed { i, it -> it.toSChapter(i + 1) }.reversed()
+        return dto.content.map { it -> it.toSChapter() }.reversed()
     }
 
     override fun chapterListRequest(manga: SManga): Request {


### PR DESCRIPTION
closes #11243

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
