### PR TITLE
Comix: SFW by default

### DIFF
--- a/src/en/comix/build.gradle
+++ b/src/en/comix/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comix'
     extClass = '.Comix'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
@@ -277,7 +277,7 @@ class Comix : HttpSource(), ConfigurableSource {
             key = NSFW_PREF
             title = "Hide NSFW content"
             summary = "Hides NSFW content from popular, latest, and search lists."
-            setDefaultValue(false)
+            setDefaultValue(true)
         }.let(screen::addPreference)
 
         SwitchPreferenceCompat(screen.context).apply {
@@ -320,7 +320,7 @@ class Comix : HttpSource(), ConfigurableSource {
         getString(PREF_SCORE_POSITION, "top") ?: "top"
 
     private fun SharedPreferences.hideNsfw() =
-        getBoolean(NSFW_PREF, false)
+        getBoolean(NSFW_PREF, true)
 
     companion object {
         private const val PREF_POSTER_QUALITY = "pref_poster_quality"


### PR DESCRIPTION
making it SFW by default like the site
Closes #11676

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
