### PR TITLE
DocTruyen3Q: Fix images load

### DIFF
--- a/src/vi/doctruyen3q/build.gradle
+++ b/src/vi/doctruyen3q/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.DocTruyen3Q'
     themePkg = 'wpcomics'
     baseUrl = 'https://doctruyen3qhubz.com'
-    overrideVersionCode = 16
+    overrideVersionCode = 17
     isNsfw = true
 }
 

--- a/src/vi/doctruyen3q/src/eu/kanade/tachiyomi/extension/vi/doctruyen3q/DocTruyen3Q.kt
+++ b/src/vi/doctruyen3q/src/eu/kanade/tachiyomi/extension/vi/doctruyen3q/DocTruyen3Q.kt
@@ -33,10 +33,9 @@ class DocTruyen3Q :
     ConfigurableSource {
 
     override fun pageListParse(document: Document): List<Page> {
-        return document.select("img.chapter-img").mapIndexed { index, element ->
-            val rawUrl = when { element.hasClass("lazy-load") -> element.attr("data-src") else -> element.attr("src") }
-            val fixedUrl = when { rawUrl.startsWith("//") -> "https:$rawUrl" else -> rawUrl }
-            Page(index, imageUrl = fixedUrl)
+        return document.select("div.page-chapter[id] img").mapIndexed { index, element ->
+            val rawUrl = element.attr("abs:src").ifEmpty { element.attr("abs:data-src") }
+            Page(index, imageUrl = rawUrl)
         }.distinctBy { it.imageUrl }
     }
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
