### PR TITLE
MangaSwat: Update `RESTART` string

### DIFF
--- a/src/ar/mangaswat/src/eu/kanade/tachiyomi/extension/ar/mangaswat/MangaSwat.kt
+++ b/src/ar/mangaswat/src/eu/kanade/tachiyomi/extension/ar/mangaswat/MangaSwat.kt
@@ -197,7 +197,7 @@ class MangaSwat :
     )
 
     companion object {
-        private const val RESTART_TACHIYOMI = "Restart Tachiyomi to apply new setting."
+        private const val RESTART_APP = "Restart the app to apply the new URL"
         private const val BASE_URL_PREF_TITLE = "Override BaseUrl"
         private const val BASE_URL_PREF = "overrideBaseUrl"
         private const val BASE_URL_PREF_SUMMARY = "For temporary uses. Updating the extension will erase this setting."
@@ -214,7 +214,7 @@ class MangaSwat :
             dialogMessage = "Default: ${super.baseUrl}"
 
             setOnPreferenceChangeListener { _, _ ->
-                Toast.makeText(screen.context, RESTART_TACHIYOMI, Toast.LENGTH_LONG).show()
+                Toast.makeText(screen.context, RESTART_APP, Toast.LENGTH_LONG).show()
                 true
             }
         }


### PR DESCRIPTION
* Just a quick change, from `RESTART_TACHIYOMI` to `RESTART_APP` string.
* No bump to versionCode since it's a minor thing + extension still needs to be fixed (for URL/redesign)

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
