### PR TITLE
Update `.github` request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_report_issue.yml
+++ b/.github/ISSUE_TEMPLATE/01_report_issue.yml
@@ -57,13 +57,13 @@ body:
       required: true
 
   - type: input
-    id: tachiyomi-version
+    id: mihon-version
     attributes:
-      label: Mihon/Tachiyomi version
+      label: Mihon/Mihon fork version
       description: |
-        You can find your Mihon/Tachiyomi version in **More → About**.
+        You can find your Mihon/Mihon fork version number in **More → About**.
       placeholder: |
-        Example: "0.18.0"
+        Example: "Mihon 0.19.3"
     validations:
       required: true
 
@@ -91,19 +91,19 @@ body:
       label: Acknowledgements
       description: Your issue will be closed if you haven't done these steps.
       options:
-        - label: I have searched the existing issues and this is a new ticket, **NOT** a duplicate or related to another open or closed issue.
+        - label: I have searched [existing issues](https://github.com/keiyoushi/extensions-source/issues) both open & closed, and confirm that this is a new unreported issue.
           required: true
         - label: I have written a short but informative title.
           required: true
-        - label: I have updated the app to version **[0.15.3](https://github.com/mihonapp/mihon/releases/latest)**.
+        - label: I have updated the app to version **[0.19.3](https://github.com/mihonapp/mihon/releases/latest)**.
           required: true
-        - label: I have updated all installed extensions.
+        - label: I have updated the extension to the latest version (as listed on the [extensions listing](https://keiyoushi.github.io/extensions/) page).
           required: true
         - label: I have tried the [troubleshooting guide](https://mihon.app/docs/guides/troubleshooting/).
           required: true
         - label: If this is an issue with the app itself, I should be opening an issue in the app repository.
           required: true
-        - label: I will fill out all of the requested information in this form.
+        - label: I will correctly fill out all of the requested information in this form.
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/02_request_source.yml
+++ b/.github/ISSUE_TEMPLATE/02_request_source.yml
@@ -47,11 +47,11 @@ body:
       options:
         - label: I have checked that the extension does not already exist by searching the [extension listing](https://keiyoushi.github.io/extensions/) and verified it does not appear there.
           required: true
-        - label: I have searched the existing issues and this is a new ticket, **NOT** a duplicate or related to another open or closed issue.
+        - label: I have searched [existing issues](https://github.com/keiyoushi/extensions-source/issues) both open & closed, and confirm that this is a new unreported issue.
           required: true
         - label: I have written a meaningful title with the source name.
           required: true
-        - label: I will fill out all of the requested information in this form.
+        - label: I will correctly fill out all of the requested information in this form.
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/03_report_url_change.yml
+++ b/.github/ISSUE_TEMPLATE/03_report_url_change.yml
@@ -45,15 +45,15 @@ body:
       label: Acknowledgements
       description: Your issue will be closed if you haven't done these steps.
       options:
-        - label: I have updated all installed extensions.
+        - label: I have updated the extension to the latest version (as listed on the [extensions listing](https://keiyoushi.github.io/extensions/) page).
           required: true
-        - label: I have opened WebView and checked that the source URL has not changed yet.
+        - label: I have checked WebView to see the source's main URL is not up-to-date, or has to redirect into the new URL.
           required: true
-        - label: I have searched the existing issues and this is a new ticket, **NOT** a duplicate or related to another open or closed issue.
+        - label: I have searched [existing issues](https://github.com/keiyoushi/extensions-source/issues/) both open & closed, and confirm that this is a new unreported issue.
           required: true
         - label: I have written a short but informative title.
           required: true
-        - label: I will fill out all of the requested information in this form.
+        - label: I will correctly fill out all of the requested information in this form.
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/04_report_dead_source.yml
+++ b/.github/ISSUE_TEMPLATE/04_report_dead_source.yml
@@ -7,7 +7,8 @@ body:
     attributes:
       value: |
         ### Notice
-        If you have a lot of dead sources to report, please go back and submit a single meta request.
+        * This request type is for dead sources, so we can remove the extension from the repo, double-check that you have chosen the correct request type first.
+        * If you have a lot of dead sources to report, please go back and submit a single meta request.
 
   - type: input
     id: source
@@ -43,7 +44,7 @@ body:
     attributes:
       label: Other details
       placeholder: |
-        Additional details and attachments.
+        Additional details and attachments about the source to remove the extension.
 
   - type: checkboxes
     id: acknowledgements
@@ -51,15 +52,15 @@ body:
       label: Acknowledgements
       description: Your issue will be closed if you haven't done these steps.
       options:
-        - label: I have updated all installed extensions.
+        - label: I have updated the extension to the latest version (as listed on the [extensions listing](https://keiyoushi.github.io/extensions/) page).
           required: true
-        - label: I have opened WebView and checked that the source website is down.
+        - label: I have opened WebView to check that the source website is down.
           required: true
-        - label: I have searched the existing issues and this is a new ticket, **NOT** a duplicate or related to another open or closed issue.
+        - label: I have searched [existing issues](https://github.com/keiyoushi/extensions-source/issues) both open & closed, and confirm that this is a new unreported issue.
           required: true
         - label: I have written a meaningful title with the source name.
           required: true
-        - label: I will fill out all of the requested information in this form.
+        - label: I will correctly fill out all of the requested information in this form.
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/05_request_feature.yml
+++ b/.github/ISSUE_TEMPLATE/05_request_feature.yml
@@ -10,7 +10,7 @@ body:
       description: |
         You can find the extension name in **Browse → Extensions**.
       placeholder: |
-        Example: "Not Real Scans"
+        Example: "Not Real Scans v1.4.1"
     validations:
       required: true
 
@@ -47,15 +47,15 @@ body:
       label: Acknowledgements
       description: Your issue will be closed if you haven't done these steps.
       options:
-        - label: I have searched the existing issues and this is a new ticket, **NOT** a duplicate or related to another open or closed issue.
+        - label: I have searched [existing issues](https://github.com/keiyoushi/extensions-source/issues) both open & closed, and confirm that this is a new unreported issue.
           required: true
         - label: I have written a short but informative title.
           required: true
-        - label: If this is an issue with the app itself, I should be opening an issue in the [app repository](https://github.com/mihonapp/mihon/issues/new/choose).
+        - label: If this is an issue with the app itself, I should be opening an issue in the [app repository](https://github.com/mihonapp/mihon/issues/).
           required: true
-        - label: I have updated the app to version **[0.15.3](https://github.com/mihonapp/mihon/releases/latest)**.
+        - label: I have updated the app to version **[0.19.3](https://github.com/mihonapp/mihon/releases/latest)**.
           required: true
-        - label: I will fill out all of the requested information in this form.
+        - label: I will correctly fill out all of the requested information in this form.
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/06_request_meta.yml
+++ b/.github/ISSUE_TEMPLATE/06_request_meta.yml
@@ -27,17 +27,17 @@ body:
       label: Acknowledgements
       description: Your issue will be closed if you haven't done these steps.
       options:
-        - label: I have searched the existing issues and this is a new ticket, **NOT** a duplicate or related to another open or closed issue.
+        - label: I have searched [existing issues](https://github.com/keiyoushi/extensions-source/issues) both open & closed, and confirm that this is a new unreported issue.
           required: true
         - label: I have written a short but informative title.
           required: true
-        - label: If this is an issue with the app itself, I should be opening an issue in the [app repository](https://github.com/mihonapp/mihon/issues/new/choose).
+        - label: If this is an issue with the app itself, I should be opening an issue in the [app repository](https://github.com/mihonapp/mihon/issues/).
           required: true
-        - label: I have updated the app to version **[0.15.3](https://github.com/mihonapp/mihon/releases/latest)**.
+        - label: I have updated the app to version **[0.19.3](https://github.com/mihonapp/mihon/releases/latest)**.
           required: true
-        - label: I have updated all installed extensions.
+        - label: I have updated the extension to the latest version (as listed on the [extensions listing](https://keiyoushi.github.io/extensions/) page).
           required: true
-        - label: I will fill out all of the requested information in this form.
+        - label: I will correctly fill out all of the requested information in this form.
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: ⚠️ Application issue
-    url: https://github.com/mihonapp/mihon/issues/new/choose
+    url: https://github.com/mihonapp/mihon/issues/
     about: Issues and requests about the app itself should be opened in Mihon's repository instead
   - name: 📦 Extension list
     url: https://keiyoushi.github.io/extensions


### PR DESCRIPTION
##### Bug Report Template - `tachiyomi-version` field changes:
* Replaced field ID to `mihon-version` (**does this break anything? Just checking/reminding, just in case**)
* Replaced "Mihon/Tachiyomi" in the field's `label` & `description` to "Mihon/Mihon fork"
* Added "number" into `description`
* Changed "0.18.0" to "Mihon 0.19.3" in the "Example"
##### Other adjustments:
* Rewritten the first acknowledgement
* Beefed up fourth acknowledgement
* Added "correctly" into the seventh acknowledgement
* URL Change Report Template - Parity acknowledgement changes
* URL Change Report Template - Slightly beefed up second acknowledgement
* Dead source Template - Parity acknowledgement changes
* Dead source Template - Tweaked second acknowledgement
* Dead source Template - Added "this is not a bug request" bit to the "Notice" section
* Dead source Template - Added a few more words in "Other Details" description
* Feature request Template - Tweaked "Source name" example
* Feature request Template - Parity acknowledgement changes
* Feature request Template - Updated reference app URL to not insta-direct to forms
* Meta request Template - Parity acknowledgement changes
* Source request Template - Parity acknowledgement changes
* Config - Updated reference app URL in contact links to not insta-direct to forms

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
