### PR TITLE
[EN] Mangakakalot fix: Resolves 403 and other previous issues.

### DIFF
--- a/src/en/mangakakalot/build.gradle
+++ b/src/en/mangakakalot/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Mangakakalot'
     themePkg = 'mangabox'
     baseUrl = 'https://www.mangakakalot.gg'
-    overrideVersionCode = 6
+    overrideVersionCode = 7
     isNsfw = true
 }
 

--- a/src/en/mangakakalot/src/eu/kanade/tachiyomi/extension/en/mangakakalot/Dto.kt
+++ b/src/en/mangakakalot/src/eu/kanade/tachiyomi/extension/en/mangakakalot/Dto.kt
@@ -1,0 +1,23 @@
+package eu.kanade.tachiyomi.extension.en.mangakakalot
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+class ChapterResponseDto(
+    val success: Boolean = false,
+    val data: ChapterDataDto? = null,
+)
+
+@Serializable
+class ChapterDataDto(
+    val chapters: List<ChapterDto> = emptyList(),
+)
+
+@Serializable
+class ChapterDto(
+    @SerialName("chapter_name") val name: String? = null,
+    @SerialName("chapter_num") val num: Float? = null,
+    @SerialName("chapter_slug") val slug: String? = null,
+    @SerialName("updated_at") val updatedAt: String? = null,
+)

--- a/src/en/mangakakalot/src/eu/kanade/tachiyomi/extension/en/mangakakalot/Mangakakalot.kt
+++ b/src/en/mangakakalot/src/eu/kanade/tachiyomi/extension/en/mangakakalot/Mangakakalot.kt
@@ -1,30 +1,208 @@
 package eu.kanade.tachiyomi.extension.en.mangakakalot
 
 import eu.kanade.tachiyomi.multisrc.mangabox.MangaBox
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
+import okhttp3.Dispatcher
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.Response
+import org.json.JSONObject
+import org.jsoup.nodes.Document
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+import java.util.concurrent.TimeUnit
 
