### PR TITLE
MangaGo: fix issues related to different user agents returning different pages/URLs

### DIFF
--- a/src/en/mangago/build.gradle
+++ b/src/en/mangago/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Mangago'
     extClass = '.Mangago'
-    extVersionCode = 26
+    extVersionCode = 27
     isNsfw = true
 }
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

---

Fixes #13469

---

The new approach should be resilient against whatever MangaGo and mirrors are doing to different user agents. Basically there is some data in a `<script>` tag that is always there (total_pages, manga id, chapter id) and a hidden input with the template format for getting pages (e.g. `/uu/to_chapter-6/pg-{page}`).

This should fix most cases since I tested a bunch of UAs with different HTML and different behaviors but It may randomly break on a random mirror for a random UA for a random chapter since basically there isnt  logic behind the weird responses. Not much more I can do.

---

For reference I have seen at least 9 mirrors/UA pairs with different weird behaviors where loading a chapter list returns different manga URLs for the same chapter :man_shrugging: 