### PR TITLE
Fix chapter number handling in MediocreToonsDto

### DIFF
--- a/src/pt/mediocretoons/build.gradle
+++ b/src/pt/mediocretoons/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Mediocre Toons'
     extClass = '.MediocreToons'
     baseUrl = 'https://mediocrescan.com'
-    extVersionCode = 14
+    extVersionCode = 15
     isNsfw = true
 }
 

--- a/src/pt/mediocretoons/src/eu/kanade/tachiyomi/extension/pt/mediocretoons/MediocreToonsDto.kt
+++ b/src/pt/mediocretoons/src/eu/kanade/tachiyomi/extension/pt/mediocretoons/MediocreToonsDto.kt
@@ -142,9 +142,9 @@ fun MediocreChapterSimpleDto.toSChapter(): SChapter {
 
 fun MediocreChapterDetailDto.toPageList(): List<Page> {
     val obraId = manga?.id ?: 0
-    val capituloNome = number?.toInt()?.toString() ?: name
+    val chapterNumber = number?.toString() ?: name
     return pages.mapIndexed { idx, p ->
-        val imageUrl = "${MediocreToons.CDN_URL}/obras/$obraId/capitulos/$capituloNome/${p.src}"
+        val imageUrl = "${MediocreToons.CDN_URL}/obras/$obraId/capitulos/$chapterNumber/${p.src}"
         Page(idx, imageUrl = imageUrl)
     }
 }

--- a/src/pt/mediocretoons/src/eu/kanade/tachiyomi/extension/pt/mediocretoons/MediocreToonsDto.kt
+++ b/src/pt/mediocretoons/src/eu/kanade/tachiyomi/extension/pt/mediocretoons/MediocreToonsDto.kt
@@ -131,13 +131,11 @@ fun MediocreMangaDto.toSManga(isDetails: Boolean = false): SManga {
     return sManga
 }
 
-fun MediocreChapterSimpleDto.toSChapter(): SChapter {
-    return SChapter.create().apply {
-        name = this@toSChapter.name
-        chapter_number = number ?: 0f
-        url = "/capitulo/$id"
-        date_upload = dateFormat.tryParse(createdAt)
-    }
+fun MediocreChapterSimpleDto.toSChapter(): SChapter = SChapter.create().apply {
+    name = this@toSChapter.name
+    chapter_number = number ?: 0f
+    url = "/capitulo/$id"
+    date_upload = dateFormat.tryParse(createdAt)
 }
 
 fun MediocreChapterDetailDto.toPageList(): List<Page> {

--- a/src/pt/mediocretoons/src/eu/kanade/tachiyomi/extension/pt/mediocretoons/MediocreToonsDto.kt
+++ b/src/pt/mediocretoons/src/eu/kanade/tachiyomi/extension/pt/mediocretoons/MediocreToonsDto.kt
@@ -142,7 +142,7 @@ fun MediocreChapterSimpleDto.toSChapter(): SChapter {
 
 fun MediocreChapterDetailDto.toPageList(): List<Page> {
     val obraId = manga?.id ?: 0
-    val chapterNumber = number?.toString() ?: name
+    val chapterNumber = number?.toString()?.removeSuffix(".0") ?: name
     return pages.mapIndexed { idx, p ->
         val imageUrl = "${MediocreToons.CDN_URL}/obras/$obraId/capitulos/$chapterNumber/${p.src}"
         Page(idx, imageUrl = imageUrl)


### PR DESCRIPTION
Fix chapter number when number is Float. Example: 0.5 or 1.5

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [X] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [X] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [X] Have removed `web_hi_res_512.png` when adding a new extension
