### PR TITLE
Fix Mangalivre: update image extractor

### DIFF
--- a/src/pt/mangalivre/build.gradle
+++ b/src/pt/mangalivre/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaLivre'
     themePkg = 'madara'
     baseUrl = 'https://mangalivre.tv'
-    overrideVersionCode = 9
+    overrideVersionCode = 10
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivreImageExtractor.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivreImageExtractor.kt
@@ -3,84 +3,117 @@ package eu.kanade.tachiyomi.extension.pt.mangalivre
 import android.util.Base64
 import keiyoushi.utils.parseAs
 import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
 
 object MangaLivreImageExtractor {
 
     private const val PADDING_SIZE = 16
-    private val PLACEHOLDER_PATTERNS = listOf("hi.png", "placeholder", "loading")
 
-    private val KEY_ARRAY_REGEX = Regex("""var\s+(\w+)\s*=\s*\[(-?\d+(?:\s*,\s*-?\d+){15,})\]""")
-    private val KEY_OFFSET_REGEX = Regex("""String\.fromCharCode\s*\(\s*\w+\s*([+\-])\s*(\d+)\s*\)""")
-    private val URL_PATTERN = Regex("""https?://[^\s"\\]+\.(webp|jpg|jpeg|png|gif)""", RegexOption.IGNORE_CASE)
+    private val KEY_STRING_REGEX = Regex("""var\s+\w+\s*=\s*["'](-?\d+[^"']+)["']""")
+
+    private val XOR_OP_REGEX = Regex("""calcVal\s*=\s*rawVal\s*\^\s*(\d+)""")
+
+    private val ADD_OP_REGEX = Regex("""calcVal\s*=\s*rawVal\s*\+\s*(\d+)""")
+
+    private val SUB_OP_REGEX = Regex("""calcVal\s*=\s*rawVal\s*-\s*(\d+)""")
+
+    private val DATA_ATTR_REGEX = Regex("""querySelectorAll\s*\(\s*['"]div\[data-(\w+)\]['"]""")
+
+    private enum class Operation { XOR, ADD, SUB }
 
     private data class DecryptionParams(
-        val keyArray: List<Int>,
-        val keyOffset: Int,
-        val operation: Char,
+        val keyParts: List<Int>,
+        val operand: Int,
+        val operation: Operation,
+        val dataAttrName: String,
     )
 
     fun extractImageUrls(document: Document): List<String>? {
         val readingContent = document.selectFirst(".reading-content") ?: return null
         val params = findDecryptionParams(document) ?: return null
 
-        val encodedData = collectEncodedData(readingContent)
+        val encodedData = collectEncodedData(readingContent, params)
         if (encodedData.isBlank()) return null
 
         val decodedStr = decodeData(encodedData, params)
         return parseUrls(decodedStr)
     }
 
-    private fun collectEncodedData(readingContent: org.jsoup.nodes.Element): String {
-        val ignoredAttrs = setOf("data-site-url", "style", "class", "id")
-
+    private fun collectEncodedData(readingContent: Element, params: DecryptionParams): String {
         return buildString {
-            for (el in readingContent.select("div.sec-part[style*=display:none]")) {
-                val dataAttr = el.attributes()
-                    .firstOrNull { it.key.startsWith("data-") && it.key !in ignoredAttrs && it.value.length > 20 }
-                if (dataAttr != null) {
-                    append(dataAttr.value)
-                }
+            for (el in readingContent.select("div.sec-part-real[data-${params.dataAttrName}]")) {
+                append(el.attr("data-${params.dataAttrName}"))
             }
         }
     }
 
     private fun findDecryptionParams(document: Document): DecryptionParams? {
-        var keyArray: List<Int>? = null
-        var keyOffset: Int? = null
-        var operation: Char? = null
+        var keyString: String? = null
+        var operand: Int? = null
+        var operation: Operation? = null
+        var dataAttrName: String? = null
 
         for (script in document.select("script:not([src])")) {
             val data = script.data()
             if (data.length < 50) continue
 
-            if (keyArray == null) {
-                KEY_ARRAY_REGEX.find(data)?.let { match ->
-                    keyArray = match.groupValues[2].split(",").mapNotNull { it.trim().toIntOrNull() }
+            if (dataAttrName == null) {
+                DATA_ATTR_REGEX.find(data)?.let { match ->
+                    dataAttrName = match.groupValues[1]
+                }
+            }
+
+            if (keyString == null) {
+                KEY_STRING_REGEX.find(data)?.let { match ->
+                    val value = match.groupValues[1]
+                    if (value.contains(Regex("""-?\d+[^0-9\-]+-?\d+"""))) {
+                        keyString = value
+                    }
                 }
             }
 
             if (operation == null) {
-                KEY_OFFSET_REGEX.find(data)?.let { match ->
-                    operation = match.groupValues[1].firstOrNull()
-                    keyOffset = match.groupValues[2].toIntOrNull()
+                XOR_OP_REGEX.find(data)?.let { match ->
+                    operand = match.groupValues[1].toIntOrNull()
+                    operation = Operation.XOR
+                }
+                if (operation == null) {
+                    ADD_OP_REGEX.find(data)?.let { match ->
+                        operand = match.groupValues[1].toIntOrNull()
+                        operation = Operation.ADD
+                    }
+                }
+                if (operation == null) {
+                    SUB_OP_REGEX.find(data)?.let { match ->
+                        operand = match.groupValues[1].toIntOrNull()
+                        operation = Operation.SUB
+                    }
                 }
             }
 
-            if (keyArray != null && keyOffset != null && operation != null) break
+            if (keyString != null && operand != null && operation != null && dataAttrName != null) break
         }
 
-        return if (keyArray != null && keyOffset != null && operation != null) {
-            DecryptionParams(keyArray!!, keyOffset!!, operation!!)
-        } else {
-            null
-        }
+        if (keyString == null || operand == null || operation == null || dataAttrName == null) return null
+
+        val separator = keyString!!.firstOrNull { !it.isDigit() && it != '-' }?.toString() ?: ":"
+        val keyParts = keyString!!.split(separator).mapNotNull { it.toIntOrNull() }
+
+        if (keyParts.isEmpty()) return null
+
+        return DecryptionParams(keyParts, operand!!, operation!!, dataAttrName!!)
     }
 
     private fun decodeData(encodedData: String, params: DecryptionParams): String {
-        val decodedBytes = runCatching { Base64.decode(encodedData, Base64.DEFAULT) }.getOrNull() ?: return ""
+        val decodedBytes = runCatching { Base64.decode(encodedData, Base64.DEFAULT) }.getOrNull()
+            ?: return ""
 
-        val realKey = params.keyArray.map { value ->
-            val charCode = if (params.operation == '+') value + params.keyOffset else value - params.keyOffset
+        val realKey = params.keyParts.map { value ->
+            val charCode = when (params.operation) {
+                Operation.XOR -> value xor params.operand
+                Operation.ADD -> value + params.operand
+                Operation.SUB -> value - params.operand
+            }
             (charCode and 0xFF).toChar()
         }.joinToString("")
 
@@ -102,25 +135,7 @@ object MangaLivreImageExtractor {
         return runCatching {
             jsonStr.parseAs<List<String>>()
                 .map { it.trim() }
-                .filter { isValidImageUrl(it) }
                 .ifEmpty { null }
-        }.getOrElse {
-            extractUrlsWithRegex(jsonStr)
-        }
-    }
-
-    private fun extractUrlsWithRegex(data: String): List<String>? {
-        val normalizedData = data.replace("\\/", "/")
-        return URL_PATTERN.findAll(normalizedData)
-            .map { it.value.trim() }
-            .filter { isValidImageUrl(it) }
-            .distinct()
-            .toList()
-            .ifEmpty { null }
-    }
-
-    private fun isValidImageUrl(url: String): Boolean {
-        return PLACEHOLDER_PATTERNS.none { url.contains(it, ignoreCase = true) } &&
-            (url.startsWith("http") || url.startsWith("/"))
+        }.getOrNull()
     }
 }


### PR DESCRIPTION
closes: #12268

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
