### PR TITLE
SpyFakku: Changes the default sort to "Date released" descending

### DIFF
--- a/src/en/spyfakku/build.gradle
+++ b/src/en/spyfakku/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'SpyFakku'
     extClass = '.SpyFakku'
-    extVersionCode = 12
+    extVersionCode = 13
     isNsfw = true
 }
 

--- a/src/en/spyfakku/src/eu/kanade/tachiyomi/extension/en/spyfakku/Filters.kt
+++ b/src/en/spyfakku/src/eu/kanade/tachiyomi/extension/en/spyfakku/Filters.kt
@@ -6,7 +6,7 @@ import eu.kanade.tachiyomi.source.model.FilterList
 
 fun getFilters(): FilterList {
     return FilterList(
-        SortFilter("Sort by", Selection(0, false), getSortsList),
+        SortFilter("Sort by", Selection(3, false), getSortsList),
         SelectFilter("Per page", getLimits),
         Filter.Separator(),
         Filter.Header("Separate tags with commas (,)"),


### PR DESCRIPTION
Makes more sense for filter to sort by Date released by default.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
