### PR TITLE
Kaguya (ID): update domain

### DIFF
--- a/src/id/yubikiri/build.gradle
+++ b/src/id/yubikiri/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Kaguya'
     extClass = '.Kaguya'
     themePkg = 'madara'
-    baseUrl = 'https://kaguya.id'
-    overrideVersionCode = 2
+    baseUrl = 'https://v1.kaguya.pro'
+    overrideVersionCode = 3
     isNsfw = true
 }
 

--- a/src/id/yubikiri/src/eu/kanade/tachiyomi/extension/id/yubikiri/Kaguya.kt
+++ b/src/id/yubikiri/src/eu/kanade/tachiyomi/extension/id/yubikiri/Kaguya.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.extension.id.yubikiri
 
+import android.util.Base64
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.source.model.SChapter
@@ -16,7 +17,7 @@ import java.util.concurrent.TimeUnit
 class Kaguya :
     Madara(
         "Kaguya",
-        "https://kaguya.id",
+        "https://v1.kaguya.pro",
         "id",
         dateFormat = SimpleDateFormat("d MMMM", Locale("en")),
     ) {
@@ -34,6 +35,11 @@ class Kaguya :
     override val mangaDetailsSelectorThumbnail = "head meta[property='og:image']" // Same as browse
 
     override fun imageFromElement(element: Element): String? {
+        if (element.hasAttr("data-aesir")) {
+            val decoded = Base64.decode(element.attr("data-aesir"), Base64.DEFAULT).toString(Charsets.UTF_8).trim()
+            if (decoded.isNotEmpty()) return decoded
+        }
+        
         return super.imageFromElement(element)
             ?.takeIf { it.isNotEmpty() }
             ?: element.attr("content") // Thumbnail from <head>

--- a/src/id/yubikiri/src/eu/kanade/tachiyomi/extension/id/yubikiri/Kaguya.kt
+++ b/src/id/yubikiri/src/eu/kanade/tachiyomi/extension/id/yubikiri/Kaguya.kt
@@ -39,7 +39,7 @@ class Kaguya :
             val decoded = Base64.decode(element.attr("data-aesir"), Base64.DEFAULT).toString(Charsets.UTF_8).trim()
             if (decoded.isNotEmpty()) return decoded
         }
-        
+
         return super.imageFromElement(element)
             ?.takeIf { it.isNotEmpty() }
             ?: element.attr("content") // Thumbnail from <head>


### PR DESCRIPTION
Closes https://github.com/keiyoushi/extensions-source/issues/13730
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
