### PR TITLE
LeitorDeManga: replace http to https from imageFromElement

### DIFF
--- a/src/pt/leitordemanga/build.gradle
+++ b/src/pt/leitordemanga/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.LeitorDeManga'
     themePkg = 'madara'
     baseUrl = 'https://leitordemanga.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
 }
 

--- a/src/pt/leitordemanga/src/eu/kanade/tachiyomi/extension/pt/leitordemanga/LeitorDeManga.kt
+++ b/src/pt/leitordemanga/src/eu/kanade/tachiyomi/extension/pt/leitordemanga/LeitorDeManga.kt
@@ -8,6 +8,7 @@ import okhttp3.FormBody
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Response
+import org.jsoup.nodes.Element
 import java.io.IOException
 import java.security.MessageDigest
 import java.text.SimpleDateFormat
@@ -23,9 +24,13 @@ class LeitorDeManga : Madara(
     override val mangaSubString = "ler-manga"
 
     override val client: OkHttpClient = super.client.newBuilder()
-        .rateLimit(1, 2, TimeUnit.SECONDS)
+        .rateLimit(3, 2, TimeUnit.SECONDS)
         .addInterceptor(::jsChallengeInterceptor)
         .build()
+
+    override fun imageFromElement(element: Element): String? {
+        return super.imageFromElement(element)?.replace("http://", "https://")
+    }
 
     // Linked to src/en/yakshascans
     private fun jsChallengeInterceptor(chain: Interceptor.Chain): Response {


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
