### PR TITLE
MangaDex: Fix API falsely returning chapters as empty

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaDex'
     extClass = '.MangaDexFactory'
-    extVersionCode = 206
+    extVersionCode = 207
     isNsfw = true
 }
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDex.kt
@@ -550,7 +550,21 @@ abstract class MangaDex(final override val lang: String, private val dexLang: St
         }
 
         return chapterListResults
-            .filterNot { it.attributes!!.isInvalid }
+            .filterNot { chapter ->
+                if (!chapter.attributes!!.isInvalid) return@filterNot false
+
+                val atHomeRequestUrl = if (preferences.forceStandardHttps) {
+                    "${MDConstants.API_URL}/at-home/server/${chapter.id}?forcePort443=true"
+                } else {
+                    "${MDConstants.API_URL}/at-home/server/${chapter.id}"
+                }
+                val request = helper.mdAtHomeRequest(atHomeRequestUrl, headers, CacheControl.FORCE_NETWORK)
+                val pages = runCatching {
+                    client.newCall(request).execute().use { it.parseAs<AtHomeDto>().chapter.data }
+                }.getOrNull()
+
+                pages.isNullOrEmpty()
+            }
             .map(helper::createChapter)
     }
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexHelper.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexHelper.kt
@@ -116,7 +116,6 @@ class MangaDexHelper(lang: String) {
         .addQueryParameter("order[volume]", "desc")
         .addQueryParameter("order[chapter]", "desc")
         .addQueryParameter("includeFuturePublishAt", "0")
-        .addQueryParameter("includeEmptyPages", "0")
         .toString()
 
     /**

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/dto/ChapterDto.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/dto/ChapterDto.kt
@@ -24,8 +24,12 @@ data class ChapterAttributesDto(
 ) : AttributesDto() {
 
     /**
-     * Returns true if the chapter is from an external website and have no pages.
+     * Returns true if the chapter have no pages.
+     *
+     * Note (03/04/2026): the API sometimes falsely reports 'pages = 0' for chapters that actually
+     * have pages (e.g. 6ba0f2ef-02d7-4999-b347-c26c02ebea40). 'isInvalid' is used only as a first-pass signal.
+     * Verify via MD@HOME before discarding any chapter.
      */
     val isInvalid: Boolean
-        get() = externalUrl != null && pages == 0
+        get() = pages == 0
 }


### PR DESCRIPTION
Closes #13798 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
