### PR TITLE
src/pt/mangalivre: Fix image parsing logic

### DIFF
--- a/src/pt/mangalivre/build.gradle
+++ b/src/pt/mangalivre/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaLivre'
     themePkg = 'madara'
     baseUrl = 'https://mangalivre.tv'
-    overrideVersionCode = 4
+    overrideVersionCode = 5
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
@@ -7,14 +7,12 @@ import android.widget.Toast
 import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.multisrc.madara.Madara
-import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.Page
 import kotlinx.serialization.decodeFromString
 import okhttp3.FormBody
-import okhttp3.Request
 import org.jsoup.nodes.Document
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -26,7 +24,7 @@ class MangaLivre :
         "Manga Livre",
         "https://mangalivre.tv",
         "pt-BR",
-        SimpleDateFormat("dd.MM.yyyy", Locale.ROOT)
+        SimpleDateFormat("dd.MM.yyyy", Locale.ROOT),
     ),
     ConfigurableSource {
 
@@ -68,7 +66,7 @@ class MangaLivre :
         val script = document.select("script")
             .asSequence()
             .map { it.data() }
-            .firstOrNull { it.contains("atob") || it.contains("\\x70\\x75\\x73\\x68") } 
+            .firstOrNull { it.contains("atob") || it.contains("\\x70\\x75\\x73\\x68") }
             ?: throw Exception("Script not found. Cloudflare might be blocking the content.")
 
         // 3. Extrai as partes em Base64
@@ -108,7 +106,7 @@ class MangaLivre :
 
     companion object {
         private const val BASE_URL_PREF = "overrideBaseUrl"
-        
+
         // Compila as regex apenas uma vez para melhor performance
         private val ARRAY_PUSH_REGEX = Regex("""\w+\[\w+\]\(['"]([^'"]+)['"]\)""")
         private val LEGACY_REGEX = Regex("""\+=\s*['"]([^'"]*)['"]""")

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
@@ -1,5 +1,7 @@
 package eu.kanade.tachiyomi.extension.pt.mangalivre
 
+import android.app.Application
+import android.content.SharedPreferences
 import android.util.Base64
 import android.widget.Toast
 import androidx.preference.EditTextPreference
@@ -9,28 +11,40 @@ import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.Page
-import keiyoushi.utils.getPreferences
 import kotlinx.serialization.decodeFromString
 import okhttp3.FormBody
 import org.jsoup.nodes.Document
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import java.text.SimpleDateFormat
 import java.util.Locale
 
 class MangaLivre :
-    Madara("Manga Livre", "https://mangalivre.tv", "pt-BR", SimpleDateFormat("dd.MM.yyyy", Locale.ROOT)),
+    Madara(
+        "Manga Livre",
+        "https://mangalivre.tv",
+        "pt-BR",
+        SimpleDateFormat("dd.MM.yyyy", Locale.ROOT)
+    ),
     ConfigurableSource {
 
     override val id: Long = 2834885536325274328
-    override val useLoadMoreRequest = LoadMoreStrategy.Always
-    override val baseUrl by lazy { preferences.getString(BASE_URL_PREF, super.baseUrl)!! }
+
+    private val preferences: SharedPreferences by lazy {
+        Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
+    }
+
+    // Define a URL padrão explicitamente para evitar erros de inicialização
+    override val baseUrl by lazy {
+        preferences.getString(BASE_URL_PREF, "https://mangalivre.tv")!!
+    }
+
     override val client = super.client.newBuilder()
         .rateLimit(2)
         .build()
 
     override val useNewChapterEndpoint = true
     override val pageListParseSelector = ""
-
-    private val preferences by lazy { getPreferences() }
 
     override fun headersBuilder() = super.headersBuilder()
         .set("Origin", baseUrl)
@@ -41,24 +55,48 @@ class MangaLivre :
     override fun xhrChaptersRequest(mangaUrl: String) =
         POST("$mangaUrl/ajax/chapters/", xhrHeaders, FormBody.Builder().build())
 
-    override fun pageListParse(document: Document): List<Page> =
-        document.select("script")
+    override fun pageListParse(document: Document): List<Page> {
+        // 1. Tenta o parser padrão primeiro (caso removam a ofuscação)
+        val standardPages = runCatching { super.pageListParse(document) }.getOrNull()
+        if (!standardPages.isNullOrEmpty()) {
+            return standardPages
+        }
+
+        // 2. Busca o script (procura por 'atob' ou o hex do 'push')
+        val script = document.select("script")
             .asSequence()
-            .map { BASE64_REGEX.findAll(it.data()).joinToString("") { m -> m.groupValues[1] } }
-            .firstNotNullOfOrNull { base64 ->
-                runCatching {
-                    val decoded = String(Base64.decode(base64, Base64.DEFAULT))
-                    json.decodeFromString<List<String>>(decoded)
-                        .mapIndexed { idx, url -> Page(idx, imageUrl = url.trim()) }
-                }.getOrNull()
-            } ?: throw Exception("Failed to load images. Please open the chapter in WebView first.")
+            .map { it.data() }
+            .firstOrNull { it.contains("atob") || it.contains("\\x70\\x75\\x73\\x68") } 
+            ?: throw Exception("Script not found. Cloudflare might be blocking the content.")
+
+        // 3. Extrai as partes em Base64
+        // Tenta o padrão novo (Array Push)
+        var base64String = ARRAY_PUSH_REGEX.findAll(script).joinToString("") { it.groupValues[1] }
+
+        // Fallback: Se o novo padrão falhar, tenta o antigo (+=)
+        if (base64String.isEmpty()) {
+            base64String = LEGACY_REGEX.findAll(script).joinToString("") { it.groupValues[1] }
+        }
+
+        if (base64String.isEmpty()) {
+            throw Exception("Failed to extract Base64 data. The obfuscation pattern has changed.")
+        }
+
+        return runCatching {
+            val decoded = String(Base64.decode(base64String, Base64.DEFAULT))
+            json.decodeFromString<List<String>>(decoded)
+                .mapIndexed { idx, url -> Page(idx, imageUrl = url.trim()) }
+        }.getOrElse {
+            throw Exception("Failed to decode images: ${it.message}")
+        }
+    }
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         EditTextPreference(screen.context).apply {
             key = BASE_URL_PREF
             title = "Override Base URL"
-            summary = "Default: ${super.baseUrl}"
-            setDefaultValue(super.baseUrl)
+            summary = "Default: https://mangalivre.tv"
+            setDefaultValue("https://mangalivre.tv")
             setOnPreferenceChangeListener { _, _ ->
                 Toast.makeText(screen.context, "Restart app to apply.", Toast.LENGTH_LONG).show()
                 true
@@ -68,6 +106,9 @@ class MangaLivre :
 
     companion object {
         private const val BASE_URL_PREF = "overrideBaseUrl"
-        private val BASE64_REGEX = Regex("""\+=\s*['"]([^'"]*)['"]""")
+        
+        // Compila as regex apenas uma vez para melhor performance
+        private val ARRAY_PUSH_REGEX = Regex("""\w+\[\w+\]\(['"]([^'"]+)['"]\)""")
+        private val LEGACY_REGEX = Regex("""\+=\s*['"]([^'"]*)['"]""")
     }
 }


### PR DESCRIPTION
The site changed the obfuscation pattern from string concatenation (`+=`) to array push (`_var[_var]('...')`).

Changes:
- Updated `pageListParse` to handle the new array push pattern.
- Added a fallback to the old regex (`+=`) to ensure backward compatibility with older chapters/cache.
- Optimized regex usage by moving them to the companion object.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
Closes #12046
Closes #12077
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension

