### PR TITLE
Fix 404s for QiScans

### DIFF
--- a/src/en/qiscans/build.gradle
+++ b/src/en/qiscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.QiScans'
     themePkg = 'iken'
     baseUrl = 'https://qiscans.org'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
     isNsfw = false
 }
 

--- a/src/en/qiscans/src/eu/kanade/tachiyomi/extension/en/qiscans/QiScans.kt
+++ b/src/en/qiscans/src/eu/kanade/tachiyomi/extension/en/qiscans/QiScans.kt
@@ -66,7 +66,9 @@ class QiScans : Iken(
         }
 
         return document.getNextJson("images").parseAs<List<PageParseDto>>().sortedBy { it.order }.mapIndexed { idx, p ->
-            Page(idx, imageUrl = p.url)
+            // Some new(~Jan 2026) chapters use this format which leads to 404s
+            val url = p.url.replace("https://media.qiscans.org/file/qiscans/upload/series", "https://media.qiscans.org/upload/series")
+            Page(idx, imageUrl = url)
         }
     }
 

--- a/src/en/qiscans/src/eu/kanade/tachiyomi/extension/en/qiscans/QiScans.kt
+++ b/src/en/qiscans/src/eu/kanade/tachiyomi/extension/en/qiscans/QiScans.kt
@@ -66,8 +66,10 @@ class QiScans : Iken(
         }
 
         return document.getNextJson("images").parseAs<List<PageParseDto>>().sortedBy { it.order }.mapIndexed { idx, p ->
-            // Some new(~Jan 2026) chapters use this format which leads to 404s
-            val url = p.url.replace("https://media.qiscans.org/file/qiscans/upload/series", "https://media.qiscans.org/upload/series")
+            // Some new(~Jan 2026) chapters use this format which is wrong and leads to 404s
+            // old: https://media.qiscans.org[/]upload/series/<series>/<chapter>/<image>.webp
+            // new: https://media.qiscans.org[/file/qiscans/]upload/series/<series>/<chapter>/<image>.webp
+            val url = p.url.replaceFirst("/file/qiscans/", "/")
             Page(idx, imageUrl = url)
         }
     }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension

Closes #12332 
