### PR TITLE
TruyenQQ: Change to HttpSource(), add parseStatus, fix description

### DIFF
--- a/src/vi/truyenqq/build.gradle
+++ b/src/vi/truyenqq/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'TruyenQQ'
     extClass = '.TruyenQQ'
-    extVersionCode = 20
+    extVersionCode = 21
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/vi/truyenqq/src/eu/kanade/tachiyomi/extension/vi/truyenqq/TruyenQQ.kt
+++ b/src/vi/truyenqq/src/eu/kanade/tachiyomi/extension/vi/truyenqq/TruyenQQ.kt
@@ -9,10 +9,12 @@ import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.ParsedHttpSource
+import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferences
 import keiyoushi.utils.tryParse
 import okhttp3.CacheControl
@@ -21,14 +23,14 @@ import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import org.jsoup.nodes.Document
+import okhttp3.Response
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 class TruyenQQ :
-    ParsedHttpSource(),
+    HttpSource(),
     ConfigurableSource {
 
     override val name: String = "TruyenQQ"
@@ -55,27 +57,27 @@ class TruyenQQ :
     override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/truyen-yeu-thich/trang-$page.html", headers)
 
     // Selector trả về array các manga (chọn cả ảnh cx được tí nữa parse)
-    override fun popularMangaSelector(): String = "ul.grid > li"
+    private fun mangaSelector(): String = "ul.grid > li"
 
-    override fun popularMangaFromElement(element: Element): SManga = SManga.create().apply {
+    override fun popularMangaParse(response: Response): MangasPage {
+        val document = response.asJsoup()
+        val manga = document.select(mangaSelector()).map(::mangaFromElement)
+        val hasNextPage = document.selectFirst(".page_redirect > a:nth-last-child(2) > p:not(.active)") != null
+        return MangasPage(manga, hasNextPage)
+    }
+
+    private fun mangaFromElement(element: Element): SManga = SManga.create().apply {
         val anchor = element.selectFirst(".book_info .qtip a")!!
         setUrlWithoutDomain(anchor.attr("href"))
         title = anchor.text()
         thumbnail_url = element.selectFirst(".book_avatar img")?.absUrl("src")
     }
 
-    // Selector của nút trang kế tiếp
-    override fun popularMangaNextPageSelector(): String = ".page_redirect > a:nth-last-child(2) > p:not(.active)"
-
     // Trang html chứa Latest (các cập nhật mới nhất)
     override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/truyen-moi-cap-nhat/trang-$page.html", headers)
 
     // Selector trả về array các manga update (giống selector ở trên)
-    override fun latestUpdatesSelector(): String = popularMangaSelector()
-
-    override fun latestUpdatesFromElement(element: Element): SManga = popularMangaFromElement(element)
-
-    override fun latestUpdatesNextPageSelector(): String = popularMangaNextPageSelector()
+    override fun latestUpdatesParse(response: Response): MangasPage = popularMangaParse(response)
 
     // Tìm kiếm
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
@@ -93,34 +95,38 @@ class TruyenQQ :
         return GET(url, headers)
     }
 
-    override fun searchMangaSelector(): String = popularMangaSelector()
+    override fun searchMangaParse(response: Response): MangasPage = popularMangaParse(response)
 
-    override fun searchMangaFromElement(element: Element): SManga = popularMangaFromElement(element)
-
-    override fun searchMangaNextPageSelector(): String = popularMangaNextPageSelector()
-
-    override fun mangaDetailsParse(document: Document): SManga = SManga.create().apply {
+    override fun mangaDetailsParse(response: Response): SManga = SManga.create().apply {
+        val document = response.asJsoup()
         val info = document.selectFirst(".list-info")!!
 
         title = document.select("h1").text()
         author = info.select(".org").joinToString { it.text() }
         genre = document.select(".list01 li").joinToString { it.text() }
-        description = document.select(".story-detail-info").joinToString {
-            it.select("a, strong, p").unwrap()
-            it.wholeText().trim()
-        }
+        description = document.select(".story-detail-info").first()
+            ?.children()
+            ?.joinToString("\n\n") { it.wholeText().trim() }
         thumbnail_url = document.selectFirst("img[itemprop=image]")?.absUrl("src")
-        status = when (info.select(".status > p:last-child").text()) {
-            "Đang Cập Nhật" -> SManga.ONGOING
-            "Hoàn Thành" -> SManga.COMPLETED
-            else -> SManga.UNKNOWN
-        }
+        status = parseStatus(info.select(".status > p:last-child").text())
+    }
+
+    private fun parseStatus(status: String?) = when {
+        status == null -> SManga.UNKNOWN
+        listOf("Đang Tiến Hành", "Đang Cập Nhật", "Đang Ra").any { status.contains(it, ignoreCase = true) } -> SManga.ONGOING
+        listOf("Hoàn Thành", "Đã Hoàn Thành").any { status.contains(it, ignoreCase = true) } -> SManga.COMPLETED
+        listOf("Tạm Ngưng", "Tạm Hoãn").any { status.contains(it, ignoreCase = true) } -> SManga.ON_HIATUS
+        else -> SManga.UNKNOWN
     }
 
     // Chapters
-    override fun chapterListSelector(): String = "div.works-chapter-list div.works-chapter-item"
+    override fun chapterListParse(response: Response): List<SChapter> = chapterListSelector()
+        .let(response.asJsoup()::select)
+        .map(::chapterFromElement)
 
-    override fun chapterFromElement(element: Element): SChapter = SChapter.create().apply {
+    private fun chapterListSelector(): String = "div.works-chapter-list div.works-chapter-item"
+
+    private fun chapterFromElement(element: Element): SChapter = SChapter.create().apply {
         setUrlWithoutDomain(element.selectFirst("a")!!.attr("href"))
         name = element.select("a").text().trim()
         date_upload = dateFormat.tryParse(element.select(".time-chap").text())
@@ -132,12 +138,12 @@ class TruyenQQ :
         .build()
 
     // Pages
-    override fun pageListParse(document: Document): List<Page> = document.select(".page-chapter img:not([src*='stress.gif'])")
+    override fun pageListParse(response: Response): List<Page> = response.asJsoup().select(".page-chapter img:not([src*='stress.gif'])")
         .mapIndexed { idx, it ->
             Page(idx, imageUrl = it.absUrl("src"))
         }
 
-    override fun imageUrlParse(document: Document): String = throw UnsupportedOperationException()
+    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
 
     override fun getFilterList(): FilterList = FilterList(
         Filter.Header("Không dùng chung với tìm kiếm bằng tên"),

--- a/src/vi/truyenqq/src/eu/kanade/tachiyomi/extension/vi/truyenqq/TruyenQQ.kt
+++ b/src/vi/truyenqq/src/eu/kanade/tachiyomi/extension/vi/truyenqq/TruyenQQ.kt
@@ -104,9 +104,9 @@ class TruyenQQ :
         title = document.select("h1").text()
         author = info.select(".org").joinToString { it.text() }
         genre = document.select(".list01 li").joinToString { it.text() }
-        description = document.select(".story-detail-info").first()
-            ?.children()
-            ?.joinToString("\n\n") { it.wholeText().trim() }
+        description = document.select(".story-detail-info")
+            .flatMap { it.children() }
+            .joinToString("\n\n") { it.wholeText().trim() }
         thumbnail_url = document.selectFirst("img[itemprop=image]")?.absUrl("src")
         status = parseStatus(info.select(".status > p:last-child").text())
     }

--- a/src/vi/truyenqq/src/eu/kanade/tachiyomi/extension/vi/truyenqq/TruyenQQ.kt
+++ b/src/vi/truyenqq/src/eu/kanade/tachiyomi/extension/vi/truyenqq/TruyenQQ.kt
@@ -105,8 +105,11 @@ class TruyenQQ :
         author = info.select(".org").joinToString { it.text() }
         genre = document.select(".list01 li").joinToString { it.text() }
         description = document.select(".story-detail-info")
-            .flatMap { it.children() }
-            .joinToString("\n\n") { it.wholeText().trim() }
+            .joinToString("\n\n") { container ->
+                val blocks = container.select("p")
+                if (blocks.isNotEmpty()) blocks.joinToString("\n\n") { it.wholeText().trim() } else container.wholeText().trim()
+            }
+
         thumbnail_url = document.selectFirst("img[itemprop=image]")?.absUrl("src")
         status = parseStatus(info.select(".status > p:last-child").text())
     }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
