### PR TITLE
Pixiv: Group author's illustrations in a single manga if searched via `user:` or url

### DIFF
--- a/src/all/pixiv/build.gradle
+++ b/src/all/pixiv/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Pixiv'
     extClass = '.PixivFactory'
-    extVersionCode = 11
+    extVersionCode = 12
     isNsfw = true
 }
 

--- a/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivConstants.kt
+++ b/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivConstants.kt
@@ -1,3 +1,3 @@
 package eu.kanade.tachiyomi.extension.all.pixiv
 
-internal val KNOWN_LOCALES = listOf("en")
+internal val KNOWN_LOCALES = listOf("en", "ja", "zh", "zh-tw", "ko")

--- a/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivFactory.kt
+++ b/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivFactory.kt
@@ -4,5 +4,5 @@ import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.SourceFactory
 
 class PixivFactory : SourceFactory {
-    override fun createSources(): List<Source> = listOf("ja", "en", "ko", "zh").map { lang -> Pixiv(lang) }
+    override fun createSources(): List<Source> = KNOWN_LOCALES.map { lang -> Pixiv(lang) }
 }

--- a/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivTypes.kt
+++ b/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/PixivTypes.kt
@@ -125,6 +125,9 @@ internal data class PixivUserData(
 
 @Serializable
 internal data class PixivUserInfo(
-    val id: String,
+    val userId: String,
     val name: String,
+    val image: String? = null,
+    val imageBig: String? = null,
+    val comment: String? = null,
 )

--- a/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/Util.kt
+++ b/src/all/pixiv/src/eu/kanade/tachiyomi/extension/all/pixiv/Util.kt
@@ -14,11 +14,6 @@ internal fun <T> Iterator<T>.truncateToList(count: Int): List<T> = buildList {
     }
 }
 
-internal fun parseSMangaUrl(url: String): Pair<String, Boolean> {
-    val isSeries = url.getOrNull(1) != 'a'
-    return Pair(url.substringAfterLast('/'), isSeries)
-}
-
 internal fun <K, V> lruCached(capacity: Int, compute: (K) -> V): (K) -> V {
     val cache = object : LruCache<K, V>(capacity) {
         override fun create(key: K): V = compute(key)


### PR DESCRIPTION
I've used AI to make these changes. I've checked a bunch of profiles and it's working correctly.

For profiles with a large number of illustrations (>1000) can be slow to group them all

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension

<img width="1023" height="1797" alt="image" src="https://github.com/user-attachments/assets/6ffb7c5a-acc0-4c62-af21-dc6e9a3e89a1" />

<img width="1023" height="1797" alt="image" src="https://github.com/user-attachments/assets/e16f6b82-b179-4a4e-a924-a7ea43a007b0" />
