### PR TITLE
Update DbMultiverse.kt

### DIFF
--- a/src/all/dragonballmultiverse/src/eu/kanade/tachiyomi/extension/all/dragonballmultiverse/DbMultiverse.kt
+++ b/src/all/dragonballmultiverse/src/eu/kanade/tachiyomi/extension/all/dragonballmultiverse/DbMultiverse.kt
@@ -39,19 +39,16 @@ abstract class DbMultiverse(override val lang: String, private val internalLang:
     }
 
     override fun pageListParse(document: Document): List<Page> {
-        return document.select("#balloonsimg")
-            .let { e ->
-                listOf(
-                    if (e.hasAttr("src")) {
-                        Page(1, "", e.attr("abs:src"))
-                    } else {
-                        e.attr("style")
-                            .substringAfter("(")
-                            .substringBefore(")")
-                            .let { Page(1, "", baseUrl + it) }
-                    },
-                )
+        return document.select("#balloonsimg img")  // Sélect <img> inside div
+        .firstOrNull()  // Take first <img> if exist
+        ?.let { img ->
+            // if src attribute exist, create URL, else return null
+            if (img.hasAttr("src")) {
+                listOf(Page(1, "", img.attr("abs:src")))
+            } else {
+                emptyList()
             }
+        } ?: emptyList()  // if no <img>, return empty list
     }
 
     override fun fetchPopularManga(page: Int): Observable<MangasPage> {


### PR DESCRIPTION
Image loader in Mihon is returning 'IllegalArgumentException: Invalide URL port: "800px;height:1131px;"

The code was reading the wrong attribute in the div. Changed it to get the real url of the image.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
