### PR TITLE
MangaPark: Fix open http connection

### DIFF
--- a/src/all/mangapark/build.gradle
+++ b/src/all/mangapark/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaPark'
     extClass = '.MangaParkFactory'
-    extVersionCode = 23
+    extVersionCode = 24
     isNsfw = true
 }
 

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaPark.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaPark.kt
@@ -272,16 +272,15 @@ class MangaPark(
 
     private fun imageFallbackInterceptor(chain: Interceptor.Chain): Response {
         val request = chain.request()
-        var response = chain.proceed(request)
+        val response = chain.proceed(request)
 
         if (response.isSuccessful) return response
 
         val urlString = request.url.toString()
 
-        if (SERVER_PATTERN.containsMatchIn(urlString)) {
-            // Close the failed response to avoid leaks
-            response.close()
+        response.close()
 
+        if (SERVER_PATTERN.containsMatchIn(urlString)) {
             // Sorted list: Most reliable servers FIRST
             val servers = listOf("s01", "s03", "s04", "s00", "s05", "s06", "s07", "s08", "s09", "s10", "s02")
 


### PR DESCRIPTION
Closes #12052

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
