### PR TITLE
QiScans: fix pages ordering

### DIFF
--- a/src/en/qiscans/build.gradle
+++ b/src/en/qiscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.QiScans'
     themePkg = 'iken'
     baseUrl = 'https://qiscans.org'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
 }
 


### PR DESCRIPTION
Closes #12123

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
