### PR TITLE
MangaCloud: fix for suwayomi

### DIFF
--- a/src/en/mangacloud/build.gradle
+++ b/src/en/mangacloud/build.gradle
@@ -1,7 +1,7 @@
 ext {
 	extName = 'MangaCloud'
 	extClass = '.MangaCloud'
-	extVersionCode = 1
+	extVersionCode = 2
 	isNsfw = false
 }
 

--- a/src/en/mangacloud/src/eu/kanade/tachiyomi/extension/en/mangacloud/Dto.kt
+++ b/src/en/mangacloud/src/eu/kanade/tachiyomi/extension/en/mangacloud/Dto.kt
@@ -74,11 +74,11 @@ class Manga(
     private val cover: Image,
 ) {
     fun toSManga(): SManga {
-        val app = Injekt.get<Application>().packageName
+        val app = runCatching { Injekt.get<Application>().packageName }.getOrNull()
         val groupTags = listOf("eu.kanade.tachiyomi.sy", "app.komikku")
-            .any { app.startsWith(it) }
+            .any { app?.startsWith(it) == true }
         val markdownDescription = listOf("app.mihon", "eu.kanade.tachiyomi.sy", "app.komikku")
-            .any { app.startsWith(it) }
+            .any { app?.startsWith(it) == true }
 
         return SManga.create().apply {
             url = id


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
