### PR TITLE
Add new options to astumaru search

### DIFF
--- a/src/en/atsumaru/build.gradle
+++ b/src/en/atsumaru/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Atsumaru'
     extClass = '.Atsumaru'
-    extVersionCode = 11
+    extVersionCode = 12
     isNsfw = true
 }
 

--- a/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/Atsumaru.kt
+++ b/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/Atsumaru.kt
@@ -67,8 +67,9 @@ class Atsumaru : HttpSource() {
         StatusFilter(getStatusList()),
         YearFilter(),
         MinChaptersFilter(),
-        Filter.Separator(),
         SortFilter(),
+        AdultFilter(),
+        OfficialFilter(),
     )
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
@@ -89,6 +90,8 @@ class Atsumaru : HttpSource() {
         var year: Int? = null
         var minChapters: Int? = null
         var sort = "popularity"
+        var showAdult = false
+        var officialTranslation = false
 
         filters.forEach { filter ->
             when (filter) {
@@ -128,6 +131,14 @@ class Atsumaru : HttpSource() {
                     sort = SortFilter.VALUES[filter.state!!.index]
                 }
 
+                is AdultFilter -> {
+                    showAdult = filter.state
+                }
+
+                is OfficialFilter -> {
+                    officialTranslation = filter.state
+                }
+
                 else -> {}
             }
         }
@@ -146,6 +157,8 @@ class Atsumaru : HttpSource() {
                 includedTags = selectedGenres.ifEmpty { null },
                 year = year,
                 minChapters = minChapters,
+                showAdult = showAdult,
+                officialTranslation = officialTranslation,
             ),
         )
     }

--- a/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/AtsumaruFilters.kt
+++ b/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/AtsumaruFilters.kt
@@ -47,6 +47,10 @@ internal class SortFilter :
     }
 }
 
+internal class AdultFilter : Filter.CheckBox("Show Adult Content", false)
+
+internal class OfficialFilter : Filter.CheckBox("Only Official Translations", false)
+
 internal data class Genre(val name: String, val id: String)
 
 internal data class Type(val name: String, val id: String)

--- a/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/Dto.kt
+++ b/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/Dto.kt
@@ -190,4 +190,6 @@ internal class SearchFilter(
     val includedTags: List<String>? = null,
     val year: Int? = null,
     val minChapters: Int? = null,
+    val showAdult: Boolean = false,
+    val officialTranslation: Boolean = false,
 )


### PR DESCRIPTION
I implemented this on my phone in the GitHub webui, ~I have no idea if I works~ it does, but it should? Also methinks it should closes #13815. Also if merged please squash, commit names are dumb.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
