### PR TITLE
GocTruyenTranhVui: Update header and not show token from WebView

### DIFF
--- a/src/vi/goctruyentranhvui/build.gradle
+++ b/src/vi/goctruyentranhvui/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Goc Truyen Tranh Vui'
     extClass = '.GocTruyenTranhVui'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 


### PR DESCRIPTION
Do not call the entire function which leads to Mihon crash. Only call the custom token for its intended purpose

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
