### PR TITLE
Hentai2Read: Handle invalid filter states

### DIFF
--- a/src/en/hentai2read/build.gradle
+++ b/src/en/hentai2read/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hentai2Read'
     extClass = '.Hentai2Read'
-    extVersionCode = 17
+    extVersionCode = 18
     isNsfw = true
 }
 

--- a/src/en/hentai2read/src/eu/kanade/tachiyomi/extension/en/hentai2read/Hentai2Read.kt
+++ b/src/en/hentai2read/src/eu/kanade/tachiyomi/extension/en/hentai2read/Hentai2Read.kt
@@ -104,7 +104,7 @@ class Hentai2Read : ParsedHttpSource() {
                         is ReleaseYear -> add("txt_wpm_pag_mng_sch_rls_yer", filter.state)
                         is ReleaseYearSelect -> add("cbo_wpm_pag_mng_sch_rls_yer", filter.state.toString())
                         is Status -> add("rad_wpm_pag_mng_sch_sts", filter.state.toString())
-                        is TagSearchMode -> add("rad_wpm_pag_mng_sch_tag_mde", arrayOf("and", "or")[filter.state])
+                        is TagSearchMode -> add("rad_wpm_pag_mng_sch_tag_mde", arrayOf("and", "or").getOrElse(filter.state) { "and" })
                         is TagList -> filter.state.forEach { tag ->
                             when (tag.state) {
                                 Filter.TriState.STATE_INCLUDE -> add("chk_wpm_pag_mng_sch_mng_tag_inc[]", tag.id.toString())
@@ -278,7 +278,7 @@ class Hentai2Read : ParsedHttpSource() {
     private class SortOrder(values: Array<Pair<String, String?>>) : UriPartFilter("Order", values)
     private open class UriPartFilter(displayName: String, val vals: Array<Pair<String, String?>>) :
         Filter.Select<String>(displayName, vals.map { it.first }.toTypedArray()) {
-        fun toUriPart() = vals[state].second
+        fun toUriPart() = vals.getOrNull(state)?.second
     }
 
     override fun getFilterList() = FilterList(


### PR DESCRIPTION
	modified:   src/en/hentai2read/build.gradle
	modified:   src/en/hentai2read/src/eu/kanade/tachiyomi/extension/en/hentai2read/Hentai2Read.kt

 Fixed two critical issues causing internal server errors:
  1. Added safe array access in TagSearchMode filter to prevent ArrayIndexOutOfBoundsException
  2. Added safe array access in UriPartFilter.toUriPart() to prevent NullPointerException

 Both fixes use Kotlin's getOrNull/getOrElse methods to handle invalid filter state values gracefully.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
