### PR TITLE
Luscious: Fix single image 401 error

### DIFF
--- a/src/all/luscious/build.gradle
+++ b/src/all/luscious/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Luscious'
     extClass = '.LusciousFactory'
-    extVersionCode = 25
+    extVersionCode = 26
     isNsfw = true
 }
 

--- a/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/Luscious.kt
+++ b/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/Luscious.kt
@@ -286,9 +286,20 @@ abstract class Luscious(
                     nextPage = data["info"]!!.jsonObject["has_next_page"]!!.jsonPrimitive.boolean
                     data["items"]!!.jsonArray.map {
                         val chapter = SChapter.create()
-                        val url = when (getResolutionPref()) {
-                            "-1" -> it.jsonObject["url_to_original"]!!.jsonPrimitive.content
-                            else -> it.jsonObject["thumbnails"]!!.jsonArray[getResolutionPref()?.toInt()!!].jsonObject["url"]!!.jsonPrimitive.content
+                        val url = when {
+                            getResolutionPref() != "-1" -> {
+                                it.jsonObject["thumbnails"]!!.jsonArray[getResolutionPref()?.toInt()!!].jsonObject["url"]!!.jsonPrimitive.content
+                            }
+                            it.jsonObject["url_to_original"]!!.jsonPrimitive.contentOrNull != null -> {
+                                it.jsonObject["url_to_original"]!!.jsonPrimitive.content
+                            }
+                            else -> {
+                                it.jsonObject["thumbnails"]!!.jsonArray.maxByOrNull {
+                                    val height = it.jsonObject["height"]!!.jsonPrimitive.int
+                                    val width = it.jsonObject["width"]!!.jsonPrimitive.int
+                                    height * width
+                                }?.jsonObject?.get("url")!!.jsonPrimitive.content ?: ""
+                            }
                         }
                         when {
                             url.startsWith("//") -> chapter.url = "https:$url"
@@ -659,7 +670,7 @@ abstract class Luscious(
 
     private fun getContentTypeFilters() = listOf(
         SelectFilterOption("All", FILTER_VALUE_IGNORE),
-        SelectFilterOption("Hentai", "0"),
+        SelectFilterOption("Hentai", "2"),
         SelectFilterOption("Non-Erotic", "5"),
         SelectFilterOption("Real People", "6"),
     )
@@ -857,8 +868,8 @@ abstract class Luscious(
 
         private const val MIRROR_PREF_KEY = "MIRROR"
         private const val MIRROR_PREF_TITLE = "Mirror"
-        private val MIRROR_PREF_ENTRIES = arrayOf("Guest", "API", "Members")
-        private val MIRROR_PREF_ENTRY_VALUES = arrayOf("https://www.luscious.net", "https://apicdn.luscious.net", "https://members.luscious.net")
+        private val MIRROR_PREF_ENTRIES = arrayOf("Guest", "Members")
+        private val MIRROR_PREF_ENTRY_VALUES = arrayOf("https://www.luscious.net", "https://members.luscious.net")
         private val MIRROR_PREF_DEFAULT_VALUE = MIRROR_PREF_ENTRY_VALUES[0]
     }
 


### PR DESCRIPTION
Closes #13848 

#13545 can be closed too, as there is no more limit in the API.

- "API" mirror was removed as the domain was removed and I can't find any domain to replace it.
- Small fix for filtering.
- For the rest, it's just the same as yesterday, I just forgot to put it in for the non-merged chapters.

I think #12279 can be closed too, can't replicate the issue, I think it was fixed by #12656.

#2036 can be closed too, as I implemented it in #11119. Sorry, I must not have seen this feature request when I made the addition...

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
