### PR TITLE
Softkomik (ID) :  add cdn urls

### DIFF
--- a/src/id/softkomik/build.gradle
+++ b/src/id/softkomik/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Softkomik'
     extClass = '.Softkomik'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = false
 }
 

--- a/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
+++ b/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
@@ -316,6 +316,8 @@ class Softkomik : HttpSource() {
     private val apiUrl = "https://v2.softdevices.my.id"
     private val coverUrl = "https://cover.softdevices.my.id/softkomik-cover"
     private val cdnUrls = listOf(
+        "https://psy1.komik.im",
+        "https://image.komik.im/softkomik",
         "https://cd1.softkomik.online/softkomik",
         "https://f1.softkomik.com/file/softkomik-image",
         "https://img.softdevices.my.id/softkomik-image",


### PR DESCRIPTION
Fix some manga got error 404, eg: Manhwa [The Villainess Hides Her Wealth](https://web.softkomik.com/the-villainess-hides-her-wealth-bahasa-indonesia)

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
