### PR TITLE
MangaTaro: handle days in relative date parsing

### DIFF
--- a/src/en/mangataro/build.gradle
+++ b/src/en/mangataro/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaTaro'
     extClass = '.MangaTaro'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = false
 }
 

--- a/src/en/mangataro/src/eu/kanade/tachiyomi/extension/en/mangataro/MangaTaro.kt
+++ b/src/en/mangataro/src/eu/kanade/tachiyomi/extension/en/mangataro/MangaTaro.kt
@@ -292,6 +292,7 @@ class MangaTaro : HttpSource() {
 
         when (unit) {
             "h" -> calendar.add(Calendar.HOUR, -amount.toInt())
+            "d" -> calendar.add(Calendar.DAY_OF_YEAR, -amount.toInt())
             "w" -> calendar.add(Calendar.WEEK_OF_YEAR, -amount.toInt())
             "mo" -> calendar.add(Calendar.MONTH, -amount.toInt())
             "y" -> calendar.add(Calendar.YEAR, -amount.toInt())
@@ -300,7 +301,7 @@ class MangaTaro : HttpSource() {
         return calendar.timeInMillis
     }
 
-    private val relativeDateRegex = Regex("""(\d+)(h|w|mo|y) ago""")
+    private val relativeDateRegex = Regex("""(\d+)(h|d|w|mo|y) ago""")
 
     override fun imageUrlParse(response: Response): String {
         throw UnsupportedOperationException()


### PR DESCRIPTION
closes #11313

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
