### PR TITLE
Astratoons (pt-BR): update image selector

### DIFF
--- a/src/pt/astratoons/build.gradle
+++ b/src/pt/astratoons/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Astratoons'
     extClass = '.Astratoons'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = false
 }
 

--- a/src/pt/astratoons/src/eu/kanade/tachiyomi/extension/pt/astratoons/Astratoons.kt
+++ b/src/pt/astratoons/src/eu/kanade/tachiyomi/extension/pt/astratoons/Astratoons.kt
@@ -126,8 +126,8 @@ class Astratoons : HttpSource() {
 
     override fun pageListParse(response: Response): List<Page> {
         val document = response.asJsoup()
-        return document.select("#reader-container canvas[data-src]").mapIndexed { index, element ->
-            val imageUrl = element.attr("data-src").replace("&amp;", "&")
+        return document.select("#reader-container img[src], #reader-container canvas[data-src]").mapIndexed { index, element ->
+            val imageUrl = element.attr("src").ifEmpty { element.attr("data-src") }
             Page(index, document.location(), imageUrl)
         }
     }


### PR DESCRIPTION
Should be backwards compatible in case they change it back. The `.replace` for `&amp;` seemed unnecessary so it was removed.

Closes #12774

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
