### PR TITLE
[pixiv] Fix user search + filters, add image quality setting

### DIFF
--- a/src/all/pixiv/build.gradle
+++ b/src/all/pixiv/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Pixiv'
     extClass = '.PixivFactory'
-    extVersionCode = 10
+    extVersionCode = 11
     isNsfw = true
 }
 

--- a/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/Pixiv.kt
+++ b/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/Pixiv.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.extension.all.pixiv
 
-import android.app.Application
 import android.content.SharedPreferences
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
@@ -11,6 +10,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.getPreferencesLazy
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromJsonElement
@@ -20,7 +20,6 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import rx.Observable
-import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
 
@@ -31,9 +30,7 @@ class Pixiv(override val lang: String) : ConfigurableSource, HttpSource() {
 
     private val json: Json by injectLazy()
 
-    private val preferences: SharedPreferences by lazy {
-        Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
-    }
+    private val preferences: SharedPreferences by getPreferencesLazy()
 
     override fun headersBuilder(): Headers.Builder =
         super.headersBuilder().add("Referer", "$baseUrl/")

--- a/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivFilters.kt
+++ b/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivFilters.kt
@@ -15,13 +15,17 @@ private val RATING_PREDICATES: Array<((PixivIllust) -> Boolean)?> =
     arrayOf(null, { it.x_restrict == "0" }, { it.x_restrict == "1" })
 
 internal class PixivFilters : MutableList<Filter<*>> by mutableListOf() {
+    init { add(Filter.Header("Deeplinks supported in search: pixiv link, aid:123, user:123, sid:123")) }
+
     private val typeFilter = object : Filter.Select<String>("Type", TYPE_VALUES, 2) {}.also(::add)
     private val tagsFilter = object : Filter.Text("Tags") {}.also(::add)
     private val tagsModeFilter = object : Filter.Select<String>("Tags mode", TAGS_MODE_VALUES, 0) {}.also(::add)
     private val usersFilter = object : Filter.Text("Users") {}.also(::add)
+    init { add(Filter.Header("The usersFilter filter acts as lookup when search query is blank (requires login via WebView)")) }
+
     private val ratingFilter = object : Filter.Select<String>("Rating", RATING_VALUES, 0) {}.also(::add)
 
-    init { add(Filter.Header("(the following are ignored when the users filter is in use)")) }
+    init { add(Filter.Header("(the following are ignored when the user filter is in use)")) }
 
     private val orderFilter = object : Filter.Sort("Order", arrayOf("Date posted")) {}.also(::add)
     private val dateBeforeFilter = object : Filter.Text("Posted before") {}.also(::add)

--- a/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivFilters.kt
+++ b/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivFilters.kt
@@ -25,7 +25,7 @@ internal class PixivFilters : MutableList<Filter<*>> by mutableListOf() {
 
     private val ratingFilter = object : Filter.Select<String>("Rating", RATING_VALUES, 0) {}.also(::add)
 
-    init { add(Filter.Header("(the following are ignored when the user filter is in use)")) }
+    init { add(Filter.Header("(the following are ignored when the users filter is in use)")) }
 
     private val orderFilter = object : Filter.Sort("Order", arrayOf("Date posted")) {}.also(::add)
     private val dateBeforeFilter = object : Filter.Text("Posted before") {}.also(::add)
@@ -51,7 +51,7 @@ internal class PixivFilters : MutableList<Filter<*>> by mutableListOf() {
 
     fun makeUsersPredicate(): ((PixivIllust) -> Boolean)? {
         val users = users.ifBlank { return null }
-        val regex = Regex(users.split(' ').joinToString("|") { Regex.escape(it) })
+        val regex = Regex(users.split(' ').joinToString("|") { Regex.escape(it) }, RegexOption.IGNORE_CASE)
 
         return { it.author_details?.user_name?.contains(regex) == true }
     }

--- a/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivTypes.kt
+++ b/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivTypes.kt
@@ -56,6 +56,9 @@ internal data class PixivIllustPage(
 
 @Serializable
 internal data class PixivIllustPageUrls(
+    val thumb_mini: String? = null,
+    val small: String? = null,
+    val regular: String? = null,
     val original: String? = null,
 )
 
@@ -96,4 +99,32 @@ internal data class PixivRankings(
 internal data class PixivRankingEntry(
     val illustId: String? = null,
     val rank: Int? = null,
+)
+
+// Data models for parsing __NEXT_DATA__ from /search/users endpoint
+@Serializable
+internal data class PixivNextData(
+    val props: PixivNextDataProps,
+)
+
+@Serializable
+internal data class PixivNextDataProps(
+    val pageProps: PixivPageProps,
+)
+
+@Serializable
+internal data class PixivPageProps(
+    val userIds: List<Long> = emptyList(),
+    val userData: PixivUserData? = null,
+)
+
+@Serializable
+internal data class PixivUserData(
+    val users: Map<String, PixivUserInfo> = emptyMap(),
+)
+
+@Serializable
+internal data class PixivUserInfo(
+    val id: String,
+    val name: String,
 )


### PR DESCRIPTION
Changes:

 * Change username search to use /search/users endpoint (closes #1968, #5195)
 * Add setting for image quality and get urls based on setting (closes #481)
 * Add back deeplink support
 * Add some smarts when getting filtered results (and avoid searches that spin forever)
 * Make user filter case insensitive
 * Rename some variable shadowing, minor formatting things

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension

Testing:

Tested on Android with Mihon

 * verified popular/latest still work
 * verified deeplinks work (for user and aid)
 * verified user filter works
 * verified user filter + search works