### PR TITLE
Kiryuu: fix HTTP 520

### DIFF
--- a/src/id/kiryuu/build.gradle
+++ b/src/id/kiryuu/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Kiryuu'
     themePkg = 'natsuid'
     baseUrl = 'https://kiryuu03.com'
-    overrideVersionCode = 44
+    overrideVersionCode = 45
     isNsfw = false
 }
 

--- a/src/id/kiryuu/src/eu/kanade/tachiyomi/extension/id/kiryuu/Kiryuu.kt
+++ b/src/id/kiryuu/src/eu/kanade/tachiyomi/extension/id/kiryuu/Kiryuu.kt
@@ -1,8 +1,11 @@
 package eu.kanade.tachiyomi.extension.id.kiryuu
 
 import eu.kanade.tachiyomi.multisrc.natsuid.NatsuId
+import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.source.model.SManga
 import okhttp3.OkHttpClient
+import okhttp3.Request
 
 class Kiryuu : NatsuId(
     "Kiryuu",
@@ -13,4 +16,12 @@ class Kiryuu : NatsuId(
     override val id = 3639673976007021338
 
     override fun OkHttpClient.Builder.customizeClient() = rateLimit(4)
+
+    override fun chapterListRequest(manga: SManga): Request {
+        val url = super.chapterListRequest(manga).url.newBuilder()
+            .setQueryParameter("page", "1")
+            .build()
+
+        return GET(url, headers)
+    }
 }


### PR DESCRIPTION
Closes: https://github.com/keiyoushi/extensions-source/issues/12491
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
