### PR TITLE
CI: Fix get_module_list to handle renamed files in git diff output

### DIFF
--- a/.github/scripts/generate-build-matrices.py
+++ b/.github/scripts/generate-build-matrices.py
@@ -23,7 +23,19 @@ def run_command(command: str) -> str:
     return result.stdout.strip()
 
 def get_module_list(ref: str) -> tuple[list[str], list[str]]:
-    changed_files = run_command(f"git diff --name-only {ref}").splitlines()
+    diff_output = run_command(f"git diff --name-status {ref}").splitlines()
+    
+    changed_files = []
+    for line in diff_output:
+        parts = line.split('\t')
+        status = parts[0]
+        if status.startswith('R'):  # Renamed/moved file
+            # parts[1] is old path, parts[2] is new path
+            changed_files.append(parts[1])  # Add old path
+            changed_files.append(parts[2])  # Add new path
+        else:
+            # For other statuses (A, M, D, etc.), just add the file path
+            changed_files.append(parts[1])
 
     modules = set()
     libs = set()

--- a/.github/scripts/generate-build-matrices.py
+++ b/.github/scripts/generate-build-matrices.py
@@ -25,11 +25,11 @@ def run_command(command: str) -> str:
 def get_module_list(ref: str) -> tuple[list[str], list[str]]:
     diff_output = run_command(f"git diff --name-status {ref}").splitlines()
     
-    changed_files = []
-    for line in diff_output:
-        _, primary, *secondary = line.split('\t', maxsplit=2)
-        changed_files.append(primary)
-        changed_files.extend(secondary)
+    changed_files = [
+        file
+        for line in diff_output
+        for file in line.split("\t", 2)[1:]
+    ]
         
     modules = set()
     libs = set()

--- a/.github/scripts/generate-build-matrices.py
+++ b/.github/scripts/generate-build-matrices.py
@@ -12,7 +12,7 @@ MULTISRC_LIB_REGEX = re.compile(r"^lib-multisrc/(?P<multisrc>\w+)")
 LIB_REGEX = re.compile(r"^lib/(?P<lib>\w+)")
 MODULE_REGEX = re.compile(r"^:src:(?P<lang>\w+):(?P<extension>\w+)$")
 CORE_FILES_REGEX = re.compile(
-    r"^(buildSrc/|core/|gradle/|build\.gradle\.kts|common\.gradle|gradle\.properties|settings\.gradle\.kts|.github/scripts)"
+    r"^(buildSrc/|core/|gradle/|build\.gradle\.kts|common\.gradle|gradle\.properties|settings\.gradle\.kts)"
 )
 
 def run_command(command: str) -> str:
@@ -27,16 +27,10 @@ def get_module_list(ref: str) -> tuple[list[str], list[str]]:
     
     changed_files = []
     for line in diff_output:
-        parts = line.split('\t')
-        status = parts[0]
-        if status.startswith('R'):  # Renamed/moved file
-            # parts[1] is old path, parts[2] is new path
-            changed_files.append(parts[1])  # Add old path
-            changed_files.append(parts[2])  # Add new path
-        else:
-            # For other statuses (A, M, D, etc.), just add the file path
-            changed_files.append(parts[1])
-
+        _, primary, *secondary = line.split('\t', maxsplit=2)
+        changed_files.append(primary)
+        changed_files.extend(secondary)
+        
     modules = set()
     libs = set()
     deleted = set()

--- a/.github/scripts/generate-build-matrices.py
+++ b/.github/scripts/generate-build-matrices.py
@@ -12,7 +12,7 @@ MULTISRC_LIB_REGEX = re.compile(r"^lib-multisrc/(?P<multisrc>\w+)")
 LIB_REGEX = re.compile(r"^lib/(?P<lib>\w+)")
 MODULE_REGEX = re.compile(r"^:src:(?P<lang>\w+):(?P<extension>\w+)$")
 CORE_FILES_REGEX = re.compile(
-    r"^(buildSrc/|core/|gradle/|build\.gradle\.kts|common\.gradle|gradle\.properties|settings\.gradle\.kts)"
+    r"^(buildSrc/|core/|gradle/|build\.gradle\.kts|common\.gradle|gradle\.properties|settings\.gradle\.kts|.github/scripts)"
 )
 
 def run_command(command: str) -> str:
@@ -39,6 +39,7 @@ def get_module_list(ref: str) -> tuple[list[str], list[str]]:
     for file in map(lambda x: Path(x).as_posix(), changed_files):
         if CORE_FILES_REGEX.search(file):
             core_files_changed = True
+            break
         elif match := EXTENSION_REGEX.search(file):
             lang = match.group("lang")
             extension = match.group("extension")


### PR DESCRIPTION
see https://github.com/keiyoushi/extensions/commit/da01f5c69a1d696222334e951946feaa35f2b7e2

---

```sh
$ mv src/en/adultwebtoon src/all
$ export IS_PR_CHECK=true
```
Previously:
```sh
$ python .github/scripts/generate-build-matrices.py main Debug                                                                                                         
Module chunks to build:
{
  "chunk": [
    {
      "number": 1,
      "modules": [
        ":src:all:adultwebtoon:assembleDebug"
      ]
    }
  ]
}

Module to delete:
[
  "all.adultwebtoon"
]
```

Now:
```sh
$ python .github/scripts/generate-build-matrices.py workflow-fix-renames Debug                                                                                  
Module chunks to build:
{
  "chunk": [
    {
      "number": 1,
      "modules": [
        ":src:all:adultwebtoon:assembleDebug"
      ]
    }
  ]
}

Module to delete:
[
  "all.adultwebtoon",
  "en.adultwebtoon"
]
```