### PR TITLE
fix: fix chapter name setter and add year based date uploaded

### DIFF
--- a/src/en/readallcomicscom/build.gradle
+++ b/src/en/readallcomicscom/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ReadAllComics'
     extClass = '.ReadAllComics'
-    extVersionCode = 5
+    extVersionCode = 6
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/readallcomicscom/src/eu/kanade/tachiyomi/extension/en/readallcomicscom/ReadAllComics.kt
+++ b/src/en/readallcomicscom/src/eu/kanade/tachiyomi/extension/en/readallcomicscom/ReadAllComics.kt
@@ -19,6 +19,7 @@ import org.jsoup.select.Elements
 import rx.Observable
 import java.text.SimpleDateFormat
 import java.util.Locale
+import java.util.TimeZone
 
 class ReadAllComics : ParsedHttpSource() {
 
@@ -127,10 +128,9 @@ class ReadAllComics : ParsedHttpSource() {
 
     override fun chapterFromElement(element: Element) = SChapter.create().apply {
         setUrlWithoutDomain(element.attr("href"))
-        val elementText = element.text()
-        name = elementText
+        name = element.text()
         // can only get the year from chapter title
-        val year = elementText.substring(elementText.lastIndexOf('(') + 1, elementText.lastIndexOf(')'))
+        val year = name.substringAfterLast('(').substringBefore(')')
         date_upload = dateFormat.tryParse("$year-1-1")
     }
 
@@ -150,6 +150,6 @@ class ReadAllComics : ParsedHttpSource() {
     override fun latestUpdatesNextPageSelector() = throw UnsupportedOperationException()
 
     companion object {
-        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US).apply { timeZone = TimeZone.getTimeZone("UTC") }
     }
 }

--- a/src/en/readallcomicscom/src/eu/kanade/tachiyomi/extension/en/readallcomicscom/ReadAllComics.kt
+++ b/src/en/readallcomicscom/src/eu/kanade/tachiyomi/extension/en/readallcomicscom/ReadAllComics.kt
@@ -9,6 +9,7 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
 import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.tryParse
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
@@ -16,6 +17,8 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import org.jsoup.select.Elements
 import rx.Observable
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 class ReadAllComics : ParsedHttpSource() {
 
@@ -124,7 +127,11 @@ class ReadAllComics : ParsedHttpSource() {
 
     override fun chapterFromElement(element: Element) = SChapter.create().apply {
         setUrlWithoutDomain(element.attr("href"))
-        name = element.attr("title")
+        val elementText = element.text()
+        name = elementText
+        // can only get the year from chapter title
+        val year = elementText.substring(elementText.lastIndexOf('(') + 1, elementText.lastIndexOf(')'))
+        date_upload = dateFormat.tryParse("$year-1-1")
     }
 
     override fun pageListParse(document: Document): List<Page> = document.select("body img:not(body div[id=\"logo\"] img)").mapIndexed { idx, element ->
@@ -141,4 +148,8 @@ class ReadAllComics : ParsedHttpSource() {
     override fun latestUpdatesFromElement(element: Element) = throw UnsupportedOperationException()
     override fun latestUpdatesSelector() = throw UnsupportedOperationException()
     override fun latestUpdatesNextPageSelector() = throw UnsupportedOperationException()
+
+    companion object {
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+    }
 }


### PR DESCRIPTION
closes https://github.com/keiyoushi/extensions-source/issues/13231

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
