### PR TITLE
StoneScape: Fix HTTP 500 errors and update selectors

### DIFF
--- a/src/en/stonescape/build.gradle
+++ b/src/en/stonescape/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.StoneScape'
     themePkg = 'madara'
     baseUrl = 'https://stonescape.xyz'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
     isNsfw = false
 }
 

--- a/src/en/stonescape/src/eu/kanade/tachiyomi/extension/en/stonescape/StoneScape.kt
+++ b/src/en/stonescape/src/eu/kanade/tachiyomi/extension/en/stonescape/StoneScape.kt
@@ -6,7 +6,13 @@ import okhttp3.OkHttpClient
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class StoneScape : Madara("StoneScape", "https://stonescape.xyz", "en", SimpleDateFormat("MMMM dd, yyyy", Locale.ENGLISH)) {
+class StoneScape :
+    Madara(
+        "StoneScape",
+        "https://stonescape.xyz",
+        "en",
+        SimpleDateFormat("MMMM dd, yyyy", Locale.ENGLISH),
+    ) {
     override val mangaSubString = "series"
 
     override val client: OkHttpClient = super.client.newBuilder().addInterceptor { chain ->
@@ -14,18 +20,24 @@ class StoneScape : Madara("StoneScape", "https://stonescape.xyz", "en", SimpleDa
         val url = res.request.url.toString()
         if (res.code == 500 && (url.contains("/$mangaSubString/") || url.contains("/manhwaseries/"))) {
             res.newBuilder().code(200).build()
-        } else res
+        } else {
+            res
+        }
     }.build()
 
     override val useLoadMoreRequest = LoadMoreStrategy.Always
 
     override fun popularMangaRequest(page: Int) = GET("$baseUrl/manhwaseries/page/$page/", headers)
+
     override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/manhwaseries/page/$page/?m_orderby=latest", headers)
 
     override fun popularMangaSelector() = "div.page-item-detail.manga"
+
     override val mangaDetailsSelectorAuthor = ".author.meta a"
+
     override val mangaDetailsSelectorDescription = ".manga-summary"
 
     override val chapterUrlSelector = "li > a"
+
     override fun chapterListSelector() = "li.wp-manga-chapter:not(.premium-block)"
 }

--- a/src/en/stonescape/src/eu/kanade/tachiyomi/extension/en/stonescape/StoneScape.kt
+++ b/src/en/stonescape/src/eu/kanade/tachiyomi/extension/en/stonescape/StoneScape.kt
@@ -1,22 +1,26 @@
 package eu.kanade.tachiyomi.extension.en.stonescape
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.GET
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class StoneScape :
-    Madara(
-        "StoneScape",
-        "https://stonescape.xyz",
-        "en",
-        SimpleDateFormat("MMMM dd, yyyy", Locale.ENGLISH),
-    ) {
+class StoneScape : Madara("StoneScape", "https://stonescape.xyz", "en", SimpleDateFormat("MMMM dd, yyyy", Locale.ENGLISH)) {
     override val mangaSubString = "series"
 
-    override val chapterUrlSelector = "li > a"
+    // Fix for site returning 500 error while still providing valid HTML
+    override val client = super.client.newBuilder().addInterceptor { chain ->
+        val res = chain.proceed(chain.request())
+        if (res.code == 500) res.newBuilder().code(200).build() else res
+    }.build()
 
-    override val mangaDetailsSelectorAuthor = ".post-content .manga-authors a"
-    override val mangaDetailsSelectorDescription = ".manga-about, ${super.mangaDetailsSelectorDescription}"
+    // Redirecting Browse/Latest to the correct URL
+    override fun popularMangaRequest(page: Int) = GET("$baseUrl/manhwaseries/page/$page/", headers)
+    override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/manhwaseries/page/$page/?m_orderby=latest", headers)
 
+    // Selectors for listing and details
+    override fun popularMangaSelector() = "div.page-item-detail.manga"
+    override val mangaDetailsSelectorAuthor = ".manga-authors a"
+    override val mangaDetailsSelectorDescription = "div.manga-summary"
     override fun chapterListSelector() = "li.wp-manga-chapter:not(.premium-block)"
 }

--- a/src/en/stonescape/src/eu/kanade/tachiyomi/extension/en/stonescape/StoneScape.kt
+++ b/src/en/stonescape/src/eu/kanade/tachiyomi/extension/en/stonescape/StoneScape.kt
@@ -8,19 +8,22 @@ import java.util.Locale
 class StoneScape : Madara("StoneScape", "https://stonescape.xyz", "en", SimpleDateFormat("MMMM dd, yyyy", Locale.ENGLISH)) {
     override val mangaSubString = "series"
 
-    // Fix for site returning 500 error while still providing valid HTML
+    // Fix for the HTTP 500 error mentioned in issue #13343
     override val client = super.client.newBuilder().addInterceptor { chain ->
         val res = chain.proceed(chain.request())
         if (res.code == 500) res.newBuilder().code(200).build() else res
     }.build()
 
-    // Redirecting Browse/Latest to the correct URL
+    // Redirect to the correct Comics listing page
     override fun popularMangaRequest(page: Int) = GET("$baseUrl/manhwaseries/page/$page/", headers)
     override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/manhwaseries/page/$page/?m_orderby=latest", headers)
 
-    // Selectors for listing and details
+    // Selectors matched to your provided HTML
     override fun popularMangaSelector() = "div.page-item-detail.manga"
-    override val mangaDetailsSelectorAuthor = ".manga-authors a"
-    override val mangaDetailsSelectorDescription = "div.manga-summary"
+    override val mangaDetailsSelectorAuthor = ".author.meta a"
+    override val mangaDetailsSelectorDescription = ".manga-summary"
+    
+    // Specifically target the link with the text to avoid empty thumbnail links
+    override val chapterUrlSelector = "li.wp-manga-chapter > a"
     override fun chapterListSelector() = "li.wp-manga-chapter:not(.premium-block)"
 }

--- a/src/en/stonescape/src/eu/kanade/tachiyomi/extension/en/stonescape/StoneScape.kt
+++ b/src/en/stonescape/src/eu/kanade/tachiyomi/extension/en/stonescape/StoneScape.kt
@@ -2,28 +2,30 @@ package eu.kanade.tachiyomi.extension.en.stonescape
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.GET
+import okhttp3.OkHttpClient
 import java.text.SimpleDateFormat
 import java.util.Locale
 
 class StoneScape : Madara("StoneScape", "https://stonescape.xyz", "en", SimpleDateFormat("MMMM dd, yyyy", Locale.ENGLISH)) {
     override val mangaSubString = "series"
 
-    // Fix for the HTTP 500 error mentioned in issue #13343
-    override val client = super.client.newBuilder().addInterceptor { chain ->
+    override val client: OkHttpClient = super.client.newBuilder().addInterceptor { chain ->
         val res = chain.proceed(chain.request())
-        if (res.code == 500) res.newBuilder().code(200).build() else res
+        val url = res.request.url.toString()
+        if (res.code == 500 && (url.contains("/$mangaSubString/") || url.contains("/manhwaseries/"))) {
+            res.newBuilder().code(200).build()
+        } else res
     }.build()
 
-    // Redirect to the correct Comics listing page
+    override val useLoadMoreRequest = LoadMoreStrategy.Always
+
     override fun popularMangaRequest(page: Int) = GET("$baseUrl/manhwaseries/page/$page/", headers)
     override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/manhwaseries/page/$page/?m_orderby=latest", headers)
 
-    // Selectors matched to your provided HTML
     override fun popularMangaSelector() = "div.page-item-detail.manga"
     override val mangaDetailsSelectorAuthor = ".author.meta a"
     override val mangaDetailsSelectorDescription = ".manga-summary"
-    
-    // Specifically target the link with the text to avoid empty thumbnail links
-    override val chapterUrlSelector = "li.wp-manga-chapter > a"
+
+    override val chapterUrlSelector = "li > a"
     override fun chapterListSelector() = "li.wp-manga-chapter:not(.premium-block)"
 }

--- a/src/en/stonescape/src/eu/kanade/tachiyomi/extension/en/stonescape/StoneScape.kt
+++ b/src/en/stonescape/src/eu/kanade/tachiyomi/extension/en/stonescape/StoneScape.kt
@@ -1,7 +1,6 @@
 package eu.kanade.tachiyomi.extension.en.stonescape
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
-import eu.kanade.tachiyomi.network.GET
 import okhttp3.OkHttpClient
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -13,27 +12,21 @@ class StoneScape :
         "en",
         SimpleDateFormat("MMMM dd, yyyy", Locale.ENGLISH),
     ) {
+    override val client: OkHttpClient = super.client.newBuilder()
+        .addInterceptor { chain ->
+            val response = chain.proceed(chain.request())
+            if (response.code == 500 && response.request.url.toString().contains("/$mangaSubString/")) {
+                response.newBuilder().code(200).build()
+            } else {
+                response
+            }
+        }
+        .build()
+
     override val mangaSubString = "series"
 
-    override val client: OkHttpClient = super.client.newBuilder().addInterceptor { chain ->
-        val res = chain.proceed(chain.request())
-        val url = res.request.url.toString()
-        if (res.code == 500 && (url.contains("/$mangaSubString/") || url.contains("/manhwaseries/"))) {
-            res.newBuilder().code(200).build()
-        } else {
-            res
-        }
-    }.build()
-
     override val useLoadMoreRequest = LoadMoreStrategy.Always
-
-    override fun popularMangaRequest(page: Int) = GET("$baseUrl/manhwaseries/page/$page/", headers)
-
-    override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/manhwaseries/page/$page/?m_orderby=latest", headers)
-
-    override fun popularMangaSelector() = "div.page-item-detail.manga"
-
-    override val mangaDetailsSelectorAuthor = ".author.meta a"
+    override val useNewChapterEndpoint = true
 
     override val mangaDetailsSelectorDescription = ".manga-summary"
 


### PR DESCRIPTION
- Bypassed the crash: I added a "fix" that tells the app to ignore the 500 error code and read the HTML anyway.
- Fixed browsing: The site moved its main list to a new link (/manhwaseries/), so I updated the app to look there.
- Updated selectors: I fixed the code so it can correctly find the author, the summary, and the list of all comics instead of just showing one.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (Closes #13343)
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
