### PR TITLE
Japscan: Fix 403

### DIFF
--- a/src/fr/japscan/build.gradle
+++ b/src/fr/japscan/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Japscan'
     extClass = '.Japscan'
-    extVersionCode = 56
+    extVersionCode = 57
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -5,7 +5,6 @@ import android.content.SharedPreferences
 import android.graphics.Bitmap
 import android.os.Handler
 import android.os.Looper
-import android.util.Base64
 import android.view.View
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
@@ -287,39 +286,16 @@ class Japscan :
     )
 
     override fun fetchPageList(chapter: SChapter): Observable<List<Page>> {
-        try {
-            val document = client.newCall(GET("$internalBaseUrl${chapter.url}")).execute().asJsoup()
-            // Get only usable crypted b64
-            val atad = document.select("i[data-atad]").attr("data-atad").substring(7)
-            val mapping =
-                "M7HXtiwLKdpIBkEbQ2OaF8Sxmz1yGReU4q5DncgsT6jVA3Pfv0WuJ9YCZNhlor".reversed()
-            val reference =
-                "uGJ657yOSbZRtplgHEYPBwCqaxQIizDWmTLMsAeNocnX0d98rf4Kj1kvh3UFV2".reversed()
-            val decrypted =
-                atad.replace(Regex("[A-Z0-9]", RegexOption.IGNORE_CASE)) { matchResult ->
-                    val char = matchResult.value[0]
-                    val index = reference.indexOf(char)
-                    (if (index != -1) mapping[index] else char).toString()
-                }
-            val fromB64 = String(Base64.decode(decrypted, Base64.DEFAULT)).parseAs<ChapterDetails>()
-            if (fromB64.imagesLink.isEmpty()) throw UnsupportedOperationException("Can't parse Images")
-            return Observable.just(
-                fromB64.imagesLink.mapIndexed { i, url ->
-                    Page(i, imageUrl = "$url?o=1")
-                },
-            )
-        } catch (e: Exception) {
-            return fallbackFetchPageList(chapter)
-        }
-    }
-
-    fun fallbackFetchPageList(chapter: SChapter): Observable<List<Page>> {
         val interfaceName = randomString()
 
         val handler = Handler(Looper.getMainLooper())
         val latch = CountDownLatch(1)
         val jsInterface = JsInterface(latch)
         var webView: WebView? = null
+        val request = client.newCall(GET("$internalBaseUrl${chapter.url}")).execute()
+        val pageContent = request.body.string()
+        val pValue = Regex("""p:\s*'([^']*)'""").find(pageContent)?.groups?.get(1)?.value
+        val vValue = Regex("""v:\s*'([^']*)'""").find(pageContent)?.groups?.get(1)?.value
 
         handler.post {
             val innerWv = WebView(Injekt.get<Application>())
@@ -376,7 +352,7 @@ class Japscan :
             .images
             .filter { it.toHttpUrl().host.endsWith(baseUrlHost) } // Pages not served through their CDN are probably ads
             .mapIndexed { i, url ->
-                Page(i, imageUrl = url)
+                Page(i, imageUrl = "$url&$pValue=$vValue")
             }
 
         return Observable.just(images)


### PR DESCRIPTION
Closes  #13599

I removed what I had previously reverse engineered, since they changed everything. This time, I'm not going to bother doing it, at least for now.
In any case, I discovered two variables in the HTML, p and v, which are used in the image path to allow them to be loaded. They are then used as GET arguments of the type p=v.
I've never used webView in my extensions, so there's probably an easier way to retrieve p and v. If you know of one, let me know, as I could learn a lot from it.
If you ever encounter any further issues with this extension, please feel free to mention me on GitHub in the issues section (for all French extensions, in fact). I would be happy to try and resolve the problem.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
