### PR TITLE
Update MangaLivre.kt

### DIFF
--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
@@ -6,7 +6,7 @@ import java.util.Locale
 
 class MangaLivre : Madara(
     "Manga Livre",
-    "https://mangalivre.tv",
+    "https://mangalivre.to",
     "pt-BR",
     SimpleDateFormat("MMMM dd, yyyy", Locale("pt")),
 ) {


### PR DESCRIPTION
The URL changed again, from "https://mangalivre.tv" to "https://mangalivre.to"

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
