### PR TITLE
YellowNote: Fix all pages having same chapter_number

### DIFF
--- a/src/all/yellownote/build.gradle
+++ b/src/all/yellownote/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'YellowNote'
     extClass = '.YellowNote'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/all/yellownote/src/eu/kanade/tachiyomi/extension/all/yellownote/YellowNote.kt
+++ b/src/all/yellownote/src/eu/kanade/tachiyomi/extension/all/yellownote/YellowNote.kt
@@ -145,7 +145,6 @@ class YellowNote :
             .removeSuffix(".html")
         return (maxPage downTo 1).map { page ->
             SChapter.create().apply {
-                chapter_number = 0F
                 setUrlWithoutDomain("$basePageUrl/$page.html")
                 name = "Page $page"
                 date_upload = uploadAt


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
