### PR TITLE
fix(rawinu): ad break page

### DIFF
--- a/src/ja/rawinu/build.gradle
+++ b/src/ja/rawinu/build.gradle
@@ -3,8 +3,12 @@ ext {
     extClass = '.RawINU'
     themePkg = 'fmreader'
     baseUrl = 'https://rawinu.com'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
     isNsfw = true
 }
 
 apply from: "$rootDir/common.gradle"
+
+dependencies {
+    implementation(project(":lib:cookieinterceptor"))
+}

--- a/src/ja/rawinu/src/eu/kanade/tachiyomi/extension/ja/rawinu/RawINU.kt
+++ b/src/ja/rawinu/src/eu/kanade/tachiyomi/extension/ja/rawinu/RawINU.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.extension.ja.rawinu
 
+import eu.kanade.tachiyomi.lib.cookieinterceptor.CookieInterceptor
 import eu.kanade.tachiyomi.multisrc.fmreader.FMReader
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
@@ -15,14 +16,17 @@ import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 
+private const val DOMAIN = "rawinu.com"
+
 class RawINU : FMReader(
     "RawINU",
-    "https://rawinu.com",
+    "https://$DOMAIN",
     "ja",
 ) {
     override val client = super.client.newBuilder()
         .rateLimitHost(baseUrl.toHttpUrl(), 2)
         .addInterceptor(::ddosChallengeInterceptor)
+        .addNetworkInterceptor(CookieInterceptor(DOMAIN, "smartlink_shown" to "1"))
         .build()
 
     private val patternDdosKey = """'([a-f0-9]{32})'""".toRegex()


### PR DESCRIPTION
changes based on https://github.com/keiyoushi/extensions-source/pull/11261
fix #11473

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
