### PR TITLE
HattoriManga: fix image url

### DIFF
--- a/src/tr/hattorimanga/build.gradle
+++ b/src/tr/hattorimanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hattori Manga'
     extClass = '.HattoriManga'
-    extVersionCode = 41
+    extVersionCode = 42
     isNsfw = true
 }
 

--- a/src/tr/hattorimanga/src/eu/kanade/tachiyomi/extension/tr/hattorimanga/HattoriManga.kt
+++ b/src/tr/hattorimanga/src/eu/kanade/tachiyomi/extension/tr/hattorimanga/HattoriManga.kt
@@ -151,7 +151,7 @@ class HattoriManga : HttpSource() {
 
     override fun pageListParse(response: Response): List<Page> {
         return response.asJsoup().select(".image-wrapper img").mapIndexed { index, element ->
-            Page(index, imageUrl = "$baseUrl${element.attr("data-src")}")
+            Page(index, imageUrl = element.absUrl("data-src"))
         }.takeIf { it.isNotEmpty() } ?: throw Exception("Oturum açmanız, WebView'ı açmanız ve oturum açmanız gerekir")
     }
 


### PR DESCRIPTION
Close: #13052 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
