### PR TITLE
fix(RoliaScan): new postId selector

### DIFF
--- a/src/en/roliascan/build.gradle
+++ b/src/en/roliascan/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Rolia Scan'
     extClass = '.RoliaScan'
-    extVersionCode = 3
+    extVersionCode = 4
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/roliascan/src/eu/kanade/tachiyomi/extension/en/roliascan/RoliaScan.kt
+++ b/src/en/roliascan/src/eu/kanade/tachiyomi/extension/en/roliascan/RoliaScan.kt
@@ -157,8 +157,10 @@ class RoliaScan : ParsedHttpSource() {
             .asJsoup()
 
         val postId = document
-            .select("input[name=current_page_id]")
-            .attr("value")
+            .select("[class*=\"postid-\"]")
+            .attr("class")
+            .substringAfter("postid-")
+            .substringBefore(" ")
 
         chapters += document.select(chapterListSelector()).map(::chapterFromElement)
         val step = 20


### PR DESCRIPTION
The `postId` selector was broken, so the request returned info from other titles.

Fixes #12225


Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
