### PR TITLE
[magusmanga/iken] Fix page ordering

### DIFF
--- a/lib-multisrc/iken/build.gradle.kts
+++ b/lib-multisrc/iken/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 11
+baseVersionCode = 12

--- a/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Iken.kt
+++ b/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Iken.kt
@@ -178,7 +178,7 @@ abstract class Iken(
         }
 
         return sortedPages.mapIndexed { idx, p ->
-            Page(idx, imageUrl = p.url)
+            Page(idx, imageUrl = p.url.replace(" ", "%20"))
         }
     }
 

--- a/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Iken.kt
+++ b/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Iken.kt
@@ -153,6 +153,9 @@ abstract class Iken(
             .map { it.toSChapter(data.post.slug) }
     }
 
+    // some extensions need to sort image urls by filename, override this to true if so
+    protected open val sortPagesByFilename = false
+
     override fun pageListParse(response: Response): List<Page> {
         val document = response.asJsoup()
 
@@ -160,7 +163,21 @@ abstract class Iken(
             throw Exception("Unlock chapter in webview")
         }
 
-        return document.getNextJson("images").parseAs<List<PageParseDto>>().mapIndexed { idx, p ->
+        val pages = document.getNextJson("images").parseAs<List<PageParseDto>>()
+
+        val sortedPages = if (sortPagesByFilename) {
+            pages.sortedWith(
+                compareBy { page ->
+                    val filename = page.url.substringAfterLast('/')
+                    val number = Regex("\\d+").find(filename)?.value?.toIntOrNull() ?: Int.MAX_VALUE
+                    number
+                },
+            )
+        } else {
+            pages
+        }
+
+        return sortedPages.mapIndexed { idx, p ->
             Page(idx, imageUrl = p.url)
         }
     }

--- a/src/en/magusmanga/build.gradle
+++ b/src/en/magusmanga/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MagusManga'
     themePkg = 'iken'
     baseUrl = 'https://magustoon.org'
-    overrideVersionCode = 44
+    overrideVersionCode = 45
     isNsfw = false
 }
 

--- a/src/en/magusmanga/src/eu/kanade/tachiyomi/extension/en/magusmanga/MagusManga.kt
+++ b/src/en/magusmanga/src/eu/kanade/tachiyomi/extension/en/magusmanga/MagusManga.kt
@@ -22,6 +22,8 @@ class MagusManga : Iken(
         .rateLimitHost(baseUrl.toHttpUrl(), 1)
         .build()
 
+    override val sortPagesByFilename = true
+
     override fun popularMangaRequest(page: Int) = GET(baseUrl, headers)
 
     override fun popularMangaParse(response: Response): MangasPage {

--- a/src/en/sanascans/build.gradle
+++ b/src/en/sanascans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.SanaScans'
     themePkg = 'iken'
     baseUrl = 'https://sanascans.com'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
     isNsfw = false
 }
 

--- a/src/en/sanascans/src/eu/kanade/tachiyomi/extension/en/sanascans/SanaScans.kt
+++ b/src/en/sanascans/src/eu/kanade/tachiyomi/extension/en/sanascans/SanaScans.kt
@@ -2,10 +2,6 @@ package eu.kanade.tachiyomi.extension.en.sanascans
 
 import eu.kanade.tachiyomi.multisrc.iken.Iken
 import eu.kanade.tachiyomi.source.model.MangasPage
-import eu.kanade.tachiyomi.source.model.Page
-import eu.kanade.tachiyomi.util.asJsoup
-import keiyoushi.utils.parseAs
-import kotlinx.serialization.Serializable
 import okhttp3.Response
 import java.text.Normalizer
 import java.util.Locale
@@ -16,6 +12,8 @@ class SanaScans : Iken(
     "https://sanascans.com",
     "https://api.sanascans.com",
 ) {
+
+    override val sortPagesByFilename = true
 
     override fun searchMangaParse(response: Response): MangasPage {
         val result = super.searchMangaParse(response)
@@ -41,45 +39,6 @@ class SanaScans : Iken(
         return MangasPage(filtered, result.hasNextPage)
     }
 
-    override fun pageListParse(response: Response): List<Page> {
-        val document = response.asJsoup()
-
-        if (document.selectFirst("svg.lucide-lock") != null) {
-            throw Exception("Unlock chapter in webview")
-        }
-
-        val pages = document.getNextJson("images")
-            .parseAs<List<SanaPageDto>>()
-            .let { pageDtos ->
-                // Sana sometimes assigns sequential `order` values to the wrong image URLs,
-                // pushing some pages (eg "04 …") to the end. The filename itself usually
-                // starts with the actual page number, so prefer that when present.
-                val hasPageNumbers = pageDtos.count { it.url.extractLeadingPageNumber() != null }
-                val useFilenameOrdering = hasPageNumbers >= (pageDtos.size / 2)
-
-                if (useFilenameOrdering) {
-                    pageDtos.sortedWith(
-                        compareBy<SanaPageDto> { it.url.extractLeadingPageNumber() ?: Int.MAX_VALUE }
-                            .thenBy { it.order ?: Int.MAX_VALUE },
-                    )
-                } else {
-                    pageDtos.sortedBy { it.order ?: Int.MAX_VALUE }
-                }
-            }
-
-        return pages.mapIndexed { idx, p ->
-            Page(idx, imageUrl = p.url.encodeSpaces())
-        }
-    }
-
-    private fun String.encodeSpaces(): String = replace(" ", "%20")
-
-    private fun String.extractLeadingPageNumber(): Int? {
-        val fileName = substringAfterLast('/')
-        val match = leadingPageNumberRegex.find(fileName) ?: return null
-        return match.groupValues[1].toIntOrNull()
-    }
-
     private fun String?.normalizeForSearch(): String {
         if (this.isNullOrBlank()) return ""
 
@@ -96,12 +55,5 @@ class SanaScans : Iken(
         private val diacriticsRegex = Regex("\\p{M}+")
         private val nonAlphanumericRegex = Regex("[^a-z0-9]+")
         private val multiSpaceRegex = Regex("\\s+")
-        private val leadingPageNumberRegex = Regex("^0*(\\d{1,5})")
     }
-
-    @Serializable
-    private data class SanaPageDto(
-        val url: String,
-        val order: Int? = null,
-    )
 }


### PR DESCRIPTION
Some extensions sort by filename instead of using json ordering, make it an overridable option

Closes #9066

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension

Testing: tested with Mihon on Android

Verified https://magustoon.org/series/behind-the-laughter-of-the-surviving-princess/chapter-53 loads correctly, also tested random chapter of random manga from sanascans (another iken extension) was still properly ordered