### PR TITLE
PandaChaika: language tags are parsed as null tags

### DIFF
--- a/src/all/pandachaika/build.gradle
+++ b/src/all/pandachaika/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'PandaChaika'
     extClass = '.PandaChaikaFactory'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/all/pandachaika/src/eu/kanade/tachiyomi/extension/all/pandachaika/PandaChaikaDto.kt
+++ b/src/all/pandachaika/src/eu/kanade/tachiyomi/extension/all/pandachaika/PandaChaikaDto.kt
@@ -54,7 +54,7 @@ class LongArchive(
         val characters = filterTags("character", tags = tags)
         val male = filterTags("male", tags = tags)
         val female = filterTags("female", tags = tags)
-        val others = filterTags(exclude = listOf("language","female", "male", "artist", "publisher", "group", "parody"), tags = tags)
+        val others = filterTags(exclude = listOf("language", "female", "male", "artist", "publisher", "group", "parody"), tags = tags)
         val parodies = filterTags("parody", tags = tags)
         var appended = false
 

--- a/src/all/pandachaika/src/eu/kanade/tachiyomi/extension/all/pandachaika/PandaChaikaDto.kt
+++ b/src/all/pandachaika/src/eu/kanade/tachiyomi/extension/all/pandachaika/PandaChaikaDto.kt
@@ -54,7 +54,7 @@ class LongArchive(
         val characters = filterTags("character", tags = tags)
         val male = filterTags("male", tags = tags)
         val female = filterTags("female", tags = tags)
-        val others = filterTags(exclude = listOf("female", "male", "artist", "publisher", "group", "parody"), tags = tags)
+        val others = filterTags(exclude = listOf("language","female", "male", "artist", "publisher", "group", "parody"), tags = tags)
         val parodies = filterTags("parody", tags = tags)
         var appended = false
 


### PR DESCRIPTION
Added the `language` namespace to the exclusion list for tags.

Seeing as a fix looked simple i tried to create a PR for it, first time touching Kotlin so haven't been able to build & test locally yet. Will read up on that in the morning as i installed IntelliJ pure for this PR

Closes #11818 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
