### PR TITLE
LectorJPG: Fix chapter invalid host

### DIFF
--- a/src/es/lectorjpg/build.gradle
+++ b/src/es/lectorjpg/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'LectorJPG'
     extClass = '.LectorJpg'
-    extVersionCode = 44
+    extVersionCode = 45
     isNsfw = true
 }
 

--- a/src/es/lectorjpg/src/eu/kanade/tachiyomi/extension/es/lectorjpg/LectorJpg.kt
+++ b/src/es/lectorjpg/src/eu/kanade/tachiyomi/extension/es/lectorjpg/LectorJpg.kt
@@ -147,7 +147,7 @@ class LectorJpg : HttpSource() {
         return document.select("div.grid > a.group").map { element ->
             SChapter.create().apply {
                 name = element.selectFirst("span.truncate")!!.text()
-                url = element.selectFirst("a")!!.attr("href")
+                setUrlWithoutDomain(element.selectFirst("a")!!.attr("abs:href"))
                 date_upload = element.selectFirst("span.w-fit")?.text()?.let { parseChapterDate(it) } ?: 0L
             }
         }


### PR DESCRIPTION
Closes #12975 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
