### PR TITLE
Kagane | Fixed Unscambler Not Recognizing PNG images

### DIFF
--- a/src/en/kagane/build.gradle
+++ b/src/en/kagane/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Kagane'
     extClass = '.Kagane'
-    extVersionCode = 13
+    extVersionCode = 14
     isNsfw = true
 }
 

--- a/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/ImageInterceptor.kt
+++ b/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/ImageInterceptor.kt
@@ -100,11 +100,23 @@ open class ImageInterceptor : Interceptor {
         fun isValidImage(data: ByteArray): Boolean {
             return when {
                 data.size >= 2 && data[0] == 0xFF.toByte() && data[1] == 0xD8.toByte() -> true
+                data.size >= 2 && data[0] == 0xFF.toByte() && data[1] == 0x0A.toByte() -> true
+                data.size >= 8 && data.copyOfRange(0, 8).contentEquals(
+                    byteArrayOf(
+                        0x89.toByte(),
+                        'P'.code.toByte(),
+                        'N'.code.toByte(),
+                        'G'.code.toByte(),
+                        0x0D,
+                        0x0A,
+                        0x1A,
+                        0x0A,
+                    ),
+                ) -> true
                 data.size >= 12 && data[0] == 'R'.code.toByte() && data[1] == 'I'.code.toByte() &&
                     data[2] == 'F'.code.toByte() && data[3] == 'F'.code.toByte() &&
                     data[8] == 'W'.code.toByte() && data[9] == 'E'.code.toByte() &&
                     data[10] == 'B'.code.toByte() && data[11] == 'P'.code.toByte() -> true
-                data.size >= 2 && data[0] == 0xFF.toByte() && data[1] == 0x0A.toByte() -> true
                 data.size >= 12 && data.copyOfRange(0, 12).contentEquals(
                     byteArrayOf(
                         0,


### PR DESCRIPTION
Closes #11992

Checklist:
- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
