### PR TITLE
BookWalker Global: various fixes/improvements

### DIFF
--- a/src/en/bookwalker/build.gradle
+++ b/src/en/bookwalker/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'BookWalker Global'
     extClass = '.BookWalker'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/BookWalker.kt
+++ b/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/BookWalker.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.extension.en.bookwalker
 
-import android.app.Application
 import android.text.Editable
 import android.text.TextWatcher
 import android.util.Log
@@ -9,7 +8,6 @@ import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.extension.en.bookwalker.dto.BookUpdateDto
-import eu.kanade.tachiyomi.extension.en.bookwalker.dto.HoldBookEntityDto
 import eu.kanade.tachiyomi.extension.en.bookwalker.dto.HoldBooksInfoDto
 import eu.kanade.tachiyomi.extension.en.bookwalker.dto.SeriesDto
 import eu.kanade.tachiyomi.extension.en.bookwalker.dto.SingleDto
@@ -33,11 +31,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.modules.SerializersModule
-import kotlinx.serialization.modules.plus
-import kotlinx.serialization.modules.polymorphic
-import kotlinx.serialization.modules.subclass
 import okhttp3.Call
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -48,8 +41,8 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import rx.Observable
 import rx.Single
-import uy.kohesive.injekt.injectLazy
 import java.util.regex.PatternSyntaxException
