### PR TITLE
Batoto: Fix getMangaUrl and null serial chapter parsing

### DIFF
--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batotov4/BatoToV4.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batotov4/BatoToV4.kt
@@ -321,7 +321,7 @@ class BatoToV4(
     }
 
     override fun getMangaUrl(manga: SManga): String {
-        return "$baseUrl/title/${manga.url}"
+        return "$baseUrl/title/${getMangaId(manga.url)}"
     }
 
     /* Match old v2 Url */

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batotov4/Dto.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batotov4/Dto.kt
@@ -114,7 +114,7 @@ class ChapterListData(
     class ChapterData(
         val comicId: String,
         val id: String,
-        val serial: Float,
+        val serial: Float? = null,
         @SerialName("dname")
         val displayName: String,
         val title: String? = null,
@@ -131,9 +131,11 @@ class ChapterListData(
         fun toSChapter(): SChapter = SChapter.create().apply {
             url = id
             name = buildString {
-                val number = serial.toString().substringBefore(".0")
-                if (!displayName.contains(number)) {
-                    append("Chapter ", number, ": ")
+                if (serial != null) {
+                    val number = serial.toString().substringBefore(".0")
+                    if (!displayName.contains(number)) {
+                        append("Chapter ", number, ": ")
+                    }
                 }
                 append(displayName)
                 if (!title.isNullOrEmpty()) {
@@ -141,7 +143,7 @@ class ChapterListData(
                     append(title)
                 }
             }
-            chapter_number = serial
+            chapter_number = serial ?: 0f
             date_upload = dateModify ?: dateCreate ?: 0L
             scanlator = groupNodes?.filter { it?.data?.name != null }?.joinToString { it!!.data!!.name!! }
                 ?: userNode?.data?.name ?: "\u200B"

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batotov4/Dto.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batotov4/Dto.kt
@@ -143,7 +143,7 @@ class ChapterListData(
                     append(title)
                 }
             }
-            chapter_number = serial ?: 0f
+            serial?.let { chapter_number = it }
             date_upload = dateModify ?: dateCreate ?: 0L
             scanlator = groupNodes?.filter { it?.data?.name != null }?.joinToString { it!!.data!!.name!! }
                 ?: userNode?.data?.name ?: "\u200B"


### PR DESCRIPTION
Closes #12663. 
- Fixes old v2 entries webview from going to "/title//series/mangaId/mangaName" by properly extracting the mangaId. For some reason, `manga.url` is not updating to be just the manga id, so we need to wrap it. 
- Fixes rare null serial occurrence in the chapter list api by making serial nullable.

Example in the api for `comicId=149027`:
```json
"data": {
	"comicId": "149027",
	"id": "2694427",
	"serial": null,
	"dname": "Read Online",
	"title": null,
	"urlPath": "/title/149027/2694427"
}
```
The chapter `name` is "Read Online" and `chapter_number` is not set.

extVersionCode has not been bumped here to reduce user updates, merge this with #12621.

Checklist:

- [ ] ~Updated `extVersionCode` value in `build.gradle` for individual extensions~
- [x] ~Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions~
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] ~Added the `isNsfw = true` flag in `build.gradle` when appropriate~
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] ~Have removed `web_hi_res_512.png` when adding a new extension~
