### PR TITLE
Manga Livre: Fix placeholder images, chapter list endpoint, page list parsing

### DIFF
--- a/src/pt/mangalivre/build.gradle
+++ b/src/pt/mangalivre/build.gradle
@@ -3,7 +3,8 @@ ext {
     extClass = '.MangaLivre'
     themePkg = 'madara'
     baseUrl = 'https://mangalivre.tv'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"
+

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
@@ -1,17 +1,118 @@
 package eu.kanade.tachiyomi.extension.pt.mangalivre
 
+import android.app.Application
+import android.content.SharedPreferences
+import android.widget.Toast
+import androidx.preference.EditTextPreference
+import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.source.ConfigurableSource
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
+import okhttp3.FormBody
+import okhttp3.Response
+import org.json.JSONArray
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class MangaLivre : Madara(
-    "Manga Livre",
-    "https://mangalivre.tv",
-    "pt-BR",
-    SimpleDateFormat("MMMM dd, yyyy", Locale("pt")),
-) {
+class MangaLivre :
+    Madara(
+        "Manga Livre",
+        "https://mangalivre.tv",
+        "pt-BR",
+        SimpleDateFormat("dd.MM.yyyy", Locale("pt")),
+    ),
+    ConfigurableSource {
 
-    override val chapterUrlSuffix: String = ""
-    override val useNewChapterEndpoint = true
     override val id: Long = 2834885536325274328
+    override val useLoadMoreRequest = LoadMoreStrategy.Always
+    override val baseUrl by lazy { getPrefBaseUrl() }
+
+    private val preferences: SharedPreferences by lazy {
+        Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
+    }
+
+    override val client = super.client.newBuilder()
+        .rateLimit(2)
+        .build()
+
+    override fun headersBuilder() = super.headersBuilder()
+        .set("Origin", baseUrl)
+        .set("X-Requested-With", "XMLHttpRequest")
+
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val html = response.body.string()
+        var document = Jsoup.parse(html)
+
+        if (document.selectFirst("li.wp-manga-chapter") == null) {
+            val mangaUrl = response.request.url.toString().trimEnd('/')
+            val headers = headersBuilder().set("Referer", mangaUrl).build()
+            val request = POST("$mangaUrl/ajax/chapters/", headers, FormBody.Builder().build())
+
+            client.newCall(request).execute().use { xhr ->
+                if (!xhr.isSuccessful) {
+                    throw IOException("Failed to fetch chapters via AJAX: ${xhr.code}. Open in WebView.")
+                }
+                document = Jsoup.parse(xhr.body.string())
+            }
+        }
+
+        val elements = document.select("li.wp-manga-chapter").ifEmpty {
+            document.select("li.chapter-li")
+        }
+
+        if (elements.isEmpty()) {
+            throw IOException("No chapters found. Open in WebView to solve Cloudflare/Turnstile.")
+        }
+
+        return elements.map { chapterFromElement(it) }
+    }
+
+    override fun pageListParse(document: Document): List<Page> {
+        val script = document.selectFirst("script:containsData(var imgs)")?.data()
+            ?: throw IOException("Images not found. Open in WebView to solve Cloudflare/Turnstile.")
+
+        val jsonString = IMAGES_REGEX.find(script)?.groupValues?.get(1)
+            ?: throw IOException("Image list not found in script.")
+
+        val jsonArray = JSONArray(jsonString)
+
+        return buildList(jsonArray.length()) {
+            for (i in 0 until jsonArray.length()) {
+                val url = jsonArray.getString(i).trim()
+                if (url.startsWith("http")) {
+                    add(Page(size, "", url))
+                }
+            }
+        }.ifEmpty { throw IOException("Image list is empty.") }
+    }
+
+    override val pageListParseSelector = ""
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        EditTextPreference(screen.context).apply {
+            key = BASE_URL_PREF
+            title = "Override Base URL"
+            summary = "Default: ${super.baseUrl}"
+            setDefaultValue(super.baseUrl)
+            setOnPreferenceChangeListener { _, _ ->
+                Toast.makeText(screen.context, "Restart app to apply.", Toast.LENGTH_LONG).show()
+                true
+            }
+        }.also { screen.addPreference(it) }
+    }
+
+    private fun getPrefBaseUrl(): String = preferences.getString(BASE_URL_PREF, super.baseUrl)!!
+
+    companion object {
+        private const val BASE_URL_PREF = "overrideBaseUrl"
+        private val IMAGES_REGEX = Regex("""var\s+imgs\s*=\s*(\[.*?\]);""")
+    }
 }


### PR DESCRIPTION
Checklist:

Fixes #11684
Fixes #11981
Fixes #11990

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Implemented custom chapter parser with AJAX fallback
- [x] Implemented custom page parser via JavaScript regex

