### PR TITLE
Nihonkuni:Resolve ad break page.

### DIFF
--- a/src/ja/mangagun/build.gradle
+++ b/src/ja/mangagun/build.gradle
@@ -8,3 +8,7 @@ ext {
 }
 
 apply from: "$rootDir/common.gradle"
+
+dependencies {
+    implementation(project(":lib:cookieinterceptor"))
+}

--- a/src/ja/mangagun/build.gradle
+++ b/src/ja/mangagun/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaGun'
     themePkg = 'fmreader'
     baseUrl = 'https://nihonkuni.com'
-    overrideVersionCode = 5
+    overrideVersionCode = 6
     isNsfw = true
 }
 

--- a/src/ja/mangagun/src/eu/kanade/tachiyomi/extension/ja/mangagun/MangaGun.kt
+++ b/src/ja/mangagun/src/eu/kanade/tachiyomi/extension/ja/mangagun/MangaGun.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.extension.ja.mangagun
 
+import eu.kanade.tachiyomi.lib.cookieinterceptor.CookieInterceptor
 import eu.kanade.tachiyomi.multisrc.fmreader.FMReader
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.asObservableSuccess
@@ -7,10 +8,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.util.asJsoup
-import okhttp3.Cookie
-import okhttp3.Interceptor
 import okhttp3.Request
-import okhttp3.Response
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
@@ -29,33 +27,8 @@ class MangaGun : FMReader("NihonKuni", "https://$DOMAIN", "ja") {
 
     override val infoElementSelector = "div.row div.row"
 
-    override val client = super.client.newBuilder().addNetworkInterceptor(::checkCookie).build()
-
-    private fun checkCookie(chain: Interceptor.Chain): Response {
-        val request = chain.request()
-        if (request.tag() == PAGE_LIST_REQUEST) {
-            // check smart link cookie
-            val cookie =
-                client.cookieJar.loadForRequest(request.url).find { it.name == COOKIE_SMART_LINK }
-            if (cookie == null) {
-                client.cookieJar.saveFromResponse(
-                    request.url,
-                    listOf(
-                        Cookie.Builder()
-                            .name(COOKIE_SMART_LINK)
-                            .domain(DOMAIN)
-                            .value("1")
-                            .build(),
-                    ),
-                )
-            }
-        }
-        return chain.proceed(request)
-    }
-
-    override fun pageListRequest(chapter: SChapter): Request {
-        return super.pageListRequest(chapter).newBuilder().tag(PAGE_LIST_REQUEST).build()
-    }
+    override val client = super.client.newBuilder()
+        .addNetworkInterceptor(CookieInterceptor(DOMAIN, "smartlink_shown" to "1")).build()
 
     // source is picky about URL format
     private fun mangaRequest(sortBy: String, page: Int): Request {
@@ -139,10 +112,5 @@ class MangaGun : FMReader("NihonKuni", "https://$DOMAIN", "ja") {
         return Jsoup.parse(html).select("img.chapter-img").mapIndexed { index, element ->
             Page(index, imageUrl = element.attr("abs:data-srcset").trim())
         }
-    }
-
-    companion object {
-        private const val PAGE_LIST_REQUEST = "page_list_request"
-        private const val COOKIE_SMART_LINK = "smartlink_shown"
     }
 }


### PR DESCRIPTION
Closes #11231 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
