### PR TITLE
24hnovel: update source

### DIFF
--- a/src/en/novel24h/build.gradle
+++ b/src/en/novel24h/build.gradle
@@ -1,9 +1,9 @@
 ext {
-    extName = 'Novel24h'
+    extName = '24HNovel'
     extClass = '.Novel24h'
     themePkg = 'madara'
     baseUrl = 'https://24hnovel.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/en/novel24h/src/eu/kanade/tachiyomi/extension/en/Novel24h/Novel24h.kt
+++ b/src/en/novel24h/src/eu/kanade/tachiyomi/extension/en/Novel24h/Novel24h.kt
@@ -1,15 +1,8 @@
 package eu.kanade.tachiyomi.extension.en.novel24h
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
-import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.source.model.FilterList
 
 class Novel24h : Madara("24HNovel", "https://24hnovel.com", "en") {
-
-    override val mangaSubString: String = "manga-tag/comic"
-
-    override fun searchMangaSelector(): String = "div.page-item-detail.manga"
-
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList) =
-        GET("$baseUrl/$mangaSubString/${searchPage(page)}?s=$query", headers)
+    override val useLoadMoreRequest = LoadMoreStrategy.Never
+    override val useNewChapterEndpoint = true
 }


### PR DESCRIPTION
- The site removed all the novels so no need to use "manga-tag/comic" anymore 
- Fix wrong extName
- Set `useNewChapterEndpoint` to true

For users the only difference is now filters work.
I didn't use the correct search previously because of novels and that broke filters.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
