### PR TITLE
Batoto: Blacklist k07 server and auto backoff from failed image servers

### DIFF
--- a/src/all/batoto/build.gradle
+++ b/src/all/batoto/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Bato.to'
     extClass = '.BatoToFactory'
-    extVersionCode = 59
+    extVersionCode = 60
     isNsfw = true
 }
 

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
@@ -16,6 +16,7 @@ import keiyoushi.utils.getPreferencesLazy
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Response
 import rx.Observable
+import java.util.concurrent.ConcurrentHashMap
 
 open class BatoTo(
     final override val lang: String,
@@ -191,5 +192,55 @@ open class BatoTo(
         )
 
         private val mirrors = mirrorsV2 + mirrorsV4
+    }
+}
+
+/**
+ * Manages image server fallback logic, including blacklisting and backoff tracking.
+ */
+class ImageServerManager() {
+    val serverPattern = Regex("https://([a-zA-Z]\\d{2})")
+
+    val fallbackServers = listOf(
+        "n03", "n00", "n01", "n02", "n04", "n05", "n06", "n07", "n08", "n09", "n10",
+        "k03", "k06", "k00", "k01", "k02", "k04", "k05", "k08", "k09",
+    )
+    val blacklist = listOf("k07")
+
+    // Server status tracking
+    data class ServerStatus(
+        val canBackoff: Boolean,
+        val statusCode: Int = 0,
+        val timestamp: Long = System.currentTimeMillis(),
+    )
+
+    val serverStatus = ConcurrentHashMap<String, ServerStatus>()
+
+    val BACKOFF_DURATION_MS = 3_600_000L // 1 hour
+
+    fun shouldSkip(server: String): Boolean {
+        return server in blacklist || isInBackoff(server)
+    }
+
+    fun isInBackoff(server: String): Boolean {
+        val status = serverStatus[server] ?: return false
+        return status.canBackoff && System.currentTimeMillis() - status.timestamp < BACKOFF_DURATION_MS
+    }
+
+    fun recordImageServerStatus(server: String, statusCode: Int) {
+        val now = System.currentTimeMillis()
+        serverStatus[server] = ServerStatus(
+            canBackoff = statusCode in 500..599,
+            statusCode = statusCode,
+            timestamp = now,
+        )
+    }
+
+    fun extractServerFromUrl(url: String): String? {
+        return serverPattern.find(url)?.groups?.get(1)?.value
+    }
+
+    fun replaceServerInUrl(url: String, newServer: String): String {
+        return url.replace(serverPattern, "https://$newServer")
     }
 }

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
@@ -203,9 +203,8 @@ class ImageServerManager() {
 
     val fallbackServers = listOf(
         "n03", "n00", "n01", "n02", "n04", "n05", "n06", "n07", "n08", "n09", "n10",
-        "k03", "k06", "k00", "k01", "k02", "k04", "k05", "k08", "k09",
     )
-    val blacklist = listOf("k07")
+    val blacklist = listOf("k00", "k01", "k03", "k04", "k05", "k06", "k07", "k08", "k09")
 
     // Server status tracking
     data class ServerStatus(

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batotov2/BatoToV2.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batotov2/BatoToV2.kt
@@ -43,6 +43,7 @@ import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
 open class BatoToV2(
@@ -66,6 +67,8 @@ open class BatoToV2(
             chain.proceed(request)
         }
         .build()
+
+    private val imageServerManager: ImageServerManager = ImageServerManager()
 
     private val json: Json by injectLazy()
 
@@ -618,52 +621,56 @@ open class BatoToV2(
 
     private fun imageFallbackInterceptor(chain: Interceptor.Chain): Response {
         val request = chain.request()
-        val response = chain.proceed(request)
 
-        if (response.isSuccessful) return response
-
+        // Extract server, or proceed normally if not found
         val urlString = request.url.toString()
+        val originalServer = this.imageServerManager.extractServerFromUrl(urlString) ?: return chain.proceed(request)
 
-        // We know the first attempt failed. Close the response body to release the
-        // connection from the pool and prevent resource leaks before we start the retry loop.
-        // This is critical; otherwise, new requests in the loop may hang or fail.
-        response.close()
-
-        if (SERVER_PATTERN.containsMatchIn(urlString)) {
-            // Sorted list: Most reliable servers FIRST
-            val servers = listOf("n03", "n00", "n01", "n02", "n04", "n05", "n06", "n07", "n08", "n09", "n10", "k03", "k06", "k07", "k00", "k01", "k02", "k04", "k05", "k08", "k09")
-
-            for (server in servers) {
-                val newUrl = urlString.replace(SERVER_PATTERN, "https://$server")
-
-                // Skip if we are about to try the exact same URL that just failed
-                if (newUrl == urlString) continue
-
-                val newRequest = request.newBuilder()
-                    .url(newUrl)
-                    .build()
-
-                try {
-                    // FORCE SHORT TIMEOUTS FOR FALLBACKS
-                    // If a fallback server doesn't answer in 5 seconds, kill it and move to next.
-                    val newResponse = chain
-                        .withConnectTimeout(5, TimeUnit.SECONDS)
-                        .withReadTimeout(10, TimeUnit.SECONDS)
-                        .proceed(newRequest)
-
-                    if (newResponse.isSuccessful) {
-                        return newResponse
-                    }
-                    // If this server also failed, close and loop to the next one
-                    newResponse.close()
-                } catch (_: Exception) {
-                    // Connection error on this mirror, ignore and loop to next
-                }
-            }
+        // Try original server if not skipped
+        if (!this.imageServerManager.shouldSkip(originalServer)) {
+            tryServer(chain, request, originalServer)?.let { return it }
         }
 
-        // If everything failed, re-run original request to return the standard error
+        // Try fallback servers
+        for (server in this.imageServerManager.fallbackServers) {
+            if (this.imageServerManager.shouldSkip(server)) continue
+
+            val newUrl = this.imageServerManager.replaceServerInUrl(urlString, server)
+            val newRequest = request.newBuilder().url(newUrl).build()
+
+            tryServer(chain, newRequest, server, withTimeout = true)?.let { return it }
+        }
+
         return chain.proceed(request)
+    }
+
+    private fun tryServer(
+        chain: Interceptor.Chain,
+        request: Request,
+        server: String,
+        withTimeout: Boolean = false,
+    ): Response? {
+        return try {
+            val modifiedChain = if (withTimeout) {
+                chain.withConnectTimeout(5, TimeUnit.SECONDS)
+                    .withReadTimeout(10, TimeUnit.SECONDS)
+            } else {
+                chain
+            }
+
+            val response = modifiedChain.proceed(request)
+            imageServerManager.recordImageServerStatus(server, response.code)
+
+            if (response.isSuccessful) {
+                response
+            } else {
+                response.close()
+                null
+            }
+        } catch (_: Exception) {
+            imageServerManager.recordImageServerStatus(server, 0) // Unknown error
+            null
+        }
     }
 
     override fun getFilterList() = FilterList(
@@ -1148,5 +1155,55 @@ open class BatoToV2(
 
         private val titleRegex: Regex =
             Regex("\\([^()]*\\)|\\{[^{}]*\\}|\\[(?:(?!]).)*]|«[^»]*»|〘[^〙]*〙|「[^」]*」|『[^』]*』|≪[^≫]*≫|﹛[^﹜]*﹜|〖[^〖〗]*〗|\uD81A\uDD0D.+?\uD81A\uDD0D|《[^》]*》|⌜.+?⌝|⟨[^⟩]*⟩|/Official|/ Official", RegexOption.IGNORE_CASE)
+    }
+}
+
+/**
+ * Manages image server fallback logic, including blacklisting and backoff tracking.
+ */
+private class ImageServerManager() {
+    val serverPattern = Regex("https://([a-zA-Z]\\d{2})")
+
+    val fallbackServers = listOf(
+        "n03", "n00", "n01", "n02", "n04", "n05", "n06", "n07", "n08", "n09", "n10",
+        "k03", "k06", "k00", "k01", "k02", "k04", "k05", "k08", "k09",
+    )
+    val blacklist = listOf("k07")
+
+    // Server status tracking
+    data class ServerStatus(
+        val canBackoff: Boolean,
+        val statusCode: Int = 0,
+        val timestamp: Long = System.currentTimeMillis(),
+    )
+
+    private val serverStatus = ConcurrentHashMap<String, ServerStatus>()
+
+    private val BACKOFF_DURATION_MS = 3_600_000L // 1 hour
+
+    fun shouldSkip(server: String): Boolean {
+        return server in blacklist || isInBackoff(server)
+    }
+
+    fun isInBackoff(server: String): Boolean {
+        val status = serverStatus[server] ?: return false
+        return status.canBackoff && System.currentTimeMillis() - status.timestamp < BACKOFF_DURATION_MS
+    }
+
+    fun recordImageServerStatus(server: String, statusCode: Int) {
+        val now = System.currentTimeMillis()
+        serverStatus[server] = ServerStatus(
+            canBackoff = statusCode in 500..599,
+            statusCode = statusCode,
+            timestamp = now,
+        )
+    }
+
+    fun extractServerFromUrl(url: String): String? {
+        return serverPattern.find(url)?.groups?.get(1)?.value
+    }
+
+    fun replaceServerInUrl(url: String, newServer: String): String {
+        return url.replace(serverPattern, "https://$newServer")
     }
 }

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batotov2/BatoToV2.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batotov2/BatoToV2.kt
@@ -651,6 +651,8 @@ open class BatoToV2(
         withTimeout: Boolean = false,
     ): Response? {
         return try {
+            // FORCE SHORT TIMEOUTS FOR FALLBACKS
+            // If a fallback server doesn't answer in 5 seconds, kill it and move to next server.
             val modifiedChain = if (withTimeout) {
                 chain.withConnectTimeout(5, TimeUnit.SECONDS)
                     .withReadTimeout(10, TimeUnit.SECONDS)

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batotov4/BatoToV4.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batotov4/BatoToV4.kt
@@ -8,6 +8,7 @@ import android.widget.Toast
 import androidx.preference.CheckBoxPreference
 import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen
+import eu.kanade.tachiyomi.extension.all.batoto.ImageServerManager
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.asObservableSuccess
@@ -34,7 +35,6 @@ import okhttp3.Response
 import okhttp3.internal.closeQuietly
 import okio.IOException
 import rx.Observable
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
 class BatoToV4(
@@ -577,53 +577,3 @@ private const val BROWSE_PAGE_SIZE = 36
 private val seriesIdRegex = Regex("""series/(\d+)""")
 private val titleRegex: Regex =
     Regex("\\([^()]*\\)|\\{[^{}]*\\}|\\[(?:(?!]).)*]|«[^»]*»|〘[^〙]*〙|「[^」]*」|『[^』]*』|≪[^≫]*≫|﹛[^﹜]*﹜|〖[^〖〗]*〗|\uD81A\uDD0D.+?\uD81A\uDD0D|《[^》]*》|⌜.+?⌝|⟨[^⟩]*⟩|/Official|/ Official", RegexOption.IGNORE_CASE)
-
-/**
- * Manages image server fallback logic, including blacklisting and backoff tracking.
- */
-private class ImageServerManager() {
-    val serverPattern = Regex("https://([a-zA-Z]\\d{2})")
-
-    val fallbackServers = listOf(
-        "n03", "n00", "n01", "n02", "n04", "n05", "n06", "n07", "n08", "n09", "n10",
-        "k03", "k06", "k00", "k01", "k02", "k04", "k05", "k08", "k09",
-    )
-    val blacklist = listOf("k07")
-
-    // Server status tracking
-    data class ServerStatus(
-        val canBackoff: Boolean,
-        val statusCode: Int = 0,
-        val timestamp: Long = System.currentTimeMillis(),
-    )
-
-    private val serverStatus = ConcurrentHashMap<String, ServerStatus>()
-
-    private val BACKOFF_DURATION_MS = 3_600_000L // 1 hour
-
-    fun shouldSkip(server: String): Boolean {
-        return server in blacklist || isInBackoff(server)
-    }
-
-    fun isInBackoff(server: String): Boolean {
-        val status = serverStatus[server] ?: return false
-        return status.canBackoff && System.currentTimeMillis() - status.timestamp < BACKOFF_DURATION_MS
-    }
-
-    fun recordImageServerStatus(server: String, statusCode: Int) {
-        val now = System.currentTimeMillis()
-        serverStatus[server] = ServerStatus(
-            canBackoff = statusCode in 500..599,
-            statusCode = statusCode,
-            timestamp = now,
-        )
-    }
-
-    fun extractServerFromUrl(url: String): String? {
-        return serverPattern.find(url)?.groups?.get(1)?.value
-    }
-
-    fun replaceServerInUrl(url: String, newServer: String): String {
-        return url.replace(serverPattern, "https://$newServer")
-    }
-}

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batotov4/BatoToV4.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batotov4/BatoToV4.kt
@@ -572,9 +572,7 @@ class BatoToV4(
 
             setOnPreferenceChangeListener { _, newValue ->
                 val blacklistStr = newValue as String
-                val blacklist = blacklistStr.split(",")
-                    .map { it.trim() }
-                    .filter { it.isNotEmpty() }
+                val blacklist = parseCommaList(blacklistStr)
 
                 imageServerManager.updateBlacklist(blacklist)
 
@@ -594,13 +592,7 @@ class BatoToV4(
 
             setOnPreferenceChangeListener { _, newValue ->
                 val fallbackStr = newValue as String
-                val fallbackList = if (fallbackStr.isEmpty()) {
-                    null
-                } else {
-                    fallbackStr.split(",")
-                        .map { it.trim() }
-                        .filter { it.isNotEmpty() }
-                }
+                val fallbackList = parseCommaList(fallbackStr)
 
                 imageServerManager.updateFallbackServers(fallbackList)
 
@@ -625,15 +617,9 @@ class BatoToV4(
 
     private fun getBlacklistSummary(): String {
         val blacklistStr = preferences.getString(BLACKLIST_SERVERS_PREF, "")!!
-        val blacklist = if (blacklistStr.isEmpty()) {
-            imageServerManager.getDefaultBlacklistedServers()
-        } else {
-            blacklistStr.split(",")
-                .map { it.trim() }
-                .filter { it.isNotEmpty() }
-        }
-        return if (blacklist.isEmpty()) {
-            "Using default: ${imageServerManager.getDefaultBlacklistedServers().joinToString(", ")}"
+        val blacklist = parseCommaList(blacklistStr) ?: imageServerManager.getDefaultBlacklistedServers()
+        return if (blacklist == imageServerManager.getDefaultBlacklistedServers()) {
+            "Using default: ${blacklist.joinToString(", ")}"
         } else {
             "Blacklisted: ${blacklist.joinToString(", ")}"
         }
@@ -641,15 +627,9 @@ class BatoToV4(
 
     private fun getFallbackSummary(fallbackStr: String? = null): String {
         val fallback = fallbackStr ?: preferences.getString(FALLBACK_SERVERS_PREF, "")!!
-        val servers = if (fallback.isEmpty()) {
-            imageServerManager.getDefaultFallbackServers()
-        } else {
-            fallback.split(",")
-                .map { it.trim() }
-                .filter { it.isNotEmpty() }
-        }
-        return if (servers.isEmpty()) {
-            "Using default: ${imageServerManager.getDefaultFallbackServers().joinToString(", ")}"
+        val servers = parseCommaList(fallback) ?: imageServerManager.getDefaultFallbackServers()
+        return if (servers == imageServerManager.getDefaultFallbackServers()) {
+            "Using default: ${servers.joinToString(", ")}"
         } else {
             "Fallback order: ${servers.joinToString(", ")}"
         }
@@ -686,6 +666,14 @@ class BatoToV4(
         }
 
         return explanation + serverList
+    }
+
+    private fun parseCommaList(value: String?): List<String>? {
+        if (value.isNullOrEmpty()) return null
+        return value.split(",")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .takeIf { it.isNotEmpty() }
     }
 
     private fun isRemoveTitleVersion(): Boolean {

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batotov4/BatoToV4.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batotov4/BatoToV4.kt
@@ -46,8 +46,6 @@ class BatoToV4(
 
     override val name: String = "Bato.to"
 
-    private val imageServerManager: ImageServerManager = ImageServerManager()
-
     override val supportsLatest = true
 
     override val client = network.cloudflareClient.newBuilder()
@@ -60,6 +58,8 @@ class BatoToV4(
             chain.proceed(request)
         }
         .build()
+
+    private val imageServerManager: ImageServerManager = ImageServerManager()
 
     // ************ Search ************ //
     override fun latestUpdatesRequest(page: Int) = throw UnsupportedOperationException()
@@ -368,7 +368,6 @@ class BatoToV4(
                 Page(
                     index = index,
                     imageUrl = url.toHttpUrl().newBuilder()
-                        .fragment(PAGE_FRAGMENT)
                         .build()
                         .toString(),
                 )
@@ -416,11 +415,6 @@ class BatoToV4(
 
     private fun imageFallbackInterceptor(chain: Interceptor.Chain): Response {
         val request = chain.request()
-
-        // Handle non-page requests normally
-        if (request.url.fragment != PAGE_FRAGMENT) {
-            return chain.proceed(request)
-        }
 
         // Extract server, or proceed normally if not found
         val urlString = request.url.toString()
@@ -573,7 +567,6 @@ private val jsonMediaType = "application/json".toMediaType()
 private const val REMOVE_TITLE_VERSION_PREF = "REMOVE_TITLE_VERSION"
 private const val REMOVE_TITLE_CUSTOM_PREF = "REMOVE_TITLE_CUSTOM"
 
-private const val PAGE_FRAGMENT = "page"
 private val userIdRegex = Regex("""/u/(\d+)""")
 
 private const val BROWSE_PAGE_SIZE = 36

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batotov4/BatoToV4.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batotov4/BatoToV4.kt
@@ -445,6 +445,8 @@ class BatoToV4(
         withTimeout: Boolean = false,
     ): Response? {
         return try {
+            // FORCE SHORT TIMEOUTS FOR FALLBACKS
+            // If a fallback server doesn't answer in 5 seconds, kill it and move to next server.
             val modifiedChain = if (withTimeout) {
                 chain.withConnectTimeout(5, TimeUnit.SECONDS)
                     .withReadTimeout(10, TimeUnit.SECONDS)

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batotov4/BatoToV4.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batotov4/BatoToV4.kt
@@ -576,6 +576,13 @@ private const val REMOVE_TITLE_CUSTOM_PREF = "REMOVE_TITLE_CUSTOM"
 private const val PAGE_FRAGMENT = "page"
 private val userIdRegex = Regex("""/u/(\d+)""")
 
+private const val BROWSE_PAGE_SIZE = 36
+
+// Match old v2 Url
+private val seriesIdRegex = Regex("""series/(\d+)""")
+private val titleRegex: Regex =
+    Regex("\\([^()]*\\)|\\{[^{}]*\\}|\\[(?:(?!]).)*]|«[^»]*»|〘[^〙]*〙|「[^」]*」|『[^』]*』|≪[^≫]*≫|﹛[^﹜]*﹜|〖[^〖〗]*〗|\uD81A\uDD0D.+?\uD81A\uDD0D|《[^》]*》|⌜.+?⌝|⟨[^⟩]*⟩|/Official|/ Official", RegexOption.IGNORE_CASE)
+
 /**
  * Manages image server fallback logic, including blacklisting and backoff tracking.
  */
@@ -625,10 +632,3 @@ private class ImageServerManager() {
         return url.replace(serverPattern, "https://$newServer")
     }
 }
-
-private const val BROWSE_PAGE_SIZE = 36
-
-// Match old v2 Url
-private val seriesIdRegex = Regex("""series/(\d+)""")
-private val titleRegex: Regex =
-    Regex("\\([^()]*\\)|\\{[^{}]*\\}|\\[(?:(?!]).)*]|«[^»]*»|〘[^〙]*〙|「[^」]*」|『[^』]*』|≪[^≫]*≫|﹛[^﹜]*﹜|〖[^〖〗]*〗|\uD81A\uDD0D.+?\uD81A\uDD0D|《[^》]*》|⌜.+?⌝|⟨[^⟩]*⟩|/Official|/ Official", RegexOption.IGNORE_CASE)


### PR DESCRIPTION
This PR adds
- An image server blacklist. Image servers on this blacklist are immediately skipped in favor of a fallback server
- A 1 hour backoff to image servers that return a 500 error code (400s will not backoff), these servers are also immediately skipped in favor of the next available fallback server.
- ~Ability to modify the fallback list, blacklist, and enable/disable backoff inside Preferences~
- ~See failed servers or backoff servers inside Preferences.~

Closes #12568, by default k07 is added to the blacklist since this server doesn't give a 500 code and isn't caught by the backoff.

Possible extras that I can do
- Remove all k servers from the fallback list, and add all of them to the default blacklist
- Switch to exponential backoff? I tested with 1 minute initial, but the experience ramped too slowly.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] ~Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions~
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] ~Added the `isNsfw = true` flag in `build.gradle` when appropriate~
- [x] Have not changed source names
- [x] ~Have explicitly kept the `id` if a source's name or language were changed~
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] ~Have removed `web_hi_res_512.png` when adding a new extension~
