### PR TITLE
Update domain Kuroi Manga, MilaSub, Opiatoon, Vcomycs

### DIFF
--- a/src/tr/kuroimanga/build.gradle
+++ b/src/tr/kuroimanga/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Kuroi Manga'
     extClass = '.KuroiManga'
     themePkg = 'madara'
-    baseUrl = 'https://www.kuroimanga.com'
-    overrideVersionCode = 2
+    baseUrl = 'https://www.kuroimanga.top'
+    overrideVersionCode = 3
     isNsfw = true
 }
 

--- a/src/tr/kuroimanga/src/eu/kanade/tachiyomi/extension/tr/kuroimanga/KuroiManga.kt
+++ b/src/tr/kuroimanga/src/eu/kanade/tachiyomi/extension/tr/kuroimanga/KuroiManga.kt
@@ -11,7 +11,7 @@ import java.util.Locale
 class KuroiManga :
     Madara(
         "Kuroi Manga",
-        "https://www.kuroimanga.com",
+        "https://www.kuroimanga.top",
         "tr",
         dateFormat = SimpleDateFormat("d MMMM yyyy", Locale("tr")),
     ) {

--- a/src/tr/milasub/build.gradle
+++ b/src/tr/milasub/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'MilaSub'
     extClass = '.MilaSub'
     themePkg = 'madara'
-    baseUrl = 'https://www.milascan.com'
-    overrideVersionCode = 2
+    baseUrl = 'https://www.millascan.com'
+    overrideVersionCode = 3
     isNsfw = true
 }
 

--- a/src/tr/milasub/src/eu/kanade/tachiyomi/extension/tr/milasub/MilaSub.kt
+++ b/src/tr/milasub/src/eu/kanade/tachiyomi/extension/tr/milasub/MilaSub.kt
@@ -9,7 +9,7 @@ import java.util.Locale
 class MilaSub :
     Madara(
         "MilaSub",
-        "https://www.milascan.com",
+        "https://www.millascan.com",
         "tr",
         dateFormat = SimpleDateFormat("d MMMM yyyy", Locale("tr")),
     ) {

--- a/src/tr/opiatoon/build.gradle
+++ b/src/tr/opiatoon/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Opiatoon'
     extClass = '.Opiatoon'
     themePkg = 'madara'
-    baseUrl = 'https://opiatoon.art'
-    overrideVersionCode = 2
+    baseUrl = 'https://opiatoon.lat'
+    overrideVersionCode = 3
     isNsfw = true
 }
 

--- a/src/tr/opiatoon/src/eu/kanade/tachiyomi/extension/tr/opiatoon/Opiatoon.kt
+++ b/src/tr/opiatoon/src/eu/kanade/tachiyomi/extension/tr/opiatoon/Opiatoon.kt
@@ -11,7 +11,7 @@ import java.util.Locale
 class Opiatoon :
     Madara(
         "Opiatoon",
-        "https://opiatoon.art",
+        "https://opiatoon.lat",
         "tr",
         dateFormat = SimpleDateFormat("d MMMM", Locale("tr")),
     ) {

--- a/src/vi/vcomycs/build.gradle
+++ b/src/vi/vcomycs/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Vcomycs'
     extClass = '.Vcomycs'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/vi/vcomycs/src/eu/kanade/tachiyomi/extension/vi/vcomycs/Vcomycs.kt
+++ b/src/vi/vcomycs/src/eu/kanade/tachiyomi/extension/vi/vcomycs/Vcomycs.kt
@@ -22,7 +22,7 @@ import java.util.TimeZone
 class Vcomycs : HttpSource() {
     override val name = "Vcomycs"
     override val lang = "vi"
-    override val baseUrl = "https://vivicomi15.info"
+    override val baseUrl = "https://vivicomi16.info"
     override val supportsLatest = true
 
     override val client = network.cloudflareClient.newBuilder()


### PR DESCRIPTION
Closes #8770
Closes #10358
Closes #12908 
Closes #13370

Compiled and tested with `./gradlew` and a physical device, not Android Studio.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