+import kotlin.collections.component1
 
 class BookWalker : ConfigurableSource, ParsedHttpSource(), BookWalkerPreferences {
 
@@ -79,18 +72,6 @@ class BookWalker : ConfigurableSource, ParsedHttpSource(), BookWalkerPreferences
         .set("User-Agent", USER_AGENT_DESKTOP)
         .build()
 
-    private val json = Json {
-        ignoreUnknownKeys = true
-        serializersModule += SerializersModule {
-            polymorphic(HoldBookEntityDto::class) {
-                subclass(SingleDto::class)
-                subclass(SeriesDto::class)
-            }
-        }
-    }
-
-    val app by injectLazy<Application>()
-
     private val preferences by getPreferencesLazy()
 
     override val showLibraryInPopular
@@ -114,6 +95,9 @@ class BookWalker : ConfigurableSource, ParsedHttpSource(), BookWalkerPreferences
 
     override val attemptToReadPreviews
         get() = preferences.getBoolean(PREF_ATTEMPT_READ_PREVIEWS, false)
+
+    override val useEarliestThumbnail: Boolean
+        get() = preferences.getBoolean(PREF_USE_EARLIEST_THUMBNAIL, false)
 
     override val excludeCategoryFilters
         get() = Regex(
@@ -200,6 +184,15 @@ class BookWalker : ConfigurableSource, ParsedHttpSource(), BookWalkerPreferences
             key = PREF_SHOW_LIBRARY_IN_POPULAR
             title = "Show My Library in Popular"
             summary = "Show your library instead of popular manga when browsing \"Popular\"."
+
+            setDefaultValue(false)
+        }.also(screen::addPreference)
+
+        SwitchPreferenceCompat(screen.context).apply {
+            key = PREF_USE_EARLIEST_THUMBNAIL
+            title = "Use First Volume Cover For Thumbnail"
+            summary = "This does not affect browsing, and may not work properly for chapter " +
+                "releases or for series with a very large number of volumes."
 
             setDefaultValue(false)
         }.also(screen::addPreference)
@@ -434,21 +427,42 @@ class BookWalker : ConfigurableSource, ParsedHttpSource(), BookWalkerPreferences
                 .asJsoup()
                 .let { validateLogin(it) }
 
-            // It generally doesn't matter which chapter we take the description from, but for
-            // series that release in volumes we want the earliest one, which will _usually_ be the
-            // last one on the page. With that said, it's not worth it to paginate in order to find
-            // the earliest volume, and volume releases don't usually have 60+ volumes anyways.
-            val firstItem = seriesPage.selectFirst(".o-tile:not(:has(.a-ribbon-pre-order)) .a-tile-ttl a")
-            val uuid = firstItem!!.absUrl("href").substringAfter("/de").substringBefore("/")
-            val bookUpdate = fetchBookUpdate(uuid)
+            val validChapters = seriesPage.select(".o-tile:not(:has($TILE_PREORDER_SELECTOR)) .a-tile-ttl a")
+
+            suspend fun linkElementToBookUpdate(link: Element): BookUpdateDto {
+                return link
+                    .absUrl("href")
+                    .substringAfter("/de")
+                    .substringBefore("/")
+                    .let { fetchBookUpdate(it)!! }
+            }
+
+            // We want to get series descriptions from the earliest chapter/volume, but we want the
+            // thumbnail from the most recent release. Technically a series could have over 60
+            // entries causing the last tile on the page to not actually be the earliest entry, but
+            // most series don't have 60+ volumes, and chapter releases tend to have the same
+            // description for every chapter. For the very few exceptions, it's not worth the effort
+            // to address that edge case right now.
+            val (latestChapter, earliestChapter) =
+                if (validChapters.size == 1 || useEarliestThumbnail) {
+                    async { linkElementToBookUpdate(validChapters.last()!!) }
+                        .let { listOf(it, it) }
+                } else {
+                    listOf(
+                        async { linkElementToBookUpdate(validChapters.first()!!) },
+                        async { linkElementToBookUpdate(validChapters.last()!!) },
+                    )
+                }.awaitAll()
 
             SManga.create().apply {
-                title = bookUpdate!!.seriesName?.cleanTitle() ?: bookUpdate.productName.cleanTitle()
-                author = bookUpdate.authors.joinToString { it.authorName }
-                description = listOfNotNull(bookUpdate.productExplanationShort, bookUpdate.productExplanationDetails)
+                title = earliestChapter.seriesName?.cleanTitle() ?: earliestChapter.productName.cleanTitle()
+                // In some cases different chapters have different authors, so we grab this from the
+                // list of available author filters rather than from the BookUpdateDto.
+                author = getAvailableFilterNames(seriesPage, "side-author").joinToString()
+                description = listOfNotNull(earliestChapter.productExplanationShort, earliestChapter.productExplanationDetails)
                     .joinToString("\n\n")
                     .trim()
-                thumbnail_url = bookUpdate.coverImageUrl
+                thumbnail_url = latestChapter.coverImageUrl
                 genre = getAvailableFilterNames(seriesPage, "side-genre").joinToString()
                 val statusIndicators = seriesPage.select("ul.side-others > li > a").map { it.ownText() }
                 status = parseStatus(statusIndicators)
@@ -546,23 +560,23 @@ class BookWalker : ConfigurableSource, ParsedHttpSource(), BookWalkerPreferences
     override fun chapterListSelector(): String {
         return when (filterChapters) {
             FilterChaptersPref.OWNED ->
-                ".book-list-area .o-tile:has(.a-read-btn-s, .a-free-btn-s)"
+                ".book-list-area .o-tile:has($TILE_READ_SELECTOR, $TILE_FREE_SELECTOR)"
             FilterChaptersPref.OBTAINABLE ->
-                ".book-list-area .o-tile:not(:has(.a-ribbon-bundle, .a-ribbon-pre-order))"
+                ".book-list-area .o-tile:not(:has($TILE_BUNDLE_SELECTOR, $TILE_PREORDER_SELECTOR))"
             else -> // preorders shown, still not showing bundles since those aren't chapters
-                ".book-list-area .o-tile:not(:has(.a-ribbon-bundle))"
+                ".book-list-area .o-tile:not(:has($TILE_BUNDLE_SELECTOR))"
         }
     }
 
     override fun chapterFromElement(element: Element): SChapter = SChapter.create().apply {
         val statusSuffix =
-            if (element.selectFirst("[data-action-label='Read']") != null) {
+            if (element.selectFirst(TILE_READ_SELECTOR) != null) {
                 "" // user is currently able to read the chapter
-            } else if (element.selectFirst(".a-label-free") != null) {
+            } else if (element.selectFirst(TILE_FREE_SELECTOR) != null) {
                 " $FREE_ICON" // it's free to read but the user technically doesn't "own" it
-            } else if (element.selectFirst(".a-cart-btn-s, .a-cart-btn-s--on") != null) {
+            } else if (element.selectFirst(TILE_BUY_SELECTOR) != null) {
                 " $PURCHASE_ICON"
-            } else if (element.selectFirst(".a-ribbon-pre-order") != null) {
+            } else if (element.selectFirst(TILE_PREORDER_SELECTOR) != null) {
                 " $PREORDER_ICON"
             } else {
                 // Some content does not fall into any of the above bins. It seems to mostly be
@@ -834,6 +848,12 @@ class BookWalker : ConfigurableSource, ParsedHttpSource(), BookWalkerPreferences
             ).joinToString("|", transform = Regex::escape),
             RegexOption.IGNORE_CASE,
         )
+
+        private const val TILE_READ_SELECTOR = ".a-read-btn-s"
+        private const val TILE_FREE_SELECTOR = ".a-label-free"
+        private const val TILE_BUY_SELECTOR = ".a-cart-btn-s, .a-cart-btn-s--on"
+        private const val TILE_PREORDER_SELECTOR = ".a-order-btn-s"
+        private const val TILE_BUNDLE_SELECTOR = ".a-ribbon-bundle"
 
         private val CHAPTER_NUMBER_PATTERNS = listOf(
             // All must have exactly one capture group for the chapter number

--- a/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/BookWalkerConstants.kt
+++ b/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/BookWalkerConstants.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.extension.en.bookwalker
 const val PREF_VALIDATE_LOGGED_IN = "validateLoggedIn"
 const val PREF_SHOW_LIBRARY_IN_POPULAR = "showLibraryInPopular"
 const val PREF_ATTEMPT_READ_PREVIEWS = "attemptReadPreviews"
+const val PREF_USE_EARLIEST_THUMBNAIL = "useEarliestThumbnail"
 const val PREF_CATEGORY_EXCLUDE_REGEX = "categoryExcludeRegex"
 const val PREF_GENRE_EXCLUDE_REGEX = "genreExcludeRegex"
 

--- a/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/BookWalkerPreferences.kt
+++ b/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/BookWalkerPreferences.kt
@@ -6,6 +6,7 @@ interface BookWalkerPreferences {
     val imageQuality: ImageQualityPref
     val filterChapters: FilterChaptersPref
     val attemptToReadPreviews: Boolean
+    val useEarliestThumbnail: Boolean
     val excludeCategoryFilters: Regex
     val excludeGenreFilters: Regex
 }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

There were a couple presumably inadvertent changes introduced by #11654 around how series details were fetched, plus the BookWalker site recently changed the markup around pre-order chapters which broke detection. This PR addresses those issues and adds a new option for those who may want it.

Added:
* Option to (try to) use the first volume cover for the series thumbnail (disabled by default)

Fixed:
* Descriptions are extracted from the first chapter/volume again rather than from the latest one
* Series with different authors for different chapters now show all of the authors again
* "Pre-order" selector adjusted to detect pre-orders properly again after site changes
