### PR TITLE
Fix potential crash when fetching filters

### DIFF
--- a/src/all/comicklive/build.gradle
+++ b/src/all/comicklive/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comick (Unoriginal)'
     extClass = '.ComickFactory'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/en/kagane/build.gradle
+++ b/src/en/kagane/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Kagane'
     extClass = '.Kagane'
-    extVersionCode = 8
+    extVersionCode = 9
     isNsfw = true
 }
 


### PR DESCRIPTION
```
java.lang.Throwable: java.io.IOException: comick.live
	at eu.kanade.tachiyomi.extension.all.comicklive.Comick$getFilterList$1$1.invokeSuspend(Comick.kt:228)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(Unknown Source:8)
	at kotlinx.coroutines.DispatchedTask.run(Unknown Source:108)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(Unknown Source:3)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Unknown Source:2)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(Unknown Source:0)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(Unknown Source:57)
```
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
