### PR TITLE
Comix: Fix parsing of official chapters

### DIFF
--- a/src/en/comix/build.gradle
+++ b/src/en/comix/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comix'
     extClass = '.Comix'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
@@ -225,8 +225,8 @@ class Comix : HttpSource(), ConfigurableSource {
                 chapterMap[key] = ch
             } else {
                 // Prefer official scan group
-                val officialNew = (ch.scanlationGroupId == 9275 || ch.isOfficial)
-                val officialCurrent = (current.scanlationGroupId == 9275 || current.isOfficial)
+                val officialNew = (ch.scanlationGroupId == 9275 || ch.isOfficial == 1)
+                val officialCurrent = (current.scanlationGroupId == 9275 || current.isOfficial == 1)
                 val better = when {
                     officialNew && !officialCurrent -> true
                     !officialNew && officialCurrent -> false

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
@@ -225,8 +225,8 @@ class Comix : HttpSource(), ConfigurableSource {
                 chapterMap[key] = ch
             } else {
                 // Prefer official scan group
-                val officialNew = ch.scanlationGroupId == 9275
-                val officialCurrent = current.scanlationGroupId == 9275
+                val officialNew = (ch.scanlationGroupId == 9275 || ch.isOfficial)
+                val officialCurrent = (current.scanlationGroupId == 9275 || current.isOfficial)
                 val better = when {
                     officialNew && !officialCurrent -> true
                     !officialNew && officialCurrent -> false

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/ComixDto.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/ComixDto.kt
@@ -185,6 +185,8 @@ class Chapter(
     val updatedAt: Long,
     @SerialName("scanlation_group")
     private val scanlationGroup: ScanlationGroup?,
+    @SerialName("is_official")
+    val isOfficial: Boolean,
 ) {
     @Serializable
     class ScanlationGroup(
@@ -200,7 +202,13 @@ class Chapter(
         }
         date_upload = this@Chapter.updatedAt * 1000
         chapter_number = this@Chapter.number.toFloat()
-        scanlator = this@Chapter.scanlationGroup?.name ?: "Unknown"
+        if (this@Chapter.scanlationGroup != null) {
+            scanlator = this@Chapter.scanlationGroup.name
+        } else if this@Chapter.isOfficial {
+            scanlator = "Official"
+        } else {
+            scanlator = "Unknown"
+        }
     }
 }
 

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/ComixDto.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/ComixDto.kt
@@ -202,12 +202,12 @@ class Chapter(
         }
         date_upload = this@Chapter.updatedAt * 1000
         chapter_number = this@Chapter.number.toFloat()
-        if (this@Chapter.scanlationGroup != null) {
-            scanlator = this@Chapter.scanlationGroup.name
-        } else if this@Chapter.isOfficial {
-            scanlator = "Official"
+        scanlator = if (this@Chapter.scanlationGroup != null) {
+            this@Chapter.scanlationGroup.name
+        } else if (this@Chapter.isOfficial) {
+            "Official"
         } else {
-            scanlator = "Unknown"
+            "Unknown"
         }
     }
 }

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/ComixDto.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/ComixDto.kt
@@ -186,7 +186,7 @@ class Chapter(
     @SerialName("scanlation_group")
     private val scanlationGroup: ScanlationGroup?,
     @SerialName("is_official")
-    val isOfficial: Boolean,
+    val isOfficial: Int,
 ) {
     @Serializable
     class ScanlationGroup(
@@ -204,7 +204,7 @@ class Chapter(
         chapter_number = this@Chapter.number.toFloat()
         scanlator = if (this@Chapter.scanlationGroup != null) {
             this@Chapter.scanlationGroup.name
-        } else if (this@Chapter.isOfficial) {
+        } else if (this@Chapter.isOfficial == 1) {
             "Official"
         } else {
             "Unknown"


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension

Fixes #12018 