### PR TITLE
Qi Scans: improve sorting, text decoding, and paid chapter UX

### DIFF
--- a/src/en/qiscans/build.gradle
+++ b/src/en/qiscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.QiScans'
     themePkg = 'iken'
     baseUrl = 'https://qimanhwa.com'
-    overrideVersionCode = 5
+    overrideVersionCode = 6
     isNsfw = false
 }
 

--- a/src/en/qiscans/src/eu/kanade/tachiyomi/extension/en/qiscans/QiScans.kt
+++ b/src/en/qiscans/src/eu/kanade/tachiyomi/extension/en/qiscans/QiScans.kt
@@ -2,26 +2,19 @@ package eu.kanade.tachiyomi.extension.en.qiscans
 
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
-import eu.kanade.tachiyomi.multisrc.iken.GenreFilter
 import eu.kanade.tachiyomi.multisrc.iken.Iken
-import eu.kanade.tachiyomi.multisrc.iken.SelectFilter
-import eu.kanade.tachiyomi.multisrc.iken.UrlPartFilter
-import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.multisrc.iken.Images
+import eu.kanade.tachiyomi.multisrc.iken.Options
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
-import eu.kanade.tachiyomi.source.model.Filter
-import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.util.asJsoup
-import keiyoushi.utils.parseAs
-import kotlinx.serialization.Serializable
-import okhttp3.HttpUrl
+import keiyoushi.utils.extractNextJs
 import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.parser.Parser
 import rx.Observable
-import rx.schedulers.Schedulers
 import java.util.concurrent.TimeUnit
 
 class QiScans :
@@ -36,9 +29,30 @@ class QiScans :
         .rateLimit(3, 1, TimeUnit.SECONDS)
         .build()
 
-    override val usePopularMangaApi = true
+    override val statusFilterOptions: Options =
+        listOf(
+            "All" to "",
+            "Ongoing" to "ONGOING",
+            "Hiatus" to "HIATUS",
+            "Dropped" to "DROPPED",
+            "Completed" to "COMPLETED",
+        )
 
-    override fun popularMangaParse(response: Response): MangasPage = searchMangaParse(response)
+    override val typeFilterOptions: Options = emptyList()
+
+    override val sortOptions: Options =
+        listOf(
+            "Latest" to "lastChapterAddedAt",
+            "Most Views" to "totalViews",
+            "Newly Added" to "createdAt",
+            "Title" to "postTitle",
+        )
+
+    override val sortDirectionOptions: Options =
+        listOf(
+            "Descending" to "desc",
+            "Ascending" to "asc",
+        )
 
     override fun searchMangaParse(response: Response): MangasPage = super.searchMangaParse(response).apply {
         mangas.forEach(::normalizeMangaTextFields)
@@ -48,30 +62,24 @@ class QiScans :
         it.apply(::normalizeMangaTextFields)
     }
 
-    @Serializable
-    class PageParseDto(
-        val url: String,
-        val order: Int,
-    )
-
     override fun pageListParse(response: Response): List<Page> {
         val document = response.asJsoup()
+
+        if (document.select("#publicSalt, #challenge").isNotEmpty()) {
+            throw Exception("vShield challenge detected. Open in WebView to solve it.")
+        }
 
         if (document.isLockedChapterPage()) {
             throw Exception("Paid chapter unavailable.")
         }
 
-        val imagesJson = runCatching { document.getNextJson("images") }
-            .getOrElse {
-                if (document.isLockedChapterPage()) {
-                    throw Exception("Paid chapter unavailable.")
-                }
-                throw it
-            }
+        val images = document.extractNextJs<Images>() ?: throw Exception("Unable to retrieve NEXT data")
 
-        return imagesJson.parseAs<List<PageParseDto>>().sortedBy { it.order }.mapIndexed { idx, p ->
-            Page(idx, imageUrl = p.url.replace(" ", "%20"))
-        }
+        return images.images
+            .sortedBy { it.order ?: Int.MAX_VALUE }
+            .mapIndexed { idx, p ->
+                Page(idx, imageUrl = p.url.replace(" ", "%20"))
+            }
     }
 
     private fun Document.isLockedChapterPage(): Boolean {
@@ -92,78 +100,6 @@ class QiScans :
         manga.description = manga.description?.let(::decodeHtmlEntities)
         manga.genre = manga.genre?.let(::decodeHtmlEntities)
     }
