### PR TITLE
BookWalker Global: fix pre-order selector

### DIFF
--- a/src/en/bookwalker/build.gradle
+++ b/src/en/bookwalker/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'BookWalker Global'
     extClass = '.BookWalker'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/BookWalker.kt
+++ b/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/BookWalker.kt
@@ -852,7 +852,7 @@ class BookWalker : ConfigurableSource, ParsedHttpSource(), BookWalkerPreferences
         private const val TILE_READ_SELECTOR = ".a-read-btn-s"
         private const val TILE_FREE_SELECTOR = ".a-label-free"
         private const val TILE_BUY_SELECTOR = ".a-cart-btn-s, .a-cart-btn-s--on"
-        private const val TILE_PREORDER_SELECTOR = ".a-order-btn-s"
+        private const val TILE_PREORDER_SELECTOR = ".a-order-btn-s, .a-order-btn-s--on"
         private const val TILE_BUNDLE_SELECTOR = ".a-ribbon-bundle"
 
         private val CHAPTER_NUMBER_PATTERNS = listOf(


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

The updated pre-order selector from #12008 only selected the pre-order button when the user had not yet pre-ordered a chapter. If the user has already pre-ordered then the class changes slightly.