### PR TITLE
MangoToons: fix pages parse

### DIFF
--- a/src/pt/mangotoons/build.gradle
+++ b/src/pt/mangotoons/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Mango Toons'
     extClass = '.MangoToons'
     baseUrl = 'https://mangotoons.com'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = false
 }
 

--- a/src/pt/mangotoons/src/eu/kanade/tachiyomi/extension/pt/mangotoons/DecryptMango.kt
+++ b/src/pt/mangotoons/src/eu/kanade/tachiyomi/extension/pt/mangotoons/DecryptMango.kt
@@ -8,7 +8,7 @@ import javax.crypto.spec.SecretKeySpec
 object DecryptMango {
 
     private const val SALT = "salt"
-    private const val KEY_STRING = "mangotoons_encryption_key_2025"
+    private const val KEY_STRING = "abmPisXlFjOLVTnYhbYQTpkWJtOGKwVttzLqstfjRBNVaEtQYF"
     private const val ALGORITHM = "AES"
     private const val TRANSFORMATION = "AES/CBC/PKCS5Padding"
 

--- a/src/pt/mangotoons/src/eu/kanade/tachiyomi/extension/pt/mangotoons/MangoToons.kt
+++ b/src/pt/mangotoons/src/eu/kanade/tachiyomi/extension/pt/mangotoons/MangoToons.kt
@@ -90,7 +90,8 @@ class MangoToons : HttpSource() {
 
     // ================= Details ===================
     override fun mangaDetailsRequest(manga: SManga): Request {
-        val id = manga.url.substringAfterLast("/")
+        val rawId = manga.url.substringAfterLast("/")
+        val id = rawId.substringBefore("-")
         return GET("$baseUrl/api/obras/$id", headers)
     }
 

--- a/src/pt/mangotoons/src/eu/kanade/tachiyomi/extension/pt/mangotoons/MangoToons.kt
+++ b/src/pt/mangotoons/src/eu/kanade/tachiyomi/extension/pt/mangotoons/MangoToons.kt
@@ -133,10 +133,12 @@ class MangoToons : HttpSource() {
 
         val result = decrypted.parseAs<MangoPageResponse>()
 
-        val pages = result.capitulo?.paginas ?: emptyList()
+        val capitulo = result.capitulo ?: return emptyList()
+        val obraId = capitulo.obraId
+        val chapterNumero = capitulo.numero
 
-        return pages.mapIndexed { index, pageDto ->
-            val imageUrl = if (pageDto.url.startsWith("http")) pageDto.url else "$cdnUrl/${pageDto.url}"
+        return capitulo.paginas.mapIndexed { index, pageDto ->
+            val imageUrl = "$baseUrl/api/cdn/obra/$obraId/capitulo/$chapterNumero/image/${pageDto.imageRandomId}"
             Page(index, imageUrl = imageUrl)
         }
     }

--- a/src/pt/mangotoons/src/eu/kanade/tachiyomi/extension/pt/mangotoons/MangoToonsDTO.kt
+++ b/src/pt/mangotoons/src/eu/kanade/tachiyomi/extension/pt/mangotoons/MangoToonsDTO.kt
@@ -100,12 +100,15 @@ class MangoPageResponse(
 
 @Serializable
 class MangoPageChapterDto(
+    @SerialName("obra_id") val obraId: Int,
+    val numero: Int,
     val paginas: List<MangoPageDto> = emptyList(),
 )
 
 @Serializable
 class MangoPageDto(
-    @SerialName("cdn_id") val url: String,
+    val numero: Int,
+    @SerialName("image_random_id") val imageRandomId: Long,
 )
 
 @Serializable


### PR DESCRIPTION
closes #12740

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
