### PR TITLE
SanaScans: fix page ordering

### DIFF
--- a/src/en/sanascans/build.gradle
+++ b/src/en/sanascans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.SanaScans'
     themePkg = 'iken'
     baseUrl = 'https://sanascans.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
 }
 


### PR DESCRIPTION
## Summary
- Fix SanaScans reader page ordering by preferring the leading page number in the image filename when present.
- Keep a fallback to the site's provided `order` when filenames don't contain page numbers.

## Test plan
- Open SanaScans → Banishment Is Fine!: As a Genius Saint, I Can Shine Anywhere → Chapter 2 and verify pages are in numeric order (page 04 is no longer pushed to the end).