### PR TITLE
JapScan: Fix - inability to read "BDs" / "comics"

### DIFF
--- a/src/fr/japscan/build.gradle
+++ b/src/fr/japscan/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Japscan'
     extClass = '.Japscan'
-    extVersionCode = 54
+    extVersionCode = 55
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import android.graphics.Bitmap
 import android.os.Handler
 import android.os.Looper
+import android.util.Base64
 import android.view.View
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
@@ -23,6 +24,7 @@ import eu.kanade.tachiyomi.source.online.ParsedHttpSource
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
@@ -43,6 +45,7 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlin.collections.mapIndexed
 
 class Japscan : ConfigurableSource, ParsedHttpSource() {
 
@@ -279,7 +282,39 @@ class Japscan : ConfigurableSource, ParsedHttpSource() {
         dateFormat.parse(date)!!.time
     }.getOrDefault(0L)
 
+    @Serializable
+    class ChapterDetails(
+        val imagesLink: List<String>,
+    )
+
     override fun fetchPageList(chapter: SChapter): Observable<List<Page>> {
+        try {
+            val document = client.newCall(GET("$internalBaseUrl${chapter.url}")).execute().asJsoup()
+            // Get only usable crypted b64
+            val atad = document.select("i[data-atad]").attr("data-atad").substring(7)
+            val mapping =
+                "M7HXtiwLKdpIBkEbQ2OaF8Sxmz1yGReU4q5DncgsT6jVA3Pfv0WuJ9YCZNhlor".reversed()
+            val reference =
+                "uGJ657yOSbZRtplgHEYPBwCqaxQIizDWmTLMsAeNocnX0d98rf4Kj1kvh3UFV2".reversed()
+            val decrypted =
+                atad.replace(Regex("[A-Z0-9]", RegexOption.IGNORE_CASE)) { matchResult ->
+                    val char = matchResult.value[0]
+                    val index = reference.indexOf(char)
+                    (if (index != -1) mapping[index] else char).toString()
+                }
+            val fromB64 = String(Base64.decode(decrypted, Base64.DEFAULT)).parseAs<ChapterDetails>()
+            if (fromB64.imagesLink.isEmpty()) throw UnsupportedOperationException("Can't parse Images")
+            return Observable.just(
+                fromB64.imagesLink.mapIndexed { i, url ->
+                    Page(i, imageUrl = "$url?o=1")
+                },
+            )
+        } catch (e: Exception) {
+            return fallbackFetchPageList(chapter)
+        }
+    }
+
+    fun fallbackFetchPageList(chapter: SChapter): Observable<List<Page>> {
         val interfaceName = randomString()
 
         val handler = Handler(Looper.getMainLooper())

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -233,7 +233,7 @@ class Japscan : ConfigurableSource, ParsedHttpSource() {
                 // Find the first attribute whose value matches the chapter URL pattern
                 val attrMatch = el.attributes().asList().firstOrNull { attr ->
                     val value = attr.value
-                    value.startsWith("/manga/") || value.startsWith("/manhua/") || value.startsWith("/manhwa/")
+                    value.startsWith("/manga/") || value.startsWith("/manhua/") || value.startsWith("/manhwa/") || value.startsWith("/bd/") || value.startsWith("/comic/")
                 }
                 if (attrMatch != null) {
                     val name = el.ownText().ifBlank { el.text() }


### PR DESCRIPTION
Closes #12541

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
