### PR TITLE
akaicomic: fix manga details parsing for API field changes

### DIFF
--- a/src/en/akaicomic/build.gradle
+++ b/src/en/akaicomic/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Akai Comic'
     extClass = '.AkaiComic'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = false
 }
 

--- a/src/en/akaicomic/src/eu/kanade/tachiyomi/extension/en/akaicomic/AkaiComic.kt
+++ b/src/en/akaicomic/src/eu/kanade/tachiyomi/extension/en/akaicomic/AkaiComic.kt
@@ -200,7 +200,9 @@ class AkaiComic : HttpSource() {
                 else -> nested
             }
         }
+
         is JsonArray -> this.firstOrNull() ?: this
+
         else -> this
     }
 

--- a/src/en/akaicomic/src/eu/kanade/tachiyomi/extension/en/akaicomic/AkaiComic.kt
+++ b/src/en/akaicomic/src/eu/kanade/tachiyomi/extension/en/akaicomic/AkaiComic.kt
@@ -10,6 +10,9 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.tryParse
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 import okhttp3.Request
 import okhttp3.Response
 import rx.Observable
@@ -102,7 +105,11 @@ class AkaiComic : HttpSource() {
 
     override fun mangaDetailsRequest(manga: SManga): Request = GET("$apiUrl/manga/${manga.url}", headers)
 
-    override fun mangaDetailsParse(response: Response): SManga = response.parseAs<MangaDto>().toSManga()
+    override fun mangaDetailsParse(response: Response): SManga {
+        val root = response.parseAs<JsonElement>()
+        val mangaElement = root.extractMangaElement()
+        return mangaElement.parseAs<MangaDto>().toSManga()
+    }
 
     // ============================== Chapters ==============================
 
@@ -155,8 +162,8 @@ class AkaiComic : HttpSource() {
     // ============================== Helpers ================================
 
     private fun MangaDto.toSManga(): SManga = SManga.create().apply {
-        url = id
-        title = seriesName
+        url = id.ifBlank { slug.orEmpty() }
+        title = seriesName.ifBlank { alternativeName?.substringBefore(",")?.trim().orEmpty() }.ifBlank { "Unknown title" }
         thumbnail_url = coverUrl
         author = this@toSManga.author
         artist = this@toSManga.artist
@@ -179,6 +186,22 @@ class AkaiComic : HttpSource() {
             else -> SManga.UNKNOWN
         }
         initialized = true
+    }
+
+    private fun JsonElement.extractMangaElement(): JsonElement = when (this) {
+        is JsonObject -> {
+            val nested = this["manga"]
+                ?: this["series"]
+                ?: this["data"]
+                ?: this["result"]
+            when (nested) {
+                is JsonArray -> nested.firstOrNull() ?: this
+                null -> this
+                else -> nested
+            }
+        }
+        is JsonArray -> this.firstOrNull() ?: this
+        else -> this
     }
 
     companion object {

--- a/src/en/akaicomic/src/eu/kanade/tachiyomi/extension/en/akaicomic/AkaiComicDto.kt
+++ b/src/en/akaicomic/src/eu/kanade/tachiyomi/extension/en/akaicomic/AkaiComicDto.kt
@@ -2,28 +2,30 @@ package eu.kanade.tachiyomi.extension.en.akaicomic
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
 
 @Serializable
 data class MangaListResponse(
-    val manga: List<MangaDto>,
-    val ok: Boolean,
-    val page: Int,
-    val pageSize: Int,
-    val total: Int,
+    @JsonNames("manga", "data", "series") val manga: List<MangaDto> = emptyList(),
+    val ok: Boolean = false,
+    val page: Int = 1,
+    @JsonNames("pageSize", "page_size") val pageSize: Int = manga.size,
+    val total: Int = manga.size,
 )
 
 @Serializable
 data class MangaDto(
-    val id: String,
-    @SerialName("series_name") val seriesName: String,
-    @SerialName("cover_url") val coverUrl: String? = null,
+    @JsonNames("id", "lid", "series_id") val id: String = "",
+    @JsonNames("series_name", "name", "title") val seriesName: String = "",
+    @JsonNames("cover_url", "cover", "thumbnail", "image") val coverUrl: String? = null,
+    @JsonNames("slug", "series_slug") val slug: String? = null,
     val author: String? = null,
     val artist: String? = null,
     val description: String? = null,
     val genres: String? = null,
     val status: String? = null,
     val type: String? = null,
-    @SerialName("alternative_name") val alternativeName: String? = null,
+    @JsonNames("alternative_name", "alt_name") val alternativeName: String? = null,
     @SerialName("updated_at") val updatedAt: String? = null,
     @SerialName("release_year") val releaseYear: String? = null,
 )


### PR DESCRIPTION
Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [X] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
