### PR TITLE
MediocreToons: Add Origin header for cross-origin requests

### DIFF
--- a/src/pt/mediocretoons/build.gradle
+++ b/src/pt/mediocretoons/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Mediocre Toons'
     extClass = '.MediocreToons'
     baseUrl = 'https://mediocrescan.com'
-    extVersionCode = 10
+    extVersionCode = 11
     isNsfw = true
 }
 

--- a/src/pt/mediocretoons/src/eu/kanade/tachiyomi/extension/pt/mediocretoons/MediocreToons.kt
+++ b/src/pt/mediocretoons/src/eu/kanade/tachiyomi/extension/pt/mediocretoons/MediocreToons.kt
@@ -153,6 +153,8 @@ class MediocreToons : HttpSource(), ConfigurableSource {
 
     override fun headersBuilder() = super.headersBuilder()
         .set("x-app-key", "toons-mediocre-app")
+        .set("Referer", "$baseUrl/")
+        .set("Origin", baseUrl)
 
     // ============================== Popular ================================
     override fun popularMangaRequest(page: Int): Request {


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
