### PR TITLE
komikcast: restore override id

### DIFF
--- a/src/id/komikcast/build.gradle
+++ b/src/id/komikcast/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Komik Cast'
     extClass = '.KomikCast'
-    extVersionCode = 72
+    extVersionCode = 73
     isNsfw = false
 }
 

--- a/src/id/komikcast/src/eu/kanade/tachiyomi/extension/id/komikcast/KomikCast.kt
+++ b/src/id/komikcast/src/eu/kanade/tachiyomi/extension/id/komikcast/KomikCast.kt
@@ -21,6 +21,9 @@ class KomikCast : HttpSource() {
 
     override val name = "Komik Cast"
 
+    // Formerly "Komik Cast (WP Manga Stream)"
+    override val id = 972717448578983812
+
     override val baseUrl = "https://v1.komikcast.fit"
 
     private val apiUrl = "https://be.komikcast.fit"


### PR DESCRIPTION
Close: #13027 
This was removed in #12994 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
