### PR TITLE
MangaOwl.io: Fix `HTTP 410` while browsing/override `mangaSubString`

### DIFF
--- a/src/en/mangaowlio/build.gradle
+++ b/src/en/mangaowlio/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaOwlIo'
     themePkg = 'madara'
     baseUrl = 'https://mangaowl.io'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/en/mangaowlio/src/eu/kanade/tachiyomi/extension/en/mangaowlio/MangaOwlIo.kt
+++ b/src/en/mangaowlio/src/eu/kanade/tachiyomi/extension/en/mangaowlio/MangaOwlIo.kt
@@ -2,6 +2,12 @@ package eu.kanade.tachiyomi.extension.en.mangaowlio
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 
-class MangaOwlIo : Madara("MangaOwl.io (unoriginal)", "https://mangaowl.io", "en") {
+class MangaOwlIo : Madara(
+    "MangaOwl.io (unoriginal)",
+    "https://mangaowl.io",
+    "en",
+) {
+    override val mangaSubString = "read-1"
+
     override val useNewChapterEndpoint = true
 }


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
