### PR TITLE
Fix: MangaLivre: erro 403 and 404

### DIFF
--- a/src/pt/mangalivre/build.gradle
+++ b/src/pt/mangalivre/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Manga Livre'
     extClass = '.MangaLivre'
     themePkg = 'madara'
-    baseUrl = 'https://mangalivre.to'
-    overrideVersionCode = 3
+    baseUrl = 'https://mangalivre.tv'
+    overrideVersionCode = 2
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/mangalivre/build.gradle
+++ b/src/pt/mangalivre/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Manga Livre'
     extClass = '.MangaLivre'
     themePkg = 'madara'
-    baseUrl = 'https://mangalivre.tv'
-    overrideVersionCode = 1
+    baseUrl = 'https://mangalivre.to'
+    overrideVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
@@ -1,6 +1,8 @@
 package eu.kanade.tachiyomi.extension.pt.mangalivre
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import okhttp3.Interceptor
+import okhttp3.Response
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -10,7 +12,28 @@ class MangaLivre : Madara(
     "pt-BR",
     SimpleDateFormat("MMMM dd, yyyy", Locale("pt")),
 ) {
-    override val useNewChapterEndpoint = true
 
+    private class MangaLivreInterceptor : Interceptor {
+        override fun intercept(chain: Interceptor.Chain): Response {
+            var request = chain.request()
+            val url = request.url.toString()
+
+            // APENAS REMOVE ?style=list - MANTÉM .tv
+            if (url.contains("?style=list")) {
+                val newUrl = url.replace("?style=list", "")
+                request = request.newBuilder()
+                    .url(newUrl)
+                    .build()
+            }
+
+            return chain.proceed(request)
+        }
+    }
+
+    override val client = super.client.newBuilder()
+        .addInterceptor(MangaLivreInterceptor())
+        .build()
+
+    override val useNewChapterEndpoint = true
     override val id: Long = 2834885536325274328
 }

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
@@ -1,8 +1,6 @@
 package eu.kanade.tachiyomi.extension.pt.mangalivre
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
-import okhttp3.Interceptor
-import okhttp3.Response
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -13,27 +11,7 @@ class MangaLivre : Madara(
     SimpleDateFormat("MMMM dd, yyyy", Locale("pt")),
 ) {
 
-    private class MangaLivreInterceptor : Interceptor {
-        override fun intercept(chain: Interceptor.Chain): Response {
-            var request = chain.request()
-            val url = request.url.toString()
-
-            // APENAS REMOVE ?style=list - MANTÉM .tv
-            if (url.contains("?style=list")) {
-                val newUrl = url.replace("?style=list", "")
-                request = request.newBuilder()
-                    .url(newUrl)
-                    .build()
-            }
-
-            return chain.proceed(request)
-        }
-    }
-
-    override val client = super.client.newBuilder()
-        .addInterceptor(MangaLivreInterceptor())
-        .build()
-
+    override val chapterUrlSuffix: String = ""
     override val useNewChapterEndpoint = true
     override val id: Long = 2834885536325274328
 }


### PR DESCRIPTION
## Description

Fixes the MangaLivre extension which was returning error 403 (Forbidden) and 404 (Not Found) when trying to read chapters.

## Problem

The extension was experiencing two sequential errors:

- Error 403 - Attempts with the alternative .to domain no longer existed
- Error 404 - The site blocked access to URLs with ?style=list

## Solution
- Added interceptor that specifically removes the ?style=list parameter from chapter URLs
- Maintained the .tv domain as per the site's current implementation
- URLs now follow the correct format: https://mangalivre.tv/manga/.../chapter-42/

## Changes
- Increased `overrideVersionCode` from 2 to 3
- Added interceptor to correct chapter URLs

## Tested
- ✅ Manga list works
- ✅ Search works
- ✅ Chapter reading works (error 404 resolved)

Closes #11532

Checklist:

- [✅] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [✅] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [✅] Have not changed source names
- [✅] Have explicitly kept the `id` if a source's name or language were changed
- [✅] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
