### PR TITLE
ZeurelScan: fixed series navigation, fixed chapters with bogus chapter number

### DIFF
--- a/src/it/zeurelscan/build.gradle
+++ b/src/it/zeurelscan/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ZeurelScan'
     extClass = '.ZeurelScan'
-    extVersionCode = 2
+    extVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/it/zeurelscan/src/eu/kanade/tachiyomi/extension/it/zeurelscan/ZeurelScan.kt
+++ b/src/it/zeurelscan/src/eu/kanade/tachiyomi/extension/it/zeurelscan/ZeurelScan.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.extension.it.zeurelscan
 
 import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.asObservable
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
@@ -33,7 +34,7 @@ class ZeurelScan : HttpSource() {
     // Popular (not actually sorted as site has no such functionality)
 
     override fun popularMangaRequest(page: Int): Request = GET(
-        baseUrl + "/series.php",
+        baseUrl + "/series",
         headers,
     )
 
@@ -53,7 +54,7 @@ class ZeurelScan : HttpSource() {
     // Latest
 
     override fun latestUpdatesRequest(page: Int): Request = GET(
-        baseUrl + "/ultimi.php",
+        baseUrl + "/ultimi",
         headers,
     )
 
@@ -111,8 +112,14 @@ class ZeurelScan : HttpSource() {
 
     // Chapters
 
+    // Continue parsing even if the server returns HTTP 400
+    override fun fetchPageList(chapter: SChapter): Observable<List<Page>> = client.newCall(pageListRequest(chapter))
+        .asObservable()
+        .map(::pageListParse)
+
     override fun chapterListParse(response: Response): List<SChapter> {
         val list = response.asJsoup().select("div.chapter")
+        var lastChapter = 0f
         return list.map {
             val str = it.selectFirst("a")!!.wholeOwnText().substringAfter("#")
 
@@ -122,8 +129,14 @@ class ZeurelScan : HttpSource() {
             val chapterNum = if (chapterNumStr.contains("_")) {
                 chapterNumStr.substringBefore("_").toFloat() + 0.1f
             } else {
-                chapterNumStr.toFloat()
+                try {
+                    chapterNumStr.toFloat()
+                } catch (e: NumberFormatException) {
+                    // Handle chapters with non-number chapter number
+                    lastChapter + 0.1f
+                }
             }
+            lastChapter = chapterNum
 
             val tmpTitle = str.substringAfter("–").trim()
             val title = if (tmpTitle.length != 0) {


### PR DESCRIPTION
- fixed 2 URLs
- fixed parsing of some chapter numbers
- fixed parsing of chapter page when server returns HTTP 400 with the correct payload

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
