### PR TITLE
feat: Support latest Terra Historicus method

### DIFF
--- a/src/zh/terrahistoricus/build.gradle
+++ b/src/zh/terrahistoricus/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Terra Historicus'
     extClass = '.TerraHistoricus'
-    extVersionCode = 3
+    extVersionCode = 4
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/zh/terrahistoricus/src/eu/kanade/tachiyomi/extension/zh/terrahistoricus/TerraHistoricus.kt
+++ b/src/zh/terrahistoricus/src/eu/kanade/tachiyomi/extension/zh/terrahistoricus/TerraHistoricus.kt
@@ -24,46 +24,32 @@ class TerraHistoricus : HttpSource() {
 
     private val topicKeys = listOf("terra-historicus", "talos-ii-historicus")
 
-    override fun popularMangaRequest(page: Int) = GET("$baseUrl/api/comic?topicKey=${topicKeys[0]}", headers)
+    override fun popularMangaRequest(page: Int) = GET("$baseUrl/api/comic?topicKey=${topicKeys[page - 1]}", headers)
+    override fun popularMangaParse(response: Response) = MangasPage(response.parseAs<List<THComic>>().map { it.toSManga() }, false)
 
-    override fun fetchPopularManga(page: Int): Observable<MangasPage> {
-        val requests = topicKeys.map { client.newCall(GET("$baseUrl/api/comic?topicKey=$it", headers)) }
-        return Observable.from(requests)
-            .flatMap { it.asObservableSuccess() }
-            .toList()
-            .map { responses ->
-                val mangas = responses.flatMap { it.parseAs<List<THComic>>().map { comic -> comic.toSManga() } }
-                MangasPage(mangas, false)
-            }
-    }
+    override fun fetchPopularManga(page: Int): Observable<MangasPage> =
+        client.newCall(popularMangaRequest(page)).asObservableSuccess().map { response ->
+            MangasPage(response.parseAs<List<THComic>>().map { it.toSManga() }, page < topicKeys.size)
+        }
 
-    override fun popularMangaParse(response: Response) = throw UnsupportedOperationException()
+    override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/api/recentUpdate?topicKey=${topicKeys[page - 1]}", headers)
+    override fun latestUpdatesParse(response: Response) = MangasPage(response.parseAs<List<THRecentUpdate>>().map { it.toSManga() }, false)
 
-    override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/api/recentUpdate?topicKey=${topicKeys[0]}", headers)
-
-    override fun fetchLatestUpdates(page: Int): Observable<MangasPage> {
-        val requests = topicKeys.map { client.newCall(GET("$baseUrl/api/recentUpdate?topicKey=$it", headers)) }
-        return Observable.from(requests)
-            .flatMap { it.asObservableSuccess() }
-            .toList()
-            .map { responses ->
-                val mangas = responses.flatMap { it.parseAs<List<THRecentUpdate>>().map { update -> update.toSManga() } }
-                MangasPage(mangas, false)
-            }
-    }
-
-    override fun latestUpdatesParse(response: Response) = throw UnsupportedOperationException()
+    override fun fetchLatestUpdates(page: Int): Observable<MangasPage> =
+        client.newCall(latestUpdatesRequest(page)).asObservableSuccess().map { response ->
+            MangasPage(response.parseAs<List<THRecentUpdate>>().map { it.toSManga() }, page < topicKeys.size)
+        }
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = fetchPopularManga(page).map { mangasPage ->
         val mangas = mangasPage.mangas.filter { it.title.contains(query) }
-        MangasPage(mangas, false)
+        MangasPage(mangas, page < topicKeys.size)
     }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList) = throw UnsupportedOperationException()
     override fun searchMangaParse(response: Response) = throw UnsupportedOperationException()
 
     // navigate webview to webpage
-    override fun mangaDetailsRequest(manga: SManga) = GET(baseUrl + manga.url.replace("/api/comic/", "/terra-historicus/"), headers)
+    override fun mangaDetailsRequest(manga: SManga) = GET(baseUrl + manga.url.removePrefix("/api"), headers)
 
     override fun fetchMangaDetails(manga: SManga): Observable<SManga> = client.newCall(chapterListRequest(manga)).asObservableSuccess()
         .map { response -> mangaDetailsParse(response).apply { initialized = true } }

