### PR TITLE
[xkcd] Add setting for comic grouping

### DIFF
--- a/src/all/xkcd/build.gradle
+++ b/src/all/xkcd/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'xkcd'
     extClass = '.XkcdFactory'
-    extVersionCode = 15
+    extVersionCode = 16
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/xkcd/src/eu/kanade/tachiyomi/extension/all/xkcd/Xkcd.kt
+++ b/src/all/xkcd/src/eu/kanade/tachiyomi/extension/all/xkcd/Xkcd.kt
@@ -1,7 +1,12 @@
 package eu.kanade.tachiyomi.extension.all.xkcd
 
+import android.content.SharedPreferences
+import androidx.preference.ListPreference
+import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.lib.textinterceptor.TextInterceptor
 import eu.kanade.tachiyomi.lib.textinterceptor.TextInterceptorHelper
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
@@ -9,11 +14,13 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.getPreferencesLazy
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
+import org.jsoup.nodes.Element
 import rx.Observable
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -21,8 +28,7 @@ import java.util.Locale
 open class Xkcd(
     final override val baseUrl: String,
     final override val lang: String,
-    dateFormat: String = "yyyy-MM-dd",
-) : HttpSource() {
+) : ConfigurableSource, HttpSource() {
     final override val name = "xkcd"
 
     final override val supportsLatest = false
@@ -61,39 +67,190 @@ open class Xkcd(
 
     protected open val imageSelector = "#comic > img"
 
-    private val dateFormat = SimpleDateFormat(dateFormat, Locale.ROOT)
+    private val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.ROOT)
 
-    protected fun String.timestamp() = dateFormat.parse(this)?.time ?: 0L
+    protected open fun String.timestamp(): Long {
+        // normalize dates like "2022-2-2" to "2022-02-02"
+        val normalized = this.split("-").let { parts ->
+            "${parts[0]}-${parts[1].padStart(2, '0')}-${parts[2].padStart(2, '0')}"
+        }
+        return dateFormat.parse(normalized)?.time ?: 0L
+    }
 
-    protected open fun String.numbered(number: Any) = "$number - $this"
+    val chapterTitleFormatter: (Int, String) -> String = { number, text -> "$number: $text" }
 
-    private fun makeSManga(): SManga =
-        SManga.create().apply {
-            title = name
-            artist = creator
-            author = creator
-            description = synopsis
-            status = SManga.ONGOING
-            thumbnail_url = "https://thumbnail/xkcd.png"
-            setUrlWithoutDomain(archive)
+    // Preferences
+
+    private val preferences: SharedPreferences by getPreferencesLazy()
+
+    companion object {
+        private const val CACHE_EXPIRY_MS = 60 * 60 * 1000L // 1 hour
+
+        enum class OrganizationMethod(val key: String, val displayName: String) {
+            SINGLE("SINGLE", "Single manga (all comics)"),
+            BY_YEAR("BY_YEAR", "By year"),
+            BY_YEAR_MONTH("BY_YEAR_MONTH", "By year-month"),
+            ;
+
+            companion object {
+                const val PREF_KEY = "organization_method"
+                val defaultOption = SINGLE
+                fun fromKey(key: String) = values().find { it.key == key } ?: defaultOption
+            }
+        }
+    }
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        ListPreference(screen.context).apply {
+            key = OrganizationMethod.PREF_KEY
+            title = "Organization Method"
+            entries = OrganizationMethod.values().map { it.displayName }.toTypedArray()
+            entryValues = OrganizationMethod.values().map { it.key }.toTypedArray()
+            setDefaultValue(OrganizationMethod.defaultOption.key)
+            summary = "Current: %s\n\n" +
+                "Changing this will show comics grouped differently. " +
+                "Your reading progress is tied to the organization method.\n\n" +
+                "Note: You may need to exit and re-enter the extension for the manga list to update."
+        }.let(screen::addPreference)
+    }
+
+    private fun getOrganizationMethod(): OrganizationMethod {
+        val key = preferences.getString(OrganizationMethod.PREF_KEY, OrganizationMethod.defaultOption.key)!!
+        return OrganizationMethod.fromKey(key)
+    }
+
+    // what key to use for grouping comics into mangas
+    private fun getChapterToKey(): (SChapter) -> String {
+        return when (getOrganizationMethod()) {
+            OrganizationMethod.SINGLE -> { chapter -> "SINGLE" }
+            OrganizationMethod.BY_YEAR -> { chapter ->
+                val date = SimpleDateFormat("yyyy-MM-dd", Locale.ROOT).format(chapter.date_upload)
+                date.split("-")[0] // Extract year
+            }
+            OrganizationMethod.BY_YEAR_MONTH -> { chapter ->
+                val date = SimpleDateFormat("yyyy-MM-dd", Locale.ROOT).format(chapter.date_upload)
+                val parts = date.split("-")
+                "${parts[0]}-${parts[1].padStart(2, '0')}" // "2024-01"
+            }
+        }
+    }
+
+    private fun getKeyToTitleFormatter(): (String) -> String {
+        return when (getOrganizationMethod()) {
+            OrganizationMethod.SINGLE -> { key -> "xkcd" }
+            OrganizationMethod.BY_YEAR -> { key -> "xkcd $key" }
+            OrganizationMethod.BY_YEAR_MONTH -> { key -> "xkcd $key" }
+        }
+    }
+
+    // Archive caching
+
+    private var comicDateMapping: Map<Int, String>? = null // Comic number -> date mapping from English
+    private var comicDateMappingTime: Long = 0
+    private var allChaptersCache: List<SChapter>? = null // Full chapter list with dates
+    private var allChaptersCacheTime: Long = 0
+
+    // some translations don't provide dates for their comics, but we can look up the dates
+    // (of english publication) given the comic number which is shared across translations
+    protected fun getComicDateMappingFromEnglishArchive(): Map<Int, String> {
+        val now = System.currentTimeMillis()
+        if (comicDateMapping == null || now - comicDateMappingTime > CACHE_EXPIRY_MS) {
+            // hardcode url and selector for English archive
+            val response = client.newCall(GET("https://xkcd.com/archive/", headers)).execute()
+            val doc = response.asJsoup()
+            comicDateMapping = doc.select("#middleContainer > a").associate { element ->
+                val number = element.attr("href").removeSurrounding("/").toInt()
+                val date = element.attr("title") // "2026-1-9" format
+                number to date
+            }
+            comicDateMappingTime = now
+        }
+        return comicDateMapping!!
+    }
+
+    private fun getAllComicsAsChapters(): List<SChapter> {
+        val now = System.currentTimeMillis()
+        if (allChaptersCache == null || now - allChaptersCacheTime > CACHE_EXPIRY_MS) {
+            val response = client.newCall(GET(baseUrl + archive, headers)).execute()
+            allChaptersCache = chapterListParse(response)
+            allChaptersCacheTime = now
+        }
+        return allChaptersCache!!
+    }
+
+    private fun getGroupedChapters(): Map<String, List<SChapter>> {
+        return getAllComicsAsChapters().groupBy(getChapterToKey())
+    }
+
+    // organize chapters into mangas according to the chosen key
+    private fun makeGroupedManga(page: Int, perPage: Int = 10): MangasPage {
+        val groupedChapters = getGroupedChapters()
+        val allKeys = groupedChapters.keys.sortedDescending() // Newest first
+
+        val startIndex = (page - 1) * perPage
+        val endIndex = minOf(startIndex + perPage, allKeys.size)
+        val hasNextPage = endIndex < allKeys.size
+
+        if (startIndex >= allKeys.size) {
+            return MangasPage(emptyList(), false)
         }
 
-    final override fun fetchPopularManga(page: Int) =
-        Observable.just(MangasPage(listOf(makeSManga()), false))
+        val pageKeys = allKeys.subList(startIndex, endIndex)
+        val mangas = pageKeys.map { key ->
+            val chapters = groupedChapters[key]!!
+            val firstChapter = chapters.firstOrNull()
+            SManga.create().apply {
+                title = getKeyToTitleFormatter()(key)
+                url = key
 
-    final override fun fetchSearchManga(page: Int, query: String, filters: FilterList) =
-        Observable.just(MangasPage(emptyList(), false))!!
+                // these constants can get overriden by translations
+                artist = creator
+                author = creator
+                description = synopsis
 
-    final override fun fetchMangaDetails(manga: SManga) =
-        Observable.just(makeSManga())!!
+                // TODO: this could theoretically be improved - xkcd doesn't retroactively
+                // publish comics so if organizing by date, the manga for periods != current
+                // period could be set to COMPLETED instead
+                status = SManga.ONGOING
 
+                // fetch real thumbnail
+                thumbnail_url = if (firstChapter != null) {
+                    fetchThumbnailUrlForChapter(firstChapter)
+                } else {
+                    "https://thumbnail/xkcd.png"
+                }
+                initialized = true
+            }
+        }
+
+        return MangasPage(mangas, hasNextPage)
+    }
+
+    // overrides
+
+    final override fun fetchPopularManga(page: Int): Observable<MangasPage> =
+        Observable.just(makeGroupedManga(page))
+
+    final override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> =
+        Observable.just(MangasPage(emptyList(), false))
+
+    final override fun fetchMangaDetails(manga: SManga): Observable<SManga> =
+        Observable.just(manga)
+
+    final override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> =
+        Observable.just(getGroupedChapters()[manga.url] ?: emptyList())
+
+    // methods for translations to override
+
+    // archiveResponse -> List<SChapter>
     override fun chapterListParse(response: Response) =
         response.asJsoup().select(chapterListSelector).map {
             SChapter.create().apply {
+                // turn comic entry from archive entry into SChapter
                 url = it.attr("href")
-                val number = url.removeSurrounding("/")
-                name = it.text().numbered(number)
-                chapter_number = number.toFloat()
+                val comicNumber = url.removeSurrounding("/").toInt()
+                name = chapterTitleFormatter(comicNumber, it.text())
+                chapter_number = comicNumber.toFloat()
                 date_upload = it.attr("title").timestamp()
             }
         }
@@ -114,6 +271,39 @@ open class Xkcd(
         val text = TextInterceptorHelper.createUrl(img.attr("alt"), img.attr("title"))
 
         return listOf(Page(0, "", image), Page(1, "", text))
+    }
+
+    protected open fun extractImageFromContainer(container: Element): Element? {
+        return container
+    }
+
+    protected open val defaultFallbackThumbnail = "https://thumbnail/xkcd.png"
+
+    protected open fun fetchThumbnailUrlForChapter(chapter: SChapter): String {
+        return try {
+            val response = client.newCall(GET(baseUrl + chapter.url, headers)).execute()
+            if (!response.isSuccessful) {
+                return defaultFallbackThumbnail
+            }
+
+            val doc = response.asJsoup()
+            val container = doc.selectFirst(imageSelector)
+
+            val img = container?.let { extractImageFromContainer(it) }
+                ?: doc.selectFirst("img[alt]") // Fallback to any img with alt text
+
+            val url = img?.let {
+                when {
+                    it.hasAttr("srcset") -> it.attr("abs:srcset").substringBefore(' ')
+                    it.hasAttr("src") -> it.attr("abs:src")
+                    else -> null
+                }
+            }
+
+            url?.takeIf { it.isNotBlank() && !it.contains("thumbnail") } ?: defaultFallbackThumbnail
+        } catch (e: Exception) {
+            defaultFallbackThumbnail
+        }
     }
 
     final override fun imageUrlParse(response: Response) =

--- a/src/all/xkcd/src/eu/kanade/tachiyomi/extension/all/xkcd/translations/XkcdES.kt
+++ b/src/all/xkcd/src/eu/kanade/tachiyomi/extension/all/xkcd/translations/XkcdES.kt
@@ -6,6 +6,8 @@ import eu.kanade.tachiyomi.util.asJsoup
 import okhttp3.Response
 
 class XkcdES : Xkcd("https://es.xkcd.com", "es") {
+    // archive url is same as EN
+
     override val synopsis =
         "Un webcómic sobre romance, sarcasmo, mates y lenguaje."
 
@@ -13,23 +15,58 @@ class XkcdES : Xkcd("https://es.xkcd.com", "es") {
     override val interactiveText =
         "Para experimentar la versión interactiva de este cómic, ábralo en WebView/navegador."
 
-    override val chapterListSelector = "#archive-ul > ul > li > a"
+    override val chapterListSelector = ".archive-entry > a"
 
     override val imageSelector = "#middleContent .strip"
 
-    override fun chapterListParse(response: Response) =
-        response.asJsoup().select(chapterListSelector).mapIndexed { idx, el ->
-            SChapter.create().apply {
-                name = el.text()
-                // convert relative path to absolute
-                url = el.attr("href").substring(2)
-                // not accurate to the original ¯\_(ツ)_/¯
-                chapter_number = idx + 1f
-                // no dates available
-                date_upload = 0L
-            }
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val englishArchive = try {
+            getComicDateMappingFromEnglishArchive()
+        } catch (e: Exception) {
+            emptyMap()
         }
 
-    override fun String.numbered(number: Any) =
-        throw UnsupportedOperationException()
+        // hardcoded override for Spanish comic that maps to wrong English comic
+        // Spanish "geografia" (1403) is actually English 1472 from 2015-01-12
+        val spanishOverrides = mapOf(
+            "/strips/geografia/" to 1472,
+        )
+
+        // reverse mapping, Spanish archive actually gives date but not comic number
+        val dateToNumber = englishArchive.entries.associate { (number, date) ->
+            val parts = date.split("-")
+            val normalizedDate = "${parts[0]}-${parts[1].padStart(2, '0')}-${parts[2].padStart(2, '0')}"
+            normalizedDate to number
+        }
+
+        return response.asJsoup().select(".archive-entry").mapNotNull { entry ->
+            val link = entry.selectFirst("a") ?: return@mapNotNull null
+            val title = link.text()
+
+            // URLs are absolute, extract the path
+            val href = link.attr("href")
+            val url = if (href.startsWith("http")) {
+                href.substringAfter(baseUrl)
+            } else {
+                href
+            }
+
+            val timeElement = entry.selectFirst("time") ?: return@mapNotNull null
+            val datePart = timeElement.text()
+
+            // check for hardcoded override first
+            val comicNumber = spanishOverrides[url] ?: dateToNumber[datePart] ?: return@mapNotNull null
+
+            SChapter.create().apply {
+                this.url = url
+                name = chapterTitleFormatter(comicNumber, title)
+                chapter_number = comicNumber.toFloat()
+                date_upload = try {
+                    datePart.timestamp()
+                } catch (e: Exception) {
+                    0L
+                }
+            }
+        }
+    }
 }

--- a/src/all/xkcd/src/eu/kanade/tachiyomi/extension/all/xkcd/translations/XkcdFR.kt
+++ b/src/all/xkcd/src/eu/kanade/tachiyomi/extension/all/xkcd/translations/XkcdFR.kt
@@ -17,30 +17,67 @@ class XkcdFR : Xkcd("https://xkcd.lapin.org", "fr") {
 
     override val imageSelector = "#content .s"
 
-    override fun String.numbered(number: Any) = "$number. $this"
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val englishDates = try {
+            getComicDateMappingFromEnglishArchive()
+        } catch (e: Exception) {
+            emptyMap()
+        }
 
-    override fun chapterListParse(response: Response) =
-        response.asJsoup().select(chapterListSelector).map {
+        val chapters = response.asJsoup().select(chapterListSelector).map {
             SChapter.create().apply {
                 url = "/" + it.attr("href")
-                val number = url.substringAfter('=')
-                name = it.text().numbered(number)
-                chapter_number = number.toFloat()
-                // no dates available
-                date_upload = 0L
+                val comicNumber = url.substringAfter('=').toIntOrNull()
+
+                name = chapterTitleFormatter(comicNumber ?: 0, it.text())
+                chapter_number = comicNumber?.toFloat() ?: 0f
+
+                // use English publication date instead of translation date
+                date_upload = if (comicNumber != null && englishDates.containsKey(comicNumber)) {
+                    val dateStr = englishDates[comicNumber]!!
+                    dateStr.timestamp()
+                } else {
+                    0L
+                }
             }
         }
 
-    override fun pageListParse(response: Response) =
-        response.asJsoup().selectFirst(imageSelector)!!.let {
-            // no interactive comics here
-            val img = it.child(2).child(0).child(0)
+        // French archive lists oldest first
+        return chapters.reversed()
+    }
 
-            // create a text image for the alt text
-            val text = TextInterceptorHelper.createUrl(it.child(0).text(), img.attr("alt"))
-
-            listOf(Page(0, "", img.attr("abs:src")), Page(1, "", text))
+    override fun extractImageFromContainer(container: org.jsoup.nodes.Element): org.jsoup.nodes.Element? {
+        return try {
+            container.child(2).child(0).child(0)
+        } catch (e: Exception) {
+            container.selectFirst("img")
         }
+    }
+
+    override fun pageListParse(response: Response): List<Page> {
+        val container = response.asJsoup().selectFirst(imageSelector)
+            ?: error(interactiveText)
+
+        // Try to find the image - French xkcd has a specific structure
+        val img = try {
+            container.child(2).child(0).child(0)
+        } catch (e: Exception) {
+            // Fallback: look for any img tag in the container
+            container.selectFirst("img") ?: error(interactiveText)
+        }
+
+        // Get alt text - try from first child, fallback to img alt
+        val altText = try {
+            container.child(0).text()
+        } catch (e: Exception) {
+            img.attr("alt")
+        }
+
+        // create a text image for the alt text
+        val text = TextInterceptorHelper.createUrl(altText, img.attr("alt"))
+
+        return listOf(Page(0, "", img.attr("abs:src")), Page(1, "", text))
+    }
 
     override val interactiveText: String
         get() = throw UnsupportedOperationException()

--- a/src/all/xkcd/src/eu/kanade/tachiyomi/extension/all/xkcd/translations/XkcdZH.kt
+++ b/src/all/xkcd/src/eu/kanade/tachiyomi/extension/all/xkcd/translations/XkcdZH.kt
@@ -31,11 +31,7 @@ class XkcdZH : Xkcd("https://xkcd.tw", "zh") {
     override fun mangaDetailsRequest(manga: SManga) = GET(baseUrl, headers)
 
     override fun chapterListParse(response: Response): List<SChapter> {
-        val englishDates = try {
-            getComicDateMappingFromEnglishArchive()
-        } catch (e: Exception) {
-            emptyMap()
-        }
+        val englishDates = getComicDateMappingFromEnglishArchive()
 
         return json.parseToJsonElement(response.body.string()).jsonObject.values.map {
             val obj = it.jsonObject

--- a/src/all/xkcd/src/eu/kanade/tachiyomi/extension/all/xkcd/translations/XkcdZH.kt
+++ b/src/all/xkcd/src/eu/kanade/tachiyomi/extension/all/xkcd/translations/XkcdZH.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.Response
 import uy.kohesive.injekt.injectLazy
 
-class XkcdZH : Xkcd("https://xkcd.tw", "zh", "yyyy-MM-dd HH:mm:ss") {
+class XkcdZH : Xkcd("https://xkcd.tw", "zh") {
     override val archive = "/api/strips.json"
 
     override val creator = "兰德尔·门罗"
@@ -28,23 +28,33 @@ class XkcdZH : Xkcd("https://xkcd.tw", "zh", "yyyy-MM-dd HH:mm:ss") {
 
     private val json by injectLazy<Json>()
 
-    override fun String.numbered(number: Any) = "[$number] $this"
-
     override fun mangaDetailsRequest(manga: SManga) = GET(baseUrl, headers)
 
-    override fun chapterListParse(response: Response) =
-        json.parseToJsonElement(response.body.string()).jsonObject.values.map {
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val englishDates = try {
+            getComicDateMappingFromEnglishArchive()
+        } catch (e: Exception) {
+            emptyMap()
+        }
+
+        return json.parseToJsonElement(response.body.string()).jsonObject.values.map {
             val obj = it.jsonObject
-            val number = obj["id"]!!.jsonPrimitive.content
+            val comicNumber = obj["id"]!!.jsonPrimitive.content.toInt()
             val title = obj["title"]!!.jsonPrimitive.content
-            val date = obj["translate_time"]!!.jsonPrimitive.content
             SChapter.create().apply {
-                url = "/$number"
-                name = title.numbered(number)
-                chapter_number = number.toFloat()
-                date_upload = date.timestamp()
+                url = "/$comicNumber"
+                name = chapterTitleFormatter(comicNumber, title)
+                chapter_number = comicNumber.toFloat()
+
+                // use English publication date instead of translation date
+                date_upload = if (englishDates.containsKey(comicNumber)) {
+                    englishDates[comicNumber]!!.timestamp()
+                } else {
+                    0L
+                }
             }
         }
+    }
 
     override fun pageListParse(response: Response): List<Page> {
         // if img tag is empty then it is an interactive comic


### PR DESCRIPTION
 - Adds a preference setting for how to group the comics, whether as a single manga, split out by year, or year and month (closes #1454)
 - Use thumbnail of most recent comic in each manga
 - Standardize chapter titles as "number: title"
 - Fill in comic dates using English original comic publication date for FR and RU
 - Use English original comic publication date for ZH instead of translation publication date
 - Some fixes for broken selectors

(random note - looks like ES site is down rn)

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension

Testing: tested with Mihon on Android

<img width="303" height="597" alt="image" src="https://github.com/user-attachments/assets/d9317ab5-ed90-4088-afd0-e690c0519977" />
<img width="303" height="597" alt="image" src="https://github.com/user-attachments/assets/df7caec9-c776-41ad-8455-361597bead33" />
<img width="303" height="597" alt="image" src="https://github.com/user-attachments/assets/74b2b5ad-7f4c-4cb0-9705-bd2403985a8c" />
<img width="303" height="597" alt="image" src="https://github.com/user-attachments/assets/db79f871-a2d1-489a-8a2c-1614b87e2c4f" />
<img width="303" height="597" alt="image" src="https://github.com/user-attachments/assets/cd4dec85-e695-493c-a02f-630419fb09d7" />
