### PR TITLE
MHScans: Add option to filter premium chapters

### DIFF
--- a/src/es/mhscans/build.gradle
+++ b/src/es/mhscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MHScans'
     themePkg = 'madara'
     baseUrl = 'https://curiosidadtop.com'
-    overrideVersionCode = 8
+    overrideVersionCode = 9
     isNsfw = false
 }
 

--- a/src/es/mhscans/src/eu/kanade/tachiyomi/extension/es/mhscans/MHScans.kt
+++ b/src/es/mhscans/src/eu/kanade/tachiyomi/extension/es/mhscans/MHScans.kt
@@ -13,12 +13,14 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
-class MHScans : Madara(
-    "MHScans",
-    "https://curiosidadtop.com",
-    "es",
-    dateFormat = SimpleDateFormat("dd 'de' MMMM 'de' yyyy", Locale("es")),
-), ConfigurableSource {
+class MHScans :
+    Madara(
+        "MHScans",
+        "https://curiosidadtop.com",
+        "es",
+        dateFormat = SimpleDateFormat("dd 'de' MMMM 'de' yyyy", Locale("es")),
+    ),
+    ConfigurableSource {
     override val mangaSubString = "series"
 
     override val client: OkHttpClient = super.client.newBuilder()

--- a/src/es/mhscans/src/eu/kanade/tachiyomi/extension/es/mhscans/MHScans.kt
+++ b/src/es/mhscans/src/eu/kanade/tachiyomi/extension/es/mhscans/MHScans.kt
@@ -1,7 +1,13 @@
 package eu.kanade.tachiyomi.extension.es.mhscans
 
+import android.content.SharedPreferences
+import android.widget.Toast
+import androidx.preference.PreferenceScreen
+import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.source.ConfigurableSource
+import keiyoushi.utils.getPreferences
 import okhttp3.OkHttpClient
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -12,7 +18,7 @@ class MHScans : Madara(
     "https://curiosidadtop.com",
     "es",
     dateFormat = SimpleDateFormat("dd 'de' MMMM 'de' yyyy", Locale("es")),
-) {
+), ConfigurableSource {
     override val mangaSubString = "series"
 
     override val client: OkHttpClient = super.client.newBuilder()
@@ -21,4 +27,35 @@ class MHScans : Madara(
 
     override val useNewChapterEndpoint = true
     override val useLoadMoreRequest = LoadMoreStrategy.Always
+
+    private val preferences: SharedPreferences = getPreferences()
+
+    override fun chapterListSelector(): String {
+        val baseSelector = super.chapterListSelector()
+        val removePremium = preferences.getBoolean(REMOVE_PREMIUM_CHAPTERS, REMOVE_PREMIUM_CHAPTERS_DEFAULT)
+
+        if (!removePremium) {
+            return baseSelector
+        }
+
+        return "$baseSelector:not(.premium)"
+    }
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        SwitchPreferenceCompat(screen.context).apply {
+            key = REMOVE_PREMIUM_CHAPTERS
+            title = "Filtrar capítulos de pago"
+            summary = "Oculta automáticamente los capítulos que requieren Taels."
+            setDefaultValue(REMOVE_PREMIUM_CHAPTERS_DEFAULT)
+            setOnPreferenceChangeListener { _, _ ->
+                Toast.makeText(screen.context, "Para aplicar los cambios, actualiza la lista de capítulos", Toast.LENGTH_LONG).show()
+                true
+            }
+        }.also { screen.addPreference(it) }
+    }
+
+    companion object {
+        private const val REMOVE_PREMIUM_CHAPTERS = "removePremiumChapters"
+        private const val REMOVE_PREMIUM_CHAPTERS_DEFAULT = true
+    }
 }


### PR DESCRIPTION
The source `MHScans` recently started uploading "premium" (paid) chapters. These chapters are locked behind a paywall and are not readable within the app, cluttering the chapter list.

This PR implements the following changes:
- Adds a toggle to filter/hide premium chapters (enabled by default).
- Uses a CSS selector modification to exclude them.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