--- a/src/zh/terrahistoricus/src/eu/kanade/tachiyomi/extension/zh/terrahistoricus/TerraHistoricus.kt
+++ b/src/zh/terrahistoricus/src/eu/kanade/tachiyomi/extension/zh/terrahistoricus/TerraHistoricus.kt
@@ -17,16 +17,42 @@ import uy.kohesive.injekt.injectLazy
 class TerraHistoricus : HttpSource() {
     override val name = "泰拉记事社"
     override val lang = "zh"
-    override val baseUrl = "https://terra-historicus.hypergryph.com"
+    override val baseUrl = "https://comic.hypergryph.com"
     override val supportsLatest = true
 
     private val json: Json by injectLazy()
 
-    override fun popularMangaRequest(page: Int) = GET("$baseUrl/api/comic", headers)
-    override fun popularMangaParse(response: Response) = MangasPage(response.parseAs<List<THComic>>().map { it.toSManga() }, false)
+    private val topicKeys = listOf("terra-historicus", "talos-ii-historicus")
 
-    override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/api/recentUpdate", headers)
-    override fun latestUpdatesParse(response: Response) = MangasPage(response.parseAs<List<THRecentUpdate>>().map { it.toSManga() }, false)
+    override fun popularMangaRequest(page: Int) = GET("$baseUrl/api/comic?topicKey=${topicKeys[0]}", headers)
+
+    override fun fetchPopularManga(page: Int): Observable<MangasPage> {
+        val requests = topicKeys.map { client.newCall(GET("$baseUrl/api/comic?topicKey=$it", headers)) }
+        return Observable.from(requests)
+            .flatMap { it.asObservableSuccess() }
+            .toList()
+            .map { responses ->
+                val mangas = responses.flatMap { it.parseAs<List<THComic>>().map { comic -> comic.toSManga() } }
+                MangasPage(mangas, false)
+            }
+    }
+
+    override fun popularMangaParse(response: Response) = throw UnsupportedOperationException()
+
+    override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/api/recentUpdate?topicKey=${topicKeys[0]}", headers)
+
+    override fun fetchLatestUpdates(page: Int): Observable<MangasPage> {
+        val requests = topicKeys.map { client.newCall(GET("$baseUrl/api/recentUpdate?topicKey=$it", headers)) }
+        return Observable.from(requests)
+            .flatMap { it.asObservableSuccess() }
+            .toList()
+            .map { responses ->
+                val mangas = responses.flatMap { it.parseAs<List<THRecentUpdate>>().map { update -> update.toSManga() } }
+                MangasPage(mangas, false)
+            }
+    }
+
+    override fun latestUpdatesParse(response: Response) = throw UnsupportedOperationException()
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = fetchPopularManga(page).map { mangasPage ->
         val mangas = mangasPage.mangas.filter { it.title.contains(query) }
@@ -37,7 +63,7 @@ class TerraHistoricus : HttpSource() {
     override fun searchMangaParse(response: Response) = throw UnsupportedOperationException()
 
     // navigate webview to webpage
-    override fun mangaDetailsRequest(manga: SManga) = GET(baseUrl + manga.url.removePrefix("/api"), headers)
+    override fun mangaDetailsRequest(manga: SManga) = GET(baseUrl + manga.url.replace("/api/comic/", "/terra-historicus/"), headers)
 
     override fun fetchMangaDetails(manga: SManga): Observable<SManga> = client.newCall(chapterListRequest(manga)).asObservableSuccess()
         .map { response -> mangaDetailsParse(response).apply { initialized = true } }

--- a/src/zh/terrahistoricus/src/eu/kanade/tachiyomi/extension/zh/terrahistoricus/TerraHistoricus.kt
+++ b/src/zh/terrahistoricus/src/eu/kanade/tachiyomi/extension/zh/terrahistoricus/TerraHistoricus.kt
@@ -27,18 +27,16 @@ class TerraHistoricus : HttpSource() {
     override fun popularMangaRequest(page: Int) = GET("$baseUrl/api/comic?topicKey=${topicKeys[page - 1]}", headers)
     override fun popularMangaParse(response: Response) = MangasPage(response.parseAs<List<THComic>>().map { it.toSManga() }, false)
 
-    override fun fetchPopularManga(page: Int): Observable<MangasPage> =
-        client.newCall(popularMangaRequest(page)).asObservableSuccess().map { response ->
-            MangasPage(response.parseAs<List<THComic>>().map { it.toSManga() }, page < topicKeys.size)
-        }
+    override fun fetchPopularManga(page: Int): Observable<MangasPage> = client.newCall(popularMangaRequest(page)).asObservableSuccess().map { response ->
+        MangasPage(response.parseAs<List<THComic>>().map { it.toSManga() }, page < topicKeys.size)
+    }
 
     override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/api/recentUpdate?topicKey=${topicKeys[page - 1]}", headers)
     override fun latestUpdatesParse(response: Response) = MangasPage(response.parseAs<List<THRecentUpdate>>().map { it.toSManga() }, false)
 
-    override fun fetchLatestUpdates(page: Int): Observable<MangasPage> =
-        client.newCall(latestUpdatesRequest(page)).asObservableSuccess().map { response ->
-            MangasPage(response.parseAs<List<THRecentUpdate>>().map { it.toSManga() }, page < topicKeys.size)
-        }
+    override fun fetchLatestUpdates(page: Int): Observable<MangasPage> = client.newCall(latestUpdatesRequest(page)).asObservableSuccess().map { response ->
+        MangasPage(response.parseAs<List<THRecentUpdate>>().map { it.toSManga() }, page < topicKeys.size)
+    }
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = fetchPopularManga(page).map { mangasPage ->
         val mangas = mangasPage.mangas.filter { it.title.contains(query) }
@@ -48,8 +46,9 @@ class TerraHistoricus : HttpSource() {
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList) = throw UnsupportedOperationException()
     override fun searchMangaParse(response: Response) = throw UnsupportedOperationException()
 
-    // navigate webview to webpage
-    override fun mangaDetailsRequest(manga: SManga) = GET(baseUrl + manga.url.removePrefix("/api"), headers)
+    override fun getMangaUrl(manga: SManga): String = baseUrl + manga.url.removePrefix("/api")
+
+    override fun getChapterUrl(chapter: SChapter): String = baseUrl + chapter.url.removePrefix("/api")
 
     override fun fetchMangaDetails(manga: SManga): Observable<SManga> = client.newCall(chapterListRequest(manga)).asObservableSuccess()
         .map { response -> mangaDetailsParse(response).apply { initialized = true } }

--- a/src/zh/terrahistoricus/src/eu/kanade/tachiyomi/extension/zh/terrahistoricus/TerraHistoricus.kt
+++ b/src/zh/terrahistoricus/src/eu/kanade/tachiyomi/extension/zh/terrahistoricus/TerraHistoricus.kt
@@ -25,22 +25,20 @@ class TerraHistoricus : HttpSource() {
     private val topicKeys = listOf("terra-historicus", "talos-ii-historicus")
 
     override fun popularMangaRequest(page: Int) = GET("$baseUrl/api/comic?topicKey=${topicKeys[page - 1]}", headers)
-    override fun popularMangaParse(response: Response) = MangasPage(response.parseAs<List<THComic>>().map { it.toSManga() }, false)
-
-    override fun fetchPopularManga(page: Int): Observable<MangasPage> = client.newCall(popularMangaRequest(page)).asObservableSuccess().map { response ->
-        MangasPage(response.parseAs<List<THComic>>().map { it.toSManga() }, page < topicKeys.size)
-    }
+    override fun popularMangaParse(response: Response) = MangasPage(
+        response.parseAs<List<THComic>>().map { it.toSManga() },
+        response.request.url.queryParameter("topicKey") != topicKeys.last(),
+    )
 
     override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/api/recentUpdate?topicKey=${topicKeys[page - 1]}", headers)
-    override fun latestUpdatesParse(response: Response) = MangasPage(response.parseAs<List<THRecentUpdate>>().map { it.toSManga() }, false)
-
-    override fun fetchLatestUpdates(page: Int): Observable<MangasPage> = client.newCall(latestUpdatesRequest(page)).asObservableSuccess().map { response ->
-        MangasPage(response.parseAs<List<THRecentUpdate>>().map { it.toSManga() }, page < topicKeys.size)
-    }
+    override fun latestUpdatesParse(response: Response) = MangasPage(
+        response.parseAs<List<THRecentUpdate>>().map { it.toSManga() },
+        response.request.url.queryParameter("topicKey") != topicKeys.last(),
+    )
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = fetchPopularManga(page).map { mangasPage ->
         val mangas = mangasPage.mangas.filter { it.title.contains(query) }
-        MangasPage(mangas, page < topicKeys.size)
+        MangasPage(mangas, mangasPage.hasNextPage)
     }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList) = throw UnsupportedOperationException()


### PR DESCRIPTION
Since Tallo II Historicus was released, Hypergryph has changed their comic website's API address and added a `Topic` item to distinguish different comic themes. This PR has been adapted to the new changes and has passed testing.

This pr will close #13842 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
