### PR TITLE
[MangaFire] Use "publishing finished" status instead of "completed" status

### DIFF
--- a/src/all/mangafire/build.gradle
+++ b/src/all/mangafire/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaFire'
     extClass = '.MangaFireFactory'
-    extVersionCode = 16
+    extVersionCode = 17
     isNsfw = true
 }
 

--- a/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/MangaFire.kt
+++ b/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/MangaFire.kt
@@ -243,9 +243,11 @@ class MangaFire(
         }
     }
 
+    // MangaFire marks manga as "completed" when their original publication is completed,
+    // even if their translation is not complete, so we use the "PUBLISHING_FINISHED" status.
     private fun Element?.parseStatus(): Int = when (this?.text()?.lowercase()) {
         "releasing" -> SManga.ONGOING
-        "completed" -> SManga.COMPLETED
+        "completed" -> SManga.PUBLISHING_FINISHED
         "on_hiatus" -> SManga.ON_HIATUS
         "discontinued" -> SManga.CANCELLED
         else -> SManga.UNKNOWN


### PR DESCRIPTION
MangaFire marks a manga as "completed" when its original publication is complete, even if it's translation is not complete. In Tachiyomi we consider that to be the PUBLICATION_FINISHED status and not COMPLETED. (We have no way of knowing whether a manga on this site is _actually_ completely translated, so we can never mark a manga as COMPLETED)

Example:
* [This manga](https://mangafire.to/manga/akumade-amai-watashi-no-kanojoo.rwnvy) is marked as completed with 19 translated chapters, but there is still one more chapter  
* [This manga](https://mangafire.to/manga/debby-the-corsifa-wa-makezugiraii.rjm2o) is marked as completed with 52 chapters (midway through volume 6), but [according to MangaUpdates](https://www.mangaupdates.com/series/8axs69w/debby-the-corsifa-wa-makezugirai) there are still several more volumes to translated.

This is pretty consistent across their library as far as I can tell.



Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
