### PR TITLE
Batoto v4: fix crash

### DIFF
--- a/src/all/batotov4/build.gradle
+++ b/src/all/batotov4/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Bato.to V4'
     extClass = '.BatoToV4Factory'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/all/batotov4/src/eu/kanade/tachiyomi/extension/all/batotov4/BatoToV4Factory.kt
+++ b/src/all/batotov4/src/eu/kanade/tachiyomi/extension/all/batotov4/BatoToV4Factory.kt
@@ -33,7 +33,6 @@ class BatoToV4Factory : SourceFactory {
         BatoToV4("es"),
         BatoToV4("es-419", "es_419"),
         BatoToV4("sv"),
-        BatoToV4("th"),
         BatoToV4("tr"),
         BatoToV4("uk"),
         BatoToV4("vi"),


### PR DESCRIPTION
Closes #12449 
double thai

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
