### PR TITLE
fix(rokaricomics): Fix search and hide paywalled chapters

### DIFF
--- a/src/en/rokaricomics/build.gradle
+++ b/src/en/rokaricomics/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.RokariComics'
     themePkg = 'mangathemesia'
     baseUrl = 'https://rokaricomics.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
 }
 

--- a/src/en/rokaricomics/src/eu/kanade/tachiyomi/extension/en/rokaricomics/RokariComics.kt
+++ b/src/en/rokaricomics/src/eu/kanade/tachiyomi/extension/en/rokaricomics/RokariComics.kt
@@ -18,12 +18,7 @@ class RokariComics : MangaThemesia(
 ) {
     // Popular - Use homepage "Popular Today" section (first page only, no pagination)
     override fun popularMangaRequest(page: Int): Request {
-        return if (page == 1) {
-            GET(baseUrl, headers)
-        } else {
-            // Return empty page for page > 1 since Popular Today is not paginated
-            GET("$baseUrl/page/0/", headers)
-        }
+        GET(baseUrl, headers)
     }
 
     override fun popularMangaParse(response: Response): MangasPage {

--- a/src/en/rokaricomics/src/eu/kanade/tachiyomi/extension/en/rokaricomics/RokariComics.kt
+++ b/src/en/rokaricomics/src/eu/kanade/tachiyomi/extension/en/rokaricomics/RokariComics.kt
@@ -17,9 +17,7 @@ class RokariComics : MangaThemesia(
     "en",
 ) {
     // Popular - Use homepage "Popular Today" section (first page only, no pagination)
-    override fun popularMangaRequest(page: Int): Request {
-        GET(baseUrl, headers)
-    }
+    override fun popularMangaRequest(page: Int): Request = GET(baseUrl, headers)
 
     override fun popularMangaParse(response: Response): MangasPage {
         val document = response.asJsoup()

--- a/src/en/rokaricomics/src/eu/kanade/tachiyomi/extension/en/rokaricomics/RokariComics.kt
+++ b/src/en/rokaricomics/src/eu/kanade/tachiyomi/extension/en/rokaricomics/RokariComics.kt
@@ -1,14 +1,120 @@
 package eu.kanade.tachiyomi.extension.en.rokaricomics
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.util.asJsoup
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Request
+import okhttp3.Response
 
 class RokariComics : MangaThemesia(
     "RokariComics",
     "https://rokaricomics.com",
     "en",
 ) {
-    override fun chapterListSelector() = "#chapterlist li:has(div.chbox):has(div.eph-num):has(a[href])"
+    // Popular - Use homepage "Popular Today" section (first page only, no pagination)
+    override fun popularMangaRequest(page: Int): Request {
+        return if (page == 1) {
+            GET(baseUrl, headers)
+        } else {
+            // Return empty page for page > 1 since Popular Today is not paginated
+            GET("$baseUrl/page/0/", headers)
+        }
+    }
+
+    override fun popularMangaParse(response: Response): MangasPage {
+        if (!response.request.url.toString().endsWith("/page/0/")) {
+            val document = response.asJsoup()
+            // Select manga from "Popular Today" section (first listupd on homepage)
+            val mangas = document.select(".bixbox:has(h2:contains(Popular)) .bs .bsx").map { element ->
+                SManga.create().apply {
+                    element.select("a").first()?.let {
+                        setUrlWithoutDomain(it.attr("href"))
+                        title = it.attr("title")
+                    }
+                    thumbnail_url = element.select("img").firstOrNull()?.let { img ->
+                        img.attr("abs:data-lazy-src").ifEmpty {
+                            img.attr("abs:data-src").ifEmpty {
+                                img.attr("abs:src")
+                            }
+                        }
+                    }
+                }
+            }
+            return MangasPage(mangas, false)
+        }
+        return MangasPage(emptyList(), false)
+    }
+
+    // Latest - Use homepage pagination which shows latest updates
+    override fun latestUpdatesRequest(page: Int): Request {
+        return if (page == 1) {
+            GET(baseUrl, headers)
+        } else {
+            GET("$baseUrl/page/$page/", headers)
+        }
+    }
+
+    override fun latestUpdatesParse(response: Response): MangasPage {
+        val document = response.asJsoup()
+        // Select manga from "Latest Update" section (second listupd on homepage)
+        val mangas = document.select(".bixbox:has(h2:contains(Latest)) .bs .bsx").map { element ->
+            SManga.create().apply {
+                element.select("a").first()?.let {
+                    setUrlWithoutDomain(it.attr("href"))
+                    title = it.attr("title")
+                }
+                thumbnail_url = element.select("img").firstOrNull()?.let { img ->
+                    img.attr("abs:data-lazy-src").ifEmpty {
+                        img.attr("abs:data-src").ifEmpty {
+                            img.attr("abs:src")
+                        }
+                    }
+                }
+            }
+        }
+        val hasNextPage = document.selectFirst("div.hpage .r, div.pagination .next") != null
+        return MangasPage(mangas, hasNextPage)
+    }
+
+    // Site changed from /manga/ directory to using search page /?s=
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+        val url = baseUrl.toHttpUrl().newBuilder()
+            .addQueryParameter("s", query)
+            .addQueryParameter("page", page.toString())
+
+        filters.forEach { filter ->
+            when (filter) {
+                is StatusFilter -> {
+                    url.addQueryParameter("status", filter.selectedValue())
+                }
+                is TypeFilter -> {
+                    url.addQueryParameter("type", filter.selectedValue())
+                }
+                is OrderByFilter -> {
+                    url.addQueryParameter("order", filter.selectedValue())
+                }
+                is GenreListFilter -> {
+                    filter.state
+                        .filter { it.state != Filter.TriState.STATE_IGNORE }
+                        .forEach {
+                            val value = if (it.state == Filter.TriState.STATE_EXCLUDE) "-${it.value}" else it.value
+                            url.addQueryParameter("genre[]", value)
+                        }
+                }
+                else -> { /* Do Nothing */ }
+            }
+        }
+        return GET(url.build(), headers)
+    }
+
+    // Filter out chapters that have the coin cost indicator (paywalled chapters)
+    // These chapters have a span with "text-gold" class containing the coin price
+    override fun chapterListSelector() = "#chapterlist li:has(div.chbox):has(div.eph-num):has(a[href]):not(:has(.text-gold))"
 
     override fun getFilterList(): FilterList {
         val filters = super.getFilterList().filterNot { it is AuthorFilter || it is YearFilter }

--- a/src/en/rokaricomics/src/eu/kanade/tachiyomi/extension/en/rokaricomics/RokariComics.kt
+++ b/src/en/rokaricomics/src/eu/kanade/tachiyomi/extension/en/rokaricomics/RokariComics.kt
@@ -22,27 +22,24 @@ class RokariComics : MangaThemesia(
     }
 
     override fun popularMangaParse(response: Response): MangasPage {
-        if (!response.request.url.toString().endsWith("/page/0/")) {
-            val document = response.asJsoup()
-            // Select manga from "Popular Today" section (first listupd on homepage)
-            val mangas = document.select(".bixbox:has(h2:contains(Popular)) .bs .bsx").map { element ->
-                SManga.create().apply {
-                    element.select("a").first()?.let {
-                        setUrlWithoutDomain(it.attr("href"))
-                        title = it.attr("title")
-                    }
-                    thumbnail_url = element.select("img").firstOrNull()?.let { img ->
-                        img.attr("abs:data-lazy-src").ifEmpty {
-                            img.attr("abs:data-src").ifEmpty {
-                                img.attr("abs:src")
-                            }
+        val document = response.asJsoup()
+        // Select manga from "Popular Today" section (first listupd on homepage)
+        val mangas = document.select(".bixbox:has(h2:contains(Popular)) .bs .bsx").map { element ->
+            SManga.create().apply {
+                element.select("a").first()?.let {
+                    setUrlWithoutDomain(it.attr("href"))
+                    title = it.attr("title")
+                }
+                thumbnail_url = element.select("img").firstOrNull()?.let { img ->
+                    img.attr("abs:data-lazy-src").ifEmpty {
+                        img.attr("abs:data-src").ifEmpty {
+                            img.attr("abs:src")
                         }
                     }
                 }
             }
-            return MangasPage(mangas, false)
         }
-        return MangasPage(emptyList(), false)
+        return MangasPage(mangas, false)
     }
 
     // Latest - Use homepage pagination which shows latest updates


### PR DESCRIPTION
- Fix 'No results found' by using /?s= search endpoint instead of /manga/
- Add Popular section using homepage 'Popular Today'
- Add Latest section using homepage pagination
- Hide paywalled chapters (chapters with coin cost indicator)

Fixes keiyoushi/extensions-source#11830
Fixes keiyoushi/extensions-source#11843

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
