### PR TITLE
[TeamX] fix chapter upload dates using data-date timestamp

### DIFF
--- a/src/ar/teamx/build.gradle
+++ b/src/ar/teamx/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Team X'
     extClass = '.TeamX'
-    extVersionCode = 24
+    extVersionCode = 25
     isNsfw = false
 }
 


### PR DESCRIPTION
The website now provides chapter dates as Unix timestamps via the
`data-date` attribute instead of absolute date strings.

This change reads and converts the timestamp (seconds → milliseconds)
directly from the chapter card, removes the broken SimpleDateFormat-based
parsing, and adjusts the chapter selector accordingly.

This restores correct chapter dates and ordering.

Closes #12736

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
