### PR TITLE
CI: resolve dependencies directly in python

### DIFF
--- a/.github/scripts/generate-build-matrices.py
+++ b/.github/scripts/generate-build-matrices.py
@@ -132,10 +132,11 @@ def get_module_list(ref: str) -> tuple[list[str], list[str]]:
     multisrcs = set()
     libs = set()
     deleted = set()
+    core_files_changed = False
 
     for file in map(lambda x: Path(x).as_posix(), changed_files):
         if CORE_FILES_REGEX.search(file):
-            return get_all_modules()
+            core_files_changed = True
         
         elif match := EXTENSION_REGEX.search(file):
             lang = match.group("lang")
@@ -153,6 +154,15 @@ def get_module_list(ref: str) -> tuple[list[str], list[str]]:
             lib = match.group("lib")
             if Path("lib", lib).is_dir():
                 libs.add(lib)
+              
+    if core_files_changed:
+        (all_modules, all_deleted) = get_all_modules()
+
+        # update existing set so we include deleted extensions
+        modules.update(all_modules)
+        deleted.update(all_deleted)
+        
+        return list(modules), list(deleted)
     
     # Resolve libs that depend on the changed libs (recursively)
     libs.update(

--- a/.github/scripts/generate-build-matrices.py
+++ b/.github/scripts/generate-build-matrices.py
@@ -12,7 +12,7 @@ MULTISRC_LIB_REGEX = re.compile(r"^lib-multisrc/(?P<multisrc>\w+)")
 LIB_REGEX = re.compile(r"^lib/(?P<lib>\w+)")
 MODULE_REGEX = re.compile(r"^:src:(?P<lang>\w+):(?P<extension>\w+)$")
 CORE_FILES_REGEX = re.compile(
-    r"^(buildSrc/|core/|gradle/|build\.gradle\.kts|common\.gradle|gradle\.properties|settings\.gradle\.kts|.github/scripts)"
+    r"^(buildSrc/|core/|gradle/|build\.gradle\.kts|common\.gradle|gradle\.properties|settings\.gradle\.kts)"
 )
 
 def run_command(command: str) -> str:
@@ -21,6 +21,62 @@ def run_command(command: str) -> str:
         print(result.stderr.strip())
         sys.exit(result.returncode)
     return result.stdout.strip()
+
+
+def resolve_multisrc_lib(libs: set[str]) -> set[str]:
+    """
+    returns all multisrc which depend on any of the
+    passed libs (/lib)
+    """
+    
+    lib_dependency = re.compile(
+        rf"project\([\"']:(?:lib):({'|'.join(map(re.escape, libs))})[\"']\)"
+    )
+    
+    multisrcs = set()
+    
+    for multisrc in Path("lib-multisrc").iterdir():
+        build_file = multisrc / "build.gradle.kts"
+        if not build_file.is_file():
+            continue
+        
+        with open(build_file) as f:
+            content = f.read()
+            
+        if (lib_dependency.search(content)):
+            multisrcs.add(multisrc.name)
+                
+    return multisrcs
+            
+def resolve_ext(multisrcs: set[str], libs: set[str]) -> set[tuple[str, str]]:
+    """
+    returns all extensions which depend on any of the
+    passed multisrcs or libs
+    """
+    
+    multisrc_dependency = re.compile(
+        rf"themePkg\s*=\s*['\"]({'|'.join(map(re.escape, multisrcs))})['\"]"
+    )
+    
+    lib_dependency = re.compile(
+        rf"project\([\"']:(?:lib):({'|'.join(map(re.escape, libs))})[\"']\)"
+    )
+    
+    extensions = set()
+    
+    for lang in Path("src").iterdir():
+        for extension in lang.iterdir():
+            build_file = extension / "build.gradle"
+            if not build_file.is_file():
+                continue
+            
+            with open(build_file) as f:
+                content = f.read()
+                
+            if (multisrc_dependency.search(content) or lib_dependency.search(content)):
+                extensions.add((lang.name, extension.name))
+    
+    return extensions
 
 def get_module_list(ref: str) -> tuple[list[str], list[str]]:
     diff_output = run_command(f"git diff --name-status {ref}").splitlines()
@@ -32,6 +88,7 @@ def get_module_list(ref: str) -> tuple[list[str], list[str]]:
     ]
         
     modules = set()
+    multisrcs = set()
     libs = set()
     deleted = set()
     core_files_changed = False
@@ -49,39 +106,27 @@ def get_module_list(ref: str) -> tuple[list[str], list[str]]:
         elif match := MULTISRC_LIB_REGEX.search(file):
             multisrc = match.group("multisrc")
             if Path("lib-multisrc", multisrc).is_dir():
-                libs.add(f":lib-multisrc:{multisrc}:printDependentExtensions")
+                multisrcs.add(multisrc)
         elif match := LIB_REGEX.search(file):
             lib = match.group("lib")
             if Path("lib", lib).is_dir():
-                libs.add(f":lib:{lib}:printDependentExtensions")
+                libs.add(lib)
+                
+    if core_files_changed:
+        return get_all_modules()
+                
+    multisrcs.update(resolve_multisrc_lib(libs))
+    
+    extensions = resolve_ext(multisrcs, libs)
+    modules.update([f":src:{lang}:{extension}" for lang, extension in extensions])
+    deleted.update([f"{lang}.{extension}" for lang, extension in extensions])
 
