### PR TITLE
LittleTyrant: update base URL, add login check interceptor, and enhance popular/lastet manga parsing

### DIFF
--- a/src/pt/littletyrant/build.gradle
+++ b/src/pt/littletyrant/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Little Tyrant'
     extClass = '.LittleTyrant'
     themePkg = 'madara'
-    baseUrl = 'https://tiraninha.baby'
-    overrideVersionCode = 1
+    baseUrl = 'https://tiraninha.world'
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/pt/littletyrant/src/eu/kanade/tachiyomi/extension/pt/littletyrant/LittleTyrant.kt
+++ b/src/pt/littletyrant/src/eu/kanade/tachiyomi/extension/pt/littletyrant/LittleTyrant.kt
@@ -2,22 +2,59 @@ package eu.kanade.tachiyomi.extension.pt.littletyrant
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.source.model.SManga
+import okhttp3.Interceptor
+import okhttp3.Response
+import org.jsoup.nodes.Element
+import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class LittleTyrant : Madara(
-    "Little Tyrant",
-    "https://tiraninha.baby",
-    "pt-BR",
-    dateFormat = SimpleDateFormat("MMM dd, yyyy", Locale("pt", "BR")),
-) {
-    override val client = super.client.newBuilder()
+class LittleTyrant :
+    Madara(
+        "Little Tyrant",
+        "https://tiraninha.world",
+        "pt-BR",
+        dateFormat = SimpleDateFormat("MMM dd, yyyy", Locale("pt", "BR")),
+    ) {
+    override val client = network.cloudflareClient.newBuilder()
         .rateLimit(2)
+        .addNetworkInterceptor(::loginCheckInterceptor)
         .build()
+
+    private fun loginCheckInterceptor(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        if (request.url.encodedPath == "/login/") {
+            throw IOException("Faça login no WebView para ver os mangás")
+        }
+        return chain.proceed(request)
+    }
 
     override val useNewChapterEndpoint = true
 
     override val useLoadMoreRequest = LoadMoreStrategy.Never
 
     override val mangaDetailsSelectorDescription = "div.manga-summary"
+
+    // Layout modern-card-layout: itens em div.page-item-detail, link em div.post-title h3 a, thumb em div.content-top (background-image)
+    override fun popularMangaSelector() = "div.page-item-detail"
+
+    override val popularMangaUrlSelector = "div.post-title h3 a"
+
+    override fun popularMangaFromElement(element: Element): SManga {
+        val manga = SManga.create()
+        with(element) {
+            selectFirst(popularMangaUrlSelector)!!.let {
+                manga.setUrlWithoutDomain(it.attr("abs:href"))
+                manga.title = it.ownText()
+            }
+            // Thumbnail vem de div.content-top style="background-image:url('...')", não tem img
+            selectFirst("div.content-top")?.attr("style")?.let { style ->
+                Regex("""url\s*\(\s*['"]?([^'")]+)['"]?\s*\)""").find(style)?.groupValues?.get(1)?.trim()?.let { url ->
+                    manga.thumbnail_url = processThumbnail(url, true)
+                }
+            }
+        }
+        return manga
+    }
 }

--- a/src/pt/littletyrant/src/eu/kanade/tachiyomi/extension/pt/littletyrant/LittleTyrant.kt
+++ b/src/pt/littletyrant/src/eu/kanade/tachiyomi/extension/pt/littletyrant/LittleTyrant.kt
@@ -41,6 +41,8 @@ class LittleTyrant :
 
     override val popularMangaUrlSelector = "div.post-title h3 a"
 
+    private fun extractThumbnailUrlFromStyle(style: String): String? = REGEX_THUMBNAIL_URL.find(style)?.groupValues?.get(1)?.trim()
+
     override fun popularMangaFromElement(element: Element): SManga {
         val manga = SManga.create()
         with(element) {
@@ -50,11 +52,15 @@ class LittleTyrant :
             }
             // Thumbnail vem de div.content-top style="background-image:url('...')", não tem img
             selectFirst("div.content-top")?.attr("style")?.let { style ->
-                Regex("""url\s*\(\s*['"]?([^'")]+)['"]?\s*\)""").find(style)?.groupValues?.get(1)?.trim()?.let { url ->
+                extractThumbnailUrlFromStyle(style)?.let { url ->
                     manga.thumbnail_url = processThumbnail(url, true)
                 }
             }
         }
         return manga
+    }
+
+    companion object {
+        val REGEX_THUMBNAIL_URL = Regex("""url\s*\(\s*['"]?([^'")]+)['"]?\s*\)""")
     }
 }

--- a/src/pt/littletyrant/src/eu/kanade/tachiyomi/extension/pt/littletyrant/LittleTyrant.kt
+++ b/src/pt/littletyrant/src/eu/kanade/tachiyomi/extension/pt/littletyrant/LittleTyrant.kt
@@ -17,7 +17,7 @@ class LittleTyrant :
         "pt-BR",
         dateFormat = SimpleDateFormat("MMM dd, yyyy", Locale("pt", "BR")),
     ) {
-    override val client = network.cloudflareClient.newBuilder()
+    override val client = super.client.newBuilder()
         .rateLimit(2)
         .addNetworkInterceptor(::loginCheckInterceptor)
         .build()


### PR DESCRIPTION
LittleTyrant: update base URL, add login check interceptor, and enhance popular/lastet manga parsing


closes: https://github.com/keiyoushi/extensions-source/issues/13311

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
