### PR TITLE
Fixes for Luscious

### DIFF
--- a/src/all/luscious/build.gradle
+++ b/src/all/luscious/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Luscious'
     extClass = '.LusciousFactory'
-    extVersionCode = 23
+    extVersionCode = 24
     isNsfw = true
 }
 

--- a/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/Luscious.kt
+++ b/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/Luscious.kt
@@ -21,11 +21,11 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.double
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.long
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
@@ -298,9 +298,9 @@ abstract class Luscious(
                             url.startsWith("//") -> chapter.url = "https:$url"
                             else -> chapter.url = url
                         }
-                        chapter.chapter_number = it.jsonObject["position"]!!.jsonPrimitive.int.toFloat()
+                        chapter.chapter_number = it.jsonObject["position"]!!.jsonPrimitive.double.toFloat()
                         chapter.name = chapter.chapter_number.toInt().toString() + " - " + it.jsonObject["title"]!!.jsonPrimitive.content
-                        chapter.date_upload = "${it.jsonObject["created"]!!.jsonPrimitive.long}000".toLong()
+                        chapter.date_upload = (it.jsonObject["created"]!!.jsonPrimitive.double.toLong()) * 1000
                         chapters.add(chapter)
                     }
                     if (nextPage) {


### PR DESCRIPTION
Fixes error when fetching chapters caused by change in timestamp format
Also fixes similar error if chapter number contains decimal

(Does not close any issues)

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
