### PR TITLE
Update HentaiCosplay

### DIFF
--- a/src/all/hentaicosplay/build.gradle
+++ b/src/all/hentaicosplay/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hentai Cosplay'
     extClass = '.HentaiCosplay'
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = true
 }
 

--- a/src/all/hentaicosplay/src/eu/kanade/tachiyomi/extension/all/hentaicosplay/HentaiCosplay.kt
+++ b/src/all/hentaicosplay/src/eu/kanade/tachiyomi/extension/all/hentaicosplay/HentaiCosplay.kt
@@ -95,7 +95,7 @@ class HentaiCosplay : HttpSource() {
         return super.fetchLatestUpdates(page)
     }
 
-    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/recently/page/$page/", headers)
+    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/search/page/$page/", headers)
 
     override fun latestUpdatesParse(response: Response) = popularMangaParse(response)
 


### PR DESCRIPTION
Closes #11468 

Replace "$baseUrl/recently/page/$page/" to "$baseUrl/search/page/$page/"

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
