### PR TITLE
SanaScans: fix page ordering

### DIFF
--- a/src/en/sanascans/build.gradle
+++ b/src/en/sanascans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.SanaScans'
     themePkg = 'iken'
     baseUrl = 'https://sanascans.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
 }
 


### PR DESCRIPTION
## Issue
Some SanaScans chapters have pages shuffled because the site’s `order` field can be assigned to the wrong image URLs.

## Fix
Prefer the leading page number in the image filename (01/02/03/…) for sorting when present, with a fallback to the API-provided `order` when filenames don’t contain page numbers.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
