### PR TITLE
MangaBuff: fix for calculating chapter_number

### DIFF
--- a/src/ru/mangabuff/build.gradle
+++ b/src/ru/mangabuff/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaBuff'
     extClass = '.MangaBuff'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/MangaBuff.kt
+++ b/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/MangaBuff.kt
@@ -263,6 +263,8 @@ class MangaBuff : ParsedHttpSource() {
         date_upload = runCatching {
             dateFormat.parse(element.selectFirst(".chapters__add-date")!!.text())!!.time
         }.getOrDefault(0L)
+        chapter_number = element.select(".chapters__value").text()
+            .substringAfter(" ").toFloatOrNull() ?: -1f
     }
 
     override fun chapterListParse(response: Response): List<SChapter> {


### PR DESCRIPTION
Checklist:

Source uses "Volume X Chapter Y" format for all the chapters in every manga and comic (Volume 1 - if it's not set/default). Mihon takes first number in that string (chapter volume) and use it as chapter number. 
With "Skip downloading duplicate read chapters" option enabled Mihon didn't start downloading new chapters automatically, and showed incorrect chapter number in notifications.

I've just added correct parsing for chapter_number.


- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
