### PR TITLE
TruyenQQ: Missed unwrap text css 'p' 

### DIFF
--- a/src/vi/truyenqq/src/eu/kanade/tachiyomi/extension/vi/truyenqq/TruyenQQ.kt
+++ b/src/vi/truyenqq/src/eu/kanade/tachiyomi/extension/vi/truyenqq/TruyenQQ.kt
@@ -109,8 +109,8 @@ class TruyenQQ : ParsedHttpSource(), ConfigurableSource {
         author = info.select(".org").joinToString { it.text() }
         genre = document.select(".list01 li").joinToString { it.text() }
         description = document.select(".story-detail-info").joinToString {
-            it.select("a, strong").unwrap()
-            it.wholeText()
+            it.select("a, strong, p").unwrap()
+            it.wholeText().trim()
         }
         thumbnail_url = document.selectFirst("img[itemprop=image]")?.absUrl("src")
         status = when (info.select(".status > p:last-child").text()) {


### PR DESCRIPTION
no need to bump version.
sorry for the omission.
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
