### PR TITLE
Update Mangahub.kt

### DIFF
--- a/src/ru/mangahub/build.gradle
+++ b/src/ru/mangahub/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Mangahub'
     extClass = '.Mangahub'
-    extVersionCode = 19
+    extVersionCode = 20
     isNsfw = true
 }
 

--- a/src/ru/mangahub/src/eu/kanade/tachiyomi/extension/ru/mangahub/Mangahub.kt
+++ b/src/ru/mangahub/src/eu/kanade/tachiyomi/extension/ru/mangahub/Mangahub.kt
@@ -118,7 +118,7 @@ open class Mangahub : ParsedHttpSource() {
     override fun searchMangaNextPageSelector(): String? = popularMangaNextPageSelector()
 
     override fun chapterListRequest(manga: SManga): Request {
-        return GET(baseUrl + ("/chapters/" + manga.url.removePrefix("/title/")), headers)
+        return GET(baseUrl + manga.url + "/chapters", headers)
     }
 
     override fun mangaDetailsParse(document: Document): SManga {


### PR DESCRIPTION
Fix Mangahub 404 error by appending '/chapters' to the URL instead of using the old prefix.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
