### PR TITLE
Comic Gardo: fix selectors

### DIFF
--- a/src/ja/comicgardo/build.gradle
+++ b/src/ja/comicgardo/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ComicGardo'
     themePkg = 'gigaviewer'
     baseUrl = 'https://comic-gardo.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = false
 }
 

--- a/src/ja/comicgardo/src/eu/kanade/tachiyomi/extension/ja/comicgardo/ComicGardo.kt
+++ b/src/ja/comicgardo/src/eu/kanade/tachiyomi/extension/ja/comicgardo/ComicGardo.kt
@@ -2,34 +2,44 @@ package eu.kanade.tachiyomi.extension.ja.comicgardo
 
 import eu.kanade.tachiyomi.multisrc.gigaviewer.GigaViewer
 import eu.kanade.tachiyomi.source.model.SManga
-import okhttp3.OkHttpClient
 import org.jsoup.nodes.Element
 
-class ComicGardo : GigaViewer(
-    "Comic Gardo",
-    "https://comic-gardo.com",
-    "ja",
-    "https://cdn-img.comic-gardo.com/public/page",
-    isPaginated = true,
-) {
+class ComicGardo :
+    GigaViewer(
+        "Comic Gardo",
+        "https://comic-gardo.com",
+        "ja",
+        "https://cdn-img.comic-gardo.com/public/page",
+        isPaginated = true,
+    ) {
 
     override val supportsLatest: Boolean = false
 
-    override val client: OkHttpClient = super.client.newBuilder()
+    override val client = super.client.newBuilder()
         .addInterceptor(::imageIntercept)
         .build()
 
     override val publisher: String = "オーバーラップ"
 
-    override fun popularMangaSelector(): String = "ul.series-section-list li.series-section-item > a"
+    override fun popularMangaSelector(): String = "a[class^=SeriesListItem_link_]"
 
     override fun popularMangaFromElement(element: Element): SManga = SManga.create().apply {
-        title = element.selectFirst("h5.series-title")!!.text()
-        thumbnail_url = element.selectFirst("div.thumb img")!!.attr("data-src")
-        setUrlWithoutDomain(element.attr("href")!!)
+        title = element.selectFirst("[class^=SeriesListItem_series_title_]")!!.text()
+        thumbnail_url = element.selectFirst("img")?.absUrl("src")
+        setUrlWithoutDomain(element.selectFirst("a")!!.absUrl("href"))
+    }
+
+    override fun searchMangaSelector(): String = "ul[class^=SearchResult_search_result_list_] li"
+
+    override fun searchMangaFromElement(element: Element): SManga = SManga.create().apply {
+        title = element.selectFirst("p[class^=SearchResultItem_series_title_]")!!.text()
+        thumbnail_url = element.selectFirst("img")?.absUrl("src")
+        setUrlWithoutDomain(element.selectFirst("a")!!.absUrl("href"))
     }
 
     override fun getCollections(): List<Collection> = listOf(
-        Collection("連載一覧", ""),
+        Collection("連載作品", ""),
+        Collection("アンソロジー・読切", "oneshot"),
+        Collection("連載終了作品", "completed"),
     )
 }


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
