### PR TITLE
MangaCrab: Fix images dont load again

### DIFF
--- a/src/es/mangacrab/build.gradle
+++ b/src/es/mangacrab/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaCrab'
     themePkg = 'madara'
     baseUrl = 'https://mangacrab.org'
-    overrideVersionCode = 16
+    overrideVersionCode = 17
     isNsfw = false
 }
 

--- a/src/es/mangacrab/src/eu/kanade/tachiyomi/extension/es/mangacrab/MangaCrab.kt
+++ b/src/es/mangacrab/src/eu/kanade/tachiyomi/extension/es/mangacrab/MangaCrab.kt
@@ -54,18 +54,22 @@ class MangaCrab :
         val url = element.attributes()
             .firstNotNullOfOrNull { attr ->
                 element.absUrl(attr.key).toHttpUrlOrNull()
-                    ?.takeIf { it.encodedPath == "/validate.php" }
+                    ?.takeIf { it.encodedQuery.toString().contains("wp-content") }
             }
 
-        val fileUrl = url
-            ?.queryParameter("file")
-            ?.takeIf { it.isNotBlank() }
-            ?.let { file ->
-                url.newBuilder()
-                    .encodedPath("/$file")
-                    .query(null)
-                    .build()
-            }
+        val fileUrl = url?.let { httpUrl ->
+            httpUrl.queryParameterNames
+                .firstNotNullOfOrNull { name ->
+                    httpUrl.queryParameterValues(name)
+                        .firstOrNull { value -> value?.contains("wp-content") == true }
+                }
+                ?.let { file ->
+                    httpUrl.newBuilder()
+                        .encodedPath("/$file")
+                        .query(null)
+                        .build()
+                }
+        }
 
         val imageAbsUrl = element.attributes().firstOrNull { it.value.toHttpUrlOrNull() != null }?.value
 


### PR DESCRIPTION
Closes #11333

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
