### PR TITLE
LilyManga: fix date format

### DIFF
--- a/src/en/lilymanga/build.gradle
+++ b/src/en/lilymanga/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.LilyManga'
     themePkg = 'madara'
     baseUrl = 'https://lilymanga.net'
-    overrideVersionCode = 4
+    overrideVersionCode = 5
     isNsfw = true
 }
 

--- a/src/en/lilymanga/src/eu/kanade/tachiyomi/extension/en/lilymanga/LilyManga.kt
+++ b/src/en/lilymanga/src/eu/kanade/tachiyomi/extension/en/lilymanga/LilyManga.kt
@@ -10,7 +10,7 @@ class LilyManga : Madara(
     "Lily Manga",
     "https://lilymanga.net",
     "en",
-    dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US),
+    dateFormat = SimpleDateFormat("dd.MM.yyyy", Locale.US),
 ) {
     override val client = super.client.newBuilder()
         .rateLimitHost(baseUrl.toHttpUrl(), 1, 2)


### PR DESCRIPTION
Simple fix for LilyManga, the date format has seemingly changed on the website, messing up the dates in Mihon.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