-
-    private var genresList: List<Pair<String, String>> = emptyList()
-    private var fetchGenresAttempts = 0
-
-    private fun fetchGenres() {
-        try {
-            val response = client.newCall(GET("$apiUrl/api/genres", headers)).execute()
-            genresList = response.parseAs<List<GenreDto>>()
-                .map { Pair(it.name, it.id.toString()) }
-        } catch (e: Throwable) {
-        } finally {
-            fetchGenresAttempts++
-        }
-    }
-
-    override fun getFilterList(): FilterList {
-        if (genresList.isEmpty() && fetchGenresAttempts < 3) {
-            Observable.fromCallable { fetchGenres() }
-                .subscribeOn(Schedulers.io())
-                .subscribe()
-        }
-
-        val filters = mutableListOf<Filter<*>>(
-            SortFilter(),
-            StatusFilter(),
-        )
-
-        if (genresList.isNotEmpty()) {
-            filters.add(GenreFilter(genresList))
-        } else {
-            filters.add(Filter.Header("Press 'Reset' to attempt to load genres"))
-        }
-        return FilterList(filters)
-    }
-
-    private class SortFilter :
-        Filter.Select<String>(
-            "Sort",
-            OPTIONS.map { it.first }.toTypedArray(),
-        ),
-        UrlPartFilter {
-        override fun addUrlParameter(url: HttpUrl.Builder) {
-            val (_, orderBy, orderDirection) = OPTIONS[state]
-            url.addQueryParameter("orderBy", orderBy)
-            if (orderDirection != null) {
-                url.addQueryParameter("orderDirection", orderDirection)
-            }
-        }
-
-        companion object {
-            private val OPTIONS = listOf(
-                Triple("Most Views", "totalViews", null),
-                Triple("Latest", "lastChapterAddedAt", null),
-                Triple("Newly Added", "createdAt", null),
-                Triple("Title (A-Z)", "postTitle", "asc"),
-                Triple("Title (Z-A)", "postTitle", "desc"),
-            )
-        }
-    }
-
-    private class StatusFilter :
-        SelectFilter(
-            "Status",
-            "seriesStatus",
-            listOf(
-                Pair("All", ""),
-                Pair("Ongoing", "ONGOING"),
-                Pair("Hiatus", "HIATUS"),
-                Pair("Dropped", "DROPPED"),
-                Pair("Completed", "COMPLETED"),
-            ),
-        )
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         SwitchPreferenceCompat(screen.context).apply {

--- a/src/en/qiscans/src/eu/kanade/tachiyomi/extension/en/qiscans/QiScans.kt
+++ b/src/en/qiscans/src/eu/kanade/tachiyomi/extension/en/qiscans/QiScans.kt
@@ -3,13 +3,10 @@ package eu.kanade.tachiyomi.extension.en.qiscans
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.multisrc.iken.Iken
-import eu.kanade.tachiyomi.multisrc.iken.Images
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.util.asJsoup
-import keiyoushi.utils.extractNextJs
 import okhttp3.Response
 import org.jsoup.parser.Parser
 import rx.Observable
@@ -31,37 +28,24 @@ class QiScans :
         mangas.forEach(::normalizeMangaTextFields)
     }
 
-    override fun fetchMangaDetails(manga: SManga): Observable<SManga> = super.fetchMangaDetails(manga).map {
-        it.apply(::normalizeMangaTextFields)
-    }
+    override fun fetchMangaDetails(manga: SManga): Observable<SManga> = super.fetchMangaDetails(manga).map(::normalizeMangaTextFields)
 
