### PR TITLE
Mangapark: Image fallback update

### DIFF
--- a/src/all/mangapark/build.gradle
+++ b/src/all/mangapark/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaPark'
     extClass = '.MangaParkFactory'
-    extVersionCode = 24
+    extVersionCode = 25
     isNsfw = true
 }
 

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaPark.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaPark.kt
@@ -61,8 +61,6 @@ class MangaPark(
         }
         rateLimitHost(apiUrl.toHttpUrl(), 1)
         addInterceptor(::imageFallbackInterceptor)
-        // intentionally after rate limit interceptor so thumbnails are not rate limited
-        addInterceptor(::thumbnailDomainInterceptor)
     }.build()
 
     override fun headersBuilder() = super.headersBuilder()
@@ -307,25 +305,6 @@ class MangaPark(
         }
 
         return chain.proceed(request)
-    }
-
-    private fun thumbnailDomainInterceptor(chain: Interceptor.Chain): Response {
-        val request = chain.request()
-        val url = request.url
-
-        return if (url.host == THUMBNAIL_LOOPBACK_HOST) {
-            val newUrl = url.newBuilder()
-                .host(domain)
-                .build()
-
-            val newRequest = request.newBuilder()
-                .url(newUrl)
-                .build()
-
-            chain.proceed(newRequest)
-        } else {
-            chain.proceed(request)
-        }
     }
 
     override fun imageUrlParse(response: Response): String {

--- a/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaPark.kt
+++ b/src/all/mangapark/src/eu/kanade/tachiyomi/extension/all/mangapark/MangaPark.kt
@@ -272,18 +272,10 @@ class MangaPark(
 
     private fun imageFallbackInterceptor(chain: Interceptor.Chain): Response {
         val request = chain.request()
-        val response = chain.proceed(request)
-
-        if (response.isSuccessful) return response
-
         val url = request.url
-
-        response.close()
-
         val fixedUrl = url.newBuilder()
             .host(baseUrl.toHttpUrl().host)
             .build()
-
         val newRequest = request.newBuilder()
             .url(fixedUrl)
             .build()


### PR DESCRIPTION
Just changed the images fallback with new working method provided by site support.
Working as of `08-Jan-2026`
But to access site need to connect to nordic vpn (i.e. netherlands,finland or poland)

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
