### PR TITLE
KomikCast: Fix duplicate key crash and missing covers

### DIFF
--- a/src/id/komikcast/build.gradle
+++ b/src/id/komikcast/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Komik Cast'
     extClass = '.KomikCast'
-    extVersionCode = 76
+    extVersionCode = 77
     isNsfw = false
 }
 


### PR DESCRIPTION
- Fix `IllegalArgumentException` by filtering duplicate series in `parseSeriesListResponse` using `distinctBy`.
- Fix missing thumbnails in suggestions/search results by adding fallback fields (`cover`, `image`) to `SeriesData` DTO.

Close #13305 
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
