### PR TITLE
Fix Manhuarm chapter loading and translation issues

### DIFF
--- a/src/all/manhuarm/build.gradle
+++ b/src/all/manhuarm/build.gradle
@@ -3,8 +3,12 @@ ext {
     extClass = '.ManhuarmFactory'
     themePkg = 'madara'
     baseUrl = 'https://manhuarmmtl.com'
-    overrideVersionCode = 7
+    overrideVersionCode = 8
     isNsfw = true
 }
 
 apply from: "$rootDir/common.gradle"
+
+dependencies {
+    compileOnly("com.squareup.okhttp3:okhttp-brotli:5.0.0-alpha.11")
+}


### PR DESCRIPTION
## Issue
Chapters fail to load in Mihon with error:
> Unexpected JSON token at offset 0: Expected start of the array '[', but had '‹'
The extension was unable to fetch OCR translation data from the server, causing chapter loading to fail completely.

## Root Cause
1. Server returns gzip-compressed JSON responses that weren't being decompressed
2. Using `cloudflareClient` for JSON requests caused 403 Forbidden responses from Cloudflare

## Changes
- Use `network.client` (plain HTTP) for JSON requests to avoid Cloudflare blocks
- Add gzip decompression for compressed server responses

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
