### PR TITLE
[Mangadex] Add support for search by URL

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaDex'
     extClass = '.MangaDexFactory'
-    extVersionCode = 204
+    extVersionCode = 205
     isNsfw = true
 }
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MDConstants.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MDConstants.kt
@@ -44,6 +44,16 @@ object MDConstants {
     const val prefixUsrSearch = "usr:"
     const val prefixListSearch = "list:"
 
+    val pathToSearchPrefix = mapOf(
+        "manga" to prefixIdSearch,
+        "title" to prefixIdSearch,
+        "chapter" to prefixChSearch,
+        "group" to prefixGrpSearch,
+        "author" to prefixAuthSearch,
+        "user" to prefixUsrSearch,
+        "list" to prefixListSearch,
+    )
+
     private const val coverQualityPref = "thumbnailQuality"
 
     fun getCoverQualityPreferenceKey(dexLang: String): String {


### PR DESCRIPTION
Supports manga/title, author, user, group, list, and chapter URLs
Closes #12668 

Rework of #12670 
(I wasn't able to open a PR against their branch so I opened this).
Co-authored-by: @keegang6705 @AwkwardPeak7 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