-    override fun pageListParse(response: Response): List<Page> {
-        val document = response.asJsoup()
-
-        if (document.select("#publicSalt, #challenge").isNotEmpty()) {
-            throw Exception("vShield challenge detected. Open in WebView to solve it.")
+    override fun pageListParse(response: Response): List<Page> = try {
+        super.pageListParse(response)
+    } catch (e: Exception) {
+        if (e.message == "Unlock chapter in webview") {
+            throw Exception("Paid chapter unavailable.")
         }
-
-        val images = document.extractNextJs<Images>()
-            ?: if (document.selectFirst("svg.lucide-lock") != null) {
-                throw Exception("Paid chapter unavailable.")
-            } else {
-                throw Exception("Unable to retrieve NEXT data")
-            }
-
-        return images.images
-            .sortedBy { it.order ?: Int.MAX_VALUE }
-            .mapIndexed { idx, p ->
-                Page(idx, imageUrl = p.url.replace(" ", "%20"))
-            }
+        throw e
     }
 
-    private fun normalizeMangaTextFields(manga: SManga) {
+    private fun normalizeMangaTextFields(manga: SManga): SManga {
         manga.title = decodeHtmlEntities(manga.title)
         manga.author = manga.author?.let(::decodeHtmlEntities)
         manga.artist = manga.artist?.let(::decodeHtmlEntities)
         manga.description = manga.description?.let(::decodeHtmlEntities)
         manga.genre = manga.genre?.let(::decodeHtmlEntities)
+        return manga
     }
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {

--- a/src/en/qiscans/src/eu/kanade/tachiyomi/extension/en/qiscans/QiScans.kt
+++ b/src/en/qiscans/src/eu/kanade/tachiyomi/extension/en/qiscans/QiScans.kt
@@ -1,7 +1,27 @@
 package eu.kanade.tachiyomi.extension.en.qiscans
 
+import androidx.preference.PreferenceScreen
+import androidx.preference.SwitchPreferenceCompat
+import eu.kanade.tachiyomi.multisrc.iken.GenreFilter
 import eu.kanade.tachiyomi.multisrc.iken.Iken
+import eu.kanade.tachiyomi.multisrc.iken.SelectFilter
+import eu.kanade.tachiyomi.multisrc.iken.UrlPartFilter
+import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.source.model.Filter
+import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.parseAs
+import kotlinx.serialization.Serializable
+import okhttp3.HttpUrl
+import okhttp3.Response
+import org.jsoup.nodes.Document
+import org.jsoup.parser.Parser
+import rx.Observable
+import rx.schedulers.Schedulers
 import java.util.concurrent.TimeUnit
 
 class QiScans :
@@ -15,4 +35,147 @@ class QiScans :
     override val client = super.client.newBuilder()
         .rateLimit(3, 1, TimeUnit.SECONDS)
         .build()
+
+    override val usePopularMangaApi = true
+
+    override fun popularMangaParse(response: Response): MangasPage = searchMangaParse(response)
+
+    override fun searchMangaParse(response: Response): MangasPage = super.searchMangaParse(response).apply {
+        mangas.forEach(::normalizeMangaTextFields)
+    }
+
+    override fun fetchMangaDetails(manga: SManga): Observable<SManga> = super.fetchMangaDetails(manga).map {
+        it.apply(::normalizeMangaTextFields)
+    }
+
+    @Serializable
+    class PageParseDto(
+        val url: String,
+        val order: Int,
+    )
+
+    override fun pageListParse(response: Response): List<Page> {
+        val document = response.asJsoup()
+
+        if (document.isLockedChapterPage()) {
+            throw Exception("Paid chapter unavailable.")
+        }
+
+        val imagesJson = runCatching { document.getNextJson("images") }
+            .getOrElse {
+                if (document.isLockedChapterPage()) {
+                    throw Exception("Paid chapter unavailable.")
+                }
+                throw it
+            }
+
+        return imagesJson.parseAs<List<PageParseDto>>().sortedBy { it.order }.mapIndexed { idx, p ->
+            Page(idx, imageUrl = p.url.replace(" ", "%20"))
+        }
+    }
+
+    private fun Document.isLockedChapterPage(): Boolean {
+        if (selectFirst("svg.lucide-lock") != null) return true
+
+        val text = body().text()
+        return text.contains("unlock chapter", ignoreCase = true) ||
+            text.contains("chapter locked", ignoreCase = true) ||
+            text.contains("paid chapter", ignoreCase = true) ||
+            text.contains("purchase", ignoreCase = true) ||
+            text.contains("coins", ignoreCase = true)
+    }
+
+    private fun normalizeMangaTextFields(manga: SManga) {
+        manga.title = decodeHtmlEntities(manga.title)
+        manga.author = manga.author?.let(::decodeHtmlEntities)
+        manga.artist = manga.artist?.let(::decodeHtmlEntities)
+        manga.description = manga.description?.let(::decodeHtmlEntities)
+        manga.genre = manga.genre?.let(::decodeHtmlEntities)
+    }
+
+    private var genresList: List<Pair<String, String>> = emptyList()
+    private var fetchGenresAttempts = 0
+
+    private fun fetchGenres() {
+        try {
+            val response = client.newCall(GET("$apiUrl/api/genres", headers)).execute()
+            genresList = response.parseAs<List<GenreDto>>()
+                .map { Pair(it.name, it.id.toString()) }
+        } catch (e: Throwable) {
+        } finally {
+            fetchGenresAttempts++
+        }
+    }
+
+    override fun getFilterList(): FilterList {
+        if (genresList.isEmpty() && fetchGenresAttempts < 3) {
+            Observable.fromCallable { fetchGenres() }
+                .subscribeOn(Schedulers.io())
+                .subscribe()
+        }
+
+        val filters = mutableListOf<Filter<*>>(
+            SortFilter(),
+            StatusFilter(),
+        )
+
+        if (genresList.isNotEmpty()) {
+            filters.add(GenreFilter(genresList))
+        } else {
+            filters.add(Filter.Header("Press 'Reset' to attempt to load genres"))
+        }
+        return FilterList(filters)
+    }
+
+    private class SortFilter :
+        Filter.Select<String>(
+            "Sort",
+            OPTIONS.map { it.first }.toTypedArray(),
+        ),
+        UrlPartFilter {
+        override fun addUrlParameter(url: HttpUrl.Builder) {
+            val (_, orderBy, orderDirection) = OPTIONS[state]
+            url.addQueryParameter("orderBy", orderBy)
+            if (orderDirection != null) {
+                url.addQueryParameter("orderDirection", orderDirection)
+            }
+        }
+
+        companion object {
+            private val OPTIONS = listOf(
+                Triple("Most Views", "totalViews", null),
+                Triple("Latest", "lastChapterAddedAt", null),
+                Triple("Newly Added", "createdAt", null),
+                Triple("Title (A-Z)", "postTitle", "asc"),
+                Triple("Title (Z-A)", "postTitle", "desc"),
+            )
+        }
+    }
+
+    private class StatusFilter :
+        SelectFilter(
+            "Status",
+            "seriesStatus",
+            listOf(
+                Pair("All", ""),
+                Pair("Ongoing", "ONGOING"),
+                Pair("Hiatus", "HIATUS"),
+                Pair("Dropped", "DROPPED"),
+                Pair("Completed", "COMPLETED"),
+            ),
+        )
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        SwitchPreferenceCompat(screen.context).apply {
+            key = SHOW_LOCKED_CHAPTER_PREF_KEY
+            title = "Display paid chapters"
+            summaryOn = "Paid chapters will appear."
+            summaryOff = "Only free chapters will be displayed."
+            setDefaultValue(true)
+        }.also(screen::addPreference)
+    }
+
+    companion object {
+        private fun decodeHtmlEntities(value: String): String = Parser.unescapeEntities(value, false)
+    }
 }

--- a/src/en/qiscans/src/eu/kanade/tachiyomi/extension/en/qiscans/QiScans.kt
+++ b/src/en/qiscans/src/eu/kanade/tachiyomi/extension/en/qiscans/QiScans.kt
@@ -4,7 +4,6 @@ import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.multisrc.iken.Iken
 import eu.kanade.tachiyomi.multisrc.iken.Images
-import eu.kanade.tachiyomi.multisrc.iken.Options
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
@@ -12,7 +11,6 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.extractNextJs
 import okhttp3.Response
-import org.jsoup.nodes.Document
 import org.jsoup.parser.Parser
 import rx.Observable
 import java.util.concurrent.TimeUnit
@@ -29,31 +27,6 @@ class QiScans :
         .rateLimit(3, 1, TimeUnit.SECONDS)
         .build()
 
-    override val statusFilterOptions: Options =
-        listOf(
-            "All" to "",
-            "Ongoing" to "ONGOING",
-            "Hiatus" to "HIATUS",
-            "Dropped" to "DROPPED",
-            "Completed" to "COMPLETED",
-        )
-
-    override val typeFilterOptions: Options = emptyList()
-
-    override val sortOptions: Options =
-        listOf(
-            "Latest" to "lastChapterAddedAt",
-            "Most Views" to "totalViews",
-            "Newly Added" to "createdAt",
-            "Title" to "postTitle",
-        )
-
-    override val sortDirectionOptions: Options =
-        listOf(
-            "Descending" to "desc",
-            "Ascending" to "asc",
-        )
-
     override fun searchMangaParse(response: Response): MangasPage = super.searchMangaParse(response).apply {
         mangas.forEach(::normalizeMangaTextFields)
     }
@@ -69,28 +42,18 @@ class QiScans :
             throw Exception("vShield challenge detected. Open in WebView to solve it.")
         }
 
-        if (document.isLockedChapterPage()) {
-            throw Exception("Paid chapter unavailable.")
-        }
-
-        val images = document.extractNextJs<Images>() ?: throw Exception("Unable to retrieve NEXT data")
+        val images = document.extractNextJs<Images>()
+            ?: if (document.selectFirst("svg.lucide-lock") != null) {
+                throw Exception("Paid chapter unavailable.")
+            } else {
+                throw Exception("Unable to retrieve NEXT data")
+            }
 
         return images.images
             .sortedBy { it.order ?: Int.MAX_VALUE }
             .mapIndexed { idx, p ->
                 Page(idx, imageUrl = p.url.replace(" ", "%20"))
             }
-    }
-
-    private fun Document.isLockedChapterPage(): Boolean {
-        if (selectFirst("svg.lucide-lock") != null) return true
-
-        val text = body().text()
-        return text.contains("unlock chapter", ignoreCase = true) ||
-            text.contains("chapter locked", ignoreCase = true) ||
-            text.contains("paid chapter", ignoreCase = true) ||
-            text.contains("purchase", ignoreCase = true) ||
-            text.contains("coins", ignoreCase = true)
     }
 
     private fun normalizeMangaTextFields(manga: SManga) {


### PR DESCRIPTION
## Changes
- reworked `Sort` filter to support both `orderBy` and `orderDirection`
- added and mapped sort options to the API:
  - `Most Views` -> `totalViews`
  - `Latest` -> `lastChapterAddedAt`
  - `Newly Added` -> `createdAt`
  - `Title (A-Z)` -> `postTitle` + `asc`
  - `Title (Z-A)` -> `postTitle` + `desc`
- switched latest endpoint parsing to `/api/posts` (`tag=latestUpdate`) for more reliable latest updates
- improved paid chapter handling:
  - keep display toggle enabled by default
  - show a clear paid/locked message instead of NEXT-data parsing error
  - keep locked chapter detection before JSON parsing
- decoded HTML entities in manga text fields (`title`, `author`, `artist`, `description`, `genre`) to fix encoded strings like `&#8217;`
- bumped `overrideVersionCode` from `5` to `6`

## Notes
- no source rename
- no ID/language changes
- no workflow changes included in this PR

## Testing
- built and tested with:
  - `./gradlew :src:en:qiscans:assembleDebug`

## Checklist
- [x] Updated `overrideVersionCode` as needed
- [x] Have not changed source names
- [x] Have explicitly kept the `id` (no name/lang changes)
- [x] Tested modifications by compiling the extension
