### PR TITLE
TempleScan Update domain 

### DIFF
--- a/src/es/templescanesp/build.gradle
+++ b/src/es/templescanesp/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Temple Scan'
     extClass = '.TempleScanEsp'
     themePkg = 'madara'
-    baseUrl = 'https://aedexnox.vxviral.xyz'
-    overrideVersionCode = 6
+    baseUrl = 'https://aedexnox.kawi.lat'
+    overrideVersionCode = 7
     isNsfw = true
 }
 

--- a/src/es/templescanesp/src/eu/kanade/tachiyomi/extension/es/templescanesp/TempleScanEsp.kt
+++ b/src/es/templescanesp/src/eu/kanade/tachiyomi/extension/es/templescanesp/TempleScanEsp.kt
@@ -21,7 +21,7 @@ import java.util.Locale
 class TempleScanEsp :
     Madara(
         "Temple Scan",
-        "https://aedexnox.vxviral.xyz",
+        "https://aedexnox.kawi.lat",
         "es",
         dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("es")),
     ),
@@ -120,7 +120,7 @@ class TempleScanEsp :
             key = FETCH_DOMAIN_PREF
             title = "Buscar dominio automáticamente"
             summary = "Intenta buscar el dominio automáticamente al abrir la fuente."
-            setDefaultValue(true)
+            setDefaultValue(false)
         }.also { screen.addPreference(it) }
     }
 


### PR DESCRIPTION
closes #11520 

_Automatically search domain, This is disabled._   The system failed, so I had to disable it for the new domain to work.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