-    def is_extension_module(module: str) -> bool:
-        if not (match := MODULE_REGEX.search(module)):
-            return False
-        lang = match.group("lang")
-        extension = match.group("extension")
-        deleted.add(f"{lang}.{extension}")
-        return True
-
-    if len(libs) != 0 and not core_files_changed:
-        modules.update([
-            module for module in
-            run_command("./gradlew -q " + " ".join(libs)).splitlines()
-            if is_extension_module(module)
-        ])
-
-    if os.getenv("IS_PR_CHECK") != "true" and not core_files_changed:
+    if os.getenv("IS_PR_CHECK") != "true":
         with Path(".github/always_build.json").open() as always_build_file:
             always_build = json.load(always_build_file)
         for extension in always_build:
             modules.add(":src:" + extension.replace(".", ":"))
             deleted.add(extension)
-
-    if core_files_changed:
-        (all_modules, all_deleted) = get_all_modules()
-
-        modules.update(all_modules)
-        deleted.update(all_deleted)
 
     return list(modules), list(deleted)
 

--- a/.github/scripts/generate-build-matrices.py
+++ b/.github/scripts/generate-build-matrices.py
@@ -12,7 +12,7 @@ MULTISRC_LIB_REGEX = re.compile(r"^lib-multisrc/(?P<multisrc>\w+)")
 LIB_REGEX = re.compile(r"^lib/(?P<lib>\w+)")
 MODULE_REGEX = re.compile(r"^:src:(?P<lang>\w+):(?P<extension>\w+)$")
 CORE_FILES_REGEX = re.compile(
-    r"^(buildSrc/|core/|gradle/|build\.gradle\.kts|common\.gradle|gradle\.properties|settings\.gradle\.kts)"
+    r"^(buildSrc/|core/|gradle/|build\.gradle\.kts|common\.gradle|gradle\.properties|settings\.gradle\.kts|.github/scripts)"
 )
 
 def run_command(command: str) -> str:

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -33,17 +33,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          java-version: 17
-          distribution: temurin
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1
-        with:
-          cache-read-only: true
-
       - id: generate-matrices
         name: Generate build matrices
         run: |

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -37,17 +37,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          java-version: 17
-          distribution: temurin
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1
-        with:
-          cache-read-only: true
-
       - name: Get last successful CI commit
         uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4.4.0
         with:

--- a/buildSrc/src/main/kotlin/Extensions.kt
+++ b/buildSrc/src/main/kotlin/Extensions.kt
@@ -1,52 +1,6 @@
-import org.gradle.api.Project
-import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.kotlin.dsl.extra
 
 var ExtensionAware.baseVersionCode: Int
     get() = extra.get("baseVersionCode") as Int
     set(value) = extra.set("baseVersionCode", value)
-
-private var reverseDependencyCache: Map<String, Set<Project>>? = null
-
-fun Project.getDependents(): Set<Project> {
-    if (reverseDependencyCache == null) {
-        reverseDependencyCache = rootProject.allprojects
-            .flatMap { p ->
-                p.configurations.flatMap { config ->
-                    config.dependencies
-                        .filterIsInstance<ProjectDependency>()
-                        .map { dep -> dep.path to p }
-                }
-            }
-            .groupBy({ it.first }, { it.second })
-            .mapValues { (_, projects) -> projects.toSet() }
-    }
-
-    return reverseDependencyCache?.get(path).orEmpty()
-}
-
-fun Project.printDependentExtensions() =
-    printDependentExtensions(mutableSetOf())
-
-private fun Project.printDependentExtensions(visited: MutableSet<String>) {
-    if (!visited.add(this.path)) return
-
-    getDependents().forEach { project ->
-        when {
-            project.path.startsWith(":src:") -> {
-                println(project.path)
-            }
-
-            project.path.startsWith(":lib-multisrc:") -> {
-                project.getDependents().forEach {
-                    if (visited.add(it.path)) println(it.path)
-                }
-            }
-
-            project.path.startsWith(":lib:") -> {
-                project.printDependentExtensions(visited)
-            }
-        }
-    }
-}

--- a/buildSrc/src/main/kotlin/lib-android.gradle.kts
+++ b/buildSrc/src/main/kotlin/lib-android.gradle.kts
@@ -19,9 +19,3 @@ dependencies {
     compileOnly(versionCatalogs.named("libs").findBundle("common").get())
     implementation(project(":core"))
 }
-
-tasks.register("printDependentExtensions") {
-    doLast {
-        project.printDependentExtensions()
-    }
-}

--- a/buildSrc/src/main/kotlin/lib-multisrc.gradle.kts
+++ b/buildSrc/src/main/kotlin/lib-multisrc.gradle.kts
@@ -38,9 +38,3 @@ dependencies {
     compileOnly(versionCatalogs.named("libs").findBundle("common").get())
     implementation(project(":core"))
 }
-
-tasks.register("printDependentExtensions") {
-    doLast {
-        project.printDependentExtensions()
-    }
-}

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,7 @@ org.gradle.jvmargs=-Xmx6144m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 org.gradle.workers.max=5
+org.gradle.configureondemand=true
 
 org.gradle.caching=true
 


### PR DESCRIPTION
previous method of calling gradle is slow, as it first restores gradle cache and then runs it. It also requires we disable gradle's `configureondemand`. 
Resolving dependencies in the script via regex skips gradle and allows us to enable `configureondemand` globally, which is especially helpful for local builds
