### PR TITLE
fix MangaStop: adding more headers

### DIFF
--- a/src/pt/mangastop/build.gradle
+++ b/src/pt/mangastop/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaStop'
     themePkg = 'mangathemesia'
     baseUrl = 'https://mangastop.net'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
     isNsfw = false
 }
 

--- a/src/pt/mangastop/src/eu/kanade/tachiyomi/extension/pt/mangastop/MangaStop.kt
+++ b/src/pt/mangastop/src/eu/kanade/tachiyomi/extension/pt/mangastop/MangaStop.kt
@@ -17,7 +17,7 @@ class MangaStop : MangaThemesia(
 ) {
     override fun headersBuilder() = super.headersBuilder()
         .set("Referer", "$baseUrl/")
-        .set("Accept", "application/xhtml+xml")
+        .set("Accept", "text/html,application/xhtml+xml")
 
     override val client = super.client.newBuilder()
         .rateLimit(3)


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
