### PR TITLE
Kagane: fix serie status

### DIFF
--- a/src/en/kagane/build.gradle
+++ b/src/en/kagane/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Kagane'
     extClass = '.Kagane'
-    extVersionCode = 22
+    extVersionCode = 23
     isNsfw = true
 }
 

--- a/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Dto.kt
+++ b/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Dto.kt
@@ -82,10 +82,8 @@ class AlternateSeries(
 class DetailsDto(
     val title: String,
     val description: String?,
-    @SerialName("publication_status")
-    val publicationStatus: String,
     @SerialName("upload_status")
-    val uploadStatus: String,
+    val publicationStatus: String,
     val format: String?,
     @SerialName("source_id")
     val sourceId: String?,

--- a/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Filters.kt
+++ b/src/en/kagane/src/eu/kanade/tachiyomi/extension/en/kagane/Filters.kt
@@ -187,7 +187,7 @@ private val FORMAT_OPTIONS = listOf("Manga", "Manhwa", "Manhua", "Comic", "Other
 internal class PublicationStatusFilter :
     JsonMultiSelectFilter(
         "Status",
-        "publication_status",
+        "upload_status",
         PUBLICATION_STATUS_OPTIONS.map { (name, value) -> MultiSelectOption(name, value) },
     )
 


### PR DESCRIPTION
Displaying the same series status as on their site

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
