### PR TITLE
Luscious: Fix image parsing url scheme error

### DIFF
--- a/src/all/luscious/build.gradle
+++ b/src/all/luscious/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Luscious'
     extClass = '.LusciousFactory'
-    extVersionCode = 24
+    extVersionCode = 25
     isNsfw = true
 }
 

--- a/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/Luscious.kt
+++ b/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/Luscious.kt
@@ -15,12 +15,12 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.utils.getPreferencesLazy
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.double
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
@@ -356,10 +356,22 @@ abstract class Luscious(
             nextPage = data["info"]!!.jsonObject["has_next_page"]!!.jsonPrimitive.boolean
             data["items"]!!.jsonArray.map {
                 val index = it.jsonObject["position"]!!.jsonPrimitive.int
-                val url = when (getResolutionPref()) {
-                    "-1" -> it.jsonObject["url_to_original"]!!.jsonPrimitive.content
-                    else -> it.jsonObject["thumbnails"]!!.jsonArray[getResolutionPref()?.toInt()!!].jsonObject["url"]!!.jsonPrimitive.content
+                val url = when {
+                    getResolutionPref() != "-1" -> {
+                        it.jsonObject["thumbnails"]!!.jsonArray[getResolutionPref()?.toInt()!!].jsonObject["url"]!!.jsonPrimitive.content
+                    }
+                    it.jsonObject["url_to_original"]!!.jsonPrimitive.contentOrNull != null -> {
+                        it.jsonObject["url_to_original"]!!.jsonPrimitive.content
+                    }
+                    else -> {
+                        it.jsonObject["thumbnails"]!!.jsonArray.maxByOrNull {
+                            val height = it.jsonObject["height"]!!.jsonPrimitive.int
+                            val width = it.jsonObject["width"]!!.jsonPrimitive.int
+                            height * width
+                        }?.jsonObject?.get("url")!!.jsonPrimitive.content ?: ""
+                    }
                 }
+
                 when {
                     url.startsWith("//") -> pages.add(Page(index, "https:$url", "https:$url"))
                     else -> pages.add(Page(index, url, url))


### PR DESCRIPTION
Closes  #13830

I can't take advantage of this PR for patch #13545, the problem comes from luscious itself. See comment on the issue for more details.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
