### PR TITLE
[ALL] Manhwa18Net: removed themePkg, implemented necessary changes

### DIFF
--- a/src/all/manhwa18net/build.gradle
+++ b/src/all/manhwa18net/build.gradle
@@ -1,9 +1,9 @@
 ext {
     extName = 'Manhwa18.net'
     extClass = '.Manhwa18Net'
-    themePkg = 'mymangacms'
     baseUrl = 'https://manhwa18.net'
-    overrideVersionCode = 8
+    extVersionCode=1
+    overrideVersionCode = 9
     isNsfw = true
 }
 

--- a/src/all/manhwa18net/build.gradle
+++ b/src/all/manhwa18net/build.gradle
@@ -2,8 +2,7 @@ ext {
     extName = 'Manhwa18.net'
     extClass = '.Manhwa18Net'
     baseUrl = 'https://manhwa18.net'
-    extVersionCode=1
-    overrideVersionCode = 9
+    extVersionCode=11
     isNsfw = true
 }
 

--- a/src/all/manhwa18net/build.gradle
+++ b/src/all/manhwa18net/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Manhwa18.net'
     extClass = '.Manhwa18Net'
     baseUrl = 'https://manhwa18.net'
-    extVersionCode=11
+    extVersionCode = 11
     isNsfw = true
 }
 

--- a/src/all/manhwa18net/src/eu/kanade/tachiyomi/extension/all/manhwa18net/Dto.kt
+++ b/src/all/manhwa18net/src/eu/kanade/tachiyomi/extension/all/manhwa18net/Dto.kt
@@ -1,0 +1,59 @@
+package eu.kanade.tachiyomi.extension.all.manhwa18net
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PageDto(
+    val props: PropsDto,
+)
+
+@Serializable
+data class PropsDto(
+    val paginate: PaginateDto? = null,
+    val popularManga: PaginateDto? = null,
+    val mangas: PaginateDto? = null,
+    val latestManhwaMain: PaginateDto? = null,
+    val manga: MangaDto? = null,
+    val chapters: List<ChapterDto>? = null,
+    val chapterContent: String? = null,
+)
+
+@Serializable
+data class PaginateDto(
+    val data: List<MangaDto>,
+    @SerialName("next_page_url")
+    val nextPageUrl: String? = null,
+)
+
+@Serializable
+data class MangaDto(
+    val name: String,
+    val slug: String,
+    @SerialName("cover_url")
+    val coverUrl: String? = null,
+    @SerialName("thumb_url")
+    val thumbUrl: String? = null,
+    val pilot: String? = null,
+    val description: String? = null,
+    val genres: List<GenreDto>? = null,
+    val artists: List<ArtistDto>? = null,
+    @SerialName("status_id")
+    val statusId: Int? = null,
+)
+
+@Serializable
+data class ChapterDto(
+    val name: String,
+    val slug: String,
+)
+
+@Serializable
+data class GenreDto(
+    val name: String,
+)
+
+@Serializable
+data class ArtistDto(
+    val name: String,
+)

--- a/src/all/manhwa18net/src/eu/kanade/tachiyomi/extension/all/manhwa18net/Filter.kt
+++ b/src/all/manhwa18net/src/eu/kanade/tachiyomi/extension/all/manhwa18net/Filter.kt
@@ -1,0 +1,41 @@
+package eu.kanade.tachiyomi.extension.all.manhwa18net
+
+import eu.kanade.tachiyomi.source.model.Filter
+import eu.kanade.tachiyomi.source.model.FilterList
+
+fun getFilters() = FilterList(
+    Filter.Header("Filters work with both search and browse"),
+    Filter.Separator(),
+    SortFilter(),
+    StatusFilter(),
+)
+
+class SortFilter :
+    UriPartFilter(
+        "Sort By",
+        arrayOf(
+            "Latest Updates" to "update",
+            "Most Viewed" to "top",
+            "Most Liked" to "like",
+            "Newest" to "new",
+        ),
+    )
+
+class StatusFilter :
+    Filter.Group<StatusCheckBox>(
+        "Status",
+        listOf(
+            StatusCheckBox("Ongoing", "Ongoing"),
+            StatusCheckBox("On Hold", "Onhold"),
+            StatusCheckBox("Completed", "completed"),
+        ),
+    )
+
+class StatusCheckBox(name: String, val uriParam: String) : Filter.CheckBox(name)
+
+open class UriPartFilter(
+    displayName: String,
+    private val vals: Array<Pair<String, String>>,
+) : Filter.Select<String>(displayName, vals.map { it.first }.toTypedArray()) {
+    fun toUriPart() = vals[state].second
+}

