### PR TITLE
Luvyaa: Update URL (`luvyaa.id`)

### DIFF
--- a/src/id/Luvyaa/build.gradle
+++ b/src/id/Luvyaa/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Luvyaa'
     extClass = '.Luvyaa'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://luvyaa.my.id'
-    overrideVersionCode = 0
+    baseUrl = 'https://luvyaa.id'
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/id/Luvyaa/src/eu/kanade/tachiyomi/extension/id/Luvyaa/Luvyaa.kt
+++ b/src/id/Luvyaa/src/eu/kanade/tachiyomi/extension/id/Luvyaa/Luvyaa.kt
@@ -4,9 +4,10 @@ import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class Luvyaa : MangaThemesia(
-    "Luvyaa",
-    "https://luvyaa.id",
-    "id",
-    dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale.US),
-)
+class Luvyaa :
+    MangaThemesia(
+        "Luvyaa",
+        "https://luvyaa.id",
+        "id",
+        dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale.US),
+    )

--- a/src/id/Luvyaa/src/eu/kanade/tachiyomi/extension/id/Luvyaa/Luvyaa.kt
+++ b/src/id/Luvyaa/src/eu/kanade/tachiyomi/extension/id/Luvyaa/Luvyaa.kt
@@ -1,4 +1,4 @@
-package eu.kanade.tachiyomi.extension.id.Luvyaa
+package eu.kanade.tachiyomi.extension.id.luvyaa
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import java.text.SimpleDateFormat
@@ -6,7 +6,7 @@ import java.util.Locale
 
 class Luvyaa : MangaThemesia(
     "Luvyaa",
-    "https://luvyaa.my.id",
+    "https://luvyaa.id",
     "id",
     dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale.US),
 )


### PR DESCRIPTION
Changes made:
- changed package name from "Luvyaa"->"luvyaa"
- Old URL was redirecting to new URL.
"https://luvyaa.my.id/" -> "https://luvyaa.id/"

closes: #13249 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
