### PR TITLE
MangaTaro: unescape title & get thumbnail directly

### DIFF
--- a/src/en/mangataro/build.gradle
+++ b/src/en/mangataro/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaTaro'
     extClass = '.MangaTaro'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = false
 }
 

--- a/src/en/mangataro/src/eu/kanade/tachiyomi/extension/en/mangataro/Dto.kt
+++ b/src/en/mangataro/src/eu/kanade/tachiyomi/extension/en/mangataro/Dto.kt
@@ -79,10 +79,10 @@ class MangaDetails(
     val slug: String,
     val title: Rendered,
     val content: Rendered,
-    @SerialName("featured_media")
-    val featuredMedia: Int,
     @SerialName("class_list")
     private val classList: List<String>,
+    @SerialName("_embedded")
+    val embedded: Embedded,
 ) {
     fun getFromClassList(type: String): List<String> {
         return classList.filter { it.startsWith("$type-") }
@@ -93,6 +93,24 @@ class MangaDetails(
             }
     }
 }
+
+@Serializable
+class Embedded(
+    @SerialName("wp:featuredmedia")
+    val featuredMedia: List<Thumbnail>,
+    @SerialName("wp:term")
+    private val terms: List<List<Term>>,
+) {
+    fun getTerms(type: String): List<String> {
+        return terms.find { it.firstOrNull()?.taxonomy == type }.orEmpty().map { it.name }
+    }
+}
+
+@Serializable
+class Term(
+    val name: String,
+    val taxonomy: String,
+)
 
 @Serializable
 class Thumbnail(

--- a/src/en/mangataro/src/eu/kanade/tachiyomi/extension/en/mangataro/MangaTaro.kt
+++ b/src/en/mangataro/src/eu/kanade/tachiyomi/extension/en/mangataro/MangaTaro.kt
@@ -21,6 +21,7 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import org.jsoup.Jsoup
+import org.jsoup.parser.Parser
 import rx.Observable
 import java.lang.UnsupportedOperationException
 import java.util.Calendar
@@ -205,7 +206,7 @@ class MangaTaro : HttpSource() {
 
         return SManga.create().apply {
             url = MangaUrl(data.id.toString(), data.slug).toJsonString()
-            title = data.title.rendered
+            title = Parser.unescapeEntities(data.title.rendered, false)
             description = Jsoup.parseBodyFragment(data.content.rendered).wholeText()
             genre = buildSet {
                 addAll(data.embedded.getTerms("post_tag"))

--- a/src/en/mangataro/src/eu/kanade/tachiyomi/extension/en/mangataro/MangaTaro.kt
+++ b/src/en/mangataro/src/eu/kanade/tachiyomi/extension/en/mangataro/MangaTaro.kt
@@ -193,6 +193,7 @@ class MangaTaro : HttpSource() {
         val url = baseUrl.toHttpUrl().newBuilder().apply {
             addPathSegments("wp-json/wp/v2/manga")
             addPathSegment(id)
+            addQueryParameter("_embed", null)
             fragment(status.toString())
         }.build()
 
@@ -201,32 +202,20 @@ class MangaTaro : HttpSource() {
 
     override fun mangaDetailsParse(response: Response): SManga {
         val data = response.parseAs<MangaDetails>()
-        val thumbnail = getThumbnail(data.featuredMedia)
 
         return SManga.create().apply {
             url = MangaUrl(data.id.toString(), data.slug).toJsonString()
             title = data.title.rendered
             description = Jsoup.parseBodyFragment(data.content.rendered).wholeText()
             genre = buildSet {
-                addAll(data.getFromClassList("tag"))
+                addAll(data.embedded.getTerms("post_tag"))
                 addAll(data.getFromClassList("type"))
             }.joinToString()
-            author = data.getFromClassList("manga_author").joinToString()
+            author = data.embedded.getTerms("manga_author").joinToString()
             status = response.request.url.fragment!!.toInt()
-            thumbnail_url = thumbnail
+            thumbnail_url = data.embedded.featuredMedia.firstOrNull()?.url
             initialized = true
         }
-    }
-
-    private fun getThumbnail(mediaId: Int): String {
-        val url = baseUrl.toHttpUrl().newBuilder().apply {
-            addPathSegments("wp-json/wp/v2/media")
-            addPathSegment(mediaId.toString())
-        }.build()
-
-        return client.newCall(GET(url, headers)).execute()
-            .parseAs<Thumbnail>()
-            .url
     }
 
     override fun getMangaUrl(manga: SManga): String {


### PR DESCRIPTION
- use `_embed` on `/wp-json/` endpoint
  - saves a network call to get thumbnail
- Unescape HTML entities in title
  - closes #11283 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
