### PR TITLE
Luscious: Fix gif issue

### DIFF
--- a/src/all/luscious/build.gradle
+++ b/src/all/luscious/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Luscious'
     extClass = '.LusciousFactory'
-    extVersionCode = 26
+    extVersionCode = 27
     isNsfw = true
 }
 

--- a/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/Luscious.kt
+++ b/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/Luscious.kt
@@ -290,6 +290,9 @@ abstract class Luscious(
                             getResolutionPref() != "-1" -> {
                                 it.jsonObject["thumbnails"]!!.jsonArray[getResolutionPref()?.toInt()!!].jsonObject["url"]!!.jsonPrimitive.content
                             }
+                            it.jsonObject["url_to_video"]!!.jsonPrimitive.contentOrNull != null -> {
+                                it.jsonObject["url_to_video"]!!.jsonPrimitive.content.toHttpUrl().newBuilder().host("ah-img.luscious.net").build().toString().replace(".mp4", ".gif")
+                            }
                             it.jsonObject["url_to_original"]!!.jsonPrimitive.contentOrNull != null -> {
                                 it.jsonObject["url_to_original"]!!.jsonPrimitive.content
                             }
@@ -370,6 +373,9 @@ abstract class Luscious(
                 val url = when {
                     getResolutionPref() != "-1" -> {
                         it.jsonObject["thumbnails"]!!.jsonArray[getResolutionPref()?.toInt()!!].jsonObject["url"]!!.jsonPrimitive.content
+                    }
+                    it.jsonObject["url_to_video"]!!.jsonPrimitive.contentOrNull != null -> {
+                        it.jsonObject["url_to_video"]!!.jsonPrimitive.content.toHttpUrl().newBuilder().host("ah-img.luscious.net").build().toString().replace(".mp4", ".gif")
                     }
                     it.jsonObject["url_to_original"]!!.jsonPrimitive.contentOrNull != null -> {
                         it.jsonObject["url_to_original"]!!.jsonPrimitive.content
@@ -821,6 +827,7 @@ abstract class Luscious(
                         created
                         title
                         url_to_original
+                        url_to_video
                         position
                         thumbnails {
                             url


### PR DESCRIPTION
Closes #13899

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
