### PR TITLE
TruyenTranh3Q: Real URL is missing from the mangaDetailsParse thumbnail

### DIFF
--- a/src/vi/truyentranh3q/build.gradle
+++ b/src/vi/truyentranh3q/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'TruyenTranh3Q'
     extClass = '.TruyenTranh3Q'
     baseUrl = 'https://manhua3q.com'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = true
 }
 

--- a/src/vi/truyentranh3q/src/eu/kanade/tachiyomi/extension/vi/truyentranh3q/TruyenTranh3Q.kt
+++ b/src/vi/truyentranh3q/src/eu/kanade/tachiyomi/extension/vi/truyentranh3q/TruyenTranh3Q.kt
@@ -129,7 +129,12 @@ class TruyenTranh3Q : ParsedHttpSource() {
                 genre = info.select(".list01 li a").joinToString { it.text() }
             }
             description = document.select(".book_detail > .story-detail-info").joinToString { it.wholeText().trim() }
-            thumbnail_url = document.selectFirst(".book_detail > .book_info > .book_avatar > img")?.absUrl("abs:src")
+            thumbnail_url = document.selectFirst(".book_detail > .book_info > .book_avatar > img")
+                ?.absUrl("abs:src")?.let { url ->
+                    url.toHttpUrlOrNull()
+                        ?.queryParameter("url")
+                        ?: url
+                }
         }
     }
 

--- a/src/vi/truyentranh3q/src/eu/kanade/tachiyomi/extension/vi/truyentranh3q/TruyenTranh3Q.kt
+++ b/src/vi/truyentranh3q/src/eu/kanade/tachiyomi/extension/vi/truyentranh3q/TruyenTranh3Q.kt
@@ -130,7 +130,7 @@ class TruyenTranh3Q : ParsedHttpSource() {
             }
             description = document.select(".book_detail > .story-detail-info").joinToString { it.wholeText().trim() }
             thumbnail_url = document.selectFirst(".book_detail > .book_info > .book_avatar > img")
-                ?.absUrl("abs:src")?.let { url ->
+                ?.absUrl("src")?.let { url ->
                     url.toHttpUrlOrNull()
                         ?.queryParameter("url")
                         ?: url


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
