### PR TITLE
Asura Scans: restore browse, filters, and chapter pages

### DIFF
--- a/src/en/asurascans/build.gradle
+++ b/src/en/asurascans/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Asura Scans'
     extClass = '.AsuraScans'
-    extVersionCode = 69
+    extVersionCode = 74
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/asurascans/build.gradle
+++ b/src/en/asurascans/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Asura Scans'
     extClass = '.AsuraScans'
-    extVersionCode = 54
+    extVersionCode = 69
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScans.kt
+++ b/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScans.kt
@@ -9,10 +9,12 @@ import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
+import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferences
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.toJsonString
@@ -37,7 +39,7 @@ class AsuraScans :
 
     override val name = "Asura Scans"
 
-    override val baseUrl = "https://asuracomic.net"
+    override val baseUrl = "https://asurascans.com"
 
     private val apiUrl = "https://gg.asuracomic.net/api"
 
@@ -48,6 +50,10 @@ class AsuraScans :
     private val dateFormat = SimpleDateFormat("MMMM d yyyy", Locale.US)
 
     private val preferences: SharedPreferences = getPreferences()
+
+    private val slugMap: MutableMap<String, String> by lazy {
+        loadSlugMap()
+    }
 
     init {
         // remove legacy preferences
@@ -105,7 +111,7 @@ class AsuraScans :
     override fun headersBuilder() = super.headersBuilder()
         .add("Referer", "$baseUrl/")
 
-    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/series?genres=&status=-1&types=-1&order=rating&page=$page", headers)
+    override fun popularMangaRequest(page: Int): Request = browseRequest(page, sort = "popular")
 
     override fun popularMangaSelector() = searchMangaSelector()
 
@@ -113,46 +119,79 @@ class AsuraScans :
 
     override fun popularMangaNextPageSelector() = searchMangaNextPageSelector()
 
-    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/page/$page", headers)
+    override fun popularMangaParse(response: Response): MangasPage = parseMangaPage(response)
+
+    override fun latestUpdatesRequest(page: Int): Request = if (page == 1) {
+        GET(baseUrl, headers)
+    } else {
+        browseRequest(page, order = "latest")
+    }
 
     override fun latestUpdatesSelector() = "div.grid.grid-rows-1.grid-cols-1 > div.w-full"
 
     override fun latestUpdatesFromElement(element: Element) = SManga.create().apply {
-        val link = element.selectFirst("a[href^=/series/]")!!
+        val link = element.selectFirst(COMIC_LINK_SELECTOR)!!
         setUrlWithoutDomain(link.attr("abs:href").toPermSlugIfNeeded())
-        title = element.selectFirst("span.text-\\[15px\\] a")!!.text()
+        title = link.text()
         thumbnail_url = element.selectFirst("img")?.attr("abs:src")
     }
 
     override fun latestUpdatesNextPageSelector() = searchMangaNextPageSelector()
 
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        val url = "$baseUrl/series".toHttpUrl().newBuilder()
-
-        url.addQueryParameter("page", page.toString())
-
-        if (query.isNotBlank()) {
-            url.addQueryParameter("name", query)
+    override fun latestUpdatesParse(response: Response): MangasPage {
+        val document = response.asJsoup()
+        return if (response.request.url.encodedPath == "/") {
+            // The homepage "Latest Updates" block does not follow the normal browse listing structure.
+            parseHomepageSectionMangas(
+                document = document,
+                sectionTitle = "Latest Updates",
+                stopTitles = setOf("Popular", "Announcements"),
+                hasNextPage = true,
+            )
+        } else {
+            parseMangaPage(document, hasNextPage = true)
         }
+    }
 
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         val genres = filters.firstInstanceOrNull<GenreFilter>()?.state.orEmpty()
             .filter(Genre::state)
-            .map(Genre::id)
+            .map(Genre::value)
             .joinToString(",")
 
-        val status = filters.firstInstanceOrNull<StatusFilter>()?.toUriPart() ?: "-1"
-        val types = filters.firstInstanceOrNull<TypeFilter>()?.toUriPart() ?: "-1"
+        val status = filters.firstInstanceOrNull<StatusFilter>()?.toUriPart().orEmpty()
         val order = filters.firstInstanceOrNull<OrderFilter>()?.toUriPart() ?: "rating"
 
-        url.addQueryParameter("genres", genres)
-        url.addQueryParameter("status", status)
-        url.addQueryParameter("types", types)
-        url.addQueryParameter("order", order)
+        return browseRequest(
+            page = page,
+            query = query.takeIf(String::isNotBlank),
+            genres = genres.takeIf(String::isNotBlank),
+            status = status.takeIf(String::isNotBlank),
+            order = order,
+        )
+    }
+
+    private fun browseRequest(
+        page: Int,
+        query: String? = null,
+        genres: String? = null,
+        status: String? = null,
+        order: String? = null,
+        sort: String? = null,
+    ): Request {
+        val url = "$baseUrl/browse".toHttpUrl().newBuilder()
+            .addQueryParameter("page", page.toString())
+
+        query?.takeIf(String::isNotBlank)?.let { url.addQueryParameter("q", it) }
+        genres?.takeIf(String::isNotBlank)?.let { url.addQueryParameter("genres", it) }
+        status?.takeIf(String::isNotBlank)?.let { url.addQueryParameter("status", it) }
+        order?.takeIf(String::isNotBlank)?.let { url.addQueryParameter("order", it) }
+        sort?.takeIf(String::isNotBlank)?.let { url.addQueryParameter("sort", it) }
 
         return GET(url.build(), headers)
     }
 
-    override fun searchMangaSelector() = "div.grid > a[href]"
+    override fun searchMangaSelector() = "div.grid $COMIC_LINK_SELECTOR"
 
     override fun searchMangaFromElement(element: Element) = SManga.create().apply {
         setUrlWithoutDomain(element.attr("abs:href").toPermSlugIfNeeded())
@@ -160,7 +199,85 @@ class AsuraScans :
         thumbnail_url = element.selectFirst("img")?.attr("abs:src")
     }
 
-    override fun searchMangaNextPageSelector() = "div.flex > a.flex.bg-themecolor:contains(Next)"
+    override fun searchMangaNextPageSelector() = NEXT_PAGE_SELECTOR
+
+    override fun searchMangaParse(response: Response): MangasPage = parseMangaPage(response)
+
+    private fun parseMangaPage(response: Response): MangasPage {
+        val document = response.asJsoup()
+        val currentPage = response.request.url.queryParameter("page")?.toIntOrNull() ?: 1
+        val hasNextPage = document.select("a[href]").any { element ->
+            element.attr("abs:href")
+                .toHttpUrlOrNull()
+                ?.queryParameter("page")
+                ?.toIntOrNull() == currentPage + 1
+        }
+        return parseMangaPage(document, hasNextPage)
+    }
+
+    private fun parseMangaPage(document: Document, hasNextPage: Boolean): MangasPage {
+        val mangas = LinkedHashMap<String, SManga>()
+
+        document.select(COMIC_LINK_SELECTOR).forEach { element ->
+            addMangaFromElement(mangas, element)
+        }
+
+        return MangasPage(mangas.values.filter { !it.parsedTitle().isNullOrBlank() }, hasNextPage)
+    }
+
+    private fun parseHomepageSectionMangas(
+        document: Document,
+        sectionTitle: String,
+        stopTitles: Set<String>,
+        hasNextPage: Boolean,
+    ): MangasPage {
+        val mangas = LinkedHashMap<String, SManga>()
+        val heading = document.select(HOMEPAGE_SECTION_HEADING_SELECTOR)
+            .firstOrNull { it.text().trim() == sectionTitle }
+            ?: return MangasPage(emptyList(), hasNextPage)
+
+        var current: Element? = heading
+        while (current != null) {
+            current = current.nextElementSibling() ?: break
+
+            val nextHeading = current.selectFirst(HOMEPAGE_SECTION_HEADING_SELECTOR)
+                ?.text()
+                ?.trim()
+            if (nextHeading in stopTitles) break
+
+            current.select(COMIC_LINK_SELECTOR).forEach { element ->
+                addMangaFromElement(mangas, element)
+            }
+        }
+
+        return MangasPage(mangas.values.filter { !it.parsedTitle().isNullOrBlank() }, hasNextPage)
+    }
+
+    private fun addMangaFromElement(mangas: LinkedHashMap<String, SManga>, element: Element) {
+        val url = element.attr("abs:href")
+        if (url.isBlank()) return
+
+        val path = url.toHttpUrlOrNull()?.encodedPath ?: return
+        val manga = mangas.getOrPut(path) {
+            SManga.create().apply {
+                setUrlWithoutDomain(url.toPermSlugIfNeeded())
+            }
+        }
+
+        if (manga.parsedTitle().isNullOrBlank()) {
+            val parsedTitle = element.selectFirst("img[alt]")?.attr("alt")
+                ?.takeIf(String::isNotBlank)
+                ?: cleanMangaTitle(element.text()).takeIf(String::isNotBlank)
+
+            if (parsedTitle != null) {
+                manga.title = parsedTitle
+            }
+        }
+
+        if (manga.thumbnail_url.isNullOrBlank()) {
+            manga.thumbnail_url = element.selectFirst("img")?.attr("abs:src")
+        }
+    }
 
     override fun getFilterList(): FilterList {
         fetchFilters()
@@ -169,7 +286,6 @@ class AsuraScans :
             filters += listOf(
                 GenreFilter("Genres", getGenreFilters()),
                 StatusFilter("Status", getStatusFilters()),
-                TypeFilter("Types", getTypeFilters()),
             )
         } else {
             filters += Filter.Header("Press 'Reset' to attempt to fetch the filters")
@@ -190,12 +306,10 @@ class AsuraScans :
     }
 
     private fun getGenreFilters(): List<Genre> = genresList.map { Genre(it.first, it.second) }
-    private fun getStatusFilters(): List<Pair<String, String>> = statusesList.map { it.first to it.second.toString() }
-    private fun getTypeFilters(): List<Pair<String, String>> = typesList.map { it.first to it.second.toString() }
+    private fun getStatusFilters(): List<Pair<String, String>> = listOf("All" to "") + statusesList
 
-    private var genresList: List<Pair<String, Int>> = emptyList()
-    private var statusesList: List<Pair<String, Int>> = emptyList()
-    private var typesList: List<Pair<String, Int>> = emptyList()
+    private var genresList: List<Pair<String, String>> = emptyList()
+    private var statusesList: List<Pair<String, String>> = emptyList()
 
     private var fetchFiltersAttempts = 0
     private var filtersState = FiltersState.NOT_FETCHED
@@ -206,12 +320,25 @@ class AsuraScans :
         fetchFiltersAttempts++
         thread {
             try {
-                val response = client.newCall(GET("$apiUrl/series/filters", headers)).execute()
-                val filters = response.body.string().parseAs<FiltersDto>()
+                val filters = client.newCall(GET("$apiUrl/series/filters", headers)).execute().use { response ->
+                    response.body.string().parseAs<FiltersDto>()
+                }
 
-                genresList = filters.genres.filter { it.id > 0 }.map { it.name.trim() to it.id }
-                statusesList = filters.statuses.map { it.name.trim() to it.id }
-                typesList = filters.types.map { it.name.trim() to it.id }
+                genresList = filters.genres
+                    .filter { it.id > 0 }
+                    .mapNotNull { item ->
+                        item.name.trim().takeIf(String::isNotBlank)?.let { name ->
+                            name to name.toBrowseSlug()
+                        }
+                    }
+
+                statusesList = filters.statuses
+                    .filter { it.id > 0 }
+                    .mapNotNull { item ->
+                        item.name.trim().takeIf(String::isNotBlank)?.let { name ->
+                            name to name.toBrowseSlug()
+                        }
+                    }
 
                 filtersState = FiltersState.FETCHED
             } catch (e: Throwable) {
@@ -221,38 +348,49 @@ class AsuraScans :
     }
 
     override fun mangaDetailsRequest(manga: SManga): Request {
-        if (!preferences.dynamicUrl()) return super.mangaDetailsRequest(manga)
-        val match = OLD_FORMAT_MANGA_REGEX.find(manga.url)?.groupValues?.get(2)
-        val slug = match ?: manga.url.substringAfter("/series/").substringBefore("/")
-        val savedSlug = preferences.slugMap[slug] ?: "$slug-"
-        return GET("$baseUrl/series/$savedSlug", headers)
+        val normalizedUrl = manga.url.normalizeComicPath()
+        if (!preferences.dynamicUrl()) return GET(baseUrl + normalizedUrl, headers)
+        val match = OLD_FORMAT_MANGA_REGEX.find(normalizedUrl)?.groupValues?.get(2)
+        val slug = match ?: normalizedUrl.extractComicSlug()
+        val savedSlug = slugMap[slug] ?: "$slug-"
+        return GET("$baseUrl/comics/$savedSlug", headers)
     }
 
     override fun mangaDetailsParse(response: Response): SManga {
-        if (preferences.dynamicUrl()) {
-            val url = response.request.url.toString()
-            val newSlug = url.substringAfter("/series/", "").substringBefore("/")
-            if (newSlug.isNotEmpty()) {
-                val absSlug = newSlug.substringBeforeLast("-")
-                preferences.slugMap = preferences.slugMap.apply { put(absSlug, newSlug) }
-            }
-        }
+        rememberDynamicSlug(response.request.url.toString())
         return super.mangaDetailsParse(response)
     }
 
     override fun mangaDetailsParse(document: Document) = SManga.create().apply {
-        title = document.selectFirst("span.text-xl.font-bold, h3.truncate")!!.ownText()
-        thumbnail_url = document.selectFirst("img[alt=poster]")?.attr("abs:src")
-        description = document.selectFirst("span.font-medium.text-sm")?.text()
-        author = document.selectFirst("div.grid > div:has(h3:eq(0):containsOwn(Author)) > h3:eq(1)")?.ownText()
-        artist = document.selectFirst("div.grid > div:has(h3:eq(0):containsOwn(Artist)) > h3:eq(1)")?.ownText()
-        genre = buildList {
-            document.selectFirst("div.flex:has(h3:eq(0):containsOwn(type)) > h3:eq(1)")
-                ?.ownText()?.let(::add)
-            document.select("div[class^=space] > div.flex > button.text-white")
-                .forEach { add(it.ownText()) }
-        }.joinToString()
-        status = parseStatus(document.selectFirst("div.flex:has(h3:eq(0):containsOwn(Status)) > h3:eq(1)")?.ownText())
+        title = document.selectFirst("meta[property=og:title]")?.attr("content")
+            ?.substringBefore(" - Asura Scans")
+            ?.takeIf(String::isNotBlank)
+            ?: document.selectFirst("h1")?.text()
+            ?: document.selectFirst("title")?.text()?.substringBefore(" - Asura Scans")
+            ?: throw Exception("Failed to parse manga title")
+
+        thumbnail_url = document.selectFirst("meta[property=og:image]")?.attr("content")
+            ?: document.selectFirst("img[src*=/asura-images/covers/]")?.attr("abs:src")
+
+        description = document.selectFirst("meta[property=og:description]")?.attr("content")
+            ?.takeIf(String::isNotBlank)
+            ?: document.select("p")
+                .map { it.text().trim() }
+                .firstOrNull { text -> text.length > 80 && !text.startsWith("By the Studio") }
+
+        genre = document.select("a[href^=/browse?genres=]")
+            .map { it.text().trim() }
+            .filter(String::isNotBlank)
+            .distinct()
+            .joinToString()
+            .ifBlank { null }
+
+        status = parseStatus(
+            document.select("body").text().let { bodyText ->
+                listOf("Ongoing", "Hiatus", "Completed", "Dropped", "Season End")
+                    .firstOrNull(bodyText::contains)
+            },
+        )
     }
 
     private fun parseStatus(status: String?) = when (status) {
@@ -264,20 +402,39 @@ class AsuraScans :
     }
 
     override fun chapterListParse(response: Response): List<SChapter> {
-        if (preferences.dynamicUrl()) {
-            val url = response.request.url.toString()
-            val newSlug = url.substringAfter("/series/", "").substringBefore("/")
-            if (newSlug.isNotEmpty()) {
-                val absSlug = newSlug.substringBeforeLast("-")
-                preferences.slugMap = preferences.slugMap.apply { put(absSlug, newSlug) }
+        rememberDynamicSlug(response.request.url.toString())
+
+        val document = response.asJsoup()
+        val chapters = LinkedHashMap<String, SChapter>()
+
+        document.select(CHAPTER_LINK_SELECTOR).forEach { element ->
+            val url = element.attr("abs:href")
+            if (!url.contains("/comics/") || !url.contains("/chapter/")) return@forEach
+
+            val rawText = element.text().replace(WHITESPACE_REGEX, " ").trim()
+            if (!rawText.isRealChapterEntry()) return@forEach
+
+            val path = url.toHttpUrlOrNull()?.encodedPath ?: return@forEach
+            if (chapters.containsKey(path)) return@forEach
+
+            val isPremium = rawText.contains("EARLY ACCESS", ignoreCase = true) ||
+                rawText.contains("Unlocks in", ignoreCase = true)
+
+            if (isPremium) return@forEach
+
+            chapters[path] = SChapter.create().apply {
+                setUrlWithoutDomain(url.toPermSlugIfNeeded())
+                name = buildChapterName(rawText, path.substringAfterLast('/'))
             }
         }
+
+        if (chapters.isNotEmpty()) return chapters.values.toList()
         return super.chapterListParse(response)
     }
 
     override fun chapterListRequest(manga: SManga) = mangaDetailsRequest(manga)
 
-    override fun chapterListSelector() = if (preferences.hidePremiumChapters()) "div.scrollbar-thumb-themecolor > div.group:not(:has(svg))" else "div.scrollbar-thumb-themecolor > div.group"
+    override fun chapterListSelector() = "div.scrollbar-thumb-themecolor > div.group:not(:has(svg))"
 
     override fun chapterFromElement(element: Element) = SChapter.create().apply {
         setUrlWithoutDomain(element.selectFirst("a")!!.attr("abs:href").toPermSlugIfNeeded())
@@ -297,12 +454,15 @@ class AsuraScans :
     }
 
     override fun pageListRequest(chapter: SChapter): Request {
-        if (!preferences.dynamicUrl()) return super.pageListRequest(chapter)
-        val match = OLD_FORMAT_CHAPTER_REGEX.containsMatchIn(chapter.url)
+        val normalizedUrl = chapter.url.normalizeComicPath().ensureTrailingSlash()
+        if (!preferences.dynamicUrl()) {
+            return GET(baseUrl + normalizedUrl, headers)
+        }
+        val match = OLD_FORMAT_CHAPTER_REGEX.containsMatchIn(normalizedUrl)
         if (match) throw Exception("Please refresh the chapter list before reading.")
-        val slug = chapter.url.substringAfter("/series/").substringBefore("/")
-        val savedSlug = preferences.slugMap[slug] ?: "$slug-"
-        return GET(baseUrl + chapter.url.replace(slug, savedSlug), headers)
+        val slug = normalizedUrl.extractComicSlug()
+        val savedSlug = slugMap[slug] ?: "$slug-"
+        return GET(baseUrl + normalizedUrl.replaceComicSlug(slug, savedSlug), headers)
     }
 
     override fun pageListParse(document: Document): List<Page> {
@@ -313,7 +473,6 @@ class AsuraScans :
         val pagesData = PAGES_REGEX.find(scriptData)?.groupValues?.get(1)
 
         if (chapterDataMatch != null && pagesData != null) {
-            // check for premium chapter
             val chapterId = chapterDataMatch.groupValues[1].toIntOrNull()
             val pages = try {
                 pagesData.unescape().parseAs<List<PageDto>>()
@@ -321,28 +480,46 @@ class AsuraScans :
                 emptyList()
             }
 
-            // If unlocked, fetch info via API
-            if (chapterId != null && pages.isEmpty()) {
+            if (pages.isNotEmpty()) {
+                return pages.sortedBy(PageDto::order).toPageList()
+            }
+
+            if (chapterId != null) {
                 return fetchChapterImages(chapterId)
             }
         }
 
-        // continue with normal chapter handling
-        if (pagesData == null) {
-            throw Exception("Failed to find chapter pages")
-        }
-
-        val pageList = pagesData.unescape().parseAs<List<PageDto>>().sortedBy { it.order }
-        return pageList.mapIndexed { i, page ->
-            val newUrl = page.url.toHttpUrlOrNull()?.run {
-                newBuilder()
-                    .fragment("pageListParse")
-                    .build()
-                    .toString()
+        // Prefer explicit image nodes before falling back to a raw HTML scan.
+        val images = document.select("img[src*=/chapters/], img[data-src*=/chapters/]")
+            .mapNotNull { el ->
+                el.attr("abs:src").ifBlank { el.attr("abs:data-src") }.ifBlank { null }
             }
+            .map(::normalizeChapterImageUrl)
+            .distinct()
 
-            Page(i, imageUrl = newUrl ?: page.url)
+        val scriptImages = extractChapterImageUrlsFromHtml(scriptData.unescape())
+
+        // The site occasionally leaves chapter CDN URLs only in embedded HTML/script payloads.
+        val htmlImages = extractChapterImageUrlsFromHtml(document.html())
+
+        val inferredImages = inferSequentialChapterImageUrls(document, scriptImages + htmlImages + images)
+        if (inferredImages.isNotEmpty()) {
+            return inferredImages.toImagePages()
         }
+
+        if (scriptImages.isNotEmpty()) {
+            return scriptImages.toImagePages()
+        }
+
+        if (htmlImages.isNotEmpty()) {
+            return htmlImages.toImagePages()
+        }
+
+        if (images.isNotEmpty()) {
+            return images.toImagePages()
+        }
+
+        throw Exception("Failed to find chapter pages")
     }
 
     private fun fetchChapterImages(chapterId: Int): List<Page> {
@@ -443,13 +620,6 @@ class AsuraScans :
         }.let(screen::addPreference)
 
         SwitchPreferenceCompat(screen.context).apply {
-            key = PREF_HIDE_PREMIUM_CHAPTERS
-            title = "Hide premium chapters"
-            summary = "Hides the chapters that require a subscription to view"
-            setDefaultValue(true)
-        }.let(screen::addPreference)
-
-        SwitchPreferenceCompat(screen.context).apply {
             key = PREF_FORCE_HIGH_QUALITY
             title = "Force high quality chapter images"
             summary = "Attempt to use high quality chapter images.\nWill increase bandwidth by ~50%."
@@ -460,55 +630,217 @@ class AsuraScans :
         }.let(screen::addPreference)
     }
 
-    private var SharedPreferences.slugMap: MutableMap<String, String>
-        get() {
-            val jsonMap = getString(PREF_SLUG_MAP, "{}")!!
-            return try {
-                jsonMap.parseAs<Map<String, String>>().toMutableMap()
-            } catch (_: Exception) {
-                mutableMapOf()
-            }
-        }
-        set(newSlugMap) {
-            edit()
-                .putString(PREF_SLUG_MAP, newSlugMap.toJsonString())
-                .apply()
-        }
-
     private fun SharedPreferences.dynamicUrl(): Boolean = getBoolean(PREF_DYNAMIC_URL, true)
-    private fun SharedPreferences.hidePremiumChapters(): Boolean = getBoolean(
-        PREF_HIDE_PREMIUM_CHAPTERS,
-        true,
-    )
     private fun SharedPreferences.forceHighQuality(): Boolean = getBoolean(
         PREF_FORCE_HIGH_QUALITY,
         false,
     )
 
+    private fun loadSlugMap(): MutableMap<String, String> {
+        val jsonMap = preferences.getString(PREF_SLUG_MAP, "{}")!!
+        return try {
+            jsonMap.parseAs<Map<String, String>>().toMutableMap()
+        } catch (_: Exception) {
+            mutableMapOf()
+        }
+    }
+
+    private fun persistSlugMapIfChanged(absSlug: String, slug: String) {
+        if (absSlug.isBlank() || slug.isBlank()) return
+        if (slugMap[absSlug] == slug) return
+
+        slugMap[absSlug] = slug
+        preferences.edit()
+            .putString(PREF_SLUG_MAP, slugMap.toJsonString())
+            .apply()
+    }
+
+    private fun rememberDynamicSlug(url: String) {
+        if (!preferences.dynamicUrl()) return
+
+        val newSlug = url.extractComicSlug()
+        if (newSlug.isEmpty()) return
+
+        val absSlug = newSlug.substringBeforeLast("-")
+        persistSlugMapIfChanged(absSlug, newSlug)
+    }
+
     private fun String.toPermSlugIfNeeded(): String {
-        if (!preferences.dynamicUrl()) return this
-        val slug = this.substringAfter("/series/").substringBefore("/")
+        val normalized = normalizeComicPath()
+        if (!preferences.dynamicUrl()) return normalized
+        val slug = normalized.extractComicSlug()
         val absSlug = slug.substringBeforeLast("-")
-        preferences.slugMap = preferences.slugMap.apply { put(absSlug, slug) }
-        return this.replace(slug, absSlug)
+        persistSlugMapIfChanged(absSlug, slug)
+        return normalized.replaceComicSlug(slug, absSlug)
+    }
+
+    private fun cleanMangaTitle(rawTitle: String): String = rawTitle.replace(WHITESPACE_REGEX, " ")
+        .replace(TRAILING_CHAPTER_NUMBER_REGEX, "")
+        .trim()
+
+    private fun buildChapterName(rawText: String, fallbackChapter: String): String {
+        val normalized = rawText.replace(WHITESPACE_REGEX, " ").trim()
+        val withoutDate = normalized.replace(CHAPTER_DATE_SUFFIX_REGEX, "").trim()
+
+        return withoutDate.ifBlank { "Chapter $fallbackChapter" }
+    }
+
+    private fun String.isRealChapterEntry(): Boolean = CHAPTER_ENTRY_REGEX.containsMatchIn(this)
+
+    private fun String.ensureTrailingSlash(): String = if (endsWith('/')) this else "$this/"
+
+    private fun normalizeChapterImageUrl(url: String): String = url
+        .replace("\\/", "/")
+        .replace("&amp;", "&")
+        .let { if (it.startsWith("//")) "https:$it" else it }
+
+    private fun extractChapterImageUrlsFromHtml(html: String): List<String> = normalizeChapterImageUrl(html)
+        .let(NORMALIZED_CHAPTER_IMAGE_URL_REGEX::findAll)
+        .map { it.value }
+        .filter(::isValidChapterImageUrl)
+        .distinct()
+        .toList()
+
+    private fun inferSequentialChapterImageUrls(document: Document, seedImages: List<String>): List<String> {
+        val knownImages = seedImages
+            .filter(::isValidChapterImageUrl)
+            .distinct()
+            .sortedWith(compareBy({ extractChapterImageNumber(it) ?: Int.MAX_VALUE }, { it }))
+
+        val pageCount = extractVisiblePageCount(document) ?: return emptyList()
+        if (knownImages.isEmpty()) return emptyList()
+
+        val knownByPage = knownImages.associateBy { extractChapterImageNumber(it) }
+        val highestKnownPage = knownByPage.keys.filterNotNull().maxOrNull() ?: knownImages.size
+        if (pageCount <= highestKnownPage) return knownImages
+
+        val pattern = buildChapterImagePattern(knownImages) ?: return knownImages
+
+        return (1..pageCount).map { pageNumber ->
+            knownByPage[pageNumber] ?: pattern.pageUrl(pageNumber)
+        }
+    }
+
+    private fun extractVisiblePageCount(document: Document): Int? {
+        val labeledPageCount = PAGE_LABEL_REGEX.findAll(document.html())
+            .mapNotNull { it.groupValues.getOrNull(1)?.toIntOrNull() }
+            .maxOrNull()
+
+        val pagerPageCount = CONSECUTIVE_PAGE_NUMBER_REGEX.findAll(document.text())
+            .mapNotNull { match ->
+                match.value.trim()
+                    .split(WHITESPACE_REGEX)
+                    .mapNotNull(String::toIntOrNull)
+                    .takeIf { values ->
+                        values.size >= 3 && values.zipWithNext().all { (left, right) -> right == left + 1 }
+                    }
+                    ?.lastOrNull()
+            }
+            .maxOrNull()
+
+        return listOfNotNull(labeledPageCount, pagerPageCount).maxOrNull()
+    }
+
+    private fun buildChapterImagePattern(seedImages: List<String>): ChapterImagePattern? {
+        val firstMatch = seedImages.firstNotNullOfOrNull(CHAPTER_IMAGE_SEQUENCE_REGEX::find) ?: return null
+        val secondMatch = seedImages
+            .mapNotNull(CHAPTER_IMAGE_SEQUENCE_REGEX::find)
+            .firstOrNull { it.groupValues[2].toIntOrNull() == 2 }
+
+        val prefix = firstMatch.groupValues[1]
+        val width = firstMatch.groupValues[2].length
+        val suffix = firstMatch.groupValues[4]
+        val subsequentPageVariant = secondMatch?.groupValues?.get(3).orEmpty()
+
+        return ChapterImagePattern(prefix, width, subsequentPageVariant, suffix)
+    }
+
+    private fun extractChapterImageNumber(url: String): Int? = CHAPTER_IMAGE_SEQUENCE_REGEX.find(url)
+        ?.groupValues
+        ?.getOrNull(2)
+        ?.toIntOrNull()
+
+    private fun isValidChapterImageUrl(url: String): Boolean {
+        val httpUrl = url.toHttpUrlOrNull() ?: return false
+        return httpUrl.host.contains("asurascans.com") && CHAPTER_IMAGE_FILENAME_REGEX.containsMatchIn(httpUrl.encodedPath)
+    }
+
+    private fun List<String>.toImagePages(): List<Page> = mapIndexed { index, url ->
+        Page(index, imageUrl = url)
+    }
+
+    private fun List<PageDto>.toPageList(): List<Page> = mapIndexed { index, page ->
+        val imageUrl = page.url.toHttpUrlOrNull()
+            ?.newBuilder()
+            ?.fragment("pageListParse")
+            ?.build()
+            ?.toString()
+            ?: page.url
+        Page(index, imageUrl = imageUrl)
+    }
+
+    private fun SManga.parsedTitle(): String? = runCatching { title }
+        .getOrNull()
+        ?.takeIf(String::isNotBlank)
+
+    private fun String.toBrowseSlug(): String = lowercase(Locale.US)
+        .replace("&", " and ")
+        .replace(Regex("[^a-z0-9]+"), "-")
+        .trim('-')
+
+    private fun String.normalizeComicPath(): String = replace("/series/", "/comics/")
+
+    private fun String.extractComicSlug(): String = when {
+        contains("/comics/") -> substringAfter("/comics/").substringBefore("/")
+        contains("/series/") -> substringAfter("/series/").substringBefore("/")
+        else -> substringAfter("/manga/").substringBefore("/")
+    }
+
+    private fun String.replaceComicSlug(oldSlug: String, newSlug: String): String {
+        val normalized = normalizeComicPath()
+        return normalized.replace("/comics/$oldSlug", "/comics/$newSlug")
     }
 
     private fun String.unescape(): String = UNESCAPE_REGEX.replace(this, "$1")
 
-    companion object {
-        private val UNESCAPE_REGEX = """\\(.)""".toRegex()
-        private val PAGES_REGEX = """\\"pages\\":(\[.*?])""".toRegex()
+    private data class ChapterImagePattern(
+        val prefix: String,
+        val width: Int,
+        val subsequentPageVariant: String,
+        val suffix: String,
+    ) {
+        fun pageUrl(pageNumber: Int): String {
+            val page = pageNumber.toString().padStart(width, '0')
+            val variant = if (pageNumber == 1) "" else subsequentPageVariant
+            return "$prefix$page$variant$suffix"
+        }
+    }
 
-        // Match chapter metadata: "chapter":{"id":123..."is_early_access":true}
+    companion object {
+        private const val COMIC_LINK_SELECTOR = "a[href^=/comics/]:not([href*=/chapter/])"
+        private const val CHAPTER_LINK_SELECTOR = "a[href*=/chapter/]"
+        private const val NEXT_PAGE_SELECTOR = "a:contains(Next page), div.flex > a.flex.bg-themecolor:contains(Next)"
+        private const val HOMEPAGE_SECTION_HEADING_SELECTOR = "h2, h3"
+
+        private val UNESCAPE_REGEX = """\\(.)""".toRegex()
+        private val WHITESPACE_REGEX = """\\s+""".toRegex()
+        private val TRAILING_CHAPTER_NUMBER_REGEX = """\s+\d+(?:\.\d+)?$""".toRegex()
+        private val CHAPTER_DATE_SUFFIX_REGEX = """\s+(Just now|last week|\d+\s+(?:minute|minutes|hour|hours|day|days|week|weeks|month|months)\s+ago|[A-Z][a-z]{2}\s+\d{1,2},\s+\d{4})$""".toRegex()
+        private val PAGES_REGEX = """\\"pages\\":(\[.*?])""".toRegex()
+        private val NORMALIZED_CHAPTER_IMAGE_URL_REGEX = """(?:https?:)?//cdn\.asurascans\.com/asura-images/chapters/[^"'\s<>]+""".toRegex()
+        private val CHAPTER_IMAGE_FILENAME_REGEX = """/(\d+(?:_p\d+)?)\.(?:webp|jpg|jpeg|png)$""".toRegex(RegexOption.IGNORE_CASE)
+        private val CHAPTER_IMAGE_SEQUENCE_REGEX = """^(.*?/)(\d+)(?:(_p\d+))?(\.[A-Za-z0-9]+(?:\?.*)?)$""".toRegex()
         private val CHAPTER_DATA_REGEX = """\\"chapter\\":\{\\"id\\":(\d+).*?\\"is_early_access\\":(true|false)""".toRegex(RegexOption.DOT_MATCHES_ALL)
+        private val CHAPTER_ENTRY_REGEX = """(?i)\bchapter\s+\d""".toRegex()
         private val CLEAN_DATE_REGEX = """(\d+)(st|nd|rd|th)""".toRegex()
+        private val PAGE_LABEL_REGEX = """Page\s+(\d+)\s*-\s*Chapter""".toRegex(RegexOption.IGNORE_CASE)
+        private val CONSECUTIVE_PAGE_NUMBER_REGEX = """(?:^|\D)(\d{1,3}(?:\s+\d{1,3}){2,})(?=\D|$)""".toRegex()
         private val OLD_FORMAT_MANGA_REGEX = """^/manga/(\d+-)?([^/]+)/?$""".toRegex()
         private val OLD_FORMAT_CHAPTER_REGEX = """^/(\d+-)?[^/]*-chapter-\d+(-\d+)*/?$""".toRegex()
         private val OPTIMIZED_IMAGE_PATH_REGEX = """^/storage/media/(\d+)/conversions/(.*)-optimized\.webp$""".toRegex()
 
         private const val PREF_SLUG_MAP = "pref_slug_map_2"
         private const val PREF_DYNAMIC_URL = "pref_dynamic_url"
-        private const val PREF_HIDE_PREMIUM_CHAPTERS = "pref_hide_premium_chapters"
         private const val PREF_FORCE_HIGH_QUALITY = "pref_force_high_quality"
     }
 }

--- a/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScans.kt
+++ b/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScans.kt
@@ -16,8 +16,13 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferences
+import keiyoushi.utils.jsonInstance
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.toJsonString
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Interceptor
@@ -466,54 +471,18 @@ class AsuraScans :
     }
 
     override fun pageListParse(document: Document): List<Page> {
-        val scriptData = document.select("script:containsData(self.__next_f.push)")
-            .joinToString("") { it.data().substringAfter("\"").substringBeforeLast("\"") }
-
-        val chapterDataMatch = CHAPTER_DATA_REGEX.find(scriptData)
-        val pagesData = PAGES_REGEX.find(scriptData)?.groupValues?.get(1)
-
-        if (chapterDataMatch != null && pagesData != null) {
-            val chapterId = chapterDataMatch.groupValues[1].toIntOrNull()
-            val pages = try {
-                pagesData.unescape().parseAs<List<PageDto>>()
-            } catch (_: Exception) {
-                emptyList()
-            }
-
-            if (pages.isNotEmpty()) {
-                return pages.sortedBy(PageDto::order).toPageList()
-            }
-
-            if (chapterId != null) {
-                return fetchChapterImages(chapterId)
-            }
+        val astroImages = extractAstroChapterReaderImageUrls(document)
+        if (astroImages.isNotEmpty()) {
+            return astroImages.toImagePages()
         }
 
-        // Prefer explicit image nodes before falling back to a raw HTML scan.
         val images = document.select("img[src*=/chapters/], img[data-src*=/chapters/]")
             .mapNotNull { el ->
                 el.attr("abs:src").ifBlank { el.attr("abs:data-src") }.ifBlank { null }
             }
             .map(::normalizeChapterImageUrl)
+            .filter(::isValidChapterImageUrl)
             .distinct()
-
-        val scriptImages = extractChapterImageUrlsFromHtml(scriptData.unescape())
-
-        // The site occasionally leaves chapter CDN URLs only in embedded HTML/script payloads.
-        val htmlImages = extractChapterImageUrlsFromHtml(document.html())
-
-        val inferredImages = inferSequentialChapterImageUrls(document, scriptImages + htmlImages + images)
-        if (inferredImages.isNotEmpty()) {
-            return inferredImages.toImagePages()
-        }
-
-        if (scriptImages.isNotEmpty()) {
-            return scriptImages.toImagePages()
-        }
-
-        if (htmlImages.isNotEmpty()) {
-            return htmlImages.toImagePages()
-        }
 
         if (images.isNotEmpty()) {
             return images.toImagePages()
@@ -694,71 +663,42 @@ class AsuraScans :
         .replace("&amp;", "&")
         .let { if (it.startsWith("//")) "https:$it" else it }
 
-    private fun extractChapterImageUrlsFromHtml(html: String): List<String> = normalizeChapterImageUrl(html)
-        .let(NORMALIZED_CHAPTER_IMAGE_URL_REGEX::findAll)
-        .map { it.value }
-        .filter(::isValidChapterImageUrl)
-        .distinct()
-        .toList()
+    private fun extractAstroChapterReaderImageUrls(document: Document): List<String> {
+        val propsPayload = document.select(ASTRO_CHAPTER_READER_SELECTOR)
+            .firstOrNull()
+            ?.attr("props")
+            .orEmpty()
 
-    private fun inferSequentialChapterImageUrls(document: Document, seedImages: List<String>): List<String> {
-        val knownImages = seedImages
-            .filter(::isValidChapterImageUrl)
-            .distinct()
-            .sortedWith(compareBy({ extractChapterImageNumber(it) ?: Int.MAX_VALUE }, { it }))
+        if (propsPayload.isBlank()) {
+            return emptyList()
+        }
 
-        val pageCount = extractVisiblePageCount(document) ?: return emptyList()
-        if (knownImages.isEmpty()) return emptyList()
+        val root = runCatching {
+            jsonInstance.parseToJsonElement(propsPayload) as? JsonObject
+        }.getOrNull() ?: return emptyList()
 
-        val knownByPage = knownImages.associateBy { extractChapterImageNumber(it) }
-        val highestKnownPage = knownByPage.keys.filterNotNull().maxOrNull() ?: knownImages.size
-        if (pageCount <= highestKnownPage) return knownImages
+        val pages = root["pages"].astroArrayItems().orEmpty()
 
-        val pattern = buildChapterImagePattern(knownImages) ?: return knownImages
-
-        return (1..pageCount).map { pageNumber ->
-            knownByPage[pageNumber] ?: pattern.pageUrl(pageNumber)
+        return pages.mapNotNull { page ->
+            page.astroObjectValue()
+                ?.get("url")
+                .astroStringValue()
+                ?.let(::normalizeChapterImageUrl)
         }
     }
 
-    private fun extractVisiblePageCount(document: Document): Int? {
-        val labeledPageCount = PAGE_LABEL_REGEX.findAll(document.html())
-            .mapNotNull { it.groupValues.getOrNull(1)?.toIntOrNull() }
-            .maxOrNull()
+    private fun JsonElement?.astroValue(): JsonElement? = (this as? JsonArray)?.getOrNull(1)
 
-        val pagerPageCount = CONSECUTIVE_PAGE_NUMBER_REGEX.findAll(document.text())
-            .mapNotNull { match ->
-                match.value.trim()
-                    .split(WHITESPACE_REGEX)
-                    .mapNotNull(String::toIntOrNull)
-                    .takeIf { values ->
-                        values.size >= 3 && values.zipWithNext().all { (left, right) -> right == left + 1 }
-                    }
-                    ?.lastOrNull()
-            }
-            .maxOrNull()
+    private fun JsonElement?.astroArrayItems(): List<JsonElement>? = astroValue() as? JsonArray
 
-        return listOfNotNull(labeledPageCount, pagerPageCount).maxOrNull()
+    private fun JsonElement?.astroObjectValue(): JsonObject? = astroValue() as? JsonObject
+
+    private fun JsonElement?.astroStringValue(): String? = astroValue()?.let { value ->
+        when (value) {
+            is kotlinx.serialization.json.JsonPrimitive -> value.contentOrNull
+            else -> null
+        }
     }
-
-    private fun buildChapterImagePattern(seedImages: List<String>): ChapterImagePattern? {
-        val firstMatch = seedImages.firstNotNullOfOrNull(CHAPTER_IMAGE_SEQUENCE_REGEX::find) ?: return null
-        val secondMatch = seedImages
-            .mapNotNull(CHAPTER_IMAGE_SEQUENCE_REGEX::find)
-            .firstOrNull { it.groupValues[2].toIntOrNull() == 2 }
-
-        val prefix = firstMatch.groupValues[1]
-        val width = firstMatch.groupValues[2].length
-        val suffix = firstMatch.groupValues[4]
-        val subsequentPageVariant = secondMatch?.groupValues?.get(3).orEmpty()
-
-        return ChapterImagePattern(prefix, width, subsequentPageVariant, suffix)
-    }
-
-    private fun extractChapterImageNumber(url: String): Int? = CHAPTER_IMAGE_SEQUENCE_REGEX.find(url)
-        ?.groupValues
-        ?.getOrNull(2)
-        ?.toIntOrNull()
 
     private fun isValidChapterImageUrl(url: String): Boolean {
         val httpUrl = url.toHttpUrlOrNull() ?: return false
@@ -801,40 +741,19 @@ class AsuraScans :
         return normalized.replace("/comics/$oldSlug", "/comics/$newSlug")
     }
 
-    private fun String.unescape(): String = UNESCAPE_REGEX.replace(this, "$1")
-
-    private data class ChapterImagePattern(
-        val prefix: String,
-        val width: Int,
-        val subsequentPageVariant: String,
-        val suffix: String,
-    ) {
-        fun pageUrl(pageNumber: Int): String {
-            val page = pageNumber.toString().padStart(width, '0')
-            val variant = if (pageNumber == 1) "" else subsequentPageVariant
-            return "$prefix$page$variant$suffix"
-        }
-    }
-
     companion object {
+        private const val ASTRO_CHAPTER_READER_SELECTOR = "astro-island[component-url*=ChapterReader], astro-island[opts*=ChapterReader]"
         private const val COMIC_LINK_SELECTOR = "a[href^=/comics/]:not([href*=/chapter/])"
         private const val CHAPTER_LINK_SELECTOR = "a[href*=/chapter/]"
         private const val NEXT_PAGE_SELECTOR = "a:contains(Next page), div.flex > a.flex.bg-themecolor:contains(Next)"
         private const val HOMEPAGE_SECTION_HEADING_SELECTOR = "h2, h3"
 
-        private val UNESCAPE_REGEX = """\\(.)""".toRegex()
         private val WHITESPACE_REGEX = """\\s+""".toRegex()
         private val TRAILING_CHAPTER_NUMBER_REGEX = """\s+\d+(?:\.\d+)?$""".toRegex()
         private val CHAPTER_DATE_SUFFIX_REGEX = """\s+(Just now|last week|\d+\s+(?:minute|minutes|hour|hours|day|days|week|weeks|month|months)\s+ago|[A-Z][a-z]{2}\s+\d{1,2},\s+\d{4})$""".toRegex()
-        private val PAGES_REGEX = """\\"pages\\":(\[.*?])""".toRegex()
-        private val NORMALIZED_CHAPTER_IMAGE_URL_REGEX = """(?:https?:)?//cdn\.asurascans\.com/asura-images/chapters/[^"'\s<>]+""".toRegex()
         private val CHAPTER_IMAGE_FILENAME_REGEX = """/(\d+(?:_p\d+)?)\.(?:webp|jpg|jpeg|png)$""".toRegex(RegexOption.IGNORE_CASE)
-        private val CHAPTER_IMAGE_SEQUENCE_REGEX = """^(.*?/)(\d+)(?:(_p\d+))?(\.[A-Za-z0-9]+(?:\?.*)?)$""".toRegex()
-        private val CHAPTER_DATA_REGEX = """\\"chapter\\":\{\\"id\\":(\d+).*?\\"is_early_access\\":(true|false)""".toRegex(RegexOption.DOT_MATCHES_ALL)
         private val CHAPTER_ENTRY_REGEX = """(?i)\bchapter\s+\d""".toRegex()
         private val CLEAN_DATE_REGEX = """(\d+)(st|nd|rd|th)""".toRegex()
-        private val PAGE_LABEL_REGEX = """Page\s+(\d+)\s*-\s*Chapter""".toRegex(RegexOption.IGNORE_CASE)
-        private val CONSECUTIVE_PAGE_NUMBER_REGEX = """(?:^|\D)(\d{1,3}(?:\s+\d{1,3}){2,})(?=\D|$)""".toRegex()
         private val OLD_FORMAT_MANGA_REGEX = """^/manga/(\d+-)?([^/]+)/?$""".toRegex()
         private val OLD_FORMAT_CHAPTER_REGEX = """^/(\d+-)?[^/]*-chapter-\d+(-\d+)*/?$""".toRegex()
         private val OPTIMIZED_IMAGE_PATH_REGEX = """^/storage/media/(\d+)/conversions/(.*)-optimized\.webp$""".toRegex()

--- a/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScansFilters.kt
+++ b/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/AsuraScansFilters.kt
@@ -2,7 +2,7 @@ package eu.kanade.tachiyomi.extension.en.asurascans
 
 import eu.kanade.tachiyomi.source.model.Filter
 
-class Genre(title: String, val id: Int) : Filter.CheckBox(title)
+class Genre(title: String, val value: String) : Filter.CheckBox(title)
 class GenreFilter(title: String, genres: List<Genre>) : Filter.Group<Genre>(title, genres)
 
 class StatusFilter(title: String, statuses: List<Pair<String, String>>) : UriPartFilter(title, statuses)


### PR DESCRIPTION
## Summary
- update Asura Scans for the migrated site structure and current browse/search contract
- hide locked early-access and timed-unlock chapters from the chapter list
- clean up the reader code by removing debug-heavy probing and broad DOM scanning
- restore full chapter page loading with bounded local image URL inference, including mixed `_p1` naming, without HEAD-request fan-out

## Validation
- built `src:en:asurascans:assembleDebug`
- installed and verified emulator package updates through version `1.4.66`
- verified live chapter structure for `Solo Max-Level Newbie` and `Martial God Regressed to Level 2` to confirm the direct-image-plus-pager inference path
- installed `tachiyomi-en.asurascans-v1.4.66-debug.apk` and relaunched Mihon on `emulator-5554`