### PR TITLE
fix(evascans): Fix search, chapter filtering, and page loading

### DIFF
--- a/src/en/evascans/build.gradle
+++ b/src/en/evascans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.EvaScans'
     themePkg = 'mangathemesia'
     baseUrl = 'https://evascans.org'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = false
 }
 

--- a/src/en/evascans/src/eu/kanade/tachiyomi/extension/en/evascans/EvaScans.kt
+++ b/src/en/evascans/src/eu/kanade/tachiyomi/extension/en/evascans/EvaScans.kt
@@ -1,6 +1,8 @@
 package eu.kanade.tachiyomi.extension.en.evascans
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import eu.kanade.tachiyomi.source.model.SManga
+import org.jsoup.nodes.Element
 
 class EvaScans : MangaThemesia(
     "Eva Scans",
@@ -8,5 +10,23 @@ class EvaScans : MangaThemesia(
     "en",
     "/series",
 ) {
-    override fun chapterListSelector(): String = "#chapterlist li:not(:has(svg))"
+    // Fix search/listing - site uses custom card layout (div elements, not article)
+    override fun searchMangaSelector() = "div.manga-card-v, .listupd .bs .bsx"
+
+    override fun searchMangaFromElement(element: Element) = SManga.create().apply {
+        // Handle the custom card layout
+        val titleElement = element.selectFirst("h3.card-v-title a") ?: element.selectFirst("a")
+        titleElement?.let {
+            setUrlWithoutDomain(it.attr("href"))
+            title = it.text()
+        }
+        thumbnail_url = element.selectFirst(".card-v-cover img")?.imgAttr()
+            ?: element.selectFirst("img")?.imgAttr()
+    }
+
+    // Fix paid chapter filtering - paid chapters have .locked-badge class
+    override fun chapterListSelector(): String = "#chapterlist li:not(:has(.locked-badge))"
+
+    // Fix page reading - site uses custom reader with camelCase ID
+    override val pageSelector = "div#readerArea img"
 }


### PR DESCRIPTION
Fixes the Eva Scans extension which was broken due to the site diverging from standard MangaThemesia template.
- Override searchMangaSelector() and searchMangaFromElement() for custom card layout
- Update chapterListSelector() to filter by .locked-badge instead of SVG
- Override pageSelector for custom reader area using camelCase ID
- Bump overrideVersionCode to 1

Closes:
#12551 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
