### PR TITLE
Madara: Add method processThumbnail() to make changes to thumbnail_url, implement for PhiliaScans

### DIFF
--- a/lib-multisrc/madara/build.gradle.kts
+++ b/lib-multisrc/madara/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 46
+baseVersionCode = 45
 
 dependencies {
     api(project(":lib:cryptoaes"))

--- a/lib-multisrc/madara/build.gradle.kts
+++ b/lib-multisrc/madara/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 45
+baseVersionCode = 46
 
 dependencies {
     api(project(":lib:cryptoaes"))

--- a/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
+++ b/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
@@ -175,7 +175,7 @@ abstract class Madara(
             }
 
             selectFirst(popularMangaUrlSelectorImg)?.let {
-                manga.thumbnail_url = imageFromElement(it)
+                manga.thumbnail_url = processThumbnail(imageFromElement(it), true)
             }
         }
 
@@ -600,7 +600,7 @@ abstract class Madara(
                 manga.title = it.ownText()
             }
             selectFirst("img")?.let {
-                manga.thumbnail_url = imageFromElement(it)
+                manga.thumbnail_url = processThumbnail(imageFromElement(it), true)
             }
         }
 
@@ -688,7 +688,7 @@ abstract class Madara(
                 }
             }
             selectFirst(mangaDetailsSelectorThumbnail)?.let {
-                manga.thumbnail_url = imageFromElement(it)
+                manga.thumbnail_url = processThumbnail(imageFromElement(it))
             }
             select(mangaDetailsSelectorStatus).last()?.let {
                 manga.status = with(it.text().filter { ch -> ch.isLetterOrDigit() || ch.isWhitespace() }.trim()) {
@@ -783,6 +783,11 @@ abstract class Madara(
             .filter(URL_REGEX::matches)
             .maxOfOrNull(String::toString)
     }
+
+    /**
+     *  Apply any additional processing to the thumbnail URL if needed.
+     */
+    protected open fun processThumbnail(url: String?, fromSearch: Boolean = false): String? = url
 
     /**
      * Set it to true if the source uses the new AJAX endpoint to

--- a/src/en/philiascans/build.gradle
+++ b/src/en/philiascans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.PhiliaScans'
     themePkg = 'madara'
     baseUrl = "https://philiascans.org"
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = false
 }
 

--- a/src/en/philiascans/src/eu/kanade/tachiyomi/extension/en/philiascans/PhiliaScans.kt
+++ b/src/en/philiascans/src/eu/kanade/tachiyomi/extension/en/philiascans/PhiliaScans.kt
@@ -111,6 +111,16 @@ class PhiliaScans : Madara(
         name = element.selectFirst("zebi")!!.text()
     }
 
+    override fun processThumbnail(url: String?, fromSearch: Boolean): String? = if (fromSearch) {
+        url?.replace(
+            // try to resolve actual cover from thumbnail, usually has -280x400 suffix
+            "-280x400.",
+            ".",
+        )
+    } else {
+        url
+    }
+
     override val pageListParseSelector = "div#ch-images img"
 
     override fun getFilterList(): FilterList {


### PR DESCRIPTION
PhiliaScans: Implement processThumbnail() to remove -280x400 suffix on search thumbnail URLs.

Only including Philia for now but several other Madara sites have these suffixes and would benefit from this being available, hence why this PR isn't just an override of imageFromElement/etc in Philia.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
