### PR TITLE
Hiperdex: Fix http 403 and blocked in WebView

### DIFF
--- a/src/en/hiperdex/build.gradle
+++ b/src/en/hiperdex/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Hiperdex'
     themePkg = 'madara'
     baseUrl = 'https://hiperdex.com'
-    overrideVersionCode = 22
+    overrideVersionCode = 23
     isNsfw = true
 }
 

--- a/src/en/hiperdex/src/eu/kanade/tachiyomi/extension/en/hiperdex/ClearanceInterceptor.kt
+++ b/src/en/hiperdex/src/eu/kanade/tachiyomi/extension/en/hiperdex/ClearanceInterceptor.kt
@@ -1,0 +1,46 @@
+package eu.kanade.tachiyomi.extension.en.hiperdex
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class ClearanceInterceptor : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val hasClearanceCookie = request.headers("Cookie").any { cookieHeader ->
+            cookieHeader.split(";").any { cookie ->
+                cookie.trim().startsWith("$COOKIE_NAME=")
+            }
+        }
+
+        if (hasClearanceCookie) return chain.proceed(request)
+
+        val response = chain.proceed(request)
+        if (response.code in ERROR_CODES && response.header("Server") in SERVER_CHECK) {
+            val hasClearanceInResponse = response.headers("Set-Cookie").any { cookieHeader ->
+                cookieHeader.split(";").any { cookie ->
+                    cookie.trim().startsWith("$COOKIE_NAME=")
+                }
+            }
+
+            if (hasClearanceInResponse) return response
+
+            val newResponse = response.newBuilder()
+                .header(
+                    "Set-Cookie",
+                    "$COOKIE_NAME=; Path=/; Domain=${request.url.host}",
+                )
+                .body(response.body)
+                .build()
+
+            return newResponse
+        }
+        return response
+    }
+
+    companion object {
+        private val ERROR_CODES = listOf(403, 503)
+        private val SERVER_CHECK = arrayOf("cloudflare-nginx", "cloudflare")
+        private const val COOKIE_NAME = "cf_clearance"
+    }
+}

--- a/src/en/hiperdex/src/eu/kanade/tachiyomi/extension/en/hiperdex/ClearanceInterceptor.kt
+++ b/src/en/hiperdex/src/eu/kanade/tachiyomi/extension/en/hiperdex/ClearanceInterceptor.kt
@@ -16,7 +16,7 @@ class ClearanceInterceptor : Interceptor {
         if (hasClearanceCookie) return chain.proceed(request)
 
         val response = chain.proceed(request)
-        if (response.code in ERROR_CODES && response.header("Server") in SERVER_CHECK) {
+        if (response.code == 403 && response.header(CF_RAY_HEADER) != null) {
             val hasClearanceInResponse = response.headers("Set-Cookie").any { cookieHeader ->
                 cookieHeader.split(";").any { cookie ->
                     cookie.trim().startsWith("$COOKIE_NAME=")
@@ -39,8 +39,7 @@ class ClearanceInterceptor : Interceptor {
     }
 
     companion object {
-        private val ERROR_CODES = listOf(403, 503)
-        private val SERVER_CHECK = arrayOf("cloudflare-nginx", "cloudflare")
         private const val COOKIE_NAME = "cf_clearance"
+        private const val CF_RAY_HEADER = "cf-ray"
     }
 }

--- a/src/en/hiperdex/src/eu/kanade/tachiyomi/extension/en/hiperdex/Hiperdex.kt
+++ b/src/en/hiperdex/src/eu/kanade/tachiyomi/extension/en/hiperdex/Hiperdex.kt
@@ -37,6 +37,7 @@ class Hiperdex :
     override val baseUrl by lazy { getPrefBaseUrl() }
 
     override val client = super.client.newBuilder()
+        .addNetworkInterceptor(ClearanceInterceptor())
         .setRandomUserAgent(
             preferences.getPrefUAType(),
             preferences.getPrefCustomUA(),
@@ -44,7 +45,7 @@ class Hiperdex :
         .rateLimit(3)
         .build()
 
-    override val useLoadMoreRequest = LoadMoreStrategy.Never
+    override val useLoadMoreRequest = LoadMoreStrategy.Always
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         EditTextPreference(screen.context).apply {


### PR DESCRIPTION
Closes #11690
Closes #11579

Aside from the issue with Cloudflare, they're blocking requests that contain `?m_orderby=`

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
