### PR TITLE
Force pagination for Manhwa-raw

### DIFF
--- a/src/all/manhwadashraw/build.gradle
+++ b/src/all/manhwadashraw/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ManhwaDashRaw'
     themePkg = 'madara'
     baseUrl = 'https://manhwa-raw.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/all/manhwadashraw/src/eu/kanade/tachiyomi/extension/all/manhwadashraw/ManhwaDashRaw.kt
+++ b/src/all/manhwadashraw/src/eu/kanade/tachiyomi/extension/all/manhwadashraw/ManhwaDashRaw.kt
@@ -1,6 +1,8 @@
 package eu.kanade.tachiyomi.extension.all.manhwadashraw
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.source.model.MangasPage
+import okhttp3.Response
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -16,4 +18,8 @@ class ManhwaDashRaw :
     override val mangaDetailsSelectorStatus = "div.post-content_item:contains(Status) > div.summary-content"
     override val mangaDetailsSelectorDescription = "div.post-content_item:contains(Summary) div.summary-container"
     override val pageListParseSelector = "div.page-break img.wp-manga-chapter-img"
+
+    override fun latestUpdatesParse(response: Response): MangasPage = MangasPage(super.latestUpdatesParse(response).mangas, true)
+    override fun popularMangaParse(response: Response): MangasPage = MangasPage(super.popularMangaParse(response).mangas, true)
+    override fun searchMangaParse(response: Response): MangasPage = MangasPage(super.searchMangaParse(response).mangas, true)
 }


### PR DESCRIPTION
Closes #13387

This PR does not address getting blocked by https://wpcerber.com/

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
