### PR TITLE
Shinigami: Fix deserialization error on related manga list

### DIFF
--- a/src/id/shinigami/build.gradle
+++ b/src/id/shinigami/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Shinigami'
     extClass = '.Shinigami'
-    extVersionCode = 76
+    extVersionCode = 77
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/shinigami/src/eu/kanade/tachiyomi/extension/id/shinigami/Shinigami.kt
+++ b/src/id/shinigami/src/eu/kanade/tachiyomi/extension/id/shinigami/Shinigami.kt
@@ -17,9 +17,9 @@ import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
+import uy.kohesive.injekt.injectLazy
 import java.text.SimpleDateFormat
 import java.util.Locale
-import uy.kohesive.injekt.injectLazy
 
 class Shinigami : HttpSource() {
     // moved from Reaper Scans (id) to Shinigami (id)
@@ -228,9 +228,7 @@ class Shinigami : HttpSource() {
         else -> SManga.UNKNOWN
     }
 
-    override fun chapterListRequest(manga: SManga): Request {
-        return GET("$apiUrl/v1/chapter/${manga.url}/list?page_size=3000", apiHeaders)
-    }
+    override fun chapterListRequest(manga: SManga): Request = GET("$apiUrl/v1/chapter/${manga.url}/list?page_size=3000", apiHeaders)
 
     override fun chapterListParse(response: Response): List<SChapter> {
         val result = response.parseAs<ShinigamiChapterListDto>()

--- a/src/id/shinigami/src/eu/kanade/tachiyomi/extension/id/shinigami/ShinigamiDto.kt
+++ b/src/id/shinigami/src/eu/kanade/tachiyomi/extension/id/shinigami/ShinigamiDto.kt
@@ -18,7 +18,7 @@ class ShinigamiBrowseDataDto(
 
 @Serializable
 class MetaDto(
-    val page: Int,
+    val page: Int = 0,
     @SerialName("total_page") val totalPage: Int? = null,
 )
 


### PR DESCRIPTION
Fix:
-  E/Shinigami: ## getRelatedMangaListByExtension: kotlinx.serialization.MissingFieldException: Field 'page' is required for type with serial name 'eu.kanade.tachiyomi.extension.id.shinigami.MetaDto', but it was missing at path: $.meta
kotlinx.serialization.MissingFieldException: Field 'page' is required for type with serial name 'eu.kanade.tachiyomi.extension.id.shinigami.MetaDto', but it was missing at path: $.meta

- JSON input: .....,"process_time":"0ms"},"data":{"id":656,"manga_id":"e244efb4.....
kotlinx.serialization.json.internal.JsonDecodingException: Unexpected JSON token at offset 148: Expected start of the array '[', but had '{' instead at path: $.data
JSON input: .....,"process_time":"0ms"},"data":{"id":656,"manga_id":"e244efb4.....
at kotlinx.serialization.json.internal.JsonExceptionsKt.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
