### PR TITLE
Fix URL : Noromax APK Extension

### DIFF
--- a/src/id/noromax/build.gradle
+++ b/src/id/noromax/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Noromax'
     extClass = '.Noromax'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://noromax01.my.id'
-    overrideVersionCode = 2
+    baseUrl = 'https://noromax02.my.id'
+    overrideVersionCode = 3
     isNsfw = true
 }
 

--- a/src/id/noromax/src/eu/kanade/tachiyomi/extension/id/noromax/Noromax.kt
+++ b/src/id/noromax/src/eu/kanade/tachiyomi/extension/id/noromax/Noromax.kt
@@ -5,12 +5,12 @@ import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 class Noromax :
     MangaThemesia(
         "Noromax",
-        "https://noromax01.my.id",
+        "https://noromax02.my.id",
         "id",
     ) {
 
-    // Site changed from ZeistManga to MangaThemesia
-    override val versionId = 2
+    // Site changed from MangaThemesia to Noromax
+    override val versionId = 3
 
     override val hasProjectPage = true
 }


### PR DESCRIPTION
Update base URL for Noromax and bump version code to 33.

Checklist:
- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension