### PR TITLE
KManga: make lock emoji optional

### DIFF
--- a/src/en/kmanga/build.gradle
+++ b/src/en/kmanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'K Manga'
     extClass = '.KManga'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = false
 }
 

--- a/src/en/kmanga/src/eu/kanade/tachiyomi/extension/en/kmanga/Dto.kt
+++ b/src/en/kmanga/src/eu/kanade/tachiyomi/extension/en/kmanga/Dto.kt
@@ -89,9 +89,9 @@ class Episode(
     val isLocked: Boolean
         get() = point > 0 && badge != 3 && rentalFinishTime == null
 
-    fun toSChapter(dateFormat: SimpleDateFormat): SChapter = SChapter.create().apply {
+    fun toSChapter(dateFormat: SimpleDateFormat, showLockedPrefix: Boolean): SChapter = SChapter.create().apply {
         url = "/title/$titleId/episode/$episodeId"
-        val lock = if (isLocked) "🔒 " else ""
+        val lock = if (showLockedPrefix && isLocked) "🔒 " else ""
         name = lock + episodeName
         chapter_number = index.toFloat()
         date_upload = dateFormat.tryParse(startTime)

--- a/src/en/kmanga/src/eu/kanade/tachiyomi/extension/en/kmanga/KManga.kt
+++ b/src/en/kmanga/src/eu/kanade/tachiyomi/extension/en/kmanga/KManga.kt
@@ -247,10 +247,11 @@ class KManga :
         val apiResponse = client.newCall(apiRequest).execute()
         val result = apiResponse.parseAs<EpisodeListResponse>()
         val hideLocked = preferences.getBoolean(HIDE_LOCKED_PREF_KEY, false)
+        val showLockedPrefix = preferences.getBoolean(LOCKED_PREFIX_PREF_KEY, true)
 
         return result.episodeList
             .filter { !hideLocked || !it.isLocked }
-            .map { it.toSChapter(dateFormat) }
+            .map { it.toSChapter(dateFormat, showLockedPrefix) }
             .reversed()
     }
 
@@ -327,6 +328,12 @@ class KManga :
             title = "Hide Locked Chapters"
             setDefaultValue(false)
         }.also(screen::addPreference)
+
+        SwitchPreferenceCompat(screen.context).apply {
+            key = LOCKED_PREFIX_PREF_KEY
+            title = "Prefix \"🔒\" to locked chapters"
+            setDefaultValue(true)
+        }.also(screen::addPreference)
     }
 
     // Filters
@@ -365,6 +372,7 @@ class KManga :
 
     companion object {
         private const val HIDE_LOCKED_PREF_KEY = "hide_locked"
+        private const val LOCKED_PREFIX_PREF_KEY = "locked_prefix"
         const val PREFIX_SEARCH = "id:"
     }
 


### PR DESCRIPTION
Close: #13758 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
