### PR TITLE
Fix non standard lang codes

### DIFF
--- a/src/all/globalcomix/build.gradle
+++ b/src/all/globalcomix/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'GlobalComix'
     extClass = '.GlobalComixFactory'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/all/globalcomix/src/eu/kanade/tachiyomi/extension/all/globalcomix/GlobalComixFactory.kt
+++ b/src/all/globalcomix/src/eu/kanade/tachiyomi/extension/all/globalcomix/GlobalComixFactory.kt
@@ -49,7 +49,10 @@ class GlobalComixFactory : SourceFactory {
     )
 }
 
-class GlobalComixAlbanian : GlobalComix("al")
+class GlobalComixAlbanian : GlobalComix("sq", "al") {
+    // lang changed from al to sq
+    override val id = 3356591153022230079
+}
 class GlobalComixArabic : GlobalComix("ar")
 class GlobalComixBulgarian : GlobalComix("bg")
 class GlobalComixBengali : GlobalComix("bn")
@@ -57,7 +60,10 @@ class GlobalComixBrazilianPortuguese : GlobalComix("pt-BR", "br")
 class GlobalComixChineseMandarin : GlobalComix("zh-Hans", "cn")
 class GlobalComixCzech : GlobalComix("cs", "cz")
 class GlobalComixGerman : GlobalComix("de")
-class GlobalComixDanish : GlobalComix("dk")
+class GlobalComixDanish : GlobalComix("da", "dk") {
+    // lang changed from dk to da
+    override val id = 5048347663546425663
+}
 class GlobalComixGreek : GlobalComix("el")
 class GlobalComixEnglish : GlobalComix("en")
 class GlobalComixSpanish : GlobalComix("es")

--- a/src/all/hentai3/build.gradle
+++ b/src/all/hentai3/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = '3Hentai'
     extClass = '.Hentai3Factory'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
+++ b/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
@@ -18,7 +18,7 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
 
-class Hentai3(
+open class Hentai3(
     override val lang: String = "all",
     private val searchLang: String = "",
 ) : HttpSource() {

--- a/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3Factory.kt
+++ b/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3Factory.kt
@@ -22,7 +22,10 @@ class Hentai3Factory : SourceFactory {
         Hentai3("tr", "turkish"),
         Hentai3("ru", "russian"),
         Hentai3("uk", "ukrainian"),
-        Hentai3("po", "polish"),
+        object : Hentai3("pl", "polish") {
+            // lang changed from po to pl
+            override val id = 7940950215101782907
+        },
         Hentai3("fi", "finnish"),
         Hentai3("de", "german"),
         Hentai3("it", "italian"),


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
