### PR TITLE
Mangaplus: Fix missing element "HIATUS"

### DIFF
--- a/src/all/mangaplus/build.gradle
+++ b/src/all/mangaplus/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MANGA Plus by SHUEISHA'
     extClass = '.MangaPlusFactory'
-    extVersionCode = 58
+    extVersionCode = 59
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusDto.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusDto.kt
@@ -114,7 +114,7 @@ class TitleDetailView(
         get() = isSimulReleased || titleLabels.isSimulpub
 
     private val isOnHiatus: Boolean
-        get() = nonAppearanceInfo.contains(HIATUS_REGEX)
+        get() = nonAppearanceInfo.contains(HIATUS_REGEX) || titleLabels.releaseSchedule == ReleaseSchedule.HIATUS
 
     private fun createGenres(intl: Intl): List<String> = buildList {
         if (isSimulpub && !isReEdition && !isOneShot && !isCompleted) {
@@ -184,6 +184,7 @@ enum class ReleaseSchedule {
     OTHER,
     COMPLETED,
     ONE_SHOT,
+    HIATUS,
 }
 
 @Serializable


### PR DESCRIPTION
Closes #13863

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
