### PR TITLE
PhiliaScans: Handle thumbnail lazy load + attempt to get full cover from thumbnail url

### DIFF
--- a/src/en/philiascans/build.gradle
+++ b/src/en/philiascans/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Philia Scans'
     extClass = '.PhiliaScans'
-    extVersionCode = 44
+    extVersionCode = 45
     isNsfw = false
 }
 

--- a/src/en/philiascans/src/eu/kanade/tachiyomi/extension/en/philiascans/PhiliaScans.kt
+++ b/src/en/philiascans/src/eu/kanade/tachiyomi/extension/en/philiascans/PhiliaScans.kt
@@ -46,7 +46,12 @@ class PhiliaScans : HttpSource() {
         val titleLink = element.selectFirst("a.c-title")!!
         title = titleLink.text()
         setUrlWithoutDomain(titleLink.attr("href"))
-        thumbnail_url = element.selectFirst("a.poster div.poster-image-wrapper > img")?.attr("abs:src")
+        thumbnail_url =
+            imageFromElement(element.selectFirst("a.poster div.poster-image-wrapper > img"))?.replace(
+                // try to resolve actual cover from thumbnail, usually has -280x400 suffix
+                "-280x400.",
+                ".",
+            )
     }
 
     override fun latestUpdatesRequest(page: Int): Request {


### PR DESCRIPTION
Philia thumbnails are now lazy-loaded, so swapping to imageFromElement. Also, their thumbnail URLs seem to all be the same as the main cover URL but with `-280x400` appended, so this also handles converting to full cover urls in popularMangaParse().

Nobody had opened an issue for thumbnails not loading, so no linked issue.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
