### PR TITLE
NineManga(es): Fix pages not found again / Update NineManga(en) domain

### DIFF
--- a/src/all/ninemanga/build.gradle
+++ b/src/all/ninemanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'NineManga'
     extClass = '.NineMangaFactory'
-    extVersionCode = 24
+    extVersionCode = 25
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/ninemanga/src/eu/kanade/tachiyomi/extension/all/ninemanga/NineMangaFactory.kt
+++ b/src/all/ninemanga/src/eu/kanade/tachiyomi/extension/all/ninemanga/NineMangaFactory.kt
@@ -31,7 +31,7 @@ class NineMangaFactory : SourceFactory {
     )
 }
 
-class NineMangaEn : NineManga("NineMangaEn", "https://ninemanga.com", "en") {
+class NineMangaEn : NineManga("NineMangaEn", "https://www.ninemanga.com", "en") {
     override fun latestUpdatesFromElement(element: Element) = SManga.create().apply {
         element.select("a.bookname").let {
             url = it.attr("abs:href").substringAfter("ninemanga.com")

--- a/src/all/ninemanga/src/eu/kanade/tachiyomi/extension/all/ninemanga/NineMangaFactory.kt
+++ b/src/all/ninemanga/src/eu/kanade/tachiyomi/extension/all/ninemanga/NineMangaFactory.kt
@@ -65,6 +65,15 @@ class NineMangaEs : NineManga("NineMangaEs", "https://es.ninemanga.com", "es") {
     private val redirectRegex = Regex("""window\.location\.href\s*=\s*["'](.*?)["']""")
 
     override fun pageListParse(document: Document): List<Page> {
+        val serverUrl = document.selectFirst("section.section div.post-content-body > a")?.attr("href")
+
+        if (serverUrl != null) {
+            val serverHeaders = headers.newBuilder()
+                .set("Referer", document.baseUri())
+                .build()
+            return pageListParse(client.newCall(GET(serverUrl, serverHeaders)).execute().asJsoup())
+        }
+
         val redirectScript = document.selectFirst("body > script:containsData(window.location.href)")?.data()
 
         if (redirectScript != null) {

--- a/src/all/ninemanga/src/eu/kanade/tachiyomi/extension/all/ninemanga/NineMangaFactory.kt
+++ b/src/all/ninemanga/src/eu/kanade/tachiyomi/extension/all/ninemanga/NineMangaFactory.kt
@@ -65,7 +65,7 @@ class NineMangaEs : NineManga("NineMangaEs", "https://es.ninemanga.com", "es") {
     private val redirectRegex = Regex("""window\.location\.href\s*=\s*["'](.*?)["']""")
 
     override fun pageListParse(document: Document): List<Page> {
-        val serverUrl = document.selectFirst("section.section div.post-content-body > a")?.attr("href")
+        val serverUrl = document.selectFirst("section.section div.post-content-body > a")?.absUrl("href")
 
         if (serverUrl != null) {
             val serverHeaders = headers.newBuilder()


### PR DESCRIPTION
Closes #11998

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
