### PR TITLE
feat(logger): Added Chunked logger and Detailed HTTP Logger

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 kotlin = "1.7.21"
 coroutines = "1.6.4"
 serialization = "1.4.0"
+okhttp = "5.0.0-alpha.11"
 
 [libraries]
 gradle-agp = { module = "com.android.tools.build:gradle", version = "8.13.0" }
@@ -21,7 +22,8 @@ coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-androi
 injekt-core = { module = "com.github.null2264.injekt:injekt-core", version = "4135455a2a" }
 rxjava = { module = "io.reactivex:rxjava", version = "1.3.8" }
 jsoup = { module = "org.jsoup:jsoup", version = "1.15.1" }
-okhttp = { module = "com.squareup.okhttp3:okhttp", version = "5.0.0-alpha.11" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 quickjs = { module = "app.cash.quickjs:quickjs-android", version = "0.9.2" }
 
 [bundles]

--- a/lib/betterhttplogging/build.gradle.kts
+++ b/lib/betterhttplogging/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    id("lib-android")
+}
+
+dependencies {
+    implementation(libs.okhttp.logging)
+    implementation(project(":lib:logcatchunker"))
+}

--- a/lib/betterhttplogging/src/main/java/eu/kanade/tachiyomi/lib/betterhttplogging/ChunkedHttpLogger.kt
+++ b/lib/betterhttplogging/src/main/java/eu/kanade/tachiyomi/lib/betterhttplogging/ChunkedHttpLogger.kt
@@ -1,0 +1,50 @@
+package eu.kanade.tachiyomi.lib.betterhttplogging
+
+import android.util.Log
+import eu.kanade.tachiyomi.lib.logcatchunker.LogWriter
+import eu.kanade.tachiyomi.lib.logcatchunker.LogcatChunker
+import okhttp3.logging.HttpLoggingInterceptor
+
+/**
+ * Creates an [HttpLoggingInterceptor.Logger] that automatically chunks long messages to avoid
+ * Android logcat truncation.
+ *
+ * Usage:
+ * ```kotlin
+ * val loggingInterceptor = HttpLoggingInterceptor(
+ *     ChunkedHttpLogger("MyTag")
+ * ).apply {
+ *     level = HttpLoggingInterceptor.Level.BODY
+ * }
+ *
+ * val client = OkHttpClient.Builder()
+ *     .addInterceptor(loggingInterceptor)
+ *     .build()
+ * ```
+ *
+ * @param tag The log tag to use for all log messages.
+ * @param chunkSize Maximum size of each log chunk (default: [LogcatChunker.DEFAULT_CHUNK_SIZE]).
+ * @param logWriter Custom log writer (default: uses Android's Log.v).
+ */
+class ChunkedHttpLogger(
+    private val tag: String,
+    private val chunkSize: Int = LogcatChunker.DEFAULT_CHUNK_SIZE,
+    private val logWriter: LogWriter = DEFAULT_LOG_WRITER,
+) : HttpLoggingInterceptor.Logger {
+
+    override fun log(message: String) {
+        LogcatChunker.logChunked(
+            message = message,
+            tag = tag,
+            chunkSize = chunkSize,
+            logWriter = logWriter,
+        )
+    }
+
+    companion object {
+        /**
+         * Default log writer that uses Android's Log.v.
+         */
+        val DEFAULT_LOG_WRITER = LogWriter { tag, msg -> Log.v(tag, msg) }
+    }
+}

--- a/lib/logcatchunker/build.gradle.kts
+++ b/lib/logcatchunker/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("lib-android")
+}

--- a/lib/logcatchunker/src/main/java/eu/kanade/tachiyomi/lib/logcatchunker/LogWriter.kt
+++ b/lib/logcatchunker/src/main/java/eu/kanade/tachiyomi/lib/logcatchunker/LogWriter.kt
@@ -1,0 +1,9 @@
+package eu.kanade.tachiyomi.lib.logcatchunker
+
+/**
+ * Interface for logging messages. Can be used to redirect log output to different targets (logcat,
+ * file, etc.).
+ */
+fun interface LogWriter {
+    fun log(tag: String, message: String)
+}

--- a/lib/logcatchunker/src/main/java/eu/kanade/tachiyomi/lib/logcatchunker/LogcatChunker.kt
+++ b/lib/logcatchunker/src/main/java/eu/kanade/tachiyomi/lib/logcatchunker/LogcatChunker.kt
@@ -1,0 +1,108 @@
+package eu.kanade.tachiyomi.lib.logcatchunker
+
+/**
+ * Utility object for chunking log messages to avoid Android's logcat truncation.
+ *
+ * Android's logcat has a message size limit (typically around 4000 characters). This utility splits
+ * long messages into multiple chunks while preserving line breaks.
+ */
+object LogcatChunker {
+
+    /**
+     * Default maximum chunk size that fits within Android logcat limits. Set slightly below 4096 to
+     * account for potential overhead.
+     */
+    const val DEFAULT_CHUNK_SIZE = 4011
+
+    /**
+     * Chunks a message and logs each chunk using the provided logger.
+     *
+     * @param message The message to chunk and log.
+     * @param tag The log tag to use.
+     * @param chunkSize Maximum size of each chunk (default: [DEFAULT_CHUNK_SIZE]).
+     * @param logWriter The function to call for each chunk.
+     */
+    fun logChunked(
+        message: String,
+        tag: String,
+        chunkSize: Int = DEFAULT_CHUNK_SIZE,
+        logWriter: LogWriter,
+    ) {
+        val chunks = chunk(message, chunkSize)
+        for (chunk in chunks) {
+            logWriter.log(tag, chunk)
+        }
+    }
+
+    /**
+     * Splits a message into chunks that respect line boundaries where possible.
+     *
+     * The algorithm:
+     * 1. Splits the message by newlines
+     * 2. If a line fits in the current chunk, add it
+     * 3. If a single line exceeds [chunkSize], it's split into multiple chunks of exactly
+     *    [chunkSize]
+     *
+     * @param message The message to chunk.
+     * @param chunkSize Maximum size of each chunk.
+     * @return List of chunks, where each chunk is a string that doesn't exceed [chunkSize].
+     */
+    fun chunk(message: String, chunkSize: Int = DEFAULT_CHUNK_SIZE): List<String> {
+        val chunks = mutableListOf<String>()
+        val currentChunk = StringBuilder()
+
+        for (originalLine in message.splitToSequence(Regex("\r?\n"))) {
+            var line = originalLine
+
+            while (line.isNotEmpty()) {
+                if (line.length <= chunkSize) {
+                    // Line fits - check if it fits in current chunk
+                    val newLength = if (currentChunk.isEmpty()) {
+                        line.length
+                    } else {
+                        currentChunk.length + 1 + line.length // +1 for newline
+                    }
+
+                    if (newLength <= chunkSize) {
+                        // Add to current chunk
+                        if (currentChunk.isNotEmpty()) {
+                            currentChunk.append('\n')
+                        }
+                        currentChunk.append(line)
+                    } else {
+                        // Start new chunk
+                        if (currentChunk.isNotEmpty()) {
+                            chunks.add(currentChunk.toString())
+                            currentChunk.clear()
+                        }
+                        currentChunk.append(line)
+                    }
+                    line = ""
+                } else {
+                    // Line is too long - need to split it
+                    // First, flush current chunk if not empty
+                    if (currentChunk.isNotEmpty()) {
+                        chunks.add(currentChunk.toString())
+                        currentChunk.clear()
+                    }
+
+                    // Add a chunk of exactly chunkSize
+                    chunks.add(line.substring(0, chunkSize))
+                    line = line.substring(chunkSize)
+                }
+            }
+        }
+
+        // Don't forget the last chunk
+        if (currentChunk.isNotEmpty()) {
+            chunks.add(currentChunk.toString())
+        }
+
+        // Handle empty message case
+        if (chunks.isEmpty()) {
+            chunks.add("")
+        }
+
+        return chunks
+    }
+}


### PR DESCRIPTION
I written theses loggers to provide detailed insight on what happens and which requests are fired because I don't have a working http proxy setup. 

Compared to a traditional setup, it has the advantage to be really fast to deploy.

The chunked logger has the purpose to log any big chunks of text in logcat while not being over the 4000ish character limit. 

They are not intended to be shipped within an app.