### PR TITLE
MangaReader.cc → MangaReader.in: update domain

### DIFF
--- a/src/en/mangareadercc/build.gradle
+++ b/src/en/mangareadercc/build.gradle
@@ -1,9 +1,9 @@
 ext {
-    extName = 'MangaReader.cc'
-    extClass = '.MangaReaderCC'
+    extName = 'MangaReader.in'
+    extClass = '.MangaReaderIN'
     themePkg = 'paprika'
-    baseUrl = 'https://www.mangareader.cc'
-    overrideVersionCode = 3
+    baseUrl = 'https://mangareader.in'
+    overrideVersionCode = 4
     isNsfw = true
 }
 

--- a/src/en/mangareadercc/src/eu/kanade/tachiyomi/extension/en/mangareadercc/MangaReaderCC.kt
+++ b/src/en/mangareadercc/src/eu/kanade/tachiyomi/extension/en/mangareadercc/MangaReaderCC.kt
@@ -1,5 +1,0 @@
-package eu.kanade.tachiyomi.extension.en.mangareadercc
-
-import eu.kanade.tachiyomi.multisrc.paprika.PaprikaAlt
-
-class MangaReaderCC : PaprikaAlt("MangaReader.cc", "https://www.mangareader.cc", "en")

--- a/src/en/mangareadercc/src/eu/kanade/tachiyomi/extension/en/mangareadercc/MangaReaderIN.kt
+++ b/src/en/mangareadercc/src/eu/kanade/tachiyomi/extension/en/mangareadercc/MangaReaderIN.kt
@@ -1,0 +1,29 @@
+package eu.kanade.tachiyomi.extension.en.mangareadercc
+
+import eu.kanade.tachiyomi.multisrc.paprika.PaprikaAlt
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.util.asJsoup
+import okhttp3.Response
+
+class MangaReaderIN : PaprikaAlt("MangaReader.in", "https://mangareader.in", "en") {
+    override val id = 7388100486112484697
+
+    override fun chapterListSelector() = "li"
+
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val document = response.asJsoup()
+        val mangaId = document.selectFirst("script:containsData(var mangaID)")!!
+            .data()
+            .substringAfter("var mangaID = '")
+            .substringBefore("';")
+        val mangaTitle = document.select("div.manga-detail h1").text()
+        val xhrRequest = GET("$baseUrl/ajax-list-chapter?mangaID=$mangaId", headers)
+        client.newCall(xhrRequest).execute().use { xhrResponse ->
+            return xhrResponse
+                .asJsoup()
+                .select(chapterListSelector())
+                .map { chapterFromElement(it, mangaTitle) }
+        }
+    }
+}


### PR DESCRIPTION
Closes #8593

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
