### PR TITLE
ComicFury: Fix missing comics on series without chapters

### DIFF
--- a/src/all/comicfury/build.gradle
+++ b/src/all/comicfury/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comic Fury'
     extClass = '.ComicFuryFactory'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = true
 }
 


### PR DESCRIPTION
Currently when parsing the ComicFury website, the extension only iterates through pages of comics that are inside chapters - for comics that _aren't_ inside chapters it ends up only loading the first page of comics. So I reworked the code for handling comics without chapters to make it more inline with how comics with chapters are handled, and now it works as expected.

Closes #12389

(first time contributing so sorry if I messed anything up).

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
