### PR TITLE
Comix: Fix parsing chapter pages

### DIFF
--- a/src/en/comix/build.gradle
+++ b/src/en/comix/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comix'
     extClass = '.Comix'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = true
 }
 

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
@@ -257,8 +257,8 @@ class Comix : HttpSource(), ConfigurableSource {
             throw Exception("No images found for chapter ${result.chapterId}")
         }
 
-        return result.images.mapIndexed { index, url ->
-            Page(index, imageUrl = url)
+        return result.images.mapIndexed { index, img ->
+            Page(index, imageUrl = img.url)
         }
     }
 

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/ComixDto.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/ComixDto.kt
@@ -220,6 +220,11 @@ class ChapterResponse(
     class Items(
         @SerialName("chapter_id")
         val chapterId: Int,
-        val images: List<String>,
+        val images: List<Images>,
+    )
+
+    @Serializable
+    class Images(
+        val url: String,
     )
 }


### PR DESCRIPTION
Fixes: #12089 
Fixes: #12093

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
