### PR TITLE
LycanToons: Fix manga view in webview and pages 

### DIFF
--- a/src/pt/lycantoons/build.gradle
+++ b/src/pt/lycantoons/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Lycan Toons'
     extClass = '.LycanToons'
     baseUrl = 'https://lycantoons.com'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = false
 }
 

--- a/src/pt/lycantoons/src/eu/kanade/tachiyomi/extension/pt/lycantoons/LycanToons.kt
+++ b/src/pt/lycantoons/src/eu/kanade/tachiyomi/extension/pt/lycantoons/LycanToons.kt
@@ -4,7 +4,6 @@ import app.cash.quickjs.QuickJs
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
-import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
@@ -15,7 +14,6 @@ import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.jsonInstance
 import keiyoushi.utils.parseAs
 import kotlinx.serialization.encodeToString
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -28,15 +26,12 @@ class LycanToons : HttpSource() {
 
     override val baseUrl = "https://lycantoons.com"
 
-    private val cdnUrl = "https://cdn.lycantoons.com/file/lycantoons"
-
     override val lang = "pt-BR"
 
     override val supportsLatest = true
 
     override val client = network.cloudflareClient.newBuilder()
         .rateLimit(2)
-        .rateLimitHost(cdnUrl.toHttpUrl(), 2)
         .build()
 
     private val pageHeaders by lazy {

--- a/src/pt/lycantoons/src/eu/kanade/tachiyomi/extension/pt/lycantoons/LycanToons.kt
+++ b/src/pt/lycantoons/src/eu/kanade/tachiyomi/extension/pt/lycantoons/LycanToons.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.extension.pt.lycantoons
 
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
@@ -27,7 +28,9 @@ class LycanToons : HttpSource() {
 
     override val supportsLatest = true
 
-    override val client = network.cloudflareClient
+    override val client = network.cloudflareClient.newBuilder()
+        .rateLimit(2)
+        .build()
 
     private val pageHeaders by lazy {
         headers.newBuilder()
@@ -71,6 +74,8 @@ class LycanToons : HttpSource() {
     override fun getFilterList(): FilterList = LycanToonsFilters.get()
 
     // =====================Details=====================
+
+    override fun getMangaUrl(manga: SManga): String = "$baseUrl${manga.url}"
 
     override fun mangaDetailsRequest(manga: SManga): Request = seriesRequest(manga.slug())
 

--- a/src/pt/lycantoons/src/eu/kanade/tachiyomi/extension/pt/lycantoons/LycanToons.kt
+++ b/src/pt/lycantoons/src/eu/kanade/tachiyomi/extension/pt/lycantoons/LycanToons.kt
@@ -1,22 +1,26 @@
 package eu.kanade.tachiyomi.extension.pt.lycantoons
 
+import app.cash.quickjs.QuickJs
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.jsonInstance
 import keiyoushi.utils.parseAs
 import kotlinx.serialization.encodeToString
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
-import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
 
 class LycanToons : HttpSource() {
 
@@ -24,12 +28,15 @@ class LycanToons : HttpSource() {
 
     override val baseUrl = "https://lycantoons.com"
 
+    private val cdnUrl = "https://cdn.lycantoons.com/file/lycantoons"
+
     override val lang = "pt-BR"
 
     override val supportsLatest = true
 
     override val client = network.cloudflareClient.newBuilder()
         .rateLimit(2)
+        .rateLimitHost(cdnUrl.toHttpUrl(), 2)
         .build()
 
     private val pageHeaders by lazy {
@@ -103,43 +110,30 @@ class LycanToons : HttpSource() {
     )
 
     override fun pageListParse(response: Response): List<Page> {
-        val html = response.body.string()
-        val (slug, chapterNumber) = response.extractSlugAndChapter()
+        val document = response.asJsoup()
+        val script = document.select("script:containsData(self.__next_f)")
+            .joinToString("\n", transform = Element::data)
 
-        val dto = extractScriptData(html)
-        val pageCount = dto.pageCount
+        val content = QuickJs.create().use {
+            it.evaluate(
+                """
+                globalThis.self = globalThis;
+                $script
+                self.__next_f.map(it => it[it.length - 1]).join('')
+                """.trimIndent(),
+            ) as String
+        }
 
-        val chapterPath = "$cdnUrl/$slug/$chapterNumber"
-        return List(pageCount) { index ->
-            val imageUrl = "$chapterPath/page-$index.jpg"
+        val images = PAGES_REGEX.find(content)!!.groupValues.last().parseAs<List<String>>()
+
+        return images.mapIndexed { index, imageUrl ->
             Page(index, imageUrl = imageUrl)
         }
-    }
-
-    private fun extractScriptData(html: String): PageListDto {
-        val document = Jsoup.parse(html)
-
-        val scriptData = document.select("script")
-            .map { it.data() }
-            .first { it.contains("chapterData") }
-
-        val rawJson = CHAPTER_DATA_REGEX.find(scriptData)!!.groupValues[1]
-
-        val cleanJson = "\"$rawJson\"".parseAs<String>()
-
-        return cleanJson.parseAs<PageListDto>()
     }
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
 
     // =====================Utils=====================
-
-    private fun Response.extractSlugAndChapter(): Pair<String, String> {
-        val segments = request.url.pathSegments
-        val slug = segments[1]
-        val chapterNumber = segments[2]
-        return slug to chapterNumber
-    }
 
     private fun metricsRequest(path: String, page: Int): Request =
         GET("$baseUrl/api/metrics/$path?limit=$PAGE_LIMIT&page=$page", headers)
@@ -156,7 +150,6 @@ class LycanToons : HttpSource() {
     companion object {
         private const val PAGE_LIMIT = 13
         private val JSON_MEDIA_TYPE = "application/json".toMediaType()
-        private const val cdnUrl = "https://cdn.lycantoons.com/file/lycantoons"
-        private val CHAPTER_DATA_REGEX = """\\?"chapterData\\?"\s*:\s*(\{.*?\})""".toRegex()
+        private val PAGES_REGEX = """"imageUrls":([^]]+])""".toRegex()
     }
 }


### PR DESCRIPTION
Closes #12013

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
