### PR TITLE
[KomikCast] Fix date parsing NumberFormatException

### DIFF
--- a/src/id/komikcast/build.gradle
+++ b/src/id/komikcast/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.KomikCast'
     themePkg = 'mangathemesia'
     baseUrl = 'https://komikcast03.com'
-    overrideVersionCode = 38
+    overrideVersionCode = 39
     isNsfw = false
 }
 

--- a/src/id/komikcast/src/eu/kanade/tachiyomi/extension/id/komikcast/KomikCast.kt
+++ b/src/id/komikcast/src/eu/kanade/tachiyomi/extension/id/komikcast/KomikCast.kt
@@ -14,6 +14,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
+import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
 
@@ -104,7 +105,7 @@ class KomikCast : MangaThemesia("Komik Cast", "https://komikcast03.com", "id", "
 
     private fun parseChapterDate2(date: String): Long {
         return if (date.endsWith("ago")) {
-            val value = date.split(' ')[0].toInt()
+            val value = date.split(' ')[0].toIntOrNull() ?: return 0L
             when {
                 "min" in date -> Calendar.getInstance().apply {
                     add(Calendar.MINUTE, -value)
@@ -130,9 +131,14 @@ class KomikCast : MangaThemesia("Komik Cast", "https://komikcast03.com", "id", "
             }
         } else {
             try {
-                dateFormat.parse(date)?.time ?: 0
+                SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.US).parse(date)?.time
+                    ?: dateFormat.parse(date)?.time ?: 0L
             } catch (_: Exception) {
-                0L
+                try {
+                    dateFormat.parse(date)?.time ?: 0L
+                } catch (_: Exception) {
+                    0L
+                }
             }
         }
     }


### PR DESCRIPTION
Fix NumberFormatException when parsing ISO 8601 date format. Changed toInt() to toIntOrNull() with safe fallback to prevent crashes when encountering dates like '2026-01-14T23:16:25+07:00'.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
