### PR TITLE
Fix Mangalionz

### DIFF
--- a/src/ar/mangalionz/build.gradle
+++ b/src/ar/mangalionz/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'MangaLionz'
     extClass = '.MangaLionz'
     themePkg = 'madara'
-    baseUrl = 'https://manga-lionz.com'
-    overrideVersionCode = 4
+    baseUrl = 'https://manga-lionz.org'
+    overrideVersionCode = 5
     isNsfw = false
 }
 

--- a/src/ar/mangalionz/src/eu/kanade/tachiyomi/extension/ar/mangalionz/MangaLionz.kt
+++ b/src/ar/mangalionz/src/eu/kanade/tachiyomi/extension/ar/mangalionz/MangaLionz.kt
@@ -1,6 +1,16 @@
 package eu.kanade.tachiyomi.extension.ar.mangalionz
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.SManga
+import keiyoushi.utils.parseAs
+import kotlinx.serialization.Serializable
+import okhttp3.FormBody
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -15,4 +25,60 @@ class MangaLionz :
     override val useLoadMoreRequest = LoadMoreStrategy.Always
 
     override val chapterUrlSuffix = ""
+
+    override fun searchMangaRequest(
+        page: Int,
+        query: String,
+        filters: FilterList,
+    ): Request = if (query.isNotBlank()) {
+        POST(
+            "$baseUrl/wp-admin/admin-ajax.php",
+            headers,
+            FormBody
+                .Builder()
+                .add("action", "wp-manga-search-manga")
+                .add("title", query)
+                .build(),
+        )
+    } else {
+        super.searchMangaRequest(page, query, filters)
+    }
+
+    override fun searchMangaParse(response: Response): MangasPage {
+        val body = response.body.string()
+
+        return try {
+            val dto = body.parseAs<SearchResponseDto>()
+
+            if (!dto.success) {
+                MangasPage(emptyList(), false)
+            } else {
+                val manga = dto.data.map {
+                    SManga.create().apply {
+                        setUrlWithoutDomain(it.url)
+                        title = it.title
+                    }
+                }
+                MangasPage(manga, false)
+            }
+        } catch (_: Exception) {
+            super.searchMangaParse(
+                response.newBuilder()
+                    .body(body.toResponseBody(response.body.contentType()))
+                    .build(),
+            )
+        }
+    }
+
+    @Serializable
+    data class SearchResponseDto(
+        val data: List<SearchEntryDto>,
+        val success: Boolean,
+    )
+
+    @Serializable
+    data class SearchEntryDto(
+        val url: String = "",
+        val title: String = "",
+    )
 }

--- a/src/ar/mangalionz/src/eu/kanade/tachiyomi/extension/ar/mangalionz/MangaLionz.kt
+++ b/src/ar/mangalionz/src/eu/kanade/tachiyomi/extension/ar/mangalionz/MangaLionz.kt
@@ -9,11 +9,13 @@ import java.util.Locale
 class MangaLionz :
     Madara(
         "MangaLionz",
-        "https://manga-lionz.com",
+        "https://manga-lionz.org",
         "ar",
         dateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("ar")),
     ) {
+
     override val useLoadMoreRequest = LoadMoreStrategy.Always
+
     override fun popularMangaFromElement(element: Element): SManga {
         val manga = SManga.create()
 

--- a/src/ar/mangalionz/src/eu/kanade/tachiyomi/extension/ar/mangalionz/MangaLionz.kt
+++ b/src/ar/mangalionz/src/eu/kanade/tachiyomi/extension/ar/mangalionz/MangaLionz.kt
@@ -1,8 +1,6 @@
 package eu.kanade.tachiyomi.extension.ar.mangalionz
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
-import eu.kanade.tachiyomi.source.model.SManga
-import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -15,23 +13,6 @@ class MangaLionz :
     ) {
 
     override val useLoadMoreRequest = LoadMoreStrategy.Always
-
-    override fun popularMangaFromElement(element: Element): SManga {
-        val manga = SManga.create()
-
-        with(element) {
-            selectFirst(popularMangaUrlSelector)!!.let {
-                manga.setUrlWithoutDomain(it.attr("abs:href"))
-                manga.title = it.ownText()
-            }
-
-            selectFirst("img")?.let {
-                manga.thumbnail_url = imageFromElement(it)?.replace("mangalionz", "mangalek")
-            }
-        }
-
-        return manga
-    }
 
     override val chapterUrlSuffix = ""
 }

--- a/src/ar/mangalionz/src/eu/kanade/tachiyomi/extension/ar/mangalionz/MangaLionz.kt
+++ b/src/ar/mangalionz/src/eu/kanade/tachiyomi/extension/ar/mangalionz/MangaLionz.kt
@@ -10,7 +10,6 @@ import kotlinx.serialization.Serializable
 import okhttp3.FormBody
 import okhttp3.Request
 import okhttp3.Response
-import okhttp3.ResponseBody.Companion.toResponseBody
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -45,10 +44,9 @@ class MangaLionz :
     }
 
     override fun searchMangaParse(response: Response): MangasPage {
-        val body = response.body.string()
-
-        return try {
-            val dto = body.parseAs<SearchResponseDto>()
+        val contentType = response.header("Content-Type")
+        return contentType?.takeIf { it.startsWith("application/json") }?.let {
+            val dto = response.parseAs<SearchResponseDto>()
 
             if (!dto.success) {
                 MangasPage(emptyList(), false)
@@ -61,13 +59,7 @@ class MangaLionz :
                 }
                 MangasPage(manga, false)
             }
-        } catch (_: Exception) {
-            super.searchMangaParse(
-                response.newBuilder()
-                    .body(body.toResponseBody(response.body.contentType()))
-                    .build(),
-            )
-        }
+        } ?: super.searchMangaParse(response)
     }
 
     @Serializable


### PR DESCRIPTION
Removed the `popularMangaFromElement` method because the site now provides thumbnails directly. 

Closes #5732

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
