### PR TITLE
AnimeSama: From .org to .eu & fixes

### DIFF
--- a/src/fr/animesama/AndroidManifest.xml
+++ b/src/fr/animesama/AndroidManifest.xml
@@ -14,7 +14,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:host="anime-sama.fr"
+                    android:host="anime-sama.eu"
                     android:pathPattern="/catalogue/..*"
                     android:scheme="https" />
             </intent-filter>

--- a/src/fr/animesama/build.gradle
+++ b/src/fr/animesama/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeSama'
     extClass = '.AnimeSama'
-    extVersionCode = 10
+    extVersionCode = 11
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/animesama/src/eu/kanade/tachiyomi/extension/fr/animesama/AnimeSama.kt
+++ b/src/fr/animesama/src/eu/kanade/tachiyomi/extension/fr/animesama/AnimeSama.kt
@@ -64,7 +64,7 @@ class AnimeSama : ParsedHttpSource() {
     private fun parseFilters(document: Document) {
         genreList = document.select("#list_genres #genreList label").mapNotNull { labelElement ->
             val input = labelElement.selectFirst("input[name=genre[]]") ?: return@mapNotNull null
-            val labelText = labelElement.selectFirst("span")?.text() ?: ""
+            val labelText = labelElement.selectFirst("span")?.text() ?: return@mapNotNull null
             val value = input.attr("value")
             labelText to value
         }

--- a/src/fr/animesama/src/eu/kanade/tachiyomi/extension/fr/animesama/AnimeSama.kt
+++ b/src/fr/animesama/src/eu/kanade/tachiyomi/extension/fr/animesama/AnimeSama.kt
@@ -30,7 +30,7 @@ class AnimeSama : ParsedHttpSource() {
 
     override val name = "AnimeSama"
 
-    override val baseUrl = "https://anime-sama.org"
+    override val baseUrl = "https://anime-sama.eu"
 
     private val cdn = "$baseUrl/s2/scans/"
 
@@ -62,9 +62,9 @@ class AnimeSama : ParsedHttpSource() {
     private fun filtersRequest() = GET("$baseUrl/catalogue", headers)
 
     private fun parseFilters(document: Document) {
-        genreList = document.select("#list_genres label").mapNotNull { labelElement ->
+        genreList = document.select("#list_genres #genreList label").mapNotNull { labelElement ->
             val input = labelElement.selectFirst("input[name=genre[]]") ?: return@mapNotNull null
-            val labelText = labelElement.ownText()
+            val labelText = labelElement.selectFirst("span")?.text() ?: ""
             val value = input.attr("value")
             labelText to value
         }
@@ -99,7 +99,7 @@ class AnimeSama : ParsedHttpSource() {
 
     override fun popularMangaFromElement(element: Element): SManga {
         return SManga.create().apply {
-            title = element.select("h1").text()
+            title = element.select(".card-title").text()
             setUrlWithoutDomain(element.select("a").attr("href"))
             thumbnail_url = element.selectFirst("img")?.absUrl("src")
         }
@@ -116,7 +116,7 @@ class AnimeSama : ParsedHttpSource() {
 
     override fun latestUpdatesFromElement(element: Element): SManga {
         return SManga.create().apply {
-            title = element.select("h1").text()
+            title = element.select(".card-title").text()
             setUrlWithoutDomain(element.select("a").attr("href").removeSuffix("scan/vf/"))
             thumbnail_url = element.selectFirst("img")?.absUrl("src")
         }

--- a/src/fr/animesama/src/eu/kanade/tachiyomi/extension/fr/animesama/AnimeSamaUrlActivity.kt
+++ b/src/fr/animesama/src/eu/kanade/tachiyomi/extension/fr/animesama/AnimeSamaUrlActivity.kt
@@ -8,7 +8,7 @@ import android.util.Log
 import kotlin.system.exitProcess
 
 /**
- * Springboard that accepts https://anime-sama.fr/catalogue/xxxxxx/ intents and redirects them to
+ * Springboard that accepts https://anime-sama.eu/catalogue/xxxxxx/ intents and redirects them to
  * the main Tachiyomi process.
  */
 class AnimeSamaUrlActivity : Activity() {


### PR DESCRIPTION
- From .org to .eu (Closes #12002)
- Fixed links opening in the app
- Repairing genres in filters that no longer had names
- Repairing manga without names before clicking on them

EDIT: Closes #12003

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
