### PR TITLE
fix mangastop: add cloudflare cliente and randomua

### DIFF
--- a/src/pt/mangastop/build.gradle
+++ b/src/pt/mangastop/build.gradle
@@ -3,8 +3,13 @@ ext {
     extClass = '.MangaStop'
     themePkg = 'mangathemesia'
     baseUrl = 'https://mangastop.net'
-    overrideVersionCode = 4
+    overrideVersionCode = 5
     isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"
+
+dependencies {
+    api(project(":lib:cookieinterceptor"))
+    implementation(project(":lib:randomua"))
+}

--- a/src/pt/mangastop/src/eu/kanade/tachiyomi/extension/pt/mangastop/MangaStop.kt
+++ b/src/pt/mangastop/src/eu/kanade/tachiyomi/extension/pt/mangastop/MangaStop.kt
@@ -1,33 +1,61 @@
+
 package eu.kanade.tachiyomi.extension.pt.mangastop
 
+import androidx.preference.PreferenceScreen
+import eu.kanade.tachiyomi.lib.cookieinterceptor.CookieInterceptor
+import eu.kanade.tachiyomi.lib.randomua.PREF_KEY_RANDOM_UA
+import eu.kanade.tachiyomi.lib.randomua.RANDOM_UA_VALUES
+import eu.kanade.tachiyomi.lib.randomua.UserAgentType
+import eu.kanade.tachiyomi.lib.randomua.addRandomUAPreferenceToScreen
+import eu.kanade.tachiyomi.lib.randomua.getPrefCustomUA
+import eu.kanade.tachiyomi.lib.randomua.getPrefUAType
+import eu.kanade.tachiyomi.lib.randomua.setRandomUserAgent
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.Page
+import keiyoushi.utils.getPreferencesLazy
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.Headers
 import org.jsoup.nodes.Document
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class MangaStop : MangaThemesia(
-    "Manga Stop",
-    "https://mangastop.net",
-    "pt-BR",
-    dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("pt", "BR")),
-) {
-    override fun headersBuilder() = super.headersBuilder()
-        .set("Referer", "$baseUrl/")
-        .set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
-        .set("Accept-Language", "pt-BR,pt;q=0.8,en-US;q=0.5,en;q=0.3")
-        .set("Sec-Fetch-Dest", "document")
-        .set("Sec-Fetch-Mode", "navigate")
-        .set("Sec-Fetch-Site", "none")
-        .set("Sec-Fetch-User", "?1")
-        .set("Upgrade-Insecure-Requests", "1")
+class MangaStop :
+    MangaThemesia(
+        "Manga Stop",
+        "https://mangastop.net",
+        "pt-BR",
+        dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("pt", "BR")),
+    ),
+    ConfigurableSource {
 
-    override val client = super.client.newBuilder()
-        .rateLimit(3)
+    private val preferences by getPreferencesLazy {
+        if (getPrefUAType() != UserAgentType.OFF || getPrefCustomUA().isNullOrBlank().not()) {
+            return@getPreferencesLazy
+        }
+        edit().putString(PREF_KEY_RANDOM_UA, RANDOM_UA_VALUES.last()).apply()
+    }
+
+    override val client = network.cloudflareClient.newBuilder()
+        .addNetworkInterceptor(
+            CookieInterceptor(baseUrl.substringAfter("//"), "wpmanga-ada" to "1"),
+        )
+        .setRandomUserAgent(
+            preferences.getPrefUAType(),
+            preferences.getPrefCustomUA(),
+        )
+        .rateLimit(2)
         .build()
+
+    override fun headersBuilder(): Headers.Builder = super.headersBuilder()
+        .add("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7")
+        .add("Accept-Language", "pt-BR,pt;q=0.9,en-US;q=0.8,en;q=0.7")
+        .add("Sec-Fetch-Dest", "document")
+        .add("Sec-Fetch-Mode", "navigate")
+        .add("Sec-Fetch-Site", "same-origin")
+        .add("Upgrade-Insecure-Requests", "1")
 
     override fun pageListParse(document: Document): List<Page> {
         val pages = super.pageListParse(document)
@@ -42,5 +70,9 @@ class MangaStop : MangaThemesia(
                 Page(i, document.location(), el.jsonPrimitive.content)
             }
             .orEmpty()
+    }
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        addRandomUAPreferenceToScreen(screen)
     }
 }

--- a/src/pt/mangastop/src/eu/kanade/tachiyomi/extension/pt/mangastop/MangaStop.kt
+++ b/src/pt/mangastop/src/eu/kanade/tachiyomi/extension/pt/mangastop/MangaStop.kt
@@ -1,4 +1,3 @@
-
 package eu.kanade.tachiyomi.extension.pt.mangastop
 
 import androidx.preference.PreferenceScreen


### PR DESCRIPTION
closes: #11890

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
