### PR TITLE
NyanuKafe: update selectors

### DIFF
--- a/src/en/nyanukafe/build.gradle
+++ b/src/en/nyanukafe/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.NyanuKafe'
     themePkg = 'keyoapp'
     baseUrl = 'https://nyanukafe.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = false
 }
 

--- a/src/en/nyanukafe/src/eu/kanade/tachiyomi/extension/en/nyanukafe/NyanuKafe.kt
+++ b/src/en/nyanukafe/src/eu/kanade/tachiyomi/extension/en/nyanukafe/NyanuKafe.kt
@@ -8,9 +8,11 @@ class NyanuKafe :
         "https://nyanukafe.com",
         "en",
     ) {
-    override val descriptionSelector: String = "div.grid > div.overflow-hidden > p"
-    override val statusSelector: String = "div[alt=Status]"
-    override val authorSelector: String = "div[alt=Author]"
-    override val artistSelector: String = "div[alt=Artist]"
-    override val typeSelector: String = "div[alt='Series Type']"
+    override fun popularMangaSelector(): String = ".series-splide .splide__slide:not(.splide__slide--clone)"
+
+    override val descriptionSelector: String = "div.grid > div#expand_content > p"
+    override val statusSelector: String = "div.w-full.flex-wrap > div:eq(3) > div:last-child"
+    override val authorSelector: String = "div.w-full.flex-wrap > div:eq(0) > div:last-child"
+    override val artistSelector: String = "div.w-full.flex-wrap > div:eq(1) > div:last-child"
+    override val typeSelector: String = "div.w-full.flex-wrap > div:eq(2) > div:last-child"
 }


### PR DESCRIPTION
Checklist:

New design broke selectors for Author, Description, Status.
There are no unique/distinct class or id for html tags to select Title/Description/Author in new design, thus pseudo selectors.
Also added selector for Popular tab.

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
