### PR TITLE
Fix chapter list pagination fetching in MediocreToons 

### DIFF
--- a/src/pt/mediocretoons/build.gradle
+++ b/src/pt/mediocretoons/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Mediocre Toons'
     extClass = '.MediocreToons'
     baseUrl = 'https://mediocrescan.com'
-    extVersionCode = 15
+    extVersionCode = 16
     isNsfw = true
 }
 

--- a/src/pt/mediocretoons/src/eu/kanade/tachiyomi/extension/pt/mediocretoons/MediocreToons.kt
+++ b/src/pt/mediocretoons/src/eu/kanade/tachiyomi/extension/pt/mediocretoons/MediocreToons.kt
@@ -22,6 +22,7 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import org.json.JSONObject
+import rx.Observable
 import uy.kohesive.injekt.api.get
 import java.text.Normalizer
 
@@ -395,18 +396,32 @@ class MediocreToons :
         return finalUrl
     }
 
-    override fun chapterListRequest(manga: SManga): Request = mangaDetailsRequest(manga)
+    override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> {
+        val id = manga.url.substringAfter("/obra/")
+        val allChapters = mutableListOf<SChapter>()
+        var page = 1
 
-    override fun chapterListParse(response: Response): List<SChapter> {
-        val manga = response.parseAs<MediocreMangaDto>()
+        do {
+            val url = "$apiUrl/capitulos".toHttpUrl().newBuilder()
+                .addQueryParameter("obr_id", id)
+                .addQueryParameter("page", page.toString())
+                .addQueryParameter("limite", "50")
+                .addQueryParameter("order", "desc")
+                .build()
 
-        val chapters = manga.chapters
-            .map { it.toSChapter() }
-            .distinctBy { it.url }
-            .sortedByDescending { it.chapter_number }
+            val response = client.newCall(GET(url, headers)).execute()
+            val dto = response.parseAs<MediocreListDto<List<MediocreChapterSimpleDto>>>()
 
-        return chapters
+            allChapters.addAll(dto.data.map { it.toSChapter() })
+
+            val hasNext = dto.pagination?.hasNextPage ?: false
+            page++
+        } while (hasNext)
+
+        return Observable.just(allChapters.distinctBy { it.url }.sortedByDescending { it.chapter_number })
     }
+
+    override fun chapterListParse(response: Response): List<SChapter> = throw UnsupportedOperationException()
 
     // =============================== Pages =================================
     override fun pageListRequest(chapter: SChapter): Request {

--- a/src/pt/mediocretoons/src/eu/kanade/tachiyomi/extension/pt/mediocretoons/MediocreToons.kt
+++ b/src/pt/mediocretoons/src/eu/kanade/tachiyomi/extension/pt/mediocretoons/MediocreToons.kt
@@ -405,7 +405,7 @@ class MediocreToons :
             val url = "$apiUrl/capitulos".toHttpUrl().newBuilder()
                 .addQueryParameter("obr_id", id)
                 .addQueryParameter("page", page.toString())
-                .addQueryParameter("limite", "50")
+                .addQueryParameter("limite", "100")
                 .addQueryParameter("order", "desc")
                 .build()
 


### PR DESCRIPTION
The method fetchChapterList now retrieves chapters in a paginated manner and returns a distinct, sorted list of chapters. The previous chapterListRequest method has been removed and chapterListParse now throws an UnsupportedOperationException.

closes: https://github.com/keiyoushi/extensions-source/issues/13506

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [X] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [X] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [X] Have removed `web_hi_res_512.png` when adding a new extension
