### PR TITLE
SakuraManga → BlossomManhwa: update domain

### DIFF
--- a/src/all/sakuramanhwa/build.gradle
+++ b/src/all/sakuramanhwa/build.gradle
@@ -1,7 +1,7 @@
 ext {
-    extName = 'SakuraManhwa'
-    extClass = '.SakuraManhwa'
-    extVersionCode = 1
+    extName = 'BlossomManhwa'
+    extClass = '.BlossomManhwa'
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/all/sakuramanhwa/src/eu/kanade/tachiyomi/extension/all/sakuramanhwa/ApiModel.kt
+++ b/src/all/sakuramanhwa/src/eu/kanade/tachiyomi/extension/all/sakuramanhwa/ApiModel.kt
@@ -4,13 +4,13 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 internal class ApiMangaInfo(
-    val manga: MangaInfo,
+    val manga: MangaDetails,
+    val metaData: MetaDataInfo,
     val chapters: List<ChapterInfo>,
 )
 
 @Serializable
-internal class MangaInfo(
-    val details: MangaDetails,
+internal class MetaDataInfo(
     val follows: Int,
     val views: Int,
 )
@@ -25,7 +25,7 @@ internal class MangaDetails(
     val slug: String,
     val type: String,
     val status: String?,
-    val author: String,
+    val authors: List<String>?,
     val rating: Float?,
     val create_at: String?,
 )


### PR DESCRIPTION
Closes #10464

Minimal changes to use the new API structure.
Omitting `rating: null` from genres.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
