### PR TITLE
MangaCrab: Fix http 403 on pages

### DIFF
--- a/src/es/mangacrab/build.gradle
+++ b/src/es/mangacrab/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaCrab'
     themePkg = 'madara'
     baseUrl = 'https://mangacrab.org'
-    overrideVersionCode = 17
+    overrideVersionCode = 18
     isNsfw = false
 }
 

--- a/src/es/mangacrab/src/eu/kanade/tachiyomi/extension/es/mangacrab/MangaCrab.kt
+++ b/src/es/mangacrab/src/eu/kanade/tachiyomi/extension/es/mangacrab/MangaCrab.kt
@@ -7,10 +7,14 @@ import eu.kanade.tachiyomi.lib.randomua.getPrefCustomUA
 import eu.kanade.tachiyomi.lib.randomua.getPrefUAType
 import eu.kanade.tachiyomi.lib.randomua.setRandomUserAgent
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.source.ConfigurableSource
+import eu.kanade.tachiyomi.source.model.Page
 import keiyoushi.utils.getPreferences
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.Request
+import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -50,6 +54,23 @@ class MangaCrab :
 
     override val pageListParseSelector = "div.page-break:not([style*='display:none']) img:not([src])"
 
+    private val imageKeyRegex = """'X-Img-Key'\s*:\s*'(.*?)'""".toRegex()
+
+    override fun pageListParse(document: Document): List<Page> {
+        launchIO { countViews(document) }
+
+        val imageKey = document.selectFirst("script:containsData('X-Img-Key')")?.data()
+            ?.let { script ->
+                imageKeyRegex.find(script)?.groups?.get(1)?.value
+            }
+            ?: throw Exception("Image key not found")
+
+        return document.select(pageListParseSelector).mapIndexed { index, element ->
+            val imageUrl = element.selectFirst("img")?.let { imageFromElement(it) }
+            Page(index, document.location(), "$imageUrl#$imageKey")
+        }
+    }
+
     override fun imageFromElement(element: Element): String? {
         val url = element.attributes()
             .firstNotNullOfOrNull { attr ->
@@ -57,31 +78,25 @@ class MangaCrab :
                     ?.takeIf { it.encodedQuery.toString().contains("wp-content") }
             }
 
-        val fileUrl = url?.let { httpUrl ->
-            httpUrl.queryParameterNames
-                .firstNotNullOfOrNull { name ->
-                    httpUrl.queryParameterValues(name)
-                        .firstOrNull { value -> value?.contains("wp-content") == true }
-                }
-                ?.let { file ->
-                    httpUrl.newBuilder()
-                        .encodedPath("/$file")
-                        .query(null)
-                        .build()
-                }
-        }
-
-        val imageAbsUrl = element.attributes().firstOrNull { it.value.toHttpUrlOrNull() != null }?.value
-
         return when {
-            fileUrl != null -> fileUrl.toString()
+            url != null -> url.toString()
             element.hasAttr("data-src") -> element.attr("abs:data-src")
             element.hasAttr("data-lazy-src") -> element.attr("abs:data-lazy-src")
             element.hasAttr("srcset") -> element.attr("abs:srcset").getSrcSetImage()
             element.hasAttr("data-cfsrc") -> element.attr("abs:data-cfsrc")
             element.hasAttr("data-src-base64") -> element.attr("abs:data-src-base64")
-            imageAbsUrl != null -> imageAbsUrl
             else -> element.attr("abs:src")
         }
+    }
+
+    override fun imageRequest(page: Page): Request {
+        val imageUrl = page.imageUrl!!.substringBeforeLast("#")
+        val imageKey = page.imageUrl!!.substringAfterLast("#")
+        val headers = headers.newBuilder()
+            .set("Referer", page.url)
+            .set("X-Img-Key", imageKey)
+            .build()
+
+        return GET(imageUrl, headers)
     }
 }


### PR DESCRIPTION
Closes #12091

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
