### PR TITLE
The Blank: Update baseUrl (removed `beta.`)

### DIFF
--- a/src/en/theblank/build.gradle
+++ b/src/en/theblank/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'The Blank'
     extClass = '.TheBlank'
-    extVersionCode = 50
+    extVersionCode = 51
     isNsfw = true
 }
 

--- a/src/en/theblank/src/eu/kanade/tachiyomi/extension/en/theblank/TheBlank.kt
+++ b/src/en/theblank/src/eu/kanade/tachiyomi/extension/en/theblank/TheBlank.kt
@@ -53,7 +53,7 @@ import javax.crypto.spec.PSource
 class TheBlank : HttpSource(), ConfigurableSource {
     override val name = "The Blank"
     override val lang = "en"
-    override val baseUrl = "https://beta.theblank.net"
+    override val baseUrl = "https://theblank.net"
     private val baseHttpUrl = baseUrl.toHttpUrl()
     override val supportsLatest = true
     override val versionId = 2


### PR DESCRIPTION
Source has swapped back to their normal URL, breaking the extension/results.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
