### PR TITLE
Atsumaru (EN): fix http 404 pages

### DIFF
--- a/src/en/atsumaru/build.gradle
+++ b/src/en/atsumaru/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Atsumaru'
     extClass = '.Atsumaru'
-    extVersionCode = 10
+    extVersionCode = 11
     isNsfw = true
 }
 

--- a/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/Atsumaru.kt
+++ b/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/Atsumaru.kt
@@ -36,7 +36,7 @@ class Atsumaru : HttpSource() {
 
     private fun apiHeadersBuilder() = headersBuilder().apply {
         add("Accept", "*/*")
-        add("Host", "atsu.moe")
+        add("Referer", baseUrl)
         add("Content-Type", "application/json")
     }
 
@@ -212,16 +212,16 @@ class Atsumaru : HttpSource() {
     override fun pageListParse(response: Response): List<Page> = response.parseAs<PageObjectDto>().readChapter.pages.mapIndexed { index, page ->
         val imageUrl = when {
             page.image.startsWith("http") -> page.image
-            page.image.startsWith("//") -> "https:$page.image"
-            else -> "$baseUrl/static/$page.image"
+            page.image.startsWith("//") -> "https:${page.image}"
+            else -> "$baseUrl/static/${page.image.removePrefix("/").removePrefix("static/")}"
         }
-        Page(index, imageUrl = imageUrl)
+        Page(index, imageUrl = imageUrl.replaceFirst(Regex("^https?:?//"), "https://"))
     }
 
     override fun imageRequest(page: Page): Request {
         val imgHeaders = headersBuilder().apply {
             add("Accept", "image/avif,image/webp,*/*")
-            add("Host", page.imageUrl!!.toHttpUrl().host)
+            add("Referer", baseUrl)
         }.build()
 
         return GET(page.imageUrl!!, imgHeaders)

--- a/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/Dto.kt
+++ b/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/Dto.kt
@@ -77,11 +77,12 @@ class MangaDto(
         url = id
         title = this@MangaDto.title
         thumbnail_url = getImagePath()?.let {
-            when {
+            val url = when {
                 it.startsWith("http") -> it
                 it.startsWith("//") -> "https:$it"
                 else -> "$baseUrl/static/$it"
             }
+            url.replaceFirst(Regex("^https?:?//"), "https://")
         }
         description = synopsis
         genre = buildList {


### PR DESCRIPTION
## Issues
Closes #13592

---

### Screenshot: 

#### TBATE 82
<details>
  <summary>Click to view TBATE 82</summary>

  ![TBATE 82](https://github.com/user-attachments/assets/c189c963-0005-439c-b58b-9c923a5d5aaa)

</details>

#### My Happy Marriage 30
<details>
  <summary>Click to view My Happy Marriage 30</summary>

  ![My Happy Marriage 30](https://github.com/user-attachments/assets/8d1832be-df8c-4d1f-904f-9d29a17a4204)

</details>

---

### Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension