### PR TITLE
Fix base URL for Poseidon Scans extension

### DIFF
--- a/src/fr/poseidonscans/build.gradle
+++ b/src/fr/poseidonscans/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Poseidon Scans'
     extClass = '.PoseidonScans'
-    extVersionCode = 47
+    extVersionCode = 48
     isNsfw = false
 }
 

--- a/src/fr/poseidonscans/src/eu/kanade/tachiyomi/extension/fr/poseidonscans/PoseidonScans.kt
+++ b/src/fr/poseidonscans/src/eu/kanade/tachiyomi/extension/fr/poseidonscans/PoseidonScans.kt
@@ -27,7 +27,7 @@ import java.util.TimeZone
 class PoseidonScans : HttpSource() {
 
     override val name = "Poseidon Scans"
-    override val baseUrl = "https://poseidonscans.com"
+    override val baseUrl = "https://poseidon-scans.com"
     override val lang = "fr"
     override val supportsLatest = true
     override val versionId = 2


### PR DESCRIPTION
Closes #11621

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
