### PR TITLE
Add Azuretoons authentication support and fix error Mihon ACCEPT_LANGUAGE

### DIFF
--- a/src/pt/azuretoons/build.gradle
+++ b/src/pt/azuretoons/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Azuretoons'
     extClass = '.Azuretoons'
     baseUrl = 'https://azuretoons.com'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/pt/azuretoons/src/eu/kanade/tachiyomi/extension/pt/azuretoons/Azuretoons.kt
+++ b/src/pt/azuretoons/src/eu/kanade/tachiyomi/extension/pt/azuretoons/Azuretoons.kt
@@ -1,20 +1,32 @@
 package eu.kanade.tachiyomi.extension.pt.azuretoons
 
+import android.content.SharedPreferences
+import androidx.preference.EditTextPreference
+import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
+import keiyoushi.utils.toJsonString
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import kotlin.jvm.Synchronized
 
-class Azuretoons : HttpSource() {
+class Azuretoons :
+    HttpSource(),
+    ConfigurableSource {
 
     override val name = "Azuretoons"
     override val baseUrl = "https://azuretoons.com"
@@ -23,16 +35,95 @@ class Azuretoons : HttpSource() {
 
     private val apiUrl = "https://azuretoons.com/api"
 
+    private var cachedToken: String? = null
+    private var tokenExpiryTime: Long = 0L
+    private val preferences: SharedPreferences by getPreferencesLazy()
+
     override val client = network.cloudflareClient.newBuilder()
         .rateLimit(2)
+        .addInterceptor(::authIntercept)
         .build()
 
+    private fun authIntercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        if (request.header("Authorization") != null) return chain.proceed(request)
+        val token = getValidToken() ?: return chain.proceed(request)
+        val response = chain.proceed(request.withAuth(token))
+        if (response.code != 401) return response
+        response.close()
+        val newToken = clearTokenAndRefresh()
+        return chain.proceed(request.withAuth(newToken.orEmpty()))
+    }
+
+    private fun Request.withAuth(token: String): Request = if (token.isNotEmpty()) {
+        newBuilder().header("Authorization", "Bearer $token").build()
+    } else {
+        this
+    }
+
+    @Synchronized
+    private fun clearTokenAndRefresh(): String? {
+        cachedToken = null
+        tokenExpiryTime = 0L
+        return getValidToken()
+    }
+
+    @Synchronized
+    private fun getValidToken(): String? {
+        val now = System.currentTimeMillis()
+        if (cachedToken != null && now < tokenExpiryTime) return cachedToken
+        return fetchNewToken()
+    }
+
+    @Synchronized
+    private fun fetchNewToken(): String? {
+        return try {
+            val email = preferences.getString(EMAIL_PREF, "")
+            val password = preferences.getString(PASSWORD_PREF, "")
+            if (email.isNullOrEmpty() || password.isNullOrEmpty()) return null
+            return loginAndGetToken(email, password)
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    @Synchronized
+    protected open fun loginAndGetToken(email: String, password: String): String? {
+        try {
+            val body = AzuretoonsLoginRequestDto(
+                identifier = email.trim(),
+                password = password,
+            ).toJsonString().toRequestBody("application/json".toMediaType())
+            val headers = headersBuilder().set("Accept", "application/json").build()
+            val response = network.cloudflareClient.newCall(
+                POST("$apiUrl/auth/login", headers, body),
+            ).execute()
+
+            if (!response.isSuccessful) {
+                response.close()
+                return null
+            }
+            val auth = response.parseAs<AzuretoonsLoginResponseDto>()
+            val token = auth.accessToken
+            val expiresIn = auth.expiresIn * 1000
+            cachedToken = token
+            tokenExpiryTime = System.currentTimeMillis() + expiresIn
+            return token
+        } catch (e: Exception) {
+            return null
+        }
+    }
+
     override fun headersBuilder() = super.headersBuilder()
+        .set("Accept", ACCEPT)
+        .set("Accept-Language", ACCEPT_LANGUAGE)
+        .set("Pragma", PRAGMA)
         .set("Referer", "$baseUrl/")
         .set("Origin", baseUrl)
 
     // ============================== Popular (Browse) =======================
     override fun popularMangaRequest(page: Int): Request = GET("$apiUrl/obras", headers)
+
     override fun popularMangaParse(response: Response): MangasPage {
         val dto = response.parseAs<List<AzuretoonsMangaDto>>()
         val mangas = dto.sortedByDescending { it.viewCount }.map { it.toSManga() }
@@ -42,6 +133,7 @@ class Azuretoons : HttpSource() {
     // ============================= Latest ===================================
 
     override fun latestUpdatesRequest(page: Int): Request = GET("$apiUrl/obras", headers)
+
     override fun latestUpdatesParse(response: Response): MangasPage {
         val dto = response.parseAs<List<AzuretoonsMangaDto>>()
         val mangas = dto.map { it.toSManga() }
@@ -110,4 +202,28 @@ class Azuretoons : HttpSource() {
     }
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        EditTextPreference(screen.context).apply {
+            key = EMAIL_PREF
+            title = "Email"
+            summary = "Email para login automático"
+            setDefaultValue("")
+        }.also(screen::addPreference)
+
+        EditTextPreference(screen.context).apply {
+            key = PASSWORD_PREF
+            title = "Senha"
+            summary = "Senha para login automático"
+            setDefaultValue("")
+        }.also(screen::addPreference)
+    }
+
+    companion object {
+        private const val ACCEPT = "*/*"
+        private const val ACCEPT_LANGUAGE = "pt-BR,pt;q=0.9,en-US;q=0.8,en;q=0.7"
+        private const val PRAGMA = "no-cache"
+        private const val EMAIL_PREF = "email"
+        private const val PASSWORD_PREF = "password"
+    }
 }

--- a/src/pt/azuretoons/src/eu/kanade/tachiyomi/extension/pt/azuretoons/AzuretoonsDto.kt
+++ b/src/pt/azuretoons/src/eu/kanade/tachiyomi/extension/pt/azuretoons/AzuretoonsDto.kt
@@ -4,11 +4,25 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import keiyoushi.utils.tryParse
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
 import org.jsoup.Jsoup
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
+
+@Serializable
+class AzuretoonsLoginRequestDto(
+    val identifier: String,
+    val password: String,
+)
+
+@Serializable
+class AzuretoonsLoginResponseDto(
+    @JsonNames("access_token", "token") val accessToken: String,
+    @SerialName("expires_in") val expiresIn: Long = 3600,
+)
 
 @Serializable
 class AzuretoonsMangaDto(


### PR DESCRIPTION
- Fix error in mihon in request to Azuretoons because without headers to ACCEPT_LANGUAGE, ACCEPT
- Implemented token-based authentication with automatic login using email and password.
- Added preference screen for storing user credentials.
- Introduced request and response DTOs for handling login requests and responses.
- Enhanced the HTTP client with an authentication interceptor to manage token expiration and refresh.

closes: https://github.com/keiyoushi/extensions-source/issues/13328

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [X] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [X] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [X] Have removed `web_hi_res_512.png` when adding a new extension
