### PR TITLE
raw18: domain bump

### DIFF
--- a/src/ja/raw18/build.gradle
+++ b/src/ja/raw18/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Raw18'
     extClass = '.Raw18'
     themePkg = 'wpcomics'
-    baseUrl = 'https://raw18.link'
-    overrideVersionCode = 1
+    baseUrl = 'https://raw18.rest'
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/ja/raw18/src/eu/kanade/tachiyomi/extension/ja/raw18/Raw18.kt
+++ b/src/ja/raw18/src/eu/kanade/tachiyomi/extension/ja/raw18/Raw18.kt
@@ -13,7 +13,7 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
 
-class Raw18 : WPComics("Raw18", "https://raw18.link", "ja", SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'", Locale.JAPANESE), null) {
+class Raw18 : WPComics("Raw18", "https://raw18.rest", "ja", SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'", Locale.JAPANESE), null) {
     override val searchPath = "search/manga"
 
     override val genresUrlDelimiter = "="


### PR DESCRIPTION
Closes #7459

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
