### PR TITLE
ReadOnePieceMangaOnline: fix chapter loading and duplicate pages

### DIFF
--- a/src/en/readonepiecemangaonline/build.gradle
+++ b/src/en/readonepiecemangaonline/build.gradle
@@ -3,8 +3,12 @@ ext {
     extClass = '.ReadOnePieceMangaOnline'
     themePkg = 'mangacatalog'
     baseUrl = 'https://ww12.readonepiece.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"
+
+dependencies {
+    implementation project(':lib:randomua')
+}

--- a/src/en/readonepiecemangaonline/src/eu/kanade/tachiyomi/extension/en/readonepiecemangaonline/ReadOnePieceMangaOnline.kt
+++ b/src/en/readonepiecemangaonline/src/eu/kanade/tachiyomi/extension/en/readonepiecemangaonline/ReadOnePieceMangaOnline.kt
@@ -1,8 +1,30 @@
 package eu.kanade.tachiyomi.extension.en.readonepiecemangaonline
 
 import eu.kanade.tachiyomi.multisrc.mangacatalog.MangaCatalog
+import eu.kanade.tachiyomi.source.model.Page
+import keiyoushi.lib.randomua.UserAgentType
+import keiyoushi.lib.randomua.setRandomUserAgent
+import okhttp3.OkHttpClient
+import org.jsoup.nodes.Document
 
 class ReadOnePieceMangaOnline : MangaCatalog("Read One Piece Manga Online", "https://ww12.readonepiece.com", "en") {
+
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
+        .setRandomUserAgent(
+            userAgentType = UserAgentType.DESKTOP,
+            filterInclude = listOf("chrome"),
+        )
+        .build()
+
+    override fun headersBuilder() = super.headersBuilder()
+        .set("Referer", "$baseUrl/")
+
+    override fun pageListParse(document: Document): List<Page> = document.select(".js-pages-container img.js-page,.img_container img")
+        .filterNot { it.parent()?.tagName() == "noscript" }
+        .map { img -> img.attr("abs:data-src").ifEmpty { img.attr("abs:src") } }
+        .filter { it.startsWith("http") }
+        .mapIndexed { index, url -> Page(index, "", url) }
+
     override val sourceList = listOf(
         Pair("One Piece", "$baseUrl/manga/one-piece/"),
         Pair("Colored", "$baseUrl/manga/one-piece-digital-colored-comics/"),


### PR DESCRIPTION
- Use cloudflareClient with a random desktop Chrome user agent to bypass Cloudflare protection
- Add Referer header to fix HTTP 403 on chapter pages
- Override pageListParse to correctly handle lazy-loaded images (data-src) and exclude <noscript> duplicate image elements that caused every page to appear twice

* Closes #12649


Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
