### PR TITLE
Fix Mangastop: adding headers

### DIFF
--- a/src/pt/mangastop/build.gradle
+++ b/src/pt/mangastop/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaStop'
     themePkg = 'mangathemesia'
     baseUrl = 'https://mangastop.net'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = false
 }
 

--- a/src/pt/mangastop/src/eu/kanade/tachiyomi/extension/pt/mangastop/MangaStop.kt
+++ b/src/pt/mangastop/src/eu/kanade/tachiyomi/extension/pt/mangastop/MangaStop.kt
@@ -11,6 +11,10 @@ class MangaStop : MangaThemesia(
     "pt-BR",
     dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("pt", "BR")),
 ) {
+    override fun headersBuilder() = super.headersBuilder()
+        .set("Referer", "$baseUrl/")
+        .set("Accept", "application/xhtml+xml")
+
     override val client = super.client.newBuilder()
         .rateLimit(3)
         .build()


### PR DESCRIPTION
Closes #11585

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
