### PR TITLE
[RU]Nudemoon fix page parse

### DIFF
--- a/src/ru/nudemoon/build.gradle
+++ b/src/ru/nudemoon/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Nude-Moon'
     extClass = '.Nudemoon'
-    extVersionCode = 23
+    extVersionCode = 24
     isNsfw = true
 }
 

--- a/src/ru/nudemoon/src/eu/kanade/tachiyomi/extension/ru/nudemoon/Nudemoon.kt
+++ b/src/ru/nudemoon/src/eu/kanade/tachiyomi/extension/ru/nudemoon/Nudemoon.kt
@@ -241,17 +241,17 @@ class Nudemoon : ParsedHttpSource(), ConfigurableSource {
         return textDate.replace("Май", "Мая").let {
             try {
                 dateParseRu.parse(it)?.time ?: 0L
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 0L
             }
         }
     }
 
     override fun pageListParse(response: Response): List<Page> = mutableListOf<Page>().apply {
-        response.asJsoup().select("div.gallery-item img").mapIndexed { index, img ->
+        response.asJsoup().select("img.border").mapIndexed { index, img ->
             add(Page(index, imageUrl = img.attr("abs:data-src")))
         }
-        if (size == 0 && cookieManager.getCookie(baseUrl).contains("fusion_user").not()) {
+        if (isEmpty() && cookieManager.getCookie(baseUrl).contains("fusion_user").not()) {
             throw Exception("Страницы не найдены. Возможно необходима авторизация в WebView")
         }
     }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
