### PR TITLE
MangaHub (AR): update domain

### DIFF
--- a/lib-multisrc/zeistmanga/src/eu/kanade/tachiyomi/multisrc/zeistmanga/ZeistManga.kt
+++ b/lib-multisrc/zeistmanga/src/eu/kanade/tachiyomi/multisrc/zeistmanga/ZeistManga.kt
@@ -404,6 +404,7 @@ abstract class ZeistManga(
         "completed",
         "completo",
         "finalizado",
+        "مكتمل",
     )
 
     protected open val statusHiatusList = listOf(

--- a/src/ar/mangahub/build.gradle
+++ b/src/ar/mangahub/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'MangaHub'
     extClass = '.MangaHub'
     themePkg = 'zeistmanga'
-    baseUrl = 'https://www.mangahub.link'
-    overrideVersionCode = 0
+    baseUrl = 'https://www.mangaxhentai.com'
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/ar/mangahub/src/eu/kanade/tachiyomi/extension/ar/mangahub/MangaHub.kt
+++ b/src/ar/mangahub/src/eu/kanade/tachiyomi/extension/ar/mangahub/MangaHub.kt
@@ -2,22 +2,42 @@ package eu.kanade.tachiyomi.extension.ar.mangahub
 
 import eu.kanade.tachiyomi.multisrc.zeistmanga.ZeistManga
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.source.model.SManga
+import okhttp3.Response
+import org.jsoup.Jsoup
 
 class MangaHub : ZeistManga(
     "MangaHub",
-    "https://www.mangahub.link",
+    "https://www.mangaxhentai.com",
     "ar",
 ) {
     override val client = super.client.newBuilder()
         .rateLimit(3)
         .build()
 
-    override val popularMangaSelector = "div#PopularPosts2 article"
-    override val popularMangaSelectorTitle = "h3"
-    override val popularMangaSelectorUrl = "a"
+    // Missing popular
+    override val supportsLatest = false
+    override fun popularMangaRequest(page: Int) = latestUpdatesRequest(page)
+    override fun popularMangaParse(response: Response) = latestUpdatesParse(response)
 
     override val mangaDetailsSelector = ".grid.gap-5.gta-series"
-    override val mangaDetailsSelectorGenres = "dt:contains(التصنيف) + dd a[rel=tag]"
+    override val mangaDetailsSelectorInfo = "dt"
+
+    override fun mangaDetailsParse(response: Response): SManga {
+        val document = Jsoup.parse(
+            response.peekBody(Long.MAX_VALUE).string(),
+            response.request.url.toString(),
+        )
+        return super.mangaDetailsParse(response).apply {
+            document
+                .selectFirst("dt:contains(الإشارات) + dd")
+                ?.text()
+                ?.split(",")
+                ?.filterNot(String::isEmpty)
+                ?.joinToString()
+                ?.also { genre = it }
+        }
+    }
 
     override val pageListSelector = "article#reader .separator, div.image-container"
 }


### PR DESCRIPTION
Closes #9218

Changes in ZeistManga multisrc is unlikely to affect other sources, so `baseVersionCode` was not bumped.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
