### PR TITLE
Armageddon: fix page parsing

### DIFF
--- a/src/en/armageddon/build.gradle
+++ b/src/en/armageddon/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Armageddon'
     themePkg = 'mangathemesia'
     baseUrl = 'https://www.silentquill.net'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/en/armageddon/src/eu/kanade/tachiyomi/extension/en/armageddon/Armageddon.kt
+++ b/src/en/armageddon/src/eu/kanade/tachiyomi/extension/en/armageddon/Armageddon.kt
@@ -1,9 +1,29 @@
 package eu.kanade.tachiyomi.extension.en.armageddon
 
+import android.util.Base64
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import eu.kanade.tachiyomi.source.model.Page
+import keiyoushi.utils.parseAs
+import org.jsoup.nodes.Document
 
 class Armageddon : MangaThemesia(
     name = "Armageddon",
     baseUrl = "https://www.silentquill.net",
     lang = "en",
-)
+) {
+    override fun pageListParse(document: Document): List<Page> {
+        val scriptContent = document.selectFirst("script:containsData(WyJodHRw)")?.data()
+            ?: return super.pageListParse(document)
+        val base64Match = Regex("""['"](WyJodHRw[\w+/=]+)['"]""").find(scriptContent)?.groupValues?.get(1)
+
+        return if (base64Match != null) {
+            val decoded = String(Base64.decode(base64Match, Base64.DEFAULT))
+            val images = decoded.parseAs<List<String>>()
+            images.mapIndexed { i, img ->
+                Page(i, document.location(), img)
+            }
+        } else {
+            super.pageListParse(document)
+        }
+    }
+}


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
