### PR TITLE
MangaTV: Fix 403 on pages

### DIFF
--- a/src/es/mangatv/build.gradle
+++ b/src/es/mangatv/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaTV'
     themePkg = 'mangathemesia'
     baseUrl = 'https://mangatv.net'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/es/mangatv/src/eu/kanade/tachiyomi/extension/es/mangatv/MangaTV.kt
+++ b/src/es/mangatv/src/eu/kanade/tachiyomi/extension/es/mangatv/MangaTV.kt
@@ -37,7 +37,7 @@ class MangaTV : MangaThemesia(
         return imageList.mapIndexed { i, jsonEl ->
             val encodedLink = jsonEl.jsonPrimitive.content
             val decodedLink = String(Base64.decode(encodedLink, Base64.DEFAULT))
-            Page(i, imageUrl = "https:$decodedLink")
+            Page(i, document.location(), "https:$decodedLink")
         }
     }
 


### PR DESCRIPTION
Closes #12846

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
