### PR TITLE
AsuraScans: Use homepage for Latest Updates (#11623)

### DIFF
--- a/src/en/asurascans/build.gradle
+++ b/src/en/asurascans/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Asura Scans'
     extClass = '.AsuraScans'
-    extVersionCode = 51
+    extVersionCode = 52
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScans.kt
+++ b/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScans.kt
@@ -117,11 +117,16 @@ class AsuraScans : ParsedHttpSource(), ConfigurableSource {
     override fun popularMangaNextPageSelector() = searchMangaNextPageSelector()
 
     override fun latestUpdatesRequest(page: Int): Request =
-        GET("$baseUrl/series?genres=&status=-1&types=-1&order=update&page=$page", headers)
+        GET("$baseUrl/page/$page", headers)
 
-    override fun latestUpdatesSelector() = searchMangaSelector()
+    override fun latestUpdatesSelector() = "div.grid.grid-rows-1.grid-cols-1 > div.w-full"
 
-    override fun latestUpdatesFromElement(element: Element) = searchMangaFromElement(element)
+    override fun latestUpdatesFromElement(element: Element) = SManga.create().apply {
+        val link = element.selectFirst("a[href^=/series/]")!!
+        setUrlWithoutDomain(link.attr("abs:href").toPermSlugIfNeeded())
+        title = element.selectFirst("span.text-\\[15px\\] a")!!.text()
+        thumbnail_url = element.selectFirst("img")?.attr("abs:src")
+    }
 
     override fun latestUpdatesNextPageSelector() = searchMangaNextPageSelector()
 


### PR DESCRIPTION
Changes the "Latest" tab to use the homepage listings (`/page/N`) instead of the `/series?order=update` search endpoint, which gives slightly different orderings. The differences (on 1/3/26) were not as drastic as the example given in the issue referenced below, but there are still two good reasons to make the switch:
 - the homepage results are listed as "Latest Updates" which is a little more consistent with the "Latest" tab (and the homepage results are more visible/front and center for someone browsing the site anyways)
  - the homepage returns 50 results per page vs the search endpoint's 15

(random aside - `popularMangaRequest` using `order=rating` also seems off but `order=bookmarks` doesn't match the all-time popular list on the homepage either, so dunno)

Closes #11623

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension

Testing: tested on Android with Mihon:

Homepage
<img width="1832" height="1522" alt="Screenshot 2026-01-03 at 9 35 40 PM" src="https://github.com/user-attachments/assets/37ecce98-be50-48fa-b495-b1b0c73ffee9" />
Search results
<img width="1832" height="1522" alt="Screenshot 2026-01-03 at 9 35 57 PM" src="https://github.com/user-attachments/assets/9c01da45-a842-4b20-836b-992663c71904" />

Latest tab with v51:
<img width="360" height="710" alt="Screenshot_20260103_211806_Mihon" src="https://github.com/user-attachments/assets/c3346514-6e51-4f7c-a17a-294824dd119f" />

Latest tab with v52:
<img width="360" height="710" alt="Screenshot_20260103_212126_Mihon" src="https://github.com/user-attachments/assets/e186570a-d167-4776-9b45-37ffc43bb648" />


