### PR TITLE
KomikCast (ID): fix 403 forbidden

### DIFF
--- a/src/id/komikcast/build.gradle
+++ b/src/id/komikcast/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Komik Cast'
     extClass = '.KomikCast'
-    extVersionCode = 74
+    extVersionCode = 75
     isNsfw = false
 }
 

--- a/src/id/komikcast/src/eu/kanade/tachiyomi/extension/id/komikcast/KomikCast.kt
+++ b/src/id/komikcast/src/eu/kanade/tachiyomi/extension/id/komikcast/KomikCast.kt
@@ -35,6 +35,8 @@ class KomikCast : HttpSource() {
         .build()
 
     override fun headersBuilder(): Headers.Builder = super.headersBuilder()
+        .add("Referer", "$baseUrl/")
+        .add("Origin", baseUrl)
         .add("Accept", "application/json")
         .add("Accept-language", "en-US,en;q=0.9,id;q=0.8")
 


### PR DESCRIPTION
Close: https://github.com/keiyoushi/extensions-source/issues/13152
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
