### PR TITLE
ReadAllComics: fix search & missing chapters

### DIFF
--- a/src/en/readallcomicscom/build.gradle
+++ b/src/en/readallcomicscom/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ReadAllComics'
     extClass = '.ReadAllComics'
-    extVersionCode = 6
+    extVersionCode = 7
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/readallcomicscom/src/eu/kanade/tachiyomi/extension/en/readallcomicscom/ReadAllComics.kt
+++ b/src/en/readallcomicscom/src/eu/kanade/tachiyomi/extension/en/readallcomicscom/ReadAllComics.kt
@@ -59,9 +59,9 @@ class ReadAllComics : HttpSource() {
 
     private fun mangaFromElement(element: Element) = SManga.create().apply {
         val titleAnchor = element.selectFirst("a.cat-title")!!
-        setUrlWithoutDomain(titleAnchor.attr("href"))
+        setUrlWithoutDomain(titleAnchor.attr("abs:href"))
         title = titleAnchor.text()
-        thumbnail_url = element.selectFirst("img.book-cover")?.attr("src")
+        thumbnail_url = element.selectFirst("img.book-cover")?.attr("abs:src")
     }
 
     // Manga details
@@ -73,16 +73,14 @@ class ReadAllComics : HttpSource() {
         val infoStrongs = archive.select(".b > p strong")
         genre = infoStrongs.firstOrNull()?.text()
         author = infoStrongs.lastOrNull()?.text()
-        description = archive.selectFirst("#hidden-description")?.also { el ->
-            el.select("hr").prepend("\\n")
-        }?.text()?.replace("\\n", "\n\n")
+        description = archive.selectFirst("#hidden-description")?.wholeText()?.trim()
     }
 
     // Chapters
 
     override fun chapterListParse(response: Response): List<SChapter> = response.asJsoup().select(".list-story a").map { element ->
         SChapter.create().apply {
-            setUrlWithoutDomain(element.attr("href"))
+            setUrlWithoutDomain(element.attr("abs:href"))
             name = element.text()
             val year = name.substringAfterLast('(').substringBefore(')')
             date_upload = dateFormat.tryParse("$year-1-1")
@@ -95,7 +93,7 @@ class ReadAllComics : HttpSource() {
         Page(idx, imageUrl = element.attr("abs:src"))
     }
 
-    override fun imageUrlParse(response: Response) = ""
+    override fun imageUrlParse(response: Response) = throw UnsupportedOperationException()
 
     // Latest (unsupported)
 

--- a/src/en/readallcomicscom/src/eu/kanade/tachiyomi/extension/en/readallcomicscom/ReadAllComics.kt
+++ b/src/en/readallcomicscom/src/eu/kanade/tachiyomi/extension/en/readallcomicscom/ReadAllComics.kt
@@ -1,7 +1,6 @@
 package eu.kanade.tachiyomi.extension.en.readallcomicscom
 
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.asObservableSuccess
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
@@ -14,7 +13,6 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Element
-import org.jsoup.select.Elements
 import rx.Observable
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -41,40 +39,22 @@ class ReadAllComics : HttpSource() {
 
     // Search
 
-    private lateinit var searchPageElements: Elements
-
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (page == 1) {
-        client.newCall(searchMangaRequest(page, query, filters))
-            .asObservableSuccess()
-            .map { searchMangaParse(it) }
-    } else {
-        Observable.just(searchPageParse(page))
-    }
-
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         val url = baseUrl.toHttpUrl().newBuilder().apply {
             addQueryParameter("story", query)
             addQueryParameter("s", "")
             addQueryParameter("type", "comic")
+            if (page > 1) addQueryParameter("paged", page.toString())
         }.build()
 
         return GET(url, headers)
     }
 
     override fun searchMangaParse(response: Response): MangasPage {
-        searchPageElements = response.asJsoup().select("ul.list-story.categories li")
-        return searchPageParse(1)
-    }
-
-    private fun searchPageParse(page: Int): MangasPage {
-        val mangas = mutableListOf<SManga>()
-        val endRange = ((page * 24) - 1).coerceAtMost(searchPageElements.lastIndex)
-
-        for (i in ((page - 1) * 24)..endRange) {
-            mangas.add(mangaFromElement(searchPageElements[i]))
-        }
-
-        return MangasPage(mangas, endRange < searchPageElements.lastIndex)
+        val document = response.asJsoup()
+        val mangas = document.select("ul.list-story.categories li").map { mangaFromElement(it) }
+        val hasNextPage = document.selectFirst("a.next") != null
+        return MangasPage(mangas, hasNextPage)
     }
 
     private fun mangaFromElement(element: Element) = SManga.create().apply {
@@ -116,7 +96,6 @@ class ReadAllComics : HttpSource() {
     }
 
     override fun imageUrlParse(response: Response) = ""
-
 
     // Latest (unsupported)
 

--- a/src/en/readallcomicscom/src/eu/kanade/tachiyomi/extension/en/readallcomicscom/ReadAllComics.kt
+++ b/src/en/readallcomicscom/src/eu/kanade/tachiyomi/extension/en/readallcomicscom/ReadAllComics.kt
@@ -90,22 +90,15 @@ class ReadAllComics : ParsedHttpSource() {
     override fun searchMangaNextPageSelector() = null
 
     override fun mangaDetailsParse(document: Document) = SManga.create().apply {
-        title = document.selectFirst("h1")!!.text()
-        genre = document.select("p strong").joinToString { it.text() }
-        author = document.select("p > strong").last()?.text()
-        description = buildString {
-            document.select(".b > strong").forEach { element ->
-                val vol = element.previousElementSibling()
-                if (isNotBlank()) {
-                    append("\n\n")
-                }
-                if (vol?.tagName() == "span") {
-                    append(vol.text(), "\n")
-                }
-                append(element.text())
-            }
-        }
-        thumbnail_url = document.select("p img").attr("abs:src")
+        val archive = document.selectFirst(".description-archive")!!
+        title = archive.selectFirst("h1")!!.text()
+        thumbnail_url = archive.selectFirst("p img")?.attr("abs:src")
+        val infoStrongs = archive.select(".b > p strong")
+        genre = infoStrongs.firstOrNull()?.text()
+        author = infoStrongs.lastOrNull()?.text()
+        description = archive.selectFirst("#hidden-description")?.also { el ->
+            el.select("hr").prepend("\\n")
+        }?.text()?.replace("\\n", "\n\n")
     }
 
     override fun chapterListSelector() = ".list-story a"

--- a/src/en/readallcomicscom/src/eu/kanade/tachiyomi/extension/en/readallcomicscom/ReadAllComics.kt
+++ b/src/en/readallcomicscom/src/eu/kanade/tachiyomi/extension/en/readallcomicscom/ReadAllComics.kt
@@ -80,12 +80,13 @@ class ReadAllComics : ParsedHttpSource() {
     }
 
     override fun searchMangaFromElement(element: Element) = SManga.create().apply {
-        setUrlWithoutDomain(element.attr("href"))
-        title = element.text()
-        thumbnail_url = ""
+        val titleAnchor = element.selectFirst("a.cat-title")!!
+        setUrlWithoutDomain(titleAnchor.attr("href"))
+        title = titleAnchor.text()
+        thumbnail_url = element.selectFirst("img.book-cover")?.attr("src")
     }
 
-    override fun searchMangaSelector() = ".categories a"
+    override fun searchMangaSelector() = "ul.list-story.categories li"
     override fun searchMangaNextPageSelector() = null
 
     override fun mangaDetailsParse(document: Document) = SManga.create().apply {

--- a/src/en/readallcomicscom/src/eu/kanade/tachiyomi/extension/en/readallcomicscom/ReadAllComics.kt
+++ b/src/en/readallcomicscom/src/eu/kanade/tachiyomi/extension/en/readallcomicscom/ReadAllComics.kt
@@ -7,13 +7,12 @@ import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.ParsedHttpSource
+import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.tryParse
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
-import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import org.jsoup.select.Elements
 import rx.Observable
@@ -21,7 +20,7 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
 
-class ReadAllComics : ParsedHttpSource() {
+class ReadAllComics : HttpSource() {
 
     override val name = "ReadAllComics"
 
@@ -31,16 +30,18 @@ class ReadAllComics : ParsedHttpSource() {
 
     override val supportsLatest = false
 
-    private lateinit var searchPageElements: Elements
-
     override val client = network.cloudflareClient
+
+    // Popular
 
     override fun fetchPopularManga(page: Int): Observable<MangasPage> = throw Exception("Use search to find comics.")
 
     override fun popularMangaRequest(page: Int) = throw UnsupportedOperationException()
-    override fun popularMangaFromElement(element: Element) = throw UnsupportedOperationException()
-    override fun popularMangaSelector() = ""
-    override fun popularMangaNextPageSelector() = null
+    override fun popularMangaParse(response: Response) = throw UnsupportedOperationException()
+
+    // Search
+
+    private lateinit var searchPageElements: Elements
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (page == 1) {
         client.newCall(searchMangaRequest(page, query, filters))
@@ -61,36 +62,32 @@ class ReadAllComics : ParsedHttpSource() {
     }
 
     override fun searchMangaParse(response: Response): MangasPage {
-        searchPageElements = response.asJsoup().select(searchMangaSelector())
-
+        searchPageElements = response.asJsoup().select("ul.list-story.categories li")
         return searchPageParse(1)
     }
 
     private fun searchPageParse(page: Int): MangasPage {
         val mangas = mutableListOf<SManga>()
-        val endRange = ((page * 24) - 1).let { if (it <= searchPageElements.lastIndex) it else searchPageElements.lastIndex }
+        val endRange = ((page * 24) - 1).coerceAtMost(searchPageElements.lastIndex)
 
-        for (i in (((page - 1) * 24)..endRange)) {
-            mangas.add(
-                searchMangaFromElement(searchPageElements[i]),
-            )
+        for (i in ((page - 1) * 24)..endRange) {
+            mangas.add(mangaFromElement(searchPageElements[i]))
         }
 
         return MangasPage(mangas, endRange < searchPageElements.lastIndex)
     }
 
-    override fun searchMangaFromElement(element: Element) = SManga.create().apply {
+    private fun mangaFromElement(element: Element) = SManga.create().apply {
         val titleAnchor = element.selectFirst("a.cat-title")!!
         setUrlWithoutDomain(titleAnchor.attr("href"))
         title = titleAnchor.text()
         thumbnail_url = element.selectFirst("img.book-cover")?.attr("src")
     }
 
-    override fun searchMangaSelector() = "ul.list-story.categories li"
-    override fun searchMangaNextPageSelector() = null
+    // Manga details
 
-    override fun mangaDetailsParse(document: Document) = SManga.create().apply {
-        val archive = document.selectFirst(".description-archive")!!
+    override fun mangaDetailsParse(response: Response) = SManga.create().apply {
+        val archive = response.asJsoup().selectFirst(".description-archive")!!
         title = archive.selectFirst("h1")!!.text()
         thumbnail_url = archive.selectFirst("p img")?.attr("abs:src")
         val infoStrongs = archive.select(".b > p strong")
@@ -101,27 +98,34 @@ class ReadAllComics : ParsedHttpSource() {
         }?.text()?.replace("\\n", "\n\n")
     }
 
-    override fun chapterListSelector() = ".list-story a"
+    // Chapters
 
-    override fun chapterFromElement(element: Element) = SChapter.create().apply {
-        setUrlWithoutDomain(element.attr("href"))
-        name = element.text()
-        // can only get the year from chapter title
-        val year = name.substringAfterLast('(').substringBefore(')')
-        date_upload = dateFormat.tryParse("$year-1-1")
+    override fun chapterListParse(response: Response): List<SChapter> = response.asJsoup().select(".list-story a").map { element ->
+        SChapter.create().apply {
+            setUrlWithoutDomain(element.attr("href"))
+            name = element.text()
+            val year = name.substringAfterLast('(').substringBefore(')')
+            date_upload = dateFormat.tryParse("$year-1-1")
+        }
     }
 
-    override fun pageListParse(document: Document): List<Page> = document.select("body img:not(body div[id=\"logo\"] img)").mapIndexed { idx, element ->
-        Page(idx, "", element.attr("abs:src"))
+    // Pages
+
+    override fun pageListParse(response: Response): List<Page> = response.asJsoup().select("body img:not(div[id=logo] img)").mapIndexed { idx, element ->
+        Page(idx, imageUrl = element.attr("abs:src"))
     }
 
-    override fun imageUrlParse(document: Document) = throw UnsupportedOperationException()
+    override fun imageUrlParse(response: Response) = ""
+
+
+    // Latest (unsupported)
+
     override fun latestUpdatesRequest(page: Int) = throw UnsupportedOperationException()
-    override fun latestUpdatesFromElement(element: Element) = throw UnsupportedOperationException()
-    override fun latestUpdatesSelector() = throw UnsupportedOperationException()
-    override fun latestUpdatesNextPageSelector() = throw UnsupportedOperationException()
+    override fun latestUpdatesParse(response: Response) = throw UnsupportedOperationException()
 
     companion object {
-        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US).apply { timeZone = TimeZone.getTimeZone("UTC") }
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
     }
 }

--- a/src/en/readallcomicscom/src/eu/kanade/tachiyomi/extension/en/readallcomicscom/ReadAllComics.kt
+++ b/src/en/readallcomicscom/src/eu/kanade/tachiyomi/extension/en/readallcomicscom/ReadAllComics.kt
@@ -35,29 +35,12 @@ class ReadAllComics : ParsedHttpSource() {
 
     override val client = network.cloudflareClient
 
-    override fun popularMangaRequest(page: Int): Request {
-        val url = baseUrl.toHttpUrl().newBuilder().apply {
-            addPathSegments("page/$page")
-        }.build()
+    override fun fetchPopularManga(page: Int): Observable<MangasPage> = throw Exception("Use search to find comics.")
 
-        return GET(url, headers)
-    }
-
-    override fun popularMangaFromElement(element: Element): SManga {
-        val manga = SManga.create().apply {
-            val category = element.classNames()
-                .firstOrNull { it.startsWith("category-") }!!
-                .substringAfter("category-")
-            setUrlWithoutDomain("/category/$category")
-            title = category.replace("-", " ").titleCaseWords()
-            thumbnail_url = element.selectFirst("img")?.attr("src")
-        }
-
-        return manga
-    }
-
-    override fun popularMangaSelector() = "#post-area > div"
-    override fun popularMangaNextPageSelector() = "a.page-numbers.next"
+    override fun popularMangaRequest(page: Int) = throw UnsupportedOperationException()
+    override fun popularMangaFromElement(element: Element) = throw UnsupportedOperationException()
+    override fun popularMangaSelector() = ""
+    override fun popularMangaNextPageSelector() = null
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (page == 1) {
         client.newCall(searchMangaRequest(page, query, filters))
@@ -136,11 +119,6 @@ class ReadAllComics : ParsedHttpSource() {
 
     override fun pageListParse(document: Document): List<Page> = document.select("body img:not(body div[id=\"logo\"] img)").mapIndexed { idx, element ->
         Page(idx, "", element.attr("abs:src"))
-    }
-
-    private fun String.titleCaseWords(): String {
-        val words = this.split(" ")
-        return words.joinToString(" ") { word -> word.replaceFirstChar { it.titlecase() } }
     }
 
     override fun imageUrlParse(document: Document) = throw UnsupportedOperationException()


### PR DESCRIPTION
Fixes:

1. Migrate from ParsedHttpSource to HttpSource
2. Popular page was showing `No results found`. Now it asks the user to use the search.
3. Search was showing repeated and broken results. Now it shows the right results with proper pagination.
4. Series description was not showing. Now it shows and is properly sectioned.

Closes #13706
Closes #13739
Closes #13740

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
