### PR TITLE
MangasIn: Fix pages invalid host

### DIFF
--- a/src/es/mangasin/build.gradle
+++ b/src/es/mangasin/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangasIn'
     themePkg = 'mmrcms'
     baseUrl = 'https://m440.in'
-    overrideVersionCode = 4
+    overrideVersionCode = 5
     isNsfw = true
 }
 

--- a/src/es/mangasin/src/eu/kanade/tachiyomi/extension/es/mangasin/MangasIn.kt
+++ b/src/es/mangasin/src/eu/kanade/tachiyomi/extension/es/mangasin/MangasIn.kt
@@ -9,14 +9,17 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.util.asJsoup
 import kotlinx.serialization.decodeFromString
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
+import java.net.URLDecoder
 import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -140,6 +143,17 @@ class MangasIn : MMRCMS(
 
                 setUrlWithoutDomain("$mangaUrl/${it.slug}")
             }
+        }
+    }
+
+    override fun pageListParse(document: Document): List<Page> {
+        return document.select("#all > img.img-responsive").mapIndexed { i, it ->
+            var url = it.imgAttr()
+            if (url.toHttpUrlOrNull() == null) {
+                val decodedB64 = String(Base64.decode(url.substringAfter("://"), Base64.DEFAULT))
+                url = URLDecoder.decode(decodedB64, "UTF-8")
+            }
+            Page(i, imageUrl = url)
         }
     }
 


### PR DESCRIPTION
Closes #11859

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
