### PR TITLE
Komik Cast (ID): Fix ISO-8601 date parsing (#12745)

### DIFF
--- a/src/id/komikcast/build.gradle
+++ b/src/id/komikcast/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.KomikCast'
     themePkg = 'mangathemesia'
     baseUrl = 'https://komikcast03.com'
-    overrideVersionCode = 38
+    overrideVersionCode = 39
     isNsfw = false
 }
 


### PR DESCRIPTION
## Description
This PR resolves the `NumberFormatException` (issue #12745) caused by ISO-8601 date strings.

- Added date parsing logic in `KomikCast.kt` for ISO-8601.

Checklist:
- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions 
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension 

https://github.com/user-attachments/assets/2b1a9acc-4165-4cf4-8733-0d80966a60a6

