### PR TITLE
Richtoscan URL Update

### DIFF
--- a/src/es/richtoscan/build.gradle
+++ b/src/es/richtoscan/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'RichtoScan'
     extClass = '.RichtoScan'
     themePkg = 'madara'
-    baseUrl = 'https://lascanderichto.com/'
-    overrideVersionCode = 2
+    baseUrl = 'https://r1.richtoon.top'
+    overrideVersionCode = 3
     isNsfw = false
 }
 

--- a/src/es/richtoscan/src/eu/kanade/tachiyomi/extension/es/richtoscan/RichtoScan.kt
+++ b/src/es/richtoscan/src/eu/kanade/tachiyomi/extension/es/richtoscan/RichtoScan.kt
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeUnit
 class RichtoScan :
     Madara(
         "RichtoScan",
-        "https://r1.richtoon.top/",
+        "https://r1.richtoon.top",
         "es",
         dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale.ROOT),
     ) {

--- a/src/es/richtoscan/src/eu/kanade/tachiyomi/extension/es/richtoscan/RichtoScan.kt
+++ b/src/es/richtoscan/src/eu/kanade/tachiyomi/extension/es/richtoscan/RichtoScan.kt
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeUnit
 class RichtoScan :
     Madara(
         "RichtoScan",
-        "https://lascanderichto.com/",
+        "https://r1.richtoon.top/",
         "es",
         dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale.ROOT),
     ) {


### PR DESCRIPTION
Updated URL returns HTTP 200 just fine, old one just redirects to the new one and serves no other purpose. 
No logic modifications. 

Should close #13996 

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
