### PR TITLE
Kaguya (ID): fix chapter list & genres

### DIFF
--- a/src/id/yubikiri/build.gradle
+++ b/src/id/yubikiri/build.gradle
@@ -3,8 +3,8 @@ ext {
     extClass = '.Kaguya'
     themePkg = 'madara'
     baseUrl = 'https://kaguya.id'
-    overrideVersionCode = 1
-    isNsfw = false
+    overrideVersionCode = 2
+    isNsfw = true
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/yubikiri/src/eu/kanade/tachiyomi/extension/id/yubikiri/Kaguya.kt
+++ b/src/id/yubikiri/src/eu/kanade/tachiyomi/extension/id/yubikiri/Kaguya.kt
@@ -1,18 +1,27 @@
 package eu.kanade.tachiyomi.extension.id.yubikiri
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.util.asJsoup
 import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
+import rx.Observable
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
-class Kaguya : Madara(
-    "Kaguya",
-    "https://kaguya.id",
-    "id",
-    dateFormat = SimpleDateFormat("d MMMM", Locale("en")),
-) {
+class Kaguya :
+    Madara(
+        "Kaguya",
+        "https://kaguya.id",
+        "id",
+        dateFormat = SimpleDateFormat("d MMMM", Locale("en")),
+    ) {
 
     override val client: OkHttpClient = super.client.newBuilder()
         .readTimeout(1, TimeUnit.MINUTES)
@@ -20,17 +29,47 @@ class Kaguya : Madara(
 
     override val id = 1557304490417397104
 
+    override val mangaSubString = "all-series"
+
     override val mangaDetailsSelectorTitle = "h1.post-title"
     override val mangaDetailsSelectorStatus = "div.summary-heading:contains(Status) + div"
     override val mangaDetailsSelectorThumbnail = "head meta[property='og:image']" // Same as browse
-
-    override val useNewChapterEndpoint = true
-
-    override val useLoadMoreRequest = LoadMoreStrategy.Never
 
     override fun imageFromElement(element: Element): String? {
         return super.imageFromElement(element)
             ?.takeIf { it.isNotEmpty() }
             ?: element.attr("content") // Thumbnail from <head>
     }
+
+    // ============================== Chapters ==============================
+    override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> = Observable.fromCallable { fetchAllChapters(manga) }
+
+    private fun fetchAllChapters(manga: SManga): List<SChapter> {
+        val chapters = mutableListOf<SChapter>()
+        var page = 1
+        while (true) {
+            val response = client.newCall(POST("${getMangaUrl(manga)}ajax/chapters?t=${page++}", xhrHeaders)).execute()
+            val document = response.asJsoup()
+            val currentPage = document.select(chapterListSelector())
+                .map(::chapterFromElement)
+
+            chapters += currentPage
+            response.close()
+
+            if (currentPage.isEmpty()) {
+                return chapters
+            }
+        }
+    }
+
+    // ============================== Filter ==============================
+    override fun parseGenres(document: Document): List<Genre> = document.select("a.btn[href*=\"genre=\"], a.dropdown-item[href*=\"genre=\"]")
+        .map { a ->
+            Genre(
+                a.text(),
+                a.attr("href").substringAfter("genre=").substringBefore("&"),
+            )
+        }.distinctBy { it.id }
+
+    override val useLoadMoreRequest = LoadMoreStrategy.Never
 }


### PR DESCRIPTION
Update:
- Update mangaSubString to "all-series"
- Update genres parser
- Fix the issue of only displaying the last 10 chapters

Close: https://github.com/keiyoushi/extensions-source/issues/9874
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
