### PR TITLE
AsuraScans: Add cached auth check and add lock emoji to premium chapters

### DIFF
--- a/src/en/asurascans/build.gradle
+++ b/src/en/asurascans/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Asura Scans'
     extClass = '.AsuraScans'
-    extVersionCode = 51
+    extVersionCode = 53
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/asurascans/build.gradle
+++ b/src/en/asurascans/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Asura Scans'
     extClass = '.AsuraScans'
-    extVersionCode = 53
+    extVersionCode = 52
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScans.kt
+++ b/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScans.kt
@@ -16,6 +16,8 @@ import keiyoushi.utils.getPreferences
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
@@ -80,6 +82,12 @@ class AsuraScans : ParsedHttpSource(), ConfigurableSource {
         .build()
 
     private var failedHighQuality = false
+
+    @Volatile
+    private var cachedPremiumAccess: Boolean? = null
+
+    @Volatile
+    private var lastPremiumCheck: Long = 0L
 
     private fun forceHighQualityInterceptor(chain: Interceptor.Chain): Response {
         val request = chain.request()
@@ -283,7 +291,9 @@ class AsuraScans : ParsedHttpSource(), ConfigurableSource {
         setUrlWithoutDomain(element.selectFirst("a")!!.attr("abs:href").toPermSlugIfNeeded())
         val chNumber = element.selectFirst("h3")!!.ownText()
         val chTitle = element.select("h3 > span").joinToString(" ") { it.ownText() }
-        name = if (chTitle.isBlank()) chNumber else "$chNumber - $chTitle"
+        val isPremiumChapter = element.selectFirst("svg") != null
+        val baseName = if (chTitle.isBlank()) chNumber else "$chNumber - $chTitle"
+        name = if (isPremiumChapter && !hasPremiumAccess()) "🔒 $baseName" else baseName
         date_upload = try {
             val text = element.selectFirst("h3 + h3")!!.ownText()
             val cleanText = text.replace(CLEAN_DATE_REGEX, "$1")
@@ -343,6 +353,10 @@ class AsuraScans : ParsedHttpSource(), ConfigurableSource {
     }
 
     private fun unlockPremiumChapter(chapterId: Int): List<Page> {
+        if (!hasPremiumAccess()) {
+            throw Exception("Premium subscription required. Please log in via WebView and ensure you have an active subscription.")
+        }
+
         val xsrfToken = getXsrfToken()
         val unlockPayload = json.encodeToString(UnlockRequestDto(chapterId))
 
@@ -399,7 +413,7 @@ class AsuraScans : ParsedHttpSource(), ConfigurableSource {
             throw Exception(errorMsg)
         }
 
-        val responseBody = body?.string() ?: throw Exception("$errorPrefix: Empty response")
+        val responseBody = body.string()
 
         return try {
             json.decodeFromString<T>(responseBody)
@@ -426,6 +440,30 @@ class AsuraScans : ParsedHttpSource(), ConfigurableSource {
         return runCatching {
             URLDecoder.decode(xsrfToken, StandardCharsets.UTF_8.name())
         }.getOrDefault(xsrfToken)
+    }
+
+    private fun hasPremiumAccess(): Boolean {
+        val now = System.currentTimeMillis()
+        val cached = cachedPremiumAccess
+        if (cached != null && now - lastPremiumCheck < PREMIUM_CHECK_CACHE_DURATION) {
+            return cached
+        }
+
+        val hasPremium = runCatching {
+            client.newCall(GET("$apiUrl/user", headers)).execute().use { resp ->
+                if (!resp.isSuccessful) return@use false
+
+                val body = resp.body.string()
+                val userData = json.parseToJsonElement(body).jsonObject
+                val data = userData["data"]?.jsonObject ?: return@use false
+                val premium = data["premium"]?.jsonObject ?: return@use false
+                premium["active"]?.jsonPrimitive?.content?.toBoolean() ?: false
+            }
+        }.getOrDefault(false)
+
+        cachedPremiumAccess = hasPremium
+        lastPremiumCheck = now
+        return hasPremium
     }
 
     override fun imageUrlParse(document: Document) = throw UnsupportedOperationException()
@@ -513,5 +551,6 @@ class AsuraScans : ParsedHttpSource(), ConfigurableSource {
         private const val PREF_DYNAMIC_URL = "pref_dynamic_url"
         private const val PREF_HIDE_PREMIUM_CHAPTERS = "pref_hide_premium_chapters"
         private const val PREF_FORCE_HIGH_QUALITY = "pref_force_high_quality"
+        private const val PREMIUM_CHECK_CACHE_DURATION = 60_000L // 60 seconds
     }
 }


### PR DESCRIPTION
Changes:
- Add `hasPremiumAccess()` to check premium status, cache results (building from #11339)
- Add 🔒 emoji to premium chapter names when applicable (closes #10691)
- Use `hasPremiumAccess()` in unlock flow for early check

After logging in the chapter titles only update after a little bit (probably the cached auth check expiring and/or having to refresh the chapter list), but I figured that was fine to keep the flow simple and not have to try to detect auth state changes or hook into webview events

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions (updates to **53 instead of 52** because of https://github.com/keiyoushi/extensions-source/pull/12534, could also just combine into one PR if needed)
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension

Testing: Verified with Mihon on Android (non-logged-in user sees lock emojis, can still access non premium chapters, after logging in can access all chapters)