### PR TITLE
Hijala: fix scrambled images

### DIFF
--- a/src/ar/hijala/build.gradle
+++ b/src/ar/hijala/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Hijala'
     themePkg = 'mangathemesia'
     baseUrl = 'https://hijala.com'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
     isNsfw = false
 }
 

--- a/src/ar/hijala/build.gradle
+++ b/src/ar/hijala/build.gradle
@@ -8,3 +8,7 @@ ext {
 }
 
 apply from: "$rootDir/common.gradle"
+
+dependencies {
+    compileOnly("com.github.tachiyomiorg:image-decoder:41c059e540")
+}

--- a/src/ar/hijala/build.gradle
+++ b/src/ar/hijala/build.gradle
@@ -8,7 +8,3 @@ ext {
 }
 
 apply from: "$rootDir/common.gradle"
-
-dependencies {
-    compileOnly("com.github.tachiyomiorg:image-decoder:41c059e540")
-}

--- a/src/ar/hijala/src/eu/kanade/tachiyomi/extension/ar/hijala/Hijala.kt
+++ b/src/ar/hijala/src/eu/kanade/tachiyomi/extension/ar/hijala/Hijala.kt
@@ -1,6 +1,23 @@
 package eu.kanade.tachiyomi.extension.ar.hijala
 
+import android.graphics.Bitmap
+import android.graphics.Canvas
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import eu.kanade.tachiyomi.network.await
+import eu.kanade.tachiyomi.source.model.Page
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import okhttp3.HttpUrl
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.asResponseBody
+import okio.Buffer
+import org.jsoup.nodes.Document
+import tachiyomi.decoder.ImageDecoder
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -11,6 +28,105 @@ class Hijala :
         "ar",
         dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("ar")),
     ) {
+
     // Site moved from ZeistManga to MangaThemesia again
     override val versionId get() = 2
+
+    override val client = network.cloudflareClient.newBuilder()
+        .addInterceptor(::scrambledImageInterceptor)
+        .build()
+
+    private fun scrambledImageInterceptor(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val url = request.url
+
+        if (url.host != SCRAMBLED_IMAGE_HOST) {
+            return chain.proceed(request)
+        }
+
+        val leftPieceUrl = url.queryParameter("leftImage")
+            ?: throw IllegalStateException("Missing leftImage")
+        val rightPieceUrl = url.queryParameter("rightImage")
+            ?: throw IllegalStateException("Missing rightImage")
+
+        val pieceBitmaps = runBlocking {
+            listOf(leftPieceUrl, rightPieceUrl).map { pieceUrl ->
+                async(Dispatchers.IO) {
+                    val pieceRequest = request.newBuilder().url(pieceUrl).build()
+                    client.newCall(pieceRequest).await().use { response ->
+                        response.body.use { body ->
+                            val decoder = ImageDecoder.newInstance(body.byteStream())
+                                ?: throw Exception("Failed to create decoder for $pieceUrl")
+                            try {
+                                decoder.decode() ?: throw Exception("Failed to decode $pieceUrl")
+                            } finally {
+                                decoder.recycle()
+                            }
+                        }
+                    }
+                }
+            }.awaitAll()
+        }
+
+        require(pieceBitmaps.size == 2) { "Expected exactly 2 bitmaps" }
+
+        val leftBitmap = pieceBitmaps[0]
+        val rightBitmap = pieceBitmaps[1]
+
+        val width = leftBitmap.width + rightBitmap.width
+        val height = maxOf(leftBitmap.height, rightBitmap.height)
+
+        val resultBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(resultBitmap)
+
+        try {
+            canvas.drawBitmap(leftBitmap, 0f, 0f, null)
+            canvas.drawBitmap(rightBitmap, leftBitmap.width.toFloat(), 0f, null)
+
+            val buffer = Buffer().apply {
+                resultBitmap.compress(Bitmap.CompressFormat.JPEG, 90, outputStream())
+            }
+
+            return Response.Builder()
+                .request(request)
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(buffer.asResponseBody("image/jpeg".toMediaType(), buffer.size))
+                .build()
+        } finally {
+            pieceBitmaps.forEach { it.recycle() }
+            resultBitmap.recycle()
+        }
+    }
+
+    override fun pageListParse(document: Document): List<Page> {
+        val pages = super.pageListParse(document)
+        document.selectFirst("#chapter-pages-js-before") ?: return pages
+
+        val chapterUrl = document.location()
+        val pairs = mutableListOf<List<String>>()
+        var i = 0
+        while (i < pages.size) {
+            val pair = pages.subList(i, minOf(i + 2, pages.size))
+            if (pair.size == 2) {
+                pairs.add(pair.mapNotNull { it.imageUrl })
+            }
+            i += 2
+        }
+
+        return pairs.mapIndexed { index, pair ->
+            val imageUrl = HttpUrl.Builder()
+                .scheme("http")
+                .host(SCRAMBLED_IMAGE_HOST)
+                .addQueryParameter("leftImage", pair[0])
+                .addQueryParameter("rightImage", pair[1])
+                .build()
+                .toString()
+
+            Page(index, chapterUrl, imageUrl)
+        }
+    }
 }
+
+private const val SCRAMBLED_IMAGE_HOST = "127.0.0.1"

--- a/src/ar/hijala/src/eu/kanade/tachiyomi/extension/ar/hijala/Hijala.kt
+++ b/src/ar/hijala/src/eu/kanade/tachiyomi/extension/ar/hijala/Hijala.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.extension.ar.hijala
 
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import eu.kanade.tachiyomi.network.await
@@ -17,7 +18,6 @@ import okhttp3.Response
 import okhttp3.ResponseBody.Companion.asResponseBody
 import okio.Buffer
 import org.jsoup.nodes.Document
-import tachiyomi.decoder.ImageDecoder
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -55,13 +55,8 @@ class Hijala :
                     val pieceRequest = request.newBuilder().url(pieceUrl).build()
                     client.newCall(pieceRequest).await().use { response ->
                         response.body.use { body ->
-                            val decoder = ImageDecoder.newInstance(body.byteStream())
-                                ?: throw Exception("Failed to create decoder for $pieceUrl")
-                            try {
-                                decoder.decode() ?: throw Exception("Failed to decode $pieceUrl")
-                            } finally {
-                                decoder.recycle()
-                            }
+                            BitmapFactory.decodeStream(body?.byteStream())
+                                ?: throw Exception("Failed to decode $pieceUrl")
                         }
                     }
                 }


### PR DESCRIPTION
Closes #12647

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
