### PR TITLE
HentaiHand: fix zh - ja swap

### DIFF
--- a/src/all/hentaihand/build.gradle
+++ b/src/all/hentaihand/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.HentaiHandFactory'
     themePkg = 'hentaihand'
     baseUrl = 'https://hentaihand.com'
-    overrideVersionCode = 5
+    overrideVersionCode = 6
     isNsfw = true
 }
 

--- a/src/all/hentaihand/src/eu/kanade/tachiyomi/extension/all/hentaihand/HentaiHandFactory.kt
+++ b/src/all/hentaihand/src/eu/kanade/tachiyomi/extension/all/hentaihand/HentaiHandFactory.kt
@@ -57,9 +57,9 @@ abstract class HentaiHandCommon(
 class HentaiHandOther : HentaiHandCommon("all") {
     override val id: Long = 1235047015955289468
 }
-class HentaiHandJa : HentaiHandCommon("ja", listOf(1, 29))
+class HentaiHandJa : HentaiHandCommon("ja", listOf(3, 29))
 class HentaiHandEn : HentaiHandCommon("en", listOf(2, 27))
-class HentaiHandZh : HentaiHandCommon("zh", listOf(3, 50))
+class HentaiHandZh : HentaiHandCommon("zh", listOf(1, 50))
 class HentaiHandBg : HentaiHandCommon("bg", listOf(4))
 class HentaiHandCeb : HentaiHandCommon("ceb", listOf(5, 44))
 class HentaiHandNoText : HentaiHandCommon("other", listOf(6)) {


### PR DESCRIPTION
Closes #13749 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
