### PR TITLE
Kagane: Status filter, Vol. Ch. in title, Edition in title

### DIFF
--- a/src/en/kagane/build.gradle
+++ b/src/en/kagane/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Kagane'
     extClass = '.Kagane'
-    extVersionCode = 21
+    extVersionCode = 22
     isNsfw = true
 }
 

--- a/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Dto.kt
+++ b/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Dto.kt
@@ -228,8 +228,19 @@ class ChapterDto(
                     }
                 }
 
-                else -> {}
-            } as String
+                "vol_chapter" -> {
+                    val volPart = if (!volumeNo.isNullOrBlank()) "Vol.$volumeNo " else ""
+                    val chPart = if (!chapterNo.isNullOrBlank()) "Ch.$chapterNo" else ""
+                    val numPart = "$volPart$chPart".trim()
+                    when {
+                        numPart.isEmpty() -> trimmedTitle
+                        trimmedTitle.isEmpty() -> numPart
+                        else -> "$numPart $trimmedTitle"
+                    }
+                }
+
+                else -> trimmedTitle
+            }
         }
     }
 

--- a/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Dto.kt
+++ b/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Dto.kt
@@ -220,7 +220,7 @@ class ChapterDto(
             return when (mode) {
                 "optional" -> {
                     when {
-                        trimmedTitle.isEmpty() && !chapterNo.isNullOrBlank() -> "Chapter $chapterNo"
+                        trimmedTitle.isEmpty() && !chapterNo.isNullOrBlank() -> "Ch.$chapterNo"
                         else -> trimmedTitle
                     }
                 }
@@ -228,8 +228,8 @@ class ChapterDto(
                 "always" -> {
                     when {
                         chapterNo.isNullOrBlank() -> trimmedTitle
-                        trimmedTitle.isEmpty() -> "Chapter $chapterNo"
-                        else -> "($chapterNo) $trimmedTitle"
+                        trimmedTitle.isEmpty() -> "Ch.$chapterNo"
+                        else -> "Ch.$chapterNo $trimmedTitle"
                     }
                 }
 

--- a/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Dto.kt
+++ b/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Dto.kt
@@ -171,7 +171,7 @@ class DetailsDto(
         "ONGOING" -> SManga.ONGOING
         "COMPLETED" -> SManga.COMPLETED
         "HIATUS" -> SManga.ON_HIATUS
-        "CANCELLED" -> SManga.CANCELLED
+        "ABANDONED" -> SManga.CANCELLED
         else -> SManga.UNKNOWN
     }
 }

--- a/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Dto.kt
+++ b/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Dto.kt
@@ -97,6 +97,8 @@ class DetailsDto(
     val seriesAlternateTitles: List<AlternateTitle> = emptyList(),
     @SerialName("series_books")
     val seriesBooks: List<ChapterDto.Book> = emptyList(),
+    @SerialName("edition_info")
+    val editionInfo: String? = null,
 ) {
     @Serializable
     class SeriesStaff(
@@ -122,7 +124,10 @@ class DetailsDto(
         val label: String?,
     )
 
-    fun toSManga(sourceName: String? = null, baseUrl: String = ""): SManga = SManga.create().apply {
+    fun toSManga(sourceName: String? = null, baseUrl: String = "", showEdition: Boolean = false, showSource: Boolean = false): SManga = SManga.create().apply {
+        val base = this@DetailsDto.title.trim()
+        val withEdition = if (showEdition && !this@DetailsDto.editionInfo.isNullOrBlank()) "$base (${this@DetailsDto.editionInfo})" else base
+        title = if (showSource && sourceName != null) "$withEdition [$sourceName]" else withEdition
         val desc = StringBuilder()
 
         // Add main description

--- a/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Filters.kt
+++ b/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Filters.kt
@@ -184,6 +184,20 @@ internal class FormatFilter :
 
 private val FORMAT_OPTIONS = listOf("Manga", "Manhwa", "Manhua", "Comic", "Other")
 
+internal class PublicationStatusFilter :
+    JsonMultiSelectFilter(
+        "Status",
+        "publication_status",
+        PUBLICATION_STATUS_OPTIONS.map { (name, value) -> MultiSelectOption(name, value) },
+    )
+
+private val PUBLICATION_STATUS_OPTIONS = listOf(
+    Pair("Ongoing", "Ongoing"),
+    Pair("Completed", "Completed"),
+    Pair("Hiatus", "Hiatus"),
+    Pair("Cancelled", "Abandoned"),
+)
+
 internal class MatchAllGenresFilter : Filter.CheckBox("Match all selected genres", true)
 
 internal class MatchAllTagsFilter : Filter.CheckBox("Match all selected tags", true)

--- a/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Kagane.kt
+++ b/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Kagane.kt
@@ -742,10 +742,12 @@ class Kagane :
         internal val CHAPTER_TITLE_MODES = arrayOf(
             "optional",
             "always",
+            "vol_chapter",
         )
         internal val CHAPTER_TITLE_MODE_NAMES = arrayOf(
             "Default (Hide numbers)",
             "Include chapter numbers",
+            "Vol. + chapter number + title",
         )
     }
 

--- a/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Kagane.kt
+++ b/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Kagane.kt
@@ -322,7 +322,7 @@ class Kagane :
                     null
                 }
         }
-        return dto.toSManga(sourceName, baseUrl)
+        return dto.toSManga(sourceName, baseUrl, preferences.showEdition, preferences.showSource)
     }
 
     override fun mangaDetailsRequest(manga: SManga): Request = mangaDetailsRequest(manga.url)
@@ -635,6 +635,9 @@ class Kagane :
     private val SharedPreferences.sourceDisplayMode: String
         get() = this.getString(SOURCE_DISPLAY_MODE, SOURCE_DISPLAY_MODE_DEFAULT) ?: SOURCE_DISPLAY_MODE_DEFAULT
 
+    private val SharedPreferences.showEdition: Boolean
+        get() = this.getBoolean(SHOW_EDITION, SHOW_EDITION_DEFAULT)
+
     private val SharedPreferences.showSource: Boolean
         get() = this.getBoolean(SHOW_SOURCE, SHOW_SOURCE_DEFAULT)
 
@@ -681,6 +684,12 @@ class Kagane :
             entries = arrayOf("Official Sources Only", "Show All (Official + Scanlations)")
             entryValues = arrayOf("official", "all")
             setDefaultValue(SOURCE_DISPLAY_MODE_DEFAULT)
+        }.let(screen::addPreference)
+
+        SwitchPreferenceCompat(screen.context).apply {
+            key = SHOW_EDITION
+            title = "Show edition name in title"
+            setDefaultValue(SHOW_EDITION_DEFAULT)
         }.let(screen::addPreference)
 
         SwitchPreferenceCompat(screen.context).apply {
@@ -731,6 +740,9 @@ class Kagane :
 
         private const val SHOW_SOURCE = "pref_show_source"
         private const val SHOW_SOURCE_DEFAULT = false
+
+        private const val SHOW_EDITION = "pref_show_edition"
+        private const val SHOW_EDITION_DEFAULT = false
 
         private const val DATA_SAVER = "data_saver_default"
 

--- a/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Kagane.kt
+++ b/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Kagane.kt
@@ -757,9 +757,9 @@ class Kagane :
             "vol_chapter",
         )
         internal val CHAPTER_TITLE_MODE_NAMES = arrayOf(
-            "Default (Hide numbers)",
-            "Include chapter numbers",
-            "Vol. + chapter number + title",
+            "Title only (e.g. 'Manga Title' / 'Ch.5')",
+            "Ch.X + title (e.g. 'Ch.5 Manga Title')",
+            "Vol.X Ch.Y + title (e.g. 'Vol.1 Ch.5 Manga Title')",
         )
     }
 

--- a/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Kagane.kt
+++ b/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Kagane.kt
@@ -768,6 +768,7 @@ class Kagane :
                 preferences.contentRating.toSet(),
             ),
             FormatFilter(),
+            PublicationStatusFilter(),
             Filter.Separator(),
         )
 


### PR DESCRIPTION
Closes #13702 
Closes #13447 
Closes #13448

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