--- a/src/all/manhwa18net/src/eu/kanade/tachiyomi/extension/all/manhwa18net/Manhwa18Net.kt
+++ b/src/all/manhwa18net/src/eu/kanade/tachiyomi/extension/all/manhwa18net/Manhwa18Net.kt
@@ -1,62 +1,258 @@
 package eu.kanade.tachiyomi.extension.all.manhwa18net
 
-import eu.kanade.tachiyomi.multisrc.mymangacms.MyMangaCMS
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.online.ParsedHttpSource
+import keiyoushi.utils.parseAs
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
 
-class Manhwa18Net : MyMangaCMS("Manhwa18.net", "https://manhwa18.net", "en") {
+class Manhwa18Net : ParsedHttpSource() {
 
-    // Migrated from FMReader to MyMangaCms.
-    override val versionId = 2
+    override val name = "Manhwa18Net"
+    override val baseUrl = "https://manhwa18.net"
+    override val lang = "all"
+    override val supportsLatest = true
 
-    override val parseAuthorString = "Author"
-    override val parseAlternativeNameString = "Other name"
-    override val parseAlternative2ndNameString = "Doujinshi"
-    override val parseStatusString = "Status"
-    override val parseStatusOngoingStringLowerCase = "on going"
-    override val parseStatusOnHoldStringLowerCase = "on hold"
-    override val parseStatusCompletedStringLowerCase = "completed"
+    override val client: OkHttpClient = network.client.newBuilder()
+        .rateLimit(3)
+        .build()
 
-    override fun getFilterList(): FilterList = FilterList(
-        Author("Author"),
-        Status(
-            "Status",
-            "All",
-            "Ongoing",
-            "On hold",
-            "Completed",
-        ),
-        Sort(
-            "Order",
-            "A-Z",
-            "Z-A",
-            "Latest update",
-            "New manhwa",
-            "Most view",
-            "Most like",
-        ),
-        GenreList(getGenreList(), "Genre"),
+    private fun extractPageJson(document: Document): JsonObject? {
+        val app = document.selectFirst("#app") ?: return null
+        val data = app.attr("data-page")
+        if (data.isBlank()) return null
+        return data.parseAs<JsonObject>()
+    }
+
+    private fun extractProps(document: Document): JsonObject? = extractPageJson(document)?.get("props")?.jsonObject
+
+    // ============================================================
+    // REQUESTS
+    // ============================================================
+
+    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/manga-list?sort=top&page=$page", headers)
+
+    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/manga-list?sort=update&page=$page", headers)
+
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+        val builder = if (query.isNotEmpty()) {
+            "$baseUrl/tim-kiem".toHttpUrl().newBuilder()
+                .addQueryParameter("q", query)
+        } else {
+            "$baseUrl/manga-list".toHttpUrl().newBuilder()
+        }
+
+        builder.addQueryParameter("page", page.toString())
+
+        filters.forEach { filter ->
+            when (filter) {
+                is SortFilter -> builder.addQueryParameter("sort", filter.toUriPart())
+
+                is StatusFilter -> {
+                    filter.state.forEach { status ->
+                        if (status.state) {
+                            builder.addQueryParameter(status.uriParam, "1")
+                        }
+                    }
+                }
+
+                else -> {}
+            }
+        }
+
+        return GET(builder.build().toString(), headers)
+    }
+
+    // ============================================================
+    // FILTERS
+    // ============================================================
+
+    override fun getFilterList() = getFilters()
+
+    // ============================================================
+    // LIST PARSING
+    // ============================================================
+
+    override fun popularMangaParse(response: Response) = parseList(response)
+    override fun latestUpdatesParse(response: Response) = parseList(response)
+    override fun searchMangaParse(response: Response) = parseList(response)
+
+    private fun parseList(response: Response): MangasPage {
+        val document = Jsoup.parse(response.body.string())
+        val props = extractProps(document) ?: return MangasPage(emptyList(), false)
+
+        val listing = props["paginate"]?.jsonObject
+            ?: props["popularManga"]?.jsonObject
+            ?: props["mangas"]?.jsonObject
+            ?: props["latestManhwaMain"]?.jsonObject
+            ?: return MangasPage(emptyList(), false)
+
+        val dataArray = listing["data"]?.jsonArray ?: return MangasPage(emptyList(), false)
+
+        val mangas = dataArray.mapNotNull {
+            val obj = it.jsonObject
+            val slug = obj["slug"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
+            val title = obj["name"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
+
+            SManga.create().apply {
+                this.title = title
+                url = "/manga/$slug"
+                thumbnail_url = fixImageUrl(
+                    obj["cover_url"]?.jsonPrimitive?.contentOrNull
+                        ?: obj["thumb_url"]?.jsonPrimitive?.contentOrNull,
+                )
+            }
+        }
+
+        val hasNextPage = listing["next_page_url"]?.jsonPrimitive?.contentOrNull != null
+        return MangasPage(mangas, hasNextPage)
+    }
+
+    // ============================================================
+    // DETAILS
+    // ============================================================
+
+    override fun mangaDetailsParse(document: Document): SManga {
+        val props = extractProps(document) ?: return SManga.create()
+        val manga = props["manga"]?.jsonObject ?: return SManga.create()
+
+        return SManga.create().apply {
+            title = manga["name"]?.jsonPrimitive?.contentOrNull ?: ""
+
+            description =
+                manga["pilot"]?.jsonPrimitive?.contentOrNull?.let { Jsoup.parse(it).text() }
+                    ?: manga["description"]?.jsonPrimitive?.contentOrNull?.let { Jsoup.parse(it).text() }
+                    ?: ""
+
+            thumbnail_url = fixImageUrl(
+                manga["cover_url"]?.jsonPrimitive?.contentOrNull
+                    ?: manga["thumb_url"]?.jsonPrimitive?.contentOrNull,
+            )
+
+            genre = manga["genres"]?.jsonArray
+                ?.mapNotNull { it.jsonObject["name"]?.jsonPrimitive?.contentOrNull }
+                ?.joinToString(", ")
+
+            author = manga["artists"]?.jsonArray
+                ?.mapNotNull { it.jsonObject["name"]?.jsonPrimitive?.contentOrNull }
+                ?.joinToString(", ")
+                ?.ifEmpty { null }
+
+            artist = author
+
+            status = when (manga["status_id"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()) {
+                0 -> SManga.ONGOING
+                1, 2 -> SManga.COMPLETED
+                else -> SManga.UNKNOWN
+            }
+        }
+    }
+
+    // ============================================================
+    // CHAPTER LIST
+    // ============================================================
+
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val document = Jsoup.parse(response.body.string())
+        val props = extractProps(document) ?: return emptyList()
+        val manga = props["manga"]?.jsonObject ?: return emptyList()
+        val slug = manga["slug"]?.jsonPrimitive?.contentOrNull ?: return emptyList()
+        val chapters = props["chapters"]?.jsonArray ?: return emptyList()
+
+        val chapterList = chapters.mapNotNull {
+            val obj = it.jsonObject
+            val chapSlug = obj["slug"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
+
+            SChapter.create().apply {
+                name = obj["name"]?.jsonPrimitive?.contentOrNull ?: ""
+                url = "/manga/$slug/$chapSlug"
+            }
+        }
+        return chapterList
+    }
+
+    private fun extractChapterNumber(name: String): Float {
+        // Extract chapter number from name like "Chapter 80" or "Chap 80"
+        val regex = """(?:chapter|chap|ch)[^\d]*(\d+(?:\.\d+)?)""".toRegex(RegexOption.IGNORE_CASE)
+        return regex.find(name)?.groupValues?.get(1)?.toFloatOrNull() ?: -1f
+    }
+
+    // ============================================================
+    // PAGE LIST
+    // ============================================================
+
+    override fun pageListParse(document: Document): List<Page> {
+        val root = extractPageJson(document) ?: return emptyList()
+        val props = root["props"]?.jsonObject ?: return emptyList()
+        val chapterContent = props["chapterContent"]?.jsonPrimitive?.contentOrNull
+            ?: return emptyList()
+
+        val contentDoc = Jsoup.parse(chapterContent)
+        val images = contentDoc.select("img")
+
+        return images.mapIndexedNotNull { index, img ->
+            val src = img.attr("src")
+                .ifBlank { img.attr("data-src") }
+                .ifBlank { img.attr("data-lazy-src") }
+
+            fixImageUrl(src)?.let {
+                Page(index, "", it)
+            }
+        }
+    }
+
+    override fun imageRequest(page: Page): Request = GET(
+        page.imageUrl!!,
+        headersBuilder()
+            .add("Referer", baseUrl)
+            .build(),
     )
 
-    // To populate this list:
-    // console.log([...document.querySelectorAll("div.search-gerne_item")].map(elem => `Genre("${elem.textContent.trim()}", ${elem.querySelector("label").getAttribute("data-genre-id")}),`).join("\n"))
-    override fun getGenreList() = listOf(
-        Genre("Adult", 4),
-        Genre("Doujinshi", 9),
-        Genre("Harem", 17),
-        Genre("Manga", 24),
-        Genre("Manhwa", 26),
-        Genre("Mature", 28),
-        Genre("NTR", 33),
-        Genre("Romance", 36),
-        Genre("Webtoon", 57),
-        Genre("Action", 59),
-        Genre("Comedy", 60),
-        Genre("BL", 61),
-        Genre("Horror", 62),
-        Genre("Raw", 63),
-        Genre("Uncensore", 64),
-    )
+    // ============================================================
+    // ABSTRACTS
+    // ============================================================
 
-    override fun dateUpdatedParser(date: String): Long =
-        runCatching { dateFormatter.parse(date.substringAfter(" - "))?.time }.getOrNull() ?: 0L
+    override fun popularMangaSelector() = throw UnsupportedOperationException()
+    override fun popularMangaFromElement(element: Element) = throw UnsupportedOperationException()
+    override fun popularMangaNextPageSelector() = throw UnsupportedOperationException()
+
+    override fun latestUpdatesSelector() = throw UnsupportedOperationException()
+    override fun latestUpdatesFromElement(element: Element) = throw UnsupportedOperationException()
+    override fun latestUpdatesNextPageSelector() = throw UnsupportedOperationException()
+
+    override fun searchMangaSelector() = throw UnsupportedOperationException()
+    override fun searchMangaFromElement(element: Element) = throw UnsupportedOperationException()
+    override fun searchMangaNextPageSelector() = throw UnsupportedOperationException()
+
+    override fun chapterListSelector() = throw UnsupportedOperationException()
+    override fun chapterFromElement(element: Element) = throw UnsupportedOperationException()
+
+    override fun imageUrlParse(document: Document) = throw UnsupportedOperationException()
+
+    // ============================================================
+    // UTIL
+    // ============================================================
+
+    private fun fixImageUrl(url: String?): String? = when {
+        url.isNullOrBlank() -> null
+        url.startsWith("http") -> url
+        url.startsWith("/") -> baseUrl + url
+        else -> "$baseUrl/$url"
+    }
 }

--- a/src/all/manhwa18net/src/eu/kanade/tachiyomi/extension/all/manhwa18net/Manhwa18Net.kt
+++ b/src/all/manhwa18net/src/eu/kanade/tachiyomi/extension/all/manhwa18net/Manhwa18Net.kt
@@ -17,6 +17,7 @@ import org.jsoup.Jsoup
 
 class Manhwa18Net : HttpSource() {
 
+    override val versionId = 2
     override val name = "Manhwa18Net"
     override val baseUrl = "https://manhwa18.net"
     override val lang = "en"

--- a/src/all/manhwa18net/src/eu/kanade/tachiyomi/extension/all/manhwa18net/Manhwa18Net.kt
+++ b/src/all/manhwa18net/src/eu/kanade/tachiyomi/extension/all/manhwa18net/Manhwa18Net.kt
@@ -18,7 +18,7 @@ import org.jsoup.Jsoup
 class Manhwa18Net : HttpSource() {
 
     override val versionId = 2
-    override val name = "Manhwa18Net"
+    override val name = "Manhwa18.Net"
     override val baseUrl = "https://manhwa18.net"
     override val lang = "en"
     override val supportsLatest = true
@@ -123,7 +123,6 @@ class Manhwa18Net : HttpSource() {
 
             description = manga.pilot?.let { Jsoup.parse(it).text() }
                 ?: manga.description?.let { Jsoup.parse(it).text() }
-                ?: ""
 
             thumbnail_url = fixImageUrl(manga.coverUrl ?: manga.thumbUrl)
 
@@ -169,8 +168,6 @@ class Manhwa18Net : HttpSource() {
 
         val contentDoc = Jsoup.parse(chapterContent)
         val images = contentDoc.select("img")
-
-        if (images.isEmpty()) throw Exception("No images found in chapter")
 
         return images.mapIndexedNotNull { index, img ->
             val src = img.attr("src")

--- a/src/all/manhwa18net/src/eu/kanade/tachiyomi/extension/all/manhwa18net/Manhwa18Net.kt
+++ b/src/all/manhwa18net/src/eu/kanade/tachiyomi/extension/all/manhwa18net/Manhwa18Net.kt
@@ -7,40 +7,35 @@ import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.ParsedHttpSource
+import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.utils.parseAs
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
-import org.jsoup.nodes.Element
 
-class Manhwa18Net : ParsedHttpSource() {
+class Manhwa18Net : HttpSource() {
 
     override val name = "Manhwa18Net"
     override val baseUrl = "https://manhwa18.net"
-    override val lang = "all"
+    override val lang = "en"
     override val supportsLatest = true
 
     override val client: OkHttpClient = network.client.newBuilder()
         .rateLimit(3)
         .build()
 
-    private fun extractPageJson(document: Document): JsonObject? {
-        val app = document.selectFirst("#app") ?: return null
-        val data = app.attr("data-page")
-        if (data.isBlank()) return null
-        return data.parseAs<JsonObject>()
-    }
+    private fun Response.asJsoup() = Jsoup.parse(body.string())
 
-    private fun extractProps(document: Document): JsonObject? = extractPageJson(document)?.get("props")?.jsonObject
+    private fun extractPageDto(response: Response): PageDto {
+        val document = response.asJsoup()
+        val app = document.selectFirst("#app")
+            ?: throw Exception("Could not find #app element")
+        val data = app.attr("data-page")
+        if (data.isBlank()) throw Exception("data-page attribute is empty")
+        return data.parseAs<PageDto>()
+    }
 
     // ============================================================
     // REQUESTS
@@ -90,73 +85,54 @@ class Manhwa18Net : ParsedHttpSource() {
     // ============================================================
 
     override fun popularMangaParse(response: Response) = parseList(response)
+
     override fun latestUpdatesParse(response: Response) = parseList(response)
+
     override fun searchMangaParse(response: Response) = parseList(response)
 
     private fun parseList(response: Response): MangasPage {
-        val document = Jsoup.parse(response.body.string())
-        val props = extractProps(document) ?: return MangasPage(emptyList(), false)
+        val props = extractPageDto(response).props
 
-        val listing = props["paginate"]?.jsonObject
-            ?: props["popularManga"]?.jsonObject
-            ?: props["mangas"]?.jsonObject
-            ?: props["latestManhwaMain"]?.jsonObject
-            ?: return MangasPage(emptyList(), false)
+        val listing = props.paginate
+            ?: props.popularManga
+            ?: props.mangas
+            ?: props.latestManhwaMain
+            ?: throw Exception("No manga listing found in response")
 
-        val dataArray = listing["data"]?.jsonArray ?: return MangasPage(emptyList(), false)
-
-        val mangas = dataArray.mapNotNull {
-            val obj = it.jsonObject
-            val slug = obj["slug"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
-            val title = obj["name"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
-
+        val mangas = listing.data.map { manga ->
             SManga.create().apply {
-                this.title = title
-                url = "/manga/$slug"
-                thumbnail_url = fixImageUrl(
-                    obj["cover_url"]?.jsonPrimitive?.contentOrNull
-                        ?: obj["thumb_url"]?.jsonPrimitive?.contentOrNull,
-                )
+                title = manga.name
+                url = "/manga/${manga.slug}"
+                thumbnail_url = fixImageUrl(manga.coverUrl ?: manga.thumbUrl)
             }
         }
 
-        val hasNextPage = listing["next_page_url"]?.jsonPrimitive?.contentOrNull != null
-        return MangasPage(mangas, hasNextPage)
+        return MangasPage(mangas, listing.nextPageUrl != null)
     }
-
     // ============================================================
     // DETAILS
     // ============================================================
 
-    override fun mangaDetailsParse(document: Document): SManga {
-        val props = extractProps(document) ?: return SManga.create()
-        val manga = props["manga"]?.jsonObject ?: return SManga.create()
+    override fun mangaDetailsParse(response: Response): SManga {
+        val props = extractPageDto(response).props
+        val manga = props.manga ?: throw Exception("Manga details not found")
 
         return SManga.create().apply {
-            title = manga["name"]?.jsonPrimitive?.contentOrNull ?: ""
+            title = manga.name
 
-            description =
-                manga["pilot"]?.jsonPrimitive?.contentOrNull?.let { Jsoup.parse(it).text() }
-                    ?: manga["description"]?.jsonPrimitive?.contentOrNull?.let { Jsoup.parse(it).text() }
-                    ?: ""
+            description = manga.pilot?.let { Jsoup.parse(it).text() }
+                ?: manga.description?.let { Jsoup.parse(it).text() }
+                ?: ""
 
-            thumbnail_url = fixImageUrl(
-                manga["cover_url"]?.jsonPrimitive?.contentOrNull
-                    ?: manga["thumb_url"]?.jsonPrimitive?.contentOrNull,
-            )
+            thumbnail_url = fixImageUrl(manga.coverUrl ?: manga.thumbUrl)
 
-            genre = manga["genres"]?.jsonArray
-                ?.mapNotNull { it.jsonObject["name"]?.jsonPrimitive?.contentOrNull }
-                ?.joinToString(", ")
+            genre = manga.genres?.joinToString(", ") { it.name }
 
-            author = manga["artists"]?.jsonArray
-                ?.mapNotNull { it.jsonObject["name"]?.jsonPrimitive?.contentOrNull }
-                ?.joinToString(", ")
-                ?.ifEmpty { null }
+            author = manga.artists?.joinToString(", ") { it.name }?.ifEmpty { null }
 
             artist = author
 
-            status = when (manga["status_id"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()) {
+            status = when (manga.statusId) {
                 0 -> SManga.ONGOING
                 1, 2 -> SManga.COMPLETED
                 else -> SManga.UNKNOWN
@@ -169,53 +145,42 @@ class Manhwa18Net : ParsedHttpSource() {
     // ============================================================
 
     override fun chapterListParse(response: Response): List<SChapter> {
-        val document = Jsoup.parse(response.body.string())
-        val props = extractProps(document) ?: return emptyList()
-        val manga = props["manga"]?.jsonObject ?: return emptyList()
-        val slug = manga["slug"]?.jsonPrimitive?.contentOrNull ?: return emptyList()
-        val chapters = props["chapters"]?.jsonArray ?: return emptyList()
+        val props = extractPageDto(response).props
+        val manga = props.manga ?: throw Exception("Manga not found")
+        val chapters = props.chapters ?: throw Exception("Chapters not found")
 
-        val chapterList = chapters.mapNotNull {
-            val obj = it.jsonObject
-            val chapSlug = obj["slug"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
-
+        return chapters.map { chapter ->
             SChapter.create().apply {
-                name = obj["name"]?.jsonPrimitive?.contentOrNull ?: ""
-                url = "/manga/$slug/$chapSlug"
+                name = chapter.name
+                url = "/manga/${manga.slug}/${chapter.slug}"
             }
         }
-        return chapterList
-    }
-
-    private fun extractChapterNumber(name: String): Float {
-        // Extract chapter number from name like "Chapter 80" or "Chap 80"
-        val regex = """(?:chapter|chap|ch)[^\d]*(\d+(?:\.\d+)?)""".toRegex(RegexOption.IGNORE_CASE)
-        return regex.find(name)?.groupValues?.get(1)?.toFloatOrNull() ?: -1f
     }
 
     // ============================================================
     // PAGE LIST
     // ============================================================
 
-    override fun pageListParse(document: Document): List<Page> {
-        val root = extractPageJson(document) ?: return emptyList()
-        val props = root["props"]?.jsonObject ?: return emptyList()
-        val chapterContent = props["chapterContent"]?.jsonPrimitive?.contentOrNull
-            ?: return emptyList()
+    override fun pageListParse(response: Response): List<Page> {
+        val props = extractPageDto(response).props
+        val chapterContent = props.chapterContent
+            ?: throw Exception("Chapter content not found")
 
         val contentDoc = Jsoup.parse(chapterContent)
         val images = contentDoc.select("img")
+
+        if (images.isEmpty()) throw Exception("No images found in chapter")
 
         return images.mapIndexedNotNull { index, img ->
             val src = img.attr("src")
                 .ifBlank { img.attr("data-src") }
                 .ifBlank { img.attr("data-lazy-src") }
 
-            fixImageUrl(src)?.let {
-                Page(index, "", it)
-            }
+            fixImageUrl(src)?.let { Page(index, "", it) }
         }
     }
+
+    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
 
     override fun imageRequest(page: Page): Request = GET(
         page.imageUrl!!,
@@ -223,27 +188,6 @@ class Manhwa18Net : ParsedHttpSource() {
             .add("Referer", baseUrl)
             .build(),
     )
-
-    // ============================================================
-    // ABSTRACTS
-    // ============================================================
-
-    override fun popularMangaSelector() = throw UnsupportedOperationException()
-    override fun popularMangaFromElement(element: Element) = throw UnsupportedOperationException()
-    override fun popularMangaNextPageSelector() = throw UnsupportedOperationException()
-
-    override fun latestUpdatesSelector() = throw UnsupportedOperationException()
-    override fun latestUpdatesFromElement(element: Element) = throw UnsupportedOperationException()
-    override fun latestUpdatesNextPageSelector() = throw UnsupportedOperationException()
-
-    override fun searchMangaSelector() = throw UnsupportedOperationException()
-    override fun searchMangaFromElement(element: Element) = throw UnsupportedOperationException()
-    override fun searchMangaNextPageSelector() = throw UnsupportedOperationException()
-
-    override fun chapterListSelector() = throw UnsupportedOperationException()
-    override fun chapterFromElement(element: Element) = throw UnsupportedOperationException()
-
-    override fun imageUrlParse(document: Document) = throw UnsupportedOperationException()
 
     // ============================================================
     // UTIL


### PR DESCRIPTION
Cause:
Source Architecture changed from MyMangaCMS to SPA (Single Page Application"

Changes:
- removed themepkg-"MyManagCMS"
- added extVersionCode and increment overrideVersionCode
- Other Necessary Changes

closes: #13339

Note: The source ordering of chapter is messed up, the user may see missing chapter number as they are not ordered properly for some content from the source even if the all chapters are present.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
