### PR TITLE
thunderscans: fix lavascans locked chapters

### DIFF
--- a/src/all/thunderscans/build.gradle
+++ b/src/all/thunderscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ThunderScansFactory'
     themePkg = 'mangathemesia'
     baseUrl = 'https://en-thunderscans.com'
-    overrideVersionCode = 11
+    overrideVersionCode = 12
     isNsfw = false
 }
 

--- a/src/all/thunderscans/src/eu/kanade/tachiyomi/extension/all/thunderscans/ThunderScansFactory.kt
+++ b/src/all/thunderscans/src/eu/kanade/tachiyomi/extension/all/thunderscans/ThunderScansFactory.kt
@@ -75,7 +75,14 @@ class LavaScans : ThunderScansBase(
 
     override val seriesThumbnailSelector = ".lh-poster img"
 
-    override fun chapterListSelector() = "#chapters-list-container .ch-item"
+    override fun chapterListSelector(): String {
+        val base = "#chapters-list-container .ch-item"
+        return if (preferences.getBoolean("pref_hide_paid_chapters", true)) {
+            "$base:not(.locked)"
+        } else {
+            base
+        }
+    }
 }
 
 class ThunderScans : ThunderScansBase(


### PR DESCRIPTION
Close: #13015 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
