### PR TITLE
RaijinScans: Fix Mihon Detection Changes

### DIFF
--- a/src/fr/raijinscans/build.gradle
+++ b/src/fr/raijinscans/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Raijin Scans'
     extClass = '.RaijinScans'
     baseUrl = 'https://raijin-scans.fr'
-    extVersionCode = 52
+    extVersionCode = 53
     isNsfw = false
 }
 

--- a/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
+++ b/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
@@ -1,6 +1,6 @@
 package eu.kanade.tachiyomi.extension.fr.raijinscans
 
-import android.util.Base64
+import android.webkit.CookieManager
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.source.model.FilterList
@@ -35,6 +35,9 @@ class RaijinScans : HttpSource() {
     private val nonceRegex = """"nonce"\s*:\s*"([^"]+)"""".toRegex()
     private val numberRegex = """(\d+)""".toRegex()
     private val descriptionScriptRegex = """content\.innerHTML = `([\s\S]+?)`;""".toRegex()
+    private val rmtRegex = """window\._rmt\s*=\s*["']([^"']+)["']""".toRegex()
+
+    private val webViewCookieManager: CookieManager by lazy { CookieManager.getInstance() }
 
     override fun headersBuilder() = super.headersBuilder().add("Referer", "$baseUrl/")
 
@@ -189,76 +192,37 @@ class RaijinScans : HttpSource() {
         }
     }
 
-    private fun protectedImageSrc(element: Element): String {
-        val encodedUrl = element.attr("data-src")
-        val imageUrl = String(Base64.decode(encodedUrl, Base64.DEFAULT))
-        return imageUrl
-    }
-
-    private fun protectedImageReverse(element: Element): String {
-        val encodedUrl = element.attr("data-r").reversed()
-        val imageUrl = String(Base64.decode(encodedUrl, Base64.DEFAULT))
-        return imageUrl
-    }
-
-    private fun protectedImageSimpleXor(element: Element): String {
-        val encodedUrl = element.attr("data-v").reversed()
-        val xorKey = 93
-        val xored = String(Base64.decode(encodedUrl, Base64.DEFAULT))
-        val decoded = xored.map { (it.code xor xorKey).toChar() }.joinToString("")
-        val imageUrl = String(Base64.decode(decoded, Base64.DEFAULT))
-        return imageUrl
-    }
-
-    private fun protectedImageM(element: Element): String {
-        val encodedUrl = element.attr("data-m").reversed()
-        val crypted = Base64.decode(encodedUrl, Base64.DEFAULT)
-        val decoded = crypted.map { ((it - 7 + 256) and 255 xor 173).toChar() }.joinToString("")
-        val imageUrl = String(Base64.decode(decoded, Base64.DEFAULT))
-        return imageUrl
-    }
-    private enum class ProtectedImageMethod {
-        UNKNOWN, SRC, REVERSE, SIMPLE_XOR, M
-    }
-
-    private fun findProtectionMethod(element: Element): Pair<ProtectedImageMethod, String> {
-        val functions = listOf(
-            ::protectedImageSrc to ProtectedImageMethod.SRC,
-            ::protectedImageReverse to ProtectedImageMethod.REVERSE,
-            ::protectedImageSimpleXor to ProtectedImageMethod.SIMPLE_XOR,
-            ::protectedImageReverse to ProtectedImageMethod.M,
-        )
-
-        for ((function, method) in functions) {
-            val result = function(element)
-            if (result.contains("$baseUrl/wp-content/uploads/WP-manga/data/manga_")) {
-                return Pair(method, result)
-            }
-        }
-        throw UnsupportedOperationException("Can't find a correct method to parse images.")
-    }
-
     // ========================== Page List =============================
-    override fun pageListParse(response: Response): List<Page> {
-        var method = ProtectedImageMethod.UNKNOWN
-        return response.asJsoup().select("div.protected-image-data").mapIndexed { index, element ->
-            if (method != ProtectedImageMethod.UNKNOWN) {
-                val imageUrl = when (method) {
-                    ProtectedImageMethod.SRC -> protectedImageSrc(element)
-                    ProtectedImageMethod.REVERSE -> protectedImageReverse(element)
-                    ProtectedImageMethod.SIMPLE_XOR -> protectedImageSimpleXor(element)
-                    ProtectedImageMethod.M -> protectedImageM(element)
-                    else -> {
-                        throw UnsupportedOperationException("Can't find image !")
-                    }
+    private fun getImages(t: String): List<Page> {
+        val requestBody = FormBody.Builder()
+            .add("t", t)
+            .add("action", "rm_get_images")
+            .build()
+
+        val request = Request.Builder()
+            .url("$baseUrl/wp-admin/admin-ajax.php")
+            .post(requestBody)
+            .headers(headers)
+            .addHeader("Cookie", webViewCookieManager.getCookie(baseUrl) ?: "")
+            .build()
+        for (i in 1..10) {
+            val adminRes = client.newCall(request).execute()
+            if (adminRes.isSuccessful) {
+                val responseJson = adminRes.parseAs<ImageResponseDto>()
+                val images = responseJson.data.u
+                return images.mapIndexed { index, imageUrl ->
+                    Page(index, imageUrl = imageUrl)
                 }
-                Page(index, imageUrl = imageUrl)
-            } else {
-                val (returnedMethod, imageUrl) = findProtectionMethod(element)
-                method = returnedMethod
-                Page(index, imageUrl = imageUrl)
             }
         }
+        throw UnsupportedOperationException("Can't fetch images. Please try again.")
+    }
+
+    override fun pageListParse(response: Response): List<Page> {
+        val matchResult = rmtRegex.find(response.body.string())
+        val t = matchResult?.groups?.get(1)?.value ?: ""
+        if (t.isBlank()) throw UnsupportedOperationException("Can't find window._rmt")
+        return getImages(t)
     }
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException("Not used.")

--- a/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScansDto.kt
+++ b/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScansDto.kt
@@ -15,3 +15,13 @@ class LatestUpdatesDataDto(
     @SerialName("current_page") val currentPage: Int,
     @SerialName("total_pages") val totalPages: Int,
 )
+
+@Serializable
+class ImageResponseDto(
+    val data: ImageResponseDataDto,
+)
+
+@Serializable
+class ImageResponseDataDto(
+    val u: List<String>,
+)


### PR DESCRIPTION
Closes #12131

RaijinScans continues to change its image parsing system. ~~For reasons unknown to me, they have completely reversed their latest changes to parsing.~~ However, it seems that they have changed their image encryption technique again ~~but have not yet implemented it.~~ **Now implemented.**
~~In this version, I have added a system to “detect” the encryption method, hoping that this will prevent the extension from crashing too often.~~ **Removed, they created decoy to bypass my detection.**
You may see me back here before long to patch something else. It's clearly a game of cat and mouse.

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
