### PR TITLE
fix(pt/kuromangas): Fixed pt/KuroMangas (Closes #12183)

### DIFF
--- a/src/pt/kuromangas/build.gradle
+++ b/src/pt/kuromangas/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'KuroMangas'
     extClass = '.KuroMangas'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = false
 }
 

--- a/src/pt/kuromangas/src/eu/kanade/tachiyomi/extension/pt/kuromangas/KuroMangas.kt
+++ b/src/pt/kuromangas/src/eu/kanade/tachiyomi/extension/pt/kuromangas/KuroMangas.kt
@@ -195,7 +195,8 @@ class KuroMangas : HttpSource(), ConfigurableSource {
     override fun pageListParse(response: Response): List<Page> {
         val chapterResponse = response.parseAs<ChapterPagesResponse>()
         return chapterResponse.pages.mapIndexed { index, pageUrl ->
-            val imageUrl = if (pageUrl.startsWith("http")) pageUrl else "$cdnUrl$pageUrl"
+            val fixedUrl = pageUrl.replaceFirst("^/uploads/".toRegex(), "/")
+            val imageUrl = if (fixedUrl.startsWith("http")) fixedUrl else "$cdnUrl$fixedUrl"
             Page(index, imageUrl = imageUrl)
         }
     }


### PR DESCRIPTION
Closes #12183

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