-class Mangakakalot : MangaBox(
-    "Mangakakalot",
-    arrayOf(
-        "www.mangakakalot.gg",
-        "www.mangakakalove.com",
-    ),
-    "en",
-) {
+class Mangakakalot :
+    MangaBox(
+        "Mangakakalot",
+        arrayOf(
+            "www.mangakakalot.gg",
+            "www.mangakakalove.com",
+        ),
+        "en",
+    ) {
+
+    /* ================================
+     * Slug Utilities
+     * ================================ */
+
+    private fun titleToSlug(title: String): String = title
+        .lowercase(Locale.ENGLISH)
+        .replace("['']".toRegex(), "")
+        .replace("[^a-z0-9\\s-]".toRegex(), "")
+        .trim()
+        .replace("[\\s-]+".toRegex(), "-")
+        .trim('-')
+
+    private val jsonDateFormat = SimpleDateFormat(
+        "yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'",
+        Locale.US,
+    ).apply {
+        timeZone = TimeZone.getTimeZone("UTC")
+    }
+
+    /**
+     * Resolves download issues for very large chapters (~100+ pages).
+     *
+     * Mangakakalot slows down or rejects image-heavy requests when connections
+     * are reused aggressively. Rate limiting alone (jitter) was insufficient.
+     *
+     * - Dispatcher limits parallel image requests
+     * - "Connection: close" forces socket reset per image
+     * - Prevents per-page stalls (30s to minutes) near chapter end
+     */
+
+    private val imageHeavyDispatcher = Dispatcher().apply {
+        maxRequests = 8
+        maxRequestsPerHost = 3
+    }
+
+    override val client: OkHttpClient = super.client.newBuilder()
+        .dispatcher(imageHeavyDispatcher)
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(60, TimeUnit.SECONDS)
+        .writeTimeout(30, TimeUnit.SECONDS)
+        .rateLimit(2, 1, TimeUnit.SECONDS)
+        .addInterceptor(ApiHeadersInterceptor())
+        .build()
+
+    /* ================================
+     * Manga Details
+     * ================================ */
+
     override fun mangaDetailsRequest(manga: SManga): Request {
-        if (LEGACY_DOMAINS.any { manga.url.startsWith(it) }) {
-            throw Exception(MIGRATE_MESSAGE)
-        }
+        val titleSlug = titleToSlug(manga.title)
+        manga.url = "/manga/$titleSlug"
         return super.mangaDetailsRequest(manga)
     }
-    companion object {
-        private val LEGACY_DOMAINS = arrayOf(
-            "https://chapmanganato.to/",
-            "https://mangakakalot.com/",
-            "https://manganelo.com/",
-            "https://readmanganato.com/",
-        )
-        private const val MIGRATE_MESSAGE = "Migrate this entry from \"Mangakakalot\" to \"Mangakakalot\" to continue reading"
+
+    override fun mangaDetailsParse(document: Document): SManga {
+        val manga = super.mangaDetailsParse(document)
+
+        val pageUrl = document.location()
+        val actualSlug = if (pageUrl.contains("/manga/")) {
+            pageUrl.substringAfter("/manga/")
+                .substringBefore("?")
+                .substringBefore("#")
+        } else {
+            titleToSlug(manga.title)
+        }
+
+        manga.url = "/manga/$actualSlug"
+        return manga
+    }
+
+    /* ================================
+     * Chapter List
+     * ================================ */
+
+    override fun chapterListRequest(manga: SManga): Request {
+        val currentSlug = manga.url.substringAfterLast("/")
+        val isIdSlug = currentSlug.matches(Regex("^[a-z]{2}\\d+$"))
+
+        val slug = if (manga.url.startsWith("/manga/") && !isIdSlug) {
+            currentSlug
+        } else {
+            val titleSlug = titleToSlug(manga.title)
+            manga.url = "/manga/$titleSlug"
+            titleSlug
+        }
+
+        val apiUrl = "$baseUrl/api/manga/$slug/chapters?limit=-1"
+        return GET(apiUrl, headers)
+    }
+
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val chapters = mutableListOf<SChapter>()
+        val body = response.body.string()
+        if (body.isEmpty()) return chapters
+
+        val json = JSONObject(body)
+        if (!json.optBoolean("success")) return chapters
+
+        val data = json.optJSONObject("data") ?: return chapters
+        val jsonChapters = data.optJSONArray("chapters") ?: return chapters
+
+        val slug = response.request.url.pathSegments
+            .dropWhile { it != "manga" }
+            .getOrNull(1)
+            ?: return chapters
+
+        for (i in 0 until jsonChapters.length()) {
+            val item = jsonChapters.getJSONObject(i)
+            val chapter = SChapter.create()
+
+            chapter.name = item.optString("chapter_name", "Chapter")
+            chapter.chapter_number = item.optDouble("chapter_num", 0.0).toFloat()
+            chapter.url = "/manga/$slug/${item.optString("chapter_slug")}"
+
+            item.optString("updated_at").takeIf { it.isNotEmpty() }?.let {
+                chapter.date_upload =
+                    runCatching { jsonDateFormat.parse(it)?.time }.getOrNull() ?: 0L
+            }
+
+            chapters.add(chapter)
+        }
+
+        return chapters
+    }
+
+    /* ================================
+     * Page List
+     * ================================ */
+
+    override fun pageListParse(document: Document): List<Page> = document
+        .select("div.container-chapter-reader img")
+        .mapIndexedNotNull { i, img ->
+            val url = img.attr("abs:src").ifEmpty { img.attr("abs:data-src") }
+            if (url.isNotEmpty()) Page(i, "", url) else null
+        }
+
+    /* ================================
+     * Image Requests
+     * ================================ */
+
+    override fun imageRequest(page: Page): Request = GET(
+        page.imageUrl.orEmpty(),
+        headersBuilder()
+            .set("Referer", "$baseUrl/")
+            .set("Connection", "close")
+            .build(),
+    )
+}
+
+    /* ================================
+     * API 403 BYPASS
+     * ================================ */
+
+class ApiHeadersInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val req = chain.request()
+        val url = req.url.toString()
+
+        if (url.contains("/api/manga/")) {
+            val segments = req.url.pathSegments
+            val idx = segments.indexOf("manga")
+
+            if (idx != -1 && idx + 1 < segments.size) {
+                val slug = segments[idx + 1]
+                val referer = "https://${req.url.host}/manga/$slug"
+
+                val newReq = req.newBuilder()
+                    .header("Referer", referer)
+                    .header("X-Requested-With", "XMLHttpRequest")
+                    .build()
+
+                return chain.proceed(newReq)
+            }
+        }
+
+        return chain.proceed(req)
     }
 }


### PR DESCRIPTION
### Cause:
- URL slug is ID-based instead of title-based
- ~~Chapter data is provided via API instead of embedded in HTML~~
- ~~Images were protected by Hotlink protection~~
- ~~API was behing WAF+anti-bot~~

### Changes:
- Solves broken chapter loading caused by the URL structure migration.
- Fixes 404 errors for old entries and maintains backward compatibility.
- Fixes ID-based slug, converts them to title based
- Fixes image download failures in large chapters.
- ~~Adds referrer to bypass hotlink protection~~
- ~~Fixes Cloudflare blocking for chapter and manga API requests.~~

Addresses issues:
closes: #13224 
closes #8714 
closes #13106 [closed] 
closes #13185 [closed]

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
