### PR TITLE
Happymh: Fix WebpExceedRange

### DIFF
--- a/src/zh/happymh/build.gradle
+++ b/src/zh/happymh/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Happymh'
     extClass = '.Happymh'
-    extVersionCode = 19
+    extVersionCode = 20
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/zh/happymh/src/eu/kanade/tachiyomi/extension/zh/happymh/Happymh.kt
+++ b/src/zh/happymh/src/eu/kanade/tachiyomi/extension/zh/happymh/Happymh.kt
@@ -255,7 +255,13 @@ class Happymh : HttpSource(), ConfigurableSource {
             // If n == 1, the image is from next chapter
             .filter { it.n == 0 }
             .mapIndexed { index, it ->
-                Page(index, "", it.url)
+                // Strip q=... for large images (> 16383px) to avoid WebpExceedRange error
+                val url = if (it.width > 16383 || it.height > 16383) {
+                    it.url.substringBefore("?q=")
+                } else {
+                    it.url
+                }
+                Page(index, "", url)
             }
     }
 

--- a/src/zh/happymh/src/eu/kanade/tachiyomi/extension/zh/happymh/dto/HappymhDto.kt
+++ b/src/zh/happymh/src/eu/kanade/tachiyomi/extension/zh/happymh/dto/HappymhDto.kt
@@ -45,5 +45,5 @@ data class PageListResponseDto(val data: PageListData)
 @Serializable
 data class PageListData(val scans: List<PageDto>) {
     @Serializable
-    data class PageDto(val n: Int, val url: String)
+    data class PageDto(val n: Int, val url: String, val width: Int = 0, val height: Int = 0)
 }


### PR DESCRIPTION
Closes https://github.com/keiyoushi/extensions-source/issues/11567

When accessing large image (>16383px in either dimension), the CDN returns a 400 XML error with Code=WebpExceedRange, causing the page to fail to load in app. 

Example response:
```
<?xml version="1.0" encoding="UTF-8"?>
<Error>
  <Code>WebpExceedRange</Code>
  <Message>Maximum width and height allowed is 16383 pixels for converting webp.</Message>
  <RequestId>{...}</RequestId>
  <HostId>ruicdn.happymh.com</HostId>
  <EC>0040-00000011</EC>
  <RecommendDoc>https://api.alibabacloud.com/troubleshoot?q=0040-00000011</RecommendDoc>
</Error>
```

The site reader itself just downloads and renders the original image directly. Here we do the same.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
