### PR TITLE
FlameComics: update api contract

### DIFF
--- a/src/en/flamecomics/build.gradle
+++ b/src/en/flamecomics/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Flame Comics'
     extClass = '.FlameComics'
-    extVersionCode = 46
+    extVersionCode = 48
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/flamecomics/build.gradle
+++ b/src/en/flamecomics/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Flame Comics'
     extClass = '.FlameComics'
-    extVersionCode = 48
+    extVersionCode = 47
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComics.kt
+++ b/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComics.kt
@@ -57,7 +57,7 @@ class FlameComics : HttpSource() {
         imageApiUrlBuilder().apply {
             addPathSegment(seriesData.series_id.toString())
             addPathSegment(seriesData.cover)
-            addQueryParameter(seriesData.last_edit, null)
+            addQueryParameter(seriesData.last_edit.toString(), null)
         }.build().toString()
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request =

--- a/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComicsDto.kt
+++ b/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComicsDto.kt
@@ -103,7 +103,7 @@ class Series(
     val artist: List<String>?,
     val status: String,
     val series_id: Int?,
-    val last_edit: String,
+    val last_edit: Long,
     val views: Int?,
 )
 


### PR DESCRIPTION
Update last_edit type to match updated FlameComics API

Closes #11641

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
