### PR TITLE
Revert 12600 Elftoon: update url

### DIFF
--- a/src/en/elftoon/build.gradle
+++ b/src/en/elftoon/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Elf Toon'
     extClass = '.ElfToon'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://elftoon.xyz'
-    overrideVersionCode = 1
+    baseUrl = 'https://elftoon.com'
+    overrideVersionCode = 0
     isNsfw = false
 }
 

--- a/src/en/elftoon/build.gradle
+++ b/src/en/elftoon/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ElfToon'
     themePkg = 'mangathemesia'
     baseUrl = 'https://elftoon.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 2
     isNsfw = false
 }
 

--- a/src/en/elftoon/src/eu/kanade/tachiyomi/extension/en/elftoon/ElfToon.kt
+++ b/src/en/elftoon/src/eu/kanade/tachiyomi/extension/en/elftoon/ElfToon.kt
@@ -2,7 +2,7 @@ package eu.kanade.tachiyomi.extension.en.elftoon
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 
-class ElfToon : MangaThemesia("Elf Toon", "https://elftoon.xyz", "en") {
+class ElfToon : MangaThemesia("Elf Toon", "https://elftoon.com", "en") {
 
     override fun chapterListSelector() = "#chapterlist li:not(:has(.gem-price-icon))"
 }


### PR DESCRIPTION
Fix unnecessary redirect as site reverted the url change

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
