### PR TITLE
fix nexusscan: change css selector

### DIFF
--- a/src/pt/spectralscan/build.gradle
+++ b/src/pt/spectralscan/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Nexus Scan'
     extClass = '.NexusScan'
-    extVersionCode = 49
+    extVersionCode = 50
     isNsfw = true
 }
 

--- a/src/pt/spectralscan/src/eu/kanade/tachiyomi/extension/pt/spectralscan/NexusScan.kt
+++ b/src/pt/spectralscan/src/eu/kanade/tachiyomi/extension/pt/spectralscan/NexusScan.kt
@@ -302,7 +302,7 @@ class NexusScan : HttpSource(), ConfigurableSource {
 
     override fun pageListParse(response: Response): List<Page> {
         val pageData = response.asJsoup()
-            .selectFirst("script#page-data")?.data()
+            .selectFirst("script#raw-payload-stream")?.data()
             ?: return emptyList()
 
         return pageData.parseAs<List<PageData>>().mapIndexed { index, page ->


### PR DESCRIPTION
closes: #12198

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
