### PR TITLE
mangago: fix url template again

### DIFF
--- a/src/en/mangago/build.gradle
+++ b/src/en/mangago/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Mangago'
     extClass = '.Mangago'
-    extVersionCode = 28
+    extVersionCode = 29
     isNsfw = true
 }
 

--- a/src/en/mangago/src/eu/kanade/tachiyomi/extension/en/mangago/Mangago.kt
+++ b/src/en/mangago/src/eu/kanade/tachiyomi/extension/en/mangago/Mangago.kt
@@ -231,14 +231,36 @@ class Mangago :
             ?.let { Regex("""total_pages\s*=\s*(\d+)""").find(it)?.groupValues?.get(1)?.toIntOrNull() }
             ?: throw Exception("Total page count not found")
 
-        val nextPageUrl = document.selectFirst("a.next_page")!!
-            .absUrl("href")
-            .toHttpUrl()
+        val slug = document.location().toHttpUrl().let {
+            val path = it.pathSegments
+
+            if (path.size > 2 && path[0] == "read-manga") {
+                path[1]
+            } else {
+                throw Exception("slug not found")
+            }
+        }
 
         val urlTemplate = document.selectFirst("input#curl")!!
             .attr("value").trim()
+            .removePrefix("/")
 
-        val pages = getPageUrls(nextPageUrl, urlTemplate, totalPages)
+        if (!urlTemplate.contains("{page}")) {
+            throw Exception("No replaceable string in url template")
+        }
+
+        val pages = (1..totalPages).map { page ->
+            val url = baseUrl.toHttpUrl().newBuilder()
+                .addPathSegment("read-manga")
+                .addPathSegment(slug)
+                .addEncodedPathSegments(urlTemplate.replace("{page}", page.toString()))
+                .fragment(page.toString())
+                .build()
+                .toString()
+
+            Page(page, url)
+        }
+
         val availableImages = getChapterImageUrls(document)
 
         pages.onEachIndexed { index, page ->
@@ -250,25 +272,6 @@ class Mangago :
         }
 
         return pages
-    }
-
-    private fun getPageUrls(nextPageUrl: HttpUrl, urlTemplate: String, totalPages: Int): List<Page> {
-        val templateRegex = urlTemplate.replace("{page}", "\\d+").toRegex()
-        val fullPath = nextPageUrl.encodedPath
-        val matchStart = templateRegex.find(fullPath)?.range?.first
-            ?: throw Exception("Template not found in URL path")
-
-        val basePath = fullPath.substring(0, matchStart)
-
-        return (1..totalPages).map { page ->
-            val resolvedPath = urlTemplate.replace("{page}", page.toString())
-            val url = nextPageUrl.newBuilder()
-                .encodedPath("$basePath$resolvedPath")
-                .fragment(page.toString())
-                .toString()
-
-            Page(page, url)
-        }
     }
 
     override fun pageListRequest(chapter: SChapter): Request {


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
