### PR TITLE
RaijinScans: Fix "Mihon detection" (Final)

### DIFF
--- a/src/fr/raijinscans/build.gradle
+++ b/src/fr/raijinscans/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Raijin Scans'
     extClass = '.RaijinScans'
     baseUrl = 'https://raijin-scans.fr'
-    extVersionCode = 53
+    extVersionCode = 54
     isNsfw = false
 }
 


### PR DESCRIPTION
### Message from one of Raijin's developers found in the source code.
```
/**
 * THE END.
 *
 * * Honestly, after much consideration, this will be the last update I will produce.
 *
 * I have locally tested many methods to break scrapers/extensions:
 * - Cloudflare Invisible Turnstile (Server-side validation)
 * - Full AES-GCM encryption (Instead of XOR)
 * - Serving raw image bytes via keys (.bin files)
 * - Canvas auto-scrambling with daily key updates
 * - WebSockets for image streaming
 * ...and many other creative ways.
 *
 * * Unfortunately, every effective solution came with
 * unacceptable performance costs for legitimate users.
 * * The main trigger for this specific update was a ban from our ad network 
 * due to "fake/bot traffic" caused entirely by similar apps and programs.
 *
 * * I am writing this here because I'm sure you read this code.
 * If you patch this version again: Congratulations, you win. 
 * You can be proud of your achievement ! even though all this time only parsing 
 * was used and one other "hooked atob".
 * * I won't bother with public repositories anymore.
 * 
 * it was fun.
 */
```
### My answer, because I think he'll watch it anyway
```
I'm glad to see how much you care about your users.
And I'm really sorry about your ad network. Maybe we
could find a solution to all this that works for both of us,
but to be honest, apart from an API, I can't see anything
else. And I obviously understand your desire not to be
scraped, but now that my solution is public, it wouldn't
be surprising if some people used it to scrape and re-upload,
unfortunately.
I'm glad I spent this week trying to find and rediscover
solutions to each of your patches. And I'll be honest, I
have immense respect for that.
As you said, it was fun, a really, really fun game.
Just know that it was pure chance that I started looking
for ways to solve all this. If it had been done a week earlier,
I probably wouldn't have touched anything.
I'm glad I got this far.

I might drop by your Discord so we can talk, without
fighting of course. I think we both have a certain respect
for each other and can have a calm discussion.

Open source always wins.
```

As you can see, this should be my last PR for Mihon detection, and I hope that will be the case. This PR fixes Raijin's final patch to make images more difficult to fetch. I hope I have understood their code correctly and won't need to redo a patch anytime soon.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
