### PR TITLE
MangaLivre: Fix image extractor

### DIFF
--- a/src/pt/mangalivre/build.gradle
+++ b/src/pt/mangalivre/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaLivre'
     themePkg = 'madara'
     baseUrl = 'https://mangalivre.tv'
-    overrideVersionCode = 8
+    overrideVersionCode = 9
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivreImageExtractor.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivreImageExtractor.kt
@@ -6,71 +6,117 @@ import org.jsoup.nodes.Document
 
 object MangaLivreImageExtractor {
 
+    private const val PADDING_SIZE = 16
     private val PLACEHOLDER_PATTERNS = listOf("hi.png", "placeholder", "loading")
-    private val SCRIPT_XOR_KEY_REGEX = Regex(""""([a-f0-9]{8})"\s*,\s*"([a-f0-9]{8})"""")
-    private const val DEFAULT_KEY1 = "2e88429b"
-    private const val DEFAULT_KEY2 = "29d076b6"
+
+    private val KEY_ARRAY_REGEX = Regex("""var\s+(\w+)\s*=\s*\[(-?\d+(?:\s*,\s*-?\d+){15,})\]""")
+    private val KEY_OFFSET_REGEX = Regex("""String\.fromCharCode\s*\(\s*\w+\s*([+\-])\s*(\d+)\s*\)""")
+    private val URL_PATTERN = Regex("""https?://[^\s"\\]+\.(webp|jpg|jpeg|png|gif)""", RegexOption.IGNORE_CASE)
+
+    private data class DecryptionParams(
+        val keyArray: List<Int>,
+        val keyOffset: Int,
+        val operation: Char,
+    )
 
     fun extractImageUrls(document: Document): List<String>? {
-        val dataXSpans = document.select("span[data-x]")
-        if (dataXSpans.isEmpty()) return null
+        val readingContent = document.selectFirst(".reading-content") ?: return null
+        val params = findDecryptionParams(document) ?: return null
 
-        val (key1, key2) = findXorKeysFromScript(document) ?: Pair(DEFAULT_KEY1, DEFAULT_KEY2)
+        val encodedData = collectEncodedData(readingContent)
+        if (encodedData.isBlank()) return null
 
-        val allEncodedData = dataXSpans.mapNotNull { span ->
-            span.attr("data-x").takeIf { it.isNotBlank() }
-        }.joinToString("")
-
-        if (allEncodedData.isBlank()) return null
-
-        val jsonArray = decodeDataXToJson(allEncodedData, key1, key2)
-        return parseUrlsFromJson(jsonArray)
+        val decodedStr = decodeData(encodedData, params)
+        return parseUrls(decodedStr)
     }
 
-    private fun decodeDataXToJson(encodedData: String, key1: String, key2: String): String {
-        val decodedBytes = Base64.decode(encodedData, Base64.DEFAULT)
+    private fun collectEncodedData(readingContent: org.jsoup.nodes.Element): String {
+        val ignoredAttrs = setOf("data-site-url", "style", "class", "id")
 
-        val result = buildString {
-            for (i in decodedBytes.indices) {
-                val block = i / 8
-                val key = if (block % 2 == 0) key1 else key2
-                val c = decodedBytes[i].toInt() and 0xFF xor key[i % 8].code
-                append(c.toChar())
+        return buildString {
+            for (el in readingContent.select("div.sec-part[style*=display:none]")) {
+                val dataAttr = el.attributes()
+                    .firstOrNull { it.key.startsWith("data-") && it.key !in ignoredAttrs && it.value.length > 20 }
+                if (dataAttr != null) {
+                    append(dataAttr.value)
+                }
             }
         }
-
-        val startIdx = result.indexOf('[')
-        val endIdx = result.lastIndexOf(']')
-        if (startIdx == -1 || endIdx == -1 || endIdx <= startIdx) {
-            return result
-        }
-
-        return result.substring(startIdx, endIdx + 1)
-            .replace("\\/", "/")
     }
 
-    private fun parseUrlsFromJson(jsonStr: String): List<String>? {
-        return try {
-            jsonStr.parseAs<List<String>>()
-                .map { it.trim() }
-                .filter { isValidImageUrl(it) }
-                .ifEmpty { null }
-        } catch (_: Exception) {
+    private fun findDecryptionParams(document: Document): DecryptionParams? {
+        var keyArray: List<Int>? = null
+        var keyOffset: Int? = null
+        var operation: Char? = null
+
+        for (script in document.select("script:not([src])")) {
+            val data = script.data()
+            if (data.length < 50) continue
+
+            if (keyArray == null) {
+                KEY_ARRAY_REGEX.find(data)?.let { match ->
+                    keyArray = match.groupValues[2].split(",").mapNotNull { it.trim().toIntOrNull() }
+                }
+            }
+
+            if (operation == null) {
+                KEY_OFFSET_REGEX.find(data)?.let { match ->
+                    operation = match.groupValues[1].firstOrNull()
+                    keyOffset = match.groupValues[2].toIntOrNull()
+                }
+            }
+
+            if (keyArray != null && keyOffset != null && operation != null) break
+        }
+
+        return if (keyArray != null && keyOffset != null && operation != null) {
+            DecryptionParams(keyArray!!, keyOffset!!, operation!!)
+        } else {
             null
         }
     }
 
-    private fun findXorKeysFromScript(document: Document): Pair<String, String>? {
-        for (script in document.select("script:not([src])")) {
-            val data = script.data()
-            if (data.length < 100) continue
+    private fun decodeData(encodedData: String, params: DecryptionParams): String {
+        val decodedBytes = runCatching { Base64.decode(encodedData, Base64.DEFAULT) }.getOrNull() ?: return ""
 
-            val match = SCRIPT_XOR_KEY_REGEX.find(data)
-            if (match != null) {
-                return Pair(match.groupValues[1], match.groupValues[2])
+        val realKey = params.keyArray.map { value ->
+            val charCode = if (params.operation == '+') value + params.keyOffset else value - params.keyOffset
+            (charCode and 0xFF).toChar()
+        }.joinToString("")
+
+        val result = buildString {
+            for (i in decodedBytes.indices) {
+                append(((decodedBytes[i].toInt() and 0xFF) xor realKey[i % realKey.length].code).toChar())
             }
         }
-        return null
+
+        val jsonStart = result.indexOf("[\"")
+        return when {
+            jsonStart >= 0 -> result.substring(jsonStart)
+            result.length > PADDING_SIZE -> result.substring(PADDING_SIZE)
+            else -> result
+        }
+    }
+
+    private fun parseUrls(jsonStr: String): List<String>? {
+        return runCatching {
+            jsonStr.parseAs<List<String>>()
+                .map { it.trim() }
+                .filter { isValidImageUrl(it) }
+                .ifEmpty { null }
+        }.getOrElse {
+            extractUrlsWithRegex(jsonStr)
+        }
+    }
+
+    private fun extractUrlsWithRegex(data: String): List<String>? {
+        val normalizedData = data.replace("\\/", "/")
+        return URL_PATTERN.findAll(normalizedData)
+            .map { it.value.trim() }
+            .filter { isValidImageUrl(it) }
+            .distinct()
+            .toList()
+            .ifEmpty { null }
     }
 
     private fun isValidImageUrl(url: String): Boolean {


### PR DESCRIPTION
closes #12240

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
