### PR TITLE
Team X: Update chapter list selectors

### DIFF
--- a/src/ar/teamx/build.gradle
+++ b/src/ar/teamx/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Team X'
     extClass = '.TeamX'
-    extVersionCode = 22
+    extVersionCode = 23
     isNsfw = false
 }
 

--- a/src/ar/teamx/src/eu/kanade/tachiyomi/extension/ar/teamx/TeamX.kt
+++ b/src/ar/teamx/src/eu/kanade/tachiyomi/extension/ar/teamx/TeamX.kt
@@ -180,19 +180,19 @@ class TeamX : ParsedHttpSource(), ConfigurableSource {
 
     private val chapterFormat = SimpleDateFormat("yyyy-MM-dd hh:mm:ss", Locale.getDefault())
 
-    override fun chapterListSelector() = "div.eplister ul a"
+    override fun chapterListSelector() = "div.chapter-card a"
 
     override fun chapterFromElement(element: Element): SChapter {
         return SChapter.create().apply {
-            val chpNum = element.select("div.epl-num").text()
-            val chpTitle = element.select("div.epl-title").text()
+            val chpNum = element.select("div.chapter-info div.chapter-number").text()
+            val chpTitle = element.select("div.chapter-info div.chapter-title").text()
 
             name = when (chpNum.isNullOrBlank()) {
                 true -> chpTitle
                 false -> "$chpNum - $chpTitle"
             }
 
-            date_upload = parseChapterDate(element.select("div.epl-date").text())
+            date_upload = parseChapterDate(element.select("div.chapter-info div.chapter-date").text())
 
             setUrlWithoutDomain(element.attr("href"))
         }


### PR DESCRIPTION
closes #11346

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
