### PR TITLE
Updating Hwago Indonesia extension url

### DIFF
--- a/src/id/hwago/build.gradle
+++ b/src/id/hwago/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Hwago'
     extClass = '.Hwago'
     themePkg = 'madara'
-    baseUrl = 'https://hwago01.xyz'
-    overrideVersionCode = 2
+    baseUrl = 'https://01.hwago.xyz/'
+    overrideVersionCode = 3
     isNsfw = false
 }
 

--- a/src/id/hwago/build.gradle
+++ b/src/id/hwago/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Hwago'
     extClass = '.Hwago'
     themePkg = 'madara'
-    baseUrl = 'https://01.hwago.xyz/'
+    baseUrl = 'https://01.hwago.xyz'
     overrideVersionCode = 3
     isNsfw = false
 }

--- a/src/id/hwago/src/eu/kanade/tachiyomi/extension/id/hwago/Hwago.kt
+++ b/src/id/hwago/src/eu/kanade/tachiyomi/extension/id/hwago/Hwago.kt
@@ -6,7 +6,7 @@ import java.util.Locale
 
 class Hwago : Madara(
     "Hwago",
-    "https://01.hwago.xyz/",
+    "https://01.hwago.xyz",
     "id",
     dateFormat = SimpleDateFormat("d MMMM yyyy", Locale("en")),
 ) {

--- a/src/id/hwago/src/eu/kanade/tachiyomi/extension/id/hwago/Hwago.kt
+++ b/src/id/hwago/src/eu/kanade/tachiyomi/extension/id/hwago/Hwago.kt
@@ -6,7 +6,7 @@ import java.util.Locale
 
 class Hwago : Madara(
     "Hwago",
-    "https://hwago01.xyz",
+    "https://01.hwago.xyz/",
     "id",
     dateFormat = SimpleDateFormat("d MMMM yyyy", Locale("en")),
 ) {


### PR DESCRIPTION
Closes #11571 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
