### PR TITLE
Zaimanhua: Fix gzip response decoding

### DIFF
--- a/src/zh/zaimanhua/build.gradle
+++ b/src/zh/zaimanhua/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Zaimanhua'
     extClass = '.Zaimanhua'
-    extVersionCode = 15
+    extVersionCode = 16
     isNsfw = false
 }
 

--- a/src/zh/zaimanhua/src/eu/kanade/tachiyomi/extension/zh/zaimanhua/Common.kt
+++ b/src/zh/zaimanhua/src/eu/kanade/tachiyomi/extension/zh/zaimanhua/Common.kt
@@ -1,6 +1,16 @@
 package eu.kanade.tachiyomi.extension.zh.zaimanhua
 
 import eu.kanade.tachiyomi.source.model.SManga
+import okhttp3.ResponseBody
+import java.util.zip.GZIPInputStream
+
+fun ResponseBody.stringCompat(contentEncoding: String?): String {
+    return if (contentEncoding == "gzip") {
+        GZIPInputStream(byteStream()).bufferedReader().use { it.readText() }
+    } else {
+        string()
+    }
+}
 
 fun parseStatus(status: String): Int = when (status) {
     "连载中" -> SManga.ONGOING

--- a/src/zh/zaimanhua/src/eu/kanade/tachiyomi/extension/zh/zaimanhua/Zaimanhua.kt
+++ b/src/zh/zaimanhua/src/eu/kanade/tachiyomi/extension/zh/zaimanhua/Zaimanhua.kt
@@ -88,7 +88,7 @@ class Zaimanhua : HttpSource(), ConfigurableSource {
         if (!request.url.toString().contains(checkTokenRegex)) return response
 
         // If chapter can read, return directly
-        val canRead = response.peekBody(Long.MAX_VALUE).string()
+        val canRead = response.peekBody(Long.MAX_VALUE).stringCompat(response.header("Content-Encoding"))
             .parseAs<ResponseDto<DataWrapperDto<CanReadDto>>>().data.data?.canRead != false
         if (canRead) return response
 


### PR DESCRIPTION
This change introduces a `stringCompat` helper function to correctly handle GZIP-encoded response bodies when peeking, preventing decoding issues in older forks like TachiyomiJ2K.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
