### PR TITLE
HentaiCosplay: Fix parseMobileListing thumbnail_url

### DIFF
--- a/src/all/hentaicosplay/build.gradle
+++ b/src/all/hentaicosplay/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hentai Cosplay'
     extClass = '.HentaiCosplay'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = true
 }
 

--- a/src/all/hentaicosplay/src/eu/kanade/tachiyomi/extension/all/hentaicosplay/HentaiCosplay.kt
+++ b/src/all/hentaicosplay/src/eu/kanade/tachiyomi/extension/all/hentaicosplay/HentaiCosplay.kt
@@ -62,7 +62,7 @@ class HentaiCosplay : HttpSource() {
                 SManga.create().apply {
                     setUrlWithoutDomain(element.absUrl("href"))
                     thumbnail_url = element.selectFirst("img")
-                        ?.absUrl("data-original")
+                        ?.absUrl("src")
                         ?.replace("http://", "https://")
                     title = element.selectFirst("span:not(.posted)")!!.text()
                     element.selectFirst("span.posted")


### PR DESCRIPTION
Checklist:
Closes #10805
- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
