### PR TITLE
Manga Crab: Refix image key issue

### DIFF
--- a/src/es/mangacrab/build.gradle
+++ b/src/es/mangacrab/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaCrab'
     themePkg = 'madara'
     baseUrl = 'https://mangacrab.org'
-    overrideVersionCode = 19
+    overrideVersionCode = 20
     isNsfw = false
 }
 

--- a/src/es/mangacrab/src/eu/kanade/tachiyomi/extension/es/mangacrab/MangaCrab.kt
+++ b/src/es/mangacrab/src/eu/kanade/tachiyomi/extension/es/mangacrab/MangaCrab.kt
@@ -54,12 +54,12 @@ class MangaCrab :
 
     override val pageListParseSelector = "div.page-break:not([style*='display:none']) img:not([src])"
 
-    private val imageKeyRegex = """'Img-Key'\s*:\s*'(.*?)'""".toRegex()
+    private val imageKeyRegex = """'Img-X'\s*:\s*'(.*?)'""".toRegex()
 
     override fun pageListParse(document: Document): List<Page> {
         launchIO { countViews(document) }
 
-        val imageKey = document.selectFirst("script:containsData('Img-Key')")?.data()
+        val imageKey = document.selectFirst("script:containsData('Img-X')")?.data()
             ?.let { script ->
                 imageKeyRegex.find(script)?.groups?.get(1)?.value
             }
@@ -94,7 +94,7 @@ class MangaCrab :
         val imageKey = page.imageUrl!!.substringAfterLast("#")
         val headers = headers.newBuilder()
             .set("Referer", page.url)
-            .set("Img-Key", imageKey)
+            .set("Img-X", imageKey)
             .build()
 
         return GET(imageUrl, headers)


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
