### PR TITLE
AsuraScans: Add premium chapter support

### DIFF
--- a/src/en/asurascans/build.gradle
+++ b/src/en/asurascans/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Asura Scans'
     extClass = '.AsuraScans'
-    extVersionCode = 50
+    extVersionCode = 51
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScansDto.kt
+++ b/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScansDto.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.extension.en.asurascans
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -18,5 +19,48 @@ class FilterItemDto(
 @Serializable
 class PageDto(
     val order: Int,
-    val url: String,
+    val url: String = "",
+    val id: Int = 0,
+)
+
+@Serializable
+class ChapterDataDto(
+    val id: Int,
+    @SerialName("is_early_access") val isEarlyAccess: Boolean = false,
+    val pages: List<PageDto> = emptyList(),
+)
+
+@Serializable
+class UnlockResponseDto(
+    val success: Boolean,
+    val data: UnlockDataDto,
+)
+
+@Serializable
+class UnlockDataDto(
+    val id: Int,
+    @SerialName("unlock_token") val unlockToken: String,
+    @SerialName("is_early_access") val isEarlyAccess: Boolean,
+    val pages: List<PageDto>,
+)
+
+@Serializable
+class MediaResponseDto(
+    val data: String,
+    @SerialName("content-type") val contentType: String = "",
+)
+
+@Serializable
+class UnlockRequestDto(
+    val chapterId: Int,
+)
+
+@Serializable
+class MediaRequestDto(
+    @SerialName("media_id")
+    val mediaId: Int,
+    @SerialName("chapter_id")
+    val chapterId: Int,
+    val token: String,
+    val quality: String,
 )


### PR DESCRIPTION
- Add support for unlocking and fetching premium chapters
- Add separate API client with minimal rate limiting for unlocking and fetching media urls via Asura api
- Extract chapter metadata (ID, early access status) from page data
- Add DTOs for unlock and media API responses
- Increment extVersionCode to 51

Takes inspiration from #11339, which was reverted due to crashes for non-logged-in users, and simplifies the approach to only change page list parsing for premium chapters. Tested with Mihon on Android (non logged in user gets error when accessing premium chapter, can still open non premium chapters, then after login can load premium chapters).

Closes #6632

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension