### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -684,7 +684,7 @@ with open(f"{package}/src/{source}.kt", "w") as f:
 
 </details>
 
-## How to build and run locally
+## Running
 
 If you do not have either a **rooted device** or an **emulator without Google Play**, you must use the **Debug build of Mihon**.
 
@@ -692,30 +692,31 @@ In Android Studio, navigate to the Mihon repository and do the following to inst
 
 1.  **Build the debug APK:**
     Open a terminal in the project root and run the following command:
-    ```bash
+    ```
     ./gradlew assembleDebug
     ```
-    This will create an APK file in `app/build/outputs/apk/debug/`.
 
 2.  **Install the debug app:**
     To install the app on a connected device or emulator, run:
-    ```bash
+    ```
     ./gradlew installDebug
     ```
 
-For local development, navigate back to the extensions-source repository and use the following run configuration to launch the app directly into the Browse panel, if it builds and runs successfully then your code changes to the extension should be in your local app:
+For local development, navigate back to the extensions-source repository and use the following run configuration to launch the app directly into the Browse panel.
 
 ![](https://i.imgur.com/6s2dvax.png)
 
-Copy the following into launch flags for the Debug build of Mihon:
+Copy the following into `Launch Flags` for the Debug build of Mihon:
 
 ```
 -W -S -n app.mihon.dev/eu.kanade.tachiyomi.ui.main.MainActivity -a eu.kanade.tachiyomi.SHOW_CATALOGUES
 ```
 
-For other builds (rooted devices only or emulators without Google Play), replace  `app.mihon.dev` with the corresponding package IDs:
+For other builds (only on rooted devices or emulators without Google Play), replace  `app.mihon.dev` with the corresponding package IDs:
 - Release build: `app.mihon`
 - Preview build: `app.mihon.debug`
+
+If it builds and runs successfully then your code changes to the extension should be in your local app.
 
 > [!IMPORTANT]
 > If you're deploying to Android 11 or higher, enable the "Always install with package manager" option in the run configurations. Without this option enabled, you might face issues such as Android Studio running an older version of the extension without the modifications you might have done.
@@ -725,18 +726,22 @@ For other builds (rooted devices only or emulators without Google Play), replace
 ### Android Debugger
 
 > [!IMPORTANT]
-> If you didn't build the main app from source with debug enabled and are using a release/beta APK, you **need** a rooted device.
-> If you are using an emulator instead, make sure you choose a profile **without** Google Play.
+> If you didn't build the main app from source with **debug enabled** and are using a release/beta APK, you **need a rooted device**.
+> If you are using an **emulator** instead, make sure you choose a profile **without Google Play**.
 
-You can leverage the Android Debugger to step through your extension while debugging.
+Follow the steps above for building and running locally if you haven't already. Debugging will not work if you did not follow the steps above.
+
+You can leverage the Android Debugger to add breakpoints and step through your extension while debugging.
 
 You *cannot* simply use Android Studio's `Debug 'module.name'` -> this will most likely result in an
 error while launching.
 
 Instead, once you've built and installed your extension on the target device, use
-`Attach Debugger to Android Process` to start debugging the app.
+`Attach Debugger to Android Process` to start debugging the app. 
 
-![](https://i.imgur.com/muhXyfu.png)
+Once the app is running on your device and `Show all processes` is checked, you should be able to select `app.mihon.dev` and press OK.
+
+![](https://i.imgur.com/SUhdB52.png)
 
 
 ### Logs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -716,7 +716,7 @@ For other builds (only on rooted devices or emulators without Google Play), repl
 - Release build: `app.mihon`
 - Preview build: `app.mihon.debug`
 
-If it builds and runs successfully then your code changes to the extension should be in your local app.
+If it builds and runs successfully then the code changes to the extension should be in your local app.
 
 > [!IMPORTANT]
 > If you're deploying to Android 11 or higher, enable the `Always install with package manager` option in the run configurations. Without this option enabled, you might face issues such as Android Studio running an older version of the extension without the modifications you might have done.
@@ -739,7 +739,7 @@ error while launching.
 Instead, once you've built and installed your extension on the target device, use
 `Attach Debugger to Android Process` to start debugging the app. 
 
-Once the app is running on your device and `Show all processes` is checked, you should be able to select `app.mihon.dev` and press OK.
+Inside the `Attach Debugger to Android Process` window, once the app is running on your device and `Show all processes` is checked, you should be able to select `app.mihon.dev` and press OK.
 
 ![](https://i.imgur.com/SUhdB52.png)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -684,22 +684,38 @@ with open(f"{package}/src/{source}.kt", "w") as f:
 
 </details>
 
-## Running
+## How to build and run locally
 
-To make local development more convenient, you can use the following run configuration to launch
-the app directly at the Browse panel:
+If you do not have either a **rooted device** or an **emulator without Google Play**, you must use the **Debug build of Mihon**.
 
-![](https://i.imgur.com/STy0UFY.png)
+In Android Studio, navigate to the Mihon repository and do the following to install the Debug app on your device:
 
-If you're running a Preview build of Mihon:
+1.  **Build the debug APK:**
+    Open a terminal in the project root and run the following command:
+    ```bash
+    ./gradlew assembleDebug
+    ```
+    This will create an APK file in `app/build/outputs/apk/debug/`.
+
+2.  **Install the debug app:**
+    To install the app on a connected device or emulator, run:
+    ```bash
+    ./gradlew installDebug
+    ```
+
+For local development, navigate back to the extensions-source repository and use the following run configuration to launch the app directly into the Browse panel, if it builds and runs successfully then your code changes to the extension should be in your local app:
+
+![](https://i.imgur.com/6s2dvax.png)
+
+Copy the following into launch flags for the Debug build of Mihon:
 
 ```
--W -S -n app.mihon.debug/eu.kanade.tachiyomi.ui.main.MainActivity -a eu.kanade.tachiyomi.SHOW_CATALOGUES
+-W -S -n app.mihon.dev/eu.kanade.tachiyomi.ui.main.MainActivity -a eu.kanade.tachiyomi.SHOW_CATALOGUES
 ```
 
-For other builds, replace the first `app.mihon.debug` with the corresponding package IDs:
+For other builds (rooted devices only or emulators without Google Play), replace  `app.mihon.dev` with the corresponding package IDs:
 - Release build: `app.mihon`
-- Debug build: `app.mihon.dev`
+- Preview build: `app.mihon.debug`
 
 > [!IMPORTANT]
 > If you're deploying to Android 11 or higher, enable the "Always install with package manager" option in the run configurations. Without this option enabled, you might face issues such as Android Studio running an older version of the extension without the modifications you might have done.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -686,21 +686,25 @@ with open(f"{package}/src/{source}.kt", "w") as f:
 
 ## Running
 
-If you do not have either a **rooted device** or an **emulator without Google Play**, you must use the **Debug build of Mihon**.
+If you do not have either a **rooted device** or an **emulator without Google Play**, you must use the **Debug build of Mihon** for debugging.
 
-In Android Studio, navigate to the Mihon repository and do the following to install the Debug app on your device:
+In Android Studio, navigate to the Mihon repository and install the debug app through one of the following ways:
 
-1.  **Build the debug APK:**
-    Open a terminal in the project root and run the following command:
-    ```
-    ./gradlew assembleDebug
-    ```
+1. Click **Debug 'app'** at the top of Android Studio to install the Mihon debug app.
 
-2.  **Install the debug app:**
-    To install the app on a connected device or emulator, run:
-    ```
-    ./gradlew installDebug
-    ```
+2. Or install the Mihon debug app through the command line:
+
+    1.  **Build the debug APK:**
+        Open a terminal in the project root and run the following command:
+        ```
+        ./gradlew assembleDebug
+        ```
+
+    2.  **Install the debug app:**
+        To install the app on a connected device or emulator, run:
+        ```
+        ./gradlew installDebug
+        ```
 
 For local development, navigate back to the extensions-source repository and use the following run configuration to launch the app directly into the Browse panel.
 
@@ -716,7 +720,7 @@ For other builds (only on rooted devices or emulators without Google Play), repl
 - Release build: `app.mihon`
 - Preview build: `app.mihon.debug`
 
-If it builds and runs successfully then the code changes to the extension should be in your local app.
+If the extension builds and runs successfully then the code changes should be ready to test in your local app.
 
 > [!IMPORTANT]
 > If you're deploying to Android 11 or higher, enable the `Always install with package manager` option in the run configurations. Without this option enabled, you might face issues such as Android Studio running an older version of the extension without the modifications you might have done.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -719,14 +719,14 @@ For other builds (only on rooted devices or emulators without Google Play), repl
 If it builds and runs successfully then your code changes to the extension should be in your local app.
 
 > [!IMPORTANT]
-> If you're deploying to Android 11 or higher, enable the "Always install with package manager" option in the run configurations. Without this option enabled, you might face issues such as Android Studio running an older version of the extension without the modifications you might have done.
+> If you're deploying to Android 11 or higher, enable the `Always install with package manager` option in the run configurations. Without this option enabled, you might face issues such as Android Studio running an older version of the extension without the modifications you might have done.
 
 ## Debugging
 
 ### Android Debugger
 
 > [!IMPORTANT]
-> If you didn't build the main app from source with **debug enabled** and are using a release/beta APK, you **need a rooted device**.
+> If you didn't **build the main app** from source with **debug enabled** and are using a release/beta APK, you **need a rooted device**.
 > If you are using an **emulator** instead, make sure you choose a profile **without Google Play**.
 
 Follow the steps above for building and running locally if you haven't already. Debugging will not work if you did not follow the steps above.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -686,27 +686,7 @@ with open(f"{package}/src/{source}.kt", "w") as f:
 
 ## Running
 
-If you do not have either a **rooted device** or an **emulator without Google Play**, you must use the **Debug build of Mihon** for debugging.
-
-In Android Studio, navigate to the Mihon repository and install the debug app through one of the following ways:
-
-1. Click **Debug 'app'** at the top of Android Studio to install the Mihon debug app.
-
-2. Or install the Mihon debug app through the command line:
-
-    1.  **Build the debug APK:**
-        Open a terminal in the project root and run the following command:
-        ```
-        ./gradlew assembleDebug
-        ```
-
-    2.  **Install the debug app:**
-        To install the app on a connected device or emulator, run:
-        ```
-        ./gradlew installDebug
-        ```
-
-For local development, navigate back to the extensions-source repository and use the following run configuration to launch the app directly into the Browse panel.
+For local development, use the following run configuration to launch the app directly into the Browse panel.
 
 ![](https://i.imgur.com/6s2dvax.png)
 
@@ -716,7 +696,7 @@ Copy the following into `Launch Flags` for the Debug build of Mihon:
 -W -S -n app.mihon.dev/eu.kanade.tachiyomi.ui.main.MainActivity -a eu.kanade.tachiyomi.SHOW_CATALOGUES
 ```
 
-For other builds (only on rooted devices or emulators without Google Play), replace  `app.mihon.dev` with the corresponding package IDs:
+For other builds, replace  `app.mihon.dev` with the corresponding package IDs:
 - Release build: `app.mihon`
 - Preview build: `app.mihon.debug`
 


### PR DESCRIPTION
updated the running and debugging section to be more verbose
updated the images from 2017 tachiyomi to the modern 2025 mihon ui

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
