### PR TITLE
[comictop] Use simpler url escaper

### DIFF
--- a/src/ja/comictop/build.gradle
+++ b/src/ja/comictop/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ComicTop'
     extClass = '.ComicTop'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/ja/comictop/src/eu/kanade/tachiyomi/extension/ja/comictop/ComicTop.kt
+++ b/src/ja/comictop/src/eu/kanade/tachiyomi/extension/ja/comictop/ComicTop.kt
@@ -6,6 +6,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
+import keiyoushi.utils.parseAs
 import keiyoushi.utils.tryParse
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
@@ -23,8 +24,6 @@ class ComicTop : ParsedHttpSource() {
     override val lang = "ja"
 
     override val supportsLatest = true
-
-    private val imageUrlPattern = Regex("""\"image\":\"([^\"]+)\"""")
 
     // ============================== Popular ===============================
     override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/popular/page/$page", headers)
@@ -95,13 +94,10 @@ class ComicTop : ParsedHttpSource() {
             ?: throw Exception("Could not find chapter data script")
 
         val chapterJson = script.substringAfter("var chapter = ").substringBefore("};") + "}"
+        val chapterData = chapterJson.parseAs<ChapterDataDto>()
 
-        val imageUrls = imageUrlPattern.findAll(chapterJson).map {
-            it.groupValues[1].replace("\\", "")
-        }.toList()
-
-        return imageUrls.mapIndexed { index, url ->
-            val fullUrl = if (url.startsWith("//")) "https:$url" else url
+        return chapterData.values.mapIndexed { index, imageDto ->
+            val fullUrl = if (imageDto.image.startsWith("//")) "https:${imageDto.image}" else imageDto.image
             Page(index, imageUrl = fullUrl)
         }
     }

--- a/src/ja/comictop/src/eu/kanade/tachiyomi/extension/ja/comictop/ComicTop.kt
+++ b/src/ja/comictop/src/eu/kanade/tachiyomi/extension/ja/comictop/ComicTop.kt
@@ -97,7 +97,7 @@ class ComicTop : ParsedHttpSource() {
         val chapterJson = script.substringAfter("var chapter = ").substringBefore("};") + "}"
 
         val imageUrls = imageUrlPattern.findAll(chapterJson).map {
-            it.groupValues[1].replace("""\\/""", "/")
+            it.groupValues[1].replace("\\", "")
         }.toList()
 
         return imageUrls.mapIndexed { index, url ->

--- a/src/ja/comictop/src/eu/kanade/tachiyomi/extension/ja/comictop/ComicTopDto.kt
+++ b/src/ja/comictop/src/eu/kanade/tachiyomi/extension/ja/comictop/ComicTopDto.kt
@@ -1,0 +1,10 @@
+package eu.kanade.tachiyomi.extension.ja.comictop
+
+import kotlinx.serialization.Serializable
+
+typealias ChapterDataDto = Map<String, ImageDto>
+
+@Serializable
+data class ImageDto(
+    val image: String,
+)


### PR DESCRIPTION
People were getting

`IllegalArgumentException: Expected URL scheme 'http' or 'https' but no scheme was found for \/\/cd...`

which suggests the urls weren't getting fully cleaned, use simpler pattern to remove all backslashes

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
