### PR TITLE
Andrey/13310 seimanga layout

### DIFF
--- a/lib-multisrc/grouple/build.gradle.kts
+++ b/lib-multisrc/grouple/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 34
+baseVersionCode = 35


### PR DESCRIPTION
 Closes #13310

 Summary
  - Fixed `GroupLe` manga details parsing for the new `cr-*` layout used by SeiManga/SelfManga.
  - Added dual parsing strategy:
    - legacy path for old `.expandable` layout
    - modern path for new `cr-*` layout
  - Restored parsing of title, cover, description, author/artist, genre tags, and status.
  - Kept backward compatibility for domains still on old layout.


Checklist:

- [+] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [+] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [+] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [+ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [+ ] Have not changed source names
- [+ ] Have explicitly kept the `id` if a source's name or language were changed
- [+] Have tested the modifications by compiling and running the extension through Android Studio
- [+ ] Have removed `web_hi_res_512.png` when adding a new extension
