### PR TITLE
Koharu: Fix API domain & remove non-relevant domain

### DIFF
--- a/src/all/koharu/build.gradle
+++ b/src/all/koharu/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'SchaleNetwork'
     extClass = '.KoharuFactory'
-    extVersionCode = 16
+    extVersionCode = 17
     isNsfw = true
 }
 

--- a/src/all/koharu/src/eu/kanade/tachiyomi/extension/all/koharu/Koharu.kt
+++ b/src/all/koharu/src/eu/kanade/tachiyomi/extension/all/koharu/Koharu.kt
@@ -74,7 +74,7 @@ class Koharu(
 
     override val id = if (lang == "en") 1484902275639232927 else super.id
 
-    private val apiUrl = baseUrl.replace("://", "://api.")
+    private val apiUrl = API_DOMAIN
 
     private val apiBooksUrl = "$apiUrl/books"
 
@@ -513,6 +513,7 @@ class Koharu(
         const val PREFIX_ID_KEY_SEARCH = "id:"
         private const val PREF_MIRROR = "pref_mirror"
         private const val MIRROR_PREF_DEFAULT = "schale.network"
+        private const val API_DOMAIN = "https://api.schale.network"
         private val mirrors = arrayOf(
             MIRROR_PREF_DEFAULT,
             "anchira.to",

--- a/src/all/koharu/src/eu/kanade/tachiyomi/extension/all/koharu/Koharu.kt
+++ b/src/all/koharu/src/eu/kanade/tachiyomi/extension/all/koharu/Koharu.kt
@@ -519,7 +519,6 @@ class Koharu(
             "gehenna.jp",
             "niyaniya.moe",
             "shupogaki.moe",
-            "hdoujin.net",
         )
         private const val PREF_IMAGERES = "pref_image_quality"
         private const val PREF_REM_ADD = "pref_remove_additional"


### PR DESCRIPTION
- All alternative domains still use same API
- Remove the sister site: hdoujin.net is redirecting to hdoujin.org and is actually a existed extension with different content.

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
