### PR TITLE
Happymh: Fix chapters pulling and reading url generation

### DIFF
--- a/src/zh/happymh/build.gradle
+++ b/src/zh/happymh/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Happymh'
     extClass = '.Happymh'
-    extVersionCode = 18
+    extVersionCode = 19
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/zh/happymh/src/eu/kanade/tachiyomi/extension/zh/happymh/dto/HappymhDto.kt
+++ b/src/zh/happymh/src/eu/kanade/tachiyomi/extension/zh/happymh/dto/HappymhDto.kt
@@ -25,7 +25,6 @@ class ChapterByPageResponseDataItem(
     val id: Long,
     val chapterName: String,
     val order: Int,
-    val codes: String,
 )
 
 @Serializable


### PR DESCRIPTION
Closes https://github.com/keiyoushi/extensions-source/issues/12939

The site updated its API, removing the codes field (causing MissingFieldException) and switching the reading endpoint to use manga slug + chapter ID. This PR updates the DTO and logic to match, and removes now-obsolete lookup code.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
