### PR TITLE
BatoTo (v4) | HOTFIX: Reorder server fallbacks

### DIFF
--- a/src/all/batoto/build.gradle
+++ b/src/all/batoto/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Bato.to'
     extClass = '.BatoToFactory'
-    extVersionCode = 57
+    extVersionCode = 58
     isNsfw = true
 }
 

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
@@ -653,7 +653,7 @@ open class BatoTo(
 
         if (SERVER_PATTERN.containsMatchIn(urlString)) {
             // Sorted list: Most reliable servers FIRST
-            val servers = listOf("k03", "k06", "k07", "k00", "k01", "k02", "k04", "k05", "k08", "k09", "n03", "n00", "n01", "n02", "n04", "n05", "n06", "n07", "n08", "n09", "n10")
+            val servers = listOf("n03", "n00", "n01", "n02", "n04", "n05", "n06", "n07", "n08", "n09", "n10", "k03", "k06", "k07", "k00", "k01", "k02", "k04", "k05", "k08", "k09")
 
             for (server in servers) {
                 val newUrl = urlString.replace(SERVER_PATTERN, "https://$server")

--- a/src/all/batotov4/build.gradle
+++ b/src/all/batotov4/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Bato.to V4'
     extClass = '.BatoToV4Factory'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/all/batotov4/src/eu/kanade/tachiyomi/extension/all/batotov4/BatoToV4.kt
+++ b/src/all/batotov4/src/eu/kanade/tachiyomi/extension/all/batotov4/BatoToV4.kt
@@ -444,7 +444,7 @@ class BatoToV4(
 
         if (SERVER_PATTERN.containsMatchIn(urlString)) {
             // Sorted list: Most reliable servers FIRST
-            val servers = listOf("k03", "k06", "k07", "k00", "k01", "k02", "k04", "k05", "k08", "k09", "n03", "n00", "n01", "n02", "n04", "n05", "n06", "n07", "n08", "n09", "n10")
+            val servers = listOf("n03", "n00", "n01", "n02", "n04", "n05", "n06", "n07", "n08", "n09", "n10", "k03", "k06", "k07", "k00", "k01", "k02", "k04", "k05", "k08", "k09")
 
             for (server in servers) {
                 val newUrl = urlString.replace(SERVER_PATTERN, "https://$server")


### PR DESCRIPTION
The current implementation lists the k subdomains first and iterates through the subdomains until it finds a successful image url. The problem is that right now the k subdomains are mostly failing and it takes 5 seconds to timeout, meaning it takes a long time to get a successful image url and thus load times can be over a minute.

We do this quick fix to reorder the subdomains to have the n subdomains first as those are mostly working. Ideally a more sophisticated solution is done, but as this is a problem happening now, we do the simplest, quickest fix to get this out as soon as possible.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
