### PR TITLE
Publus/Bookwalker Global: extend Publus and migrate Bookwalker to Publus

### DIFF
--- a/lib/publus/src/main/java/eu/kanade/tachiyomi/lib/publus/Publus.kt
+++ b/lib/publus/src/main/java/eu/kanade/tachiyomi/lib/publus/Publus.kt
@@ -114,8 +114,8 @@ object Publus {
                 k1 = k1,
                 k2 = k2,
                 k3 = k3,
-                s = p.scrambled,
                 extra = p.extra,
+                s = p.scrambled,
             )
 
             val fragmentJson = fragmentData.toJsonString()

--- a/lib/publus/src/main/java/eu/kanade/tachiyomi/lib/publus/Publus.kt
+++ b/lib/publus/src/main/java/eu/kanade/tachiyomi/lib/publus/Publus.kt
@@ -9,6 +9,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.toJsonString
 import kotlinx.serialization.Serializable
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Response
@@ -31,6 +32,8 @@ class PublusFragment(
     val k1: List<Int>,
     val k2: List<Int>,
     val k3: List<Int>,
+    val extra: Map<String, String>? = null,
+    val s: Boolean = true,
 )
 
 class PublusPage(
@@ -44,6 +47,16 @@ class PublusPage(
     val blockHeight: Int,
     val width: Int,
     val height: Int,
+    val hti: String? = null,
+    val cfg: String? = null,
+    val bid: String? = null,
+    val uuid: String? = null,
+    val pfCd: String? = null,
+    val policy: String? = null,
+    val signature: String? = null,
+    val keyPairId: String? = null,
+    val extra: Map<String, String>? = null,
+    val scrambled: Boolean = true,
 )
 
 class PublusPageAttributes(
@@ -73,29 +86,42 @@ object Publus {
         val k2 = keys[1].toList()
         val k3 = keys[2].toList()
 
-        return pages.map {
-            val filename = PublusImage.generateFilename(it.filename, keys)
-            val imgUrl = imageUrlPrefix + filename
+        return pages.map { p ->
+            val filename = PublusImage.generateFilename(p.filename, keys)
+            val urlBuilder = (imageUrlPrefix + filename).toHttpUrl().newBuilder()
+
+            p.hti?.let { urlBuilder.addQueryParameter("hti", it) }
+            p.cfg?.let { urlBuilder.addQueryParameter("cfg", it) }
+            p.bid?.let { urlBuilder.addQueryParameter("bid", it) }
+            p.uuid?.let { urlBuilder.addQueryParameter("uuid", it) }
+            p.pfCd?.let { urlBuilder.addQueryParameter("pfCd", it) }
+            p.policy?.let { urlBuilder.addQueryParameter("Policy", it) }
+            p.signature?.let { urlBuilder.addQueryParameter("Signature", it) }
+            p.keyPairId?.let { urlBuilder.addQueryParameter("Key-Pair-Id", it) }
+
+            val imgUrl = urlBuilder.build().toString()
 
             val fragmentData = PublusFragment(
-                file = it.filename,
-                no = it.no,
-                ns = it.ns,
-                ps = it.ps,
-                rs = it.rs,
-                bw = it.blockWidth,
-                bh = it.blockHeight,
-                cw = it.width,
-                ch = it.height,
+                file = p.filename,
+                no = p.no,
+                ns = p.ns,
+                ps = p.ps,
+                rs = p.rs,
+                bw = p.blockWidth,
+                bh = p.blockHeight,
+                cw = p.width,
+                ch = p.height,
                 k1 = k1,
                 k2 = k2,
-                k3 = k3
+                k3 = k3,
+                s = p.scrambled,
+                extra = p.extra,
             )
 
             val fragmentJson = fragmentData.toJsonString()
             val fragment = Base64.encodeToString(fragmentJson.toByteArray(), Base64.URL_SAFE or Base64.NO_WRAP)
 
-            Page(it.index, imageUrl = "$imgUrl#$fragment")
+            Page(p.index, imageUrl = "$imgUrl#$fragment")
         }
     }
 
@@ -109,14 +135,20 @@ object Publus {
             }
 
             val response = chain.proceed(request)
+            if (!response.isSuccessful) {
+                return response
+            }
 
             val fragmentJson = String(
                 Base64.decode(url.fragment, Base64.URL_SAFE),
                 StandardCharsets.UTF_8
             )
             val params = fragmentJson.parseAs<PublusFragment>()
+            if (!params.s) {
+                return response
+            }
 
-            val bitmap = BitmapFactory.decodeStream(response.body.byteStream())
+            val bitmap = BitmapFactory.decodeStream(response.body.byteStream()) ?: return response
 
             val keys = listOf(
                 params.k1.toIntArray(),

--- a/lib/publus/src/main/java/eu/kanade/tachiyomi/lib/publus/Publus.kt
+++ b/lib/publus/src/main/java/eu/kanade/tachiyomi/lib/publus/Publus.kt
@@ -468,6 +468,10 @@ object Publus {
 
     object PublusImage {
         fun generateFilename(pageId: String, keys: List<IntArray>): String {
+            if (keys.isEmpty() || keys[0].isEmpty()) {
+                return "$pageId/0.jpeg"
+            }
+
             val k1 = keys[0]; val k2 = keys[1]; val k3 = keys[2]
             val fileName = "0"
             val parentFolder = "$pageId/"

--- a/src/en/bookwalker/build.gradle
+++ b/src/en/bookwalker/build.gradle
@@ -1,8 +1,12 @@
 ext {
     extName = 'BookWalker Global'
     extClass = '.BookWalker'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 
 apply from: "$rootDir/common.gradle"
+
+dependencies {
+    implementation(project(":lib:publus"))
+}

--- a/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/BookWalker.kt
+++ b/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/BookWalker.kt
@@ -738,25 +738,23 @@ class BookWalker : ConfigurableSource, ParsedHttpSource(), BookWalkerPreferences
                     put("cid", cid)
                     put("bid", "0")
                     put("cr", cr!!)
-                    put("base", viewerUrl)
                     if (u1 != null) put("u1", u1)
                     if (u2 != null) put("u2", u2)
                 }
 
-                val pageDefinitions = container.contents.mapIndexed { index, contentEntry ->
-                    val pageJson = rootJson[contentEntry.file]
-                        ?: throw Exception("Page config not found for ${contentEntry.file}")
+                val pageContent = container.contents.map {
+                    val pageJson = rootJson[it.file]
+                        ?: throw Exception("Page config not found for ${it.file}")
 
                     val pageConfig = pageJson.toString().parseAs<PublusPageConfig>()
                     val details = pageConfig.fileLinkInfo.pageLinkInfoList[0].page
                     val isScrambled = details.blockWidth > 0 && details.blockHeight > 0
-
                     val bw = if (details.blockWidth == 0) 32 else details.blockWidth
                     val bh = if (details.blockHeight == 0) 32 else details.blockHeight
 
                     PublusPage(
-                        index = index,
-                        filename = contentEntry.file,
+                        index = it.index,
+                        filename = it.file,
                         no = details.no,
                         ns = details.ns,
                         ps = details.ps,
@@ -778,7 +776,7 @@ class BookWalker : ConfigurableSource, ParsedHttpSource(), BookWalkerPreferences
                     )
                 }
 
-                generatePages(pageDefinitions, result.keys, contentUrl)
+                generatePages(pageContent, result.keys, contentUrl)
             } else {
                 webViewViewer(initialReaderUrl, pagesCount)
             }
@@ -871,8 +869,7 @@ class BookWalker : ConfigurableSource, ParsedHttpSource(), BookWalkerPreferences
                         val currentCache = authCache[cid]
                         if (currentCache == null || System.currentTimeMillis() - currentCache.second > 45000) {
                             try {
-                                val viewerBase = extra["base"]!!
-                                val refreshUrl = "$viewerBase/browserWebApi/c".toHttpUrl().newBuilder().apply {
+                                val refreshUrl = "$viewerUrl/browserWebApi/c".toHttpUrl().newBuilder().apply {
                                     addQueryParameter("cid", cid)
                                     addQueryParameter("BID", extra["bid"])
                                     addQueryParameter("cr", extra["cr"])

--- a/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/BookWalker.kt
+++ b/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/BookWalker.kt
@@ -1,16 +1,33 @@
 package eu.kanade.tachiyomi.extension.en.bookwalker
 
+import android.annotation.SuppressLint
+import android.app.Application
+import android.os.Handler
+import android.os.Looper
 import android.text.Editable
 import android.text.TextWatcher
+import android.util.Base64
 import android.util.Log
+import android.webkit.WebView
+import android.webkit.WebViewClient
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
+import eu.kanade.tachiyomi.extension.en.bookwalker.dto.AuthInfo
 import eu.kanade.tachiyomi.extension.en.bookwalker.dto.BookUpdateDto
+import eu.kanade.tachiyomi.extension.en.bookwalker.dto.CPhpResponse
+import eu.kanade.tachiyomi.extension.en.bookwalker.dto.ConfigPack
 import eu.kanade.tachiyomi.extension.en.bookwalker.dto.HoldBooksInfoDto
+import eu.kanade.tachiyomi.extension.en.bookwalker.dto.PublusConfiguration
+import eu.kanade.tachiyomi.extension.en.bookwalker.dto.PublusPageConfig
 import eu.kanade.tachiyomi.extension.en.bookwalker.dto.SeriesDto
 import eu.kanade.tachiyomi.extension.en.bookwalker.dto.SingleDto
+import eu.kanade.tachiyomi.lib.publus.Publus.Decoder
+import eu.kanade.tachiyomi.lib.publus.Publus.PublusInterceptor
+import eu.kanade.tachiyomi.lib.publus.Publus.generatePages
+import eu.kanade.tachiyomi.lib.publus.PublusFragment
+import eu.kanade.tachiyomi.lib.publus.PublusPage
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.await
@@ -31,6 +48,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonElement
 import okhttp3.Call
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -41,6 +59,12 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import rx.Observable
 import rx.Single
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.regex.PatternSyntaxException
 import kotlin.collections.component1
 
@@ -58,8 +82,10 @@ class BookWalker : ConfigurableSource, ParsedHttpSource(), BookWalkerPreferences
     private val rimgUrl = "https://rimg.$domain"
     private val cUrl = "https://c.$domain"
     private val memberApiUrl = "https://member-app.$domain/api"
+    private val viewerUrl = "https://viewer.$domain"
 
-    override val client = network.client.newBuilder()
+    override val client = network.cloudflareClient.newBuilder()
+        .addInterceptor(PublusInterceptor())
         .addInterceptor(BookWalkerImageRequestInterceptor(this))
         .build()
 
@@ -628,6 +654,8 @@ class BookWalker : ConfigurableSource, ParsedHttpSource(), BookWalkerPreferences
         chapter_number = chapterNumber?.second ?: -1f
     }
 
+    private val authCache = ConcurrentHashMap<String, Pair<AuthInfo, Long>>()
+
     override fun fetchPageList(chapter: SChapter): Observable<List<Page>> {
         return rxSingle {
             val document = client.newCall(GET(baseUrl + chapter.url, callHeaders))
@@ -646,7 +674,7 @@ class BookWalker : ConfigurableSource, ParsedHttpSource(), BookWalkerPreferences
             }
 
             val isFreeChapter = document.selectFirst(".a-cart-btn:contains(Free)") != null
-            val readerUrl = document.selectFirst("a.a-read-on-btn")?.attr("href")
+            val initialReaderUrl = document.selectFirst("a.a-read-on-btn")?.attr("href")
                 ?: if (attemptToReadPreviews || isFreeChapter) {
                     document.selectFirst(".free-preview > a")?.attr("href")
                         ?: throw Error("No preview available")
@@ -654,47 +682,249 @@ class BookWalker : ConfigurableSource, ParsedHttpSource(), BookWalkerPreferences
                     throw Error("You don't own this chapter, or you aren't logged in")
                 }
 
-            // We need to use the full cooperative URL every time we try to load a chapter since
-            // the reader page relies on transient cookies set in the cooperative flow.
-            // This call is simply being used to ensure the user is logged in.
-            // Note that this is not fool-proof since the app may cache the page list, so sometimes
-            // the best we can do is detect that the user is not logged in when loading the page
-            // and fail to load the image at that point.
-            tryCooperativeRedirect(readerUrl, "You must log in again. Open in WebView and click the shopping cart.")
+            val chapterUrl = client.newCall(GET(initialReaderUrl, callHeaders)).await().request.url
+            val cid = chapterUrl.queryParameter("cid")
+            val cty = chapterUrl.queryParameter("cty")?.toIntOrNull()
+            val isTrial = chapterUrl.host == "viewer-trial.$domain"
 
-            IntRange(0, pagesCount - 1).map {
-                // The page index query parameter exists only to prevent the app from trying to
-                // be smart about caching by page URLs, since the URL is the same for all the pages.
-                // It doesn't do anything, and in fact gets stripped back out in imageRequest.
-                Page(
-                    it,
-                    imageUrl = readerUrl.toHttpUrl().newBuilder()
-                        .setQueryParameter(PAGE_INDEX_QUERY_PARAM, it.toString())
-                        .build()
-                        .toString(),
-                )
+            val cookies = client.cookieJar.loadForRequest(chapterUrl)
+            val u1 = cookies.find { it.name == "u1" }?.value
+            val u2 = cookies.find { it.name == "u2" }?.value
+
+            if (cid != null && !isTrial) {
+                if (cty != null && cty != 1 && cty != 2) {
+                    return@rxSingle webViewViewer(initialReaderUrl, pagesCount)
+                }
+
+                val loaderUrl = "$viewerUrl/browserWebApi/03/getLoader"
+                val loaderScript = client.newCall(GET(loaderUrl, callHeaders)).awaitSuccess().body.string()
+                val cr = fetchCr(loaderScript, chapterUrl.toString())
+                val cApiUrl = "$viewerUrl/browserWebApi/c".toHttpUrl().newBuilder().apply {
+                    addQueryParameter("cid", cid)
+                    if (u1 != null) addQueryParameter("u1", u1)
+                    if (u2 != null) addQueryParameter("u2", u2)
+                    addQueryParameter("BID", "0") // universal
+                    addQueryParameter("cr", cr)
+                }.build()
+
+                val cResponse = client.newCall(GET(cApiUrl, callHeaders)).awaitSuccess()
+                val content = cResponse.parseAs<CPhpResponse>()
+                if (content.cty != 1 && content.cty != 2) {
+                    return@rxSingle webViewViewer(initialReaderUrl, pagesCount)
+                }
+
+                authCache[cid] = Pair(content.authInfo, System.currentTimeMillis())
+                val contentUrl = content.url
+                val configPack = "configuration_pack.json"
+                val configUrl = "$contentUrl$configPack".toHttpUrl().newBuilder()
+                    .addQueryParameter("hti", content.authInfo.hti)
+                    .addQueryParameter("cfg", content.authInfo.cfg.toString())
+                    .addQueryParameter("bid", content.authInfo.bid)
+                    .addQueryParameter("uuid", content.authInfo.uuid)
+                    .addQueryParameter("pfCd", content.authInfo.pfCd)
+                    .addQueryParameter("Policy", content.authInfo.policy)
+                    .addQueryParameter("Signature", content.authInfo.signature)
+                    .addQueryParameter("Key-Pair-Id", content.authInfo.keyPairId)
+                    .build()
+
+                val configResponse = client.newCall(GET(configUrl, callHeaders)).awaitSuccess()
+                val packData = configResponse.parseAs<ConfigPack>().data
+                val result = Decoder(packData).decode()
+                val rootJson = result.json.parseAs<Map<String, JsonElement>>()
+                val configElement = rootJson["configuration"] ?: throw Exception("Configuration not found in decrypted JSON")
+                val container = configElement.parseAs<PublusConfiguration>()
+
+                val sessionData = mutableMapOf<String, String>().apply {
+                    put("cid", cid)
+                    put("bid", "0")
+                    put("cr", cr!!)
+                    put("base", viewerUrl)
+                    if (u1 != null) put("u1", u1)
+                    if (u2 != null) put("u2", u2)
+                }
+
+                val pageDefinitions = container.contents.mapIndexed { index, contentEntry ->
+                    val pageJson = rootJson[contentEntry.file]
+                        ?: throw Exception("Page config not found for ${contentEntry.file}")
+
+                    val pageConfig = pageJson.toString().parseAs<PublusPageConfig>()
+                    val details = pageConfig.fileLinkInfo.pageLinkInfoList[0].page
+                    val isScrambled = details.blockWidth > 0 && details.blockHeight > 0
+
+                    val bw = if (details.blockWidth == 0) 32 else details.blockWidth
+                    val bh = if (details.blockHeight == 0) 32 else details.blockHeight
+
+                    PublusPage(
+                        index = index,
+                        filename = contentEntry.file,
+                        no = details.no,
+                        ns = details.ns,
+                        ps = details.ps,
+                        rs = details.rs,
+                        blockWidth = bw,
+                        blockHeight = bh,
+                        width = details.size.width,
+                        height = details.size.height,
+                        hti = content.authInfo.hti,
+                        cfg = content.authInfo.cfg.toString(),
+                        bid = content.authInfo.bid,
+                        uuid = content.authInfo.uuid,
+                        pfCd = content.authInfo.pfCd,
+                        policy = content.authInfo.policy,
+                        signature = content.authInfo.signature,
+                        keyPairId = content.authInfo.keyPairId,
+                        extra = sessionData,
+                        scrambled = isScrambled,
+                    )
+                }
+
+                generatePages(pageDefinitions, result.keys, contentUrl)
+            } else {
+                webViewViewer(initialReaderUrl, pagesCount)
             }
         }.toObservable()
+    }
+
+    private suspend fun webViewViewer(url: String, pagesCount: Int): List<Page> {
+        // We need to use the full cooperative URL every time we try to load a chapter since
+        // the reader page relies on transient cookies set in the cooperative flow.
+        // This call is simply being used to ensure the user is logged in.
+        // Note that this is not fool-proof since the app may cache the page list, so sometimes
+        // the best we can do is detect that the user is not logged in when loading the page
+        // and fail to load the image at that point.
+        tryCooperativeRedirect(url, "You must log in again. Open in WebView and click the shopping cart.")
+        return IntRange(0, pagesCount - 1).map {
+            // The page index query parameter exists only to prevent the app from trying to
+            // be smart about caching by page URLs, since the URL is the same for all the pages.
+            // It doesn't do anything, and in fact gets stripped back out in imageRequest.
+            Page(
+                it,
+                imageUrl = url.toHttpUrl().newBuilder()
+                    .setQueryParameter(PAGE_INDEX_QUERY_PARAM, it.toString())
+                    .build()
+                    .toString(),
+            )
+        }
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun fetchCr(scriptContent: String, viewerUrl: String): String? {
+        val match = Regex("""^(\w+)=function\(\)\{[\s\S]*?\};""", RegexOption.MULTILINE).find(scriptContent)
+            ?: return null
+        val functionName = match.groupValues[1]
+
+        val latch = CountDownLatch(1)
+        var result: String? = null
+
+        Handler(Looper.getMainLooper()).post {
+            val webView = WebView(Injekt.get<Application>())
+            with(webView.settings) {
+                javaScriptEnabled = true
+                domStorageEnabled = true
+                databaseEnabled = true
+                blockNetworkImage = true
+            }
+            webView.webViewClient = object : WebViewClient() {
+                override fun onPageFinished(view: WebView, url: String?) {
+                    view.evaluateJavascript(scriptContent) {
+                        view.evaluateJavascript("$functionName()") { // c9P = function()
+                            result = it?.trim('"')
+                            if (result == "null" || result.isNullOrBlank()) result = null
+                            latch.countDown()
+                        }
+                    }
+                }
+            }
+            webView.loadDataWithBaseURL(viewerUrl, " ", "text/html", "utf-8", null)
+        }
+
+        latch.await(10, TimeUnit.SECONDS)
+        return result
     }
 
     override fun pageListParse(document: Document): List<Page> =
         throw UnsupportedOperationException()
 
+    override fun imageUrlParse(response: Response): String {
+        return response.request.url.toString()
+    }
+
     override fun imageUrlParse(document: Document): String =
         throw UnsupportedOperationException()
 
     override fun imageRequest(page: Page): Request {
+        val imageUrl = page.imageUrl!!
+        if (imageUrl.contains("#")) {
+            val fragment = imageUrl.substringAfter("#")
+            val fragmentJson = String(Base64.decode(fragment, Base64.URL_SAFE), StandardCharsets.UTF_8)
+            val params = fragmentJson.parseAs<PublusFragment>()
+            val extra = params.extra
+            if (extra != null && extra.containsKey("cid")) {
+                val cid = extra["cid"]!!
+                val cached = authCache[cid]
+
+                var authInfo = cached?.first
+
+                // Auth data expires after 60 seconds
+                if (cached == null || System.currentTimeMillis() - cached.second > 45000) {
+                    synchronized(authCache) {
+                        val currentCache = authCache[cid]
+                        if (currentCache == null || System.currentTimeMillis() - currentCache.second > 45000) {
+                            try {
+                                val viewerBase = extra["base"]!!
+                                val refreshUrl = "$viewerBase/browserWebApi/c".toHttpUrl().newBuilder().apply {
+                                    addQueryParameter("cid", cid)
+                                    addQueryParameter("BID", extra["bid"])
+                                    addQueryParameter("cr", extra["cr"])
+                                    extra["u1"]?.let { addQueryParameter("u1", it) }
+                                    extra["u2"]?.let { addQueryParameter("u2", it) }
+                                }.build()
+
+                                val response = client.newCall(GET(refreshUrl, callHeaders)).execute()
+                                if (response.isSuccessful) {
+                                    val newCData = response.parseAs<CPhpResponse>()
+                                    authInfo = newCData.authInfo
+                                    authCache[cid] = Pair(newCData.authInfo, System.currentTimeMillis())
+                                }
+                                response.close()
+                            } catch (_: Exception) {
+                            }
+                        } else {
+                            authInfo = currentCache.first
+                        }
+                    }
+                }
+
+                if (authInfo != null) {
+                    val baseUrl = imageUrl.substringBefore("?")
+                    val newUrl = baseUrl.toHttpUrl().newBuilder().apply {
+                        addQueryParameter("hti", authInfo!!.hti)
+                        addQueryParameter("cfg", authInfo!!.cfg.toString())
+                        addQueryParameter("bid", authInfo!!.bid)
+                        addQueryParameter("uuid", authInfo!!.uuid)
+                        addQueryParameter("pfCd", authInfo!!.pfCd)
+                        addQueryParameter("Policy", authInfo!!.policy)
+                        addQueryParameter("Signature", authInfo!!.signature)
+                        addQueryParameter("Key-Pair-Id", authInfo!!.keyPairId)
+                    }.build().toString()
+
+                    return GET("$newUrl#$fragment", callHeaders)
+                }
+            }
+            return GET(imageUrl, callHeaders)
+        }
+
         // This URL doesn't actually contain the image. It will be intercepted, and the actual image
         // will be extracted from a webview of the URL being sent here.
-        val imageUrl = page.imageUrl!!.toHttpUrl()
+
         return GET(
-            imageUrl.newBuilder()
+            imageUrl.toHttpUrl().newBuilder()
                 .removeAllQueryParameters(PAGE_INDEX_QUERY_PARAM)
                 .build()
                 .toString(),
             callHeaders.newBuilder()
                 .set(HEADER_IS_REQUEST_FROM_EXTENSION, "true")
-                .set(HEADER_PAGE_INDEX, imageUrl.queryParameter(PAGE_INDEX_QUERY_PARAM)!!)
+                .set(HEADER_PAGE_INDEX, imageUrl.toHttpUrl().queryParameter(PAGE_INDEX_QUERY_PARAM)!!)
                 .build(),
         )
     }
@@ -783,12 +1013,12 @@ class BookWalker : ConfigurableSource, ParsedHttpSource(), BookWalkerPreferences
                 else -> null
             }
             numericId?.let { "$cUrl/coverImage_${it - 1}.$extension" } ?: url
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             url
         }
     }
 
-    // Fetch manga details form api.
+    // Fetch manga details from api.
     private suspend fun fetchBookUpdate(uuid: String): BookUpdateDto? {
         val apiUrl = "$memberApiUrl/books/updates".toHttpUrl().newBuilder()
             .addQueryParameter("fileType", "EPUB")

--- a/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/BookWalker.kt
+++ b/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/BookWalker.kt
@@ -892,18 +892,17 @@ class BookWalker : ConfigurableSource, ParsedHttpSource(), BookWalkerPreferences
                     }
                 }
 
-                @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
-                if (authInfo != null) {
+                authInfo?.let {
                     val baseUrl = imageUrl.substringBefore("?")
                     val newUrl = baseUrl.toHttpUrl().newBuilder().apply {
-                        addQueryParameter("hti", authInfo!!.hti)
-                        addQueryParameter("cfg", authInfo!!.cfg.toString())
-                        addQueryParameter("bid", authInfo!!.bid)
-                        addQueryParameter("uuid", authInfo!!.uuid)
-                        addQueryParameter("pfCd", authInfo!!.pfCd)
-                        addQueryParameter("Policy", authInfo!!.policy)
-                        addQueryParameter("Signature", authInfo!!.signature)
-                        addQueryParameter("Key-Pair-Id", authInfo!!.keyPairId)
+                        addQueryParameter("hti", it.hti)
+                        addQueryParameter("cfg", it.cfg.toString())
+                        addQueryParameter("bid", it.bid)
+                        addQueryParameter("uuid", it.uuid)
+                        addQueryParameter("pfCd", it.pfCd)
+                        addQueryParameter("Policy", it.policy)
+                        addQueryParameter("Signature", it.signature)
+                        addQueryParameter("Key-Pair-Id", it.keyPairId)
                     }.build().toString()
 
                     return GET("$newUrl#$fragment", callHeaders)

--- a/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/BookWalker.kt
+++ b/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/BookWalker.kt
@@ -723,7 +723,7 @@ class BookWalker : ConfigurableSource, ParsedHttpSource(), BookWalkerPreferences
                     return@rxSingle webViewViewer(readerUrl, pagesCount)
                 }
 
-                // For trail pages, auth data is valid for 1 hour.
+                // For trial pages, auth data is valid for 1 hour.
                 // For normal pages, auth data is valid for 60 seconds.
                 if (!isTrial) {
                     authCache[cid] = Pair(content.authInfo, System.currentTimeMillis())

--- a/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/dto/PublusDto.kt
+++ b/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/dto/PublusDto.kt
@@ -1,0 +1,70 @@
+package eu.kanade.tachiyomi.extension.en.bookwalker.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+class CPhpResponse(
+    val url: String,
+    val cty: Int,
+    @SerialName("auth_info") val authInfo: AuthInfo,
+)
+
+@Serializable
+class AuthInfo(
+    val hti: String,
+    val cfg: Int,
+    val bid: String,
+    val uuid: String,
+    val pfCd: String,
+    @SerialName("Policy") val policy: String,
+    @SerialName("Signature") val signature: String,
+    @SerialName("Key-Pair-Id") val keyPairId: String,
+)
+
+@Serializable
+class ConfigPack(
+    val data: String,
+)
+
+@Serializable
+class PublusConfiguration(
+    val contents: List<PublusContentEntry>,
+)
+
+@Serializable
+class PublusContentEntry(
+    val file: String,
+)
+
+@Serializable
+class PublusPageConfig(
+    @SerialName("FileLinkInfo") val fileLinkInfo: PublusFileLinkInfo,
+)
+
+@Serializable
+class PublusFileLinkInfo(
+    @SerialName("PageLinkInfoList") val pageLinkInfoList: List<PublusPageLinkInfoWrapper>,
+)
+
+@Serializable
+class PublusPageLinkInfoWrapper(
+    @SerialName("Page") val page: PublusPageDetails,
+)
+
+@Serializable
+class PublusPageDetails(
+    @SerialName("No") val no: Int = 0,
+    @SerialName("NS") val ns: Long = 0L,
+    @SerialName("PS") val ps: Long = 0L,
+    @SerialName("RS") val rs: Long = 0L,
+    @SerialName("BlockWidth") val blockWidth: Int = 0,
+    @SerialName("BlockHeight") val blockHeight: Int = 0,
+    @SerialName("Size") val size: PublusPageSize,
+)
+
+@Serializable
+class PublusPageSize(
+    @SerialName("Width") val width: Int,
+    @SerialName("Height") val height: Int,
+)

--- a/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/dto/PublusDto.kt
+++ b/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/dto/PublusDto.kt
@@ -12,10 +12,9 @@ class CPhpResponse(
 
 @Serializable
 class AuthInfo(
-    val hti: String,
-    val cfg: Int,
-    val bid: String,
-    val uuid: String,
+    val hti: String?,
+    val cfg: Int?,
+    val uuid: String?,
     val pfCd: String,
     @SerialName("Policy") val policy: String,
     @SerialName("Signature") val signature: String,

--- a/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/dto/PublusDto.kt
+++ b/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/dto/PublusDto.kt
@@ -35,6 +35,7 @@ class PublusConfiguration(
 @Serializable
 class PublusContentEntry(
     val file: String,
+    val index: Int,
 )
 
 @Serializable


### PR DESCRIPTION
WebView viewer is still used for novels because Publus works differently, as the text spans more pages than actually exist, but scramble and hash generation logic would work on novel pages.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
