### PR TITLE
Fix Base Url Domain Kiryuu

### DIFF
--- a/src/id/kiryuu/build.gradle
+++ b/src/id/kiryuu/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Kiryuu'
     extClass = '.Kiryuu'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://kiryuu02.com'
+    baseUrl = 'https://kiryuu03.com'
     overrideVersionCode = 13
     isNsfw = false
 }


### PR DESCRIPTION
Update The BaseUrl Domain Kiryuu

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
