### PR TITLE
Fix Mangastop: Add ClientHintsInterceptor

### DIFF
--- a/src/pt/mangastop/build.gradle
+++ b/src/pt/mangastop/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaStop'
     themePkg = 'mangathemesia'
     baseUrl = 'https://mangastop.net'
-    overrideVersionCode = 5
+    overrideVersionCode = 6
     isNsfw = false
 }
 

--- a/src/pt/mangastop/src/eu/kanade/tachiyomi/extension/pt/mangastop/ClientHintsInterceptor.kt
+++ b/src/pt/mangastop/src/eu/kanade/tachiyomi/extension/pt/mangastop/ClientHintsInterceptor.kt
@@ -1,0 +1,45 @@
+package eu.kanade.tachiyomi.extension.pt.mangastop
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class ClientHintsInterceptor : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val userAgent = request.header("User-Agent")
+            ?: return chain.proceed(request)
+
+        val chromeVersion = CHROME_REGEX.find(userAgent)?.groupValues?.get(1) ?: "134"
+        val isMobile = userAgent.contains("Android") || userAgent.contains("Mobile")
+        val isEdge = userAgent.contains("Edg/")
+
+        val secChUa = if (isEdge) {
+            val edgeVersion = EDGE_REGEX.find(userAgent)?.groupValues?.get(1) ?: chromeVersion
+            "\"Microsoft Edge\";v=\"$edgeVersion\", \"Chromium\";v=\"$chromeVersion\", \"Not?A_Brand\";v=\"99\""
+        } else {
+            "\"Chromium\";v=\"$chromeVersion\", \"Google Chrome\";v=\"$chromeVersion\", \"Not?A_Brand\";v=\"99\""
+        }
+
+        val platform = when {
+            userAgent.contains("Windows") -> "\"Windows\""
+            userAgent.contains("Android") -> "\"Android\""
+            userAgent.contains("Mac") -> "\"macOS\""
+            userAgent.contains("Linux") -> "\"Linux\""
+            else -> "\"Windows\""
+        }
+
+        val newRequest = request.newBuilder()
+            .header("Sec-Ch-Ua", secChUa)
+            .header("Sec-Ch-Ua-Mobile", if (isMobile) "?1" else "?0")
+            .header("Sec-Ch-Ua-Platform", platform)
+            .build()
+
+        return chain.proceed(newRequest)
+    }
+
+    companion object {
+        private val CHROME_REGEX = Regex("""Chrome/(\d+)""")
+        private val EDGE_REGEX = Regex("""Edg/(\d+)""")
+    }
+}

--- a/src/pt/mangastop/src/eu/kanade/tachiyomi/extension/pt/mangastop/MangaStop.kt
+++ b/src/pt/mangastop/src/eu/kanade/tachiyomi/extension/pt/mangastop/MangaStop.kt
@@ -45,6 +45,7 @@ class MangaStop :
             preferences.getPrefUAType(),
             preferences.getPrefCustomUA(),
         )
+        .addInterceptor(ClientHintsInterceptor())
         .rateLimit(2)
         .build()
 
@@ -53,7 +54,8 @@ class MangaStop :
         .add("Accept-Language", "pt-BR,pt;q=0.9,en-US;q=0.8,en;q=0.7")
         .add("Sec-Fetch-Dest", "document")
         .add("Sec-Fetch-Mode", "navigate")
-        .add("Sec-Fetch-Site", "same-origin")
+        .add("Sec-Fetch-Site", "none")
+        .add("Sec-Fetch-User", "?1")
         .add("Upgrade-Insecure-Requests", "1")
 
     override fun pageListParse(document: Document): List<Page> {


### PR DESCRIPTION
closes #12082

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
