### PR TITLE
Hentaifox: fix "Top" categories filter

### DIFF
--- a/src/all/hentaifox/build.gradle
+++ b/src/all/hentaifox/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.HentaiFoxFactory'
     themePkg = 'galleryadults'
     baseUrl = 'https://hentaifox.com'
-    overrideVersionCode = 6
+    overrideVersionCode = 7
     isNsfw = true
 }
 

--- a/src/all/hentaifox/src/eu/kanade/tachiyomi/extension/all/hentaifox/HentaiFox.kt
+++ b/src/all/hentaifox/src/eu/kanade/tachiyomi/extension/all/hentaifox/HentaiFox.kt
@@ -143,7 +143,7 @@ class HentaiFox(
         }
         return xhrHeaders.newBuilder()
             .add("X-Csrf-Token", csrfToken)
-            .add("Referer", baseUrl)
+            .add("Referer", "$baseUrl/")
             .build()
     }
 

--- a/src/all/hentaifox/src/eu/kanade/tachiyomi/extension/all/hentaifox/HentaiFox.kt
+++ b/src/all/hentaifox/src/eu/kanade/tachiyomi/extension/all/hentaifox/HentaiFox.kt
@@ -143,6 +143,7 @@ class HentaiFox(
         }
         return xhrHeaders.newBuilder()
             .add("X-Csrf-Token", csrfToken)
+            .add("Referer", baseUrl)
             .build()
     }
 


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

This PR fixes the "Top" categories filter as the site has recently enforced the usage of the "Referer" header for Sidebar requests.
