### PR TITLE
Zaimanhua: get chapter list form PC API

### DIFF
--- a/src/zh/zaimanhua/build.gradle
+++ b/src/zh/zaimanhua/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Zaimanhua'
     extClass = '.Zaimanhua'
-    extVersionCode = 16
+    extVersionCode = 17
     isNsfw = false
 }
 

--- a/src/zh/zaimanhua/src/eu/kanade/tachiyomi/extension/zh/zaimanhua/ZaimanhuaDto.kt
+++ b/src/zh/zaimanhua/src/eu/kanade/tachiyomi/extension/zh/zaimanhua/ZaimanhuaDto.kt
@@ -19,12 +19,6 @@ class MangaDto(
     private val types: List<TagDto>?,
     private val status: List<TagDto>?,
     private val authors: List<TagDto>?,
-    @SerialName("chapters")
-    private val chapterGroups: List<ChapterGroupDto>,
-    @SerialName("last_update_chapter_id")
-    private val lastUpdateChapterId: Int,
-    @SerialName("last_updatetime")
-    private val lastUpdateTime: Long,
 ) {
     fun toSManga() = SManga.create().apply {
         url = id.toString()
@@ -36,12 +30,28 @@ class MangaDto(
         thumbnail_url = cover
         initialized = true
     }
+}
 
+@Serializable
+class ChapterDataDto(
+    private val id: Int,
+    // Only `manhua.zaimanhua.com/api/v1/comic2/comic/detail?id=xxx`(pc) use `lastUpdateChapterId`,
+    // `lastUpdateTime`, `chapterList`.
+    // The app api use `last_update_chapter_id`, `last_updatetime`, `chapters`.
+    @JsonNames("last_update_chapter_id")
+    private val lastUpdateChapterId: Int,
+    @JsonNames("last_updatetime")
+    private val lastUpdateTime: Long,
+    @JsonNames("chapters")
+    val chapterList: List<ChapterGroupDto>?,
+    val isHideChapter: Int?,
+    val canRead: Boolean?,
+) {
     fun parseChapterList(): List<SChapter> {
         val mangaId = id.toString()
         val lastUpdateChapter = lastUpdateChapterId.toString()
-        val size = chapterGroups.sumOf { it.size }
-        return chapterGroups.flatMapTo(ArrayList(size)) {
+        val size = chapterList!!.sumOf { it.size }
+        return chapterList.flatMapTo(ArrayList(size)) {
             it.toSChapterList(mangaId, lastUpdateChapter, lastUpdateTime)
         }
     }
@@ -167,6 +177,7 @@ class UserDto(
 
 @Serializable
 class DataWrapperDto<T>(
+    @JsonNames("comicInfo")
     val data: T?,
 )
 


### PR DESCRIPTION
Use the PC API to fetch the full chapter list for user with read access, as the mobile API may hide some chapters.
Also fetch pageList with pc header, as the default header may return empty list even if the user has read access.

close #12699 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
