### PR TITLE
YuriGarden: multi fix 2

### DIFF
--- a/src/vi/yurigarden/build.gradle
+++ b/src/vi/yurigarden/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'YuriGarden'
     extClass = '.YuriGarden'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/vi/yurigarden/src/eu/kanade/tachiyomi/extension/vi/yurigarden/YuriGarden.kt
+++ b/src/vi/yurigarden/src/eu/kanade/tachiyomi/extension/vi/yurigarden/YuriGarden.kt
@@ -186,7 +186,7 @@ class YuriGarden :
             title = comic.title
             author = comic.authors.joinToString { it.name }
             description = comic.description
-            genre = comic.genres.joinToString()
+            genre = comic.genres.mapNotNull { genreMap[it] }.joinToString()
             status = when (comic.status) {
                 "ongoing" -> SManga.ONGOING
                 "completed" -> SManga.COMPLETED
@@ -208,13 +208,30 @@ class YuriGarden :
     override fun chapterListParse(response: Response): List<SChapter> {
         val chapters = response.parseAs<List<ChapterData>>()
 
+        val comicId = response.request.url.pathSegments.last()
+
         return chapters
-            .sortedByDescending { it.order }
+            .sortedWith(
+                compareByDescending<ChapterData> { it.order }
+                    .thenByDescending { it.id },
+            )
             .map { chapter ->
                 SChapter.create().apply {
-                    url = "/chapter/${chapter.id}"
-                    name = "Chapter ${chapter.order.toBigDecimal().stripTrailingZeros().toPlainString()}"
+                    url = "/comic/$comicId/${chapter.id}"
+                    name = buildString {
+                        if (chapter.volume != null) {
+                            append("Vol.${chapter.volume.toBigDecimal().stripTrailingZeros().toPlainString()} ")
+                        }
+                        if (chapter.order < 0) {
+                            append("Oneshot")
+                        } else {
+                            append("Ch.${chapter.order.toBigDecimal().stripTrailingZeros().toPlainString()}")
+                        }
+                        if (chapter.name.isNotEmpty()) append(": ${chapter.name}")
+                    }
                     date_upload = chapter.publishedAt
+                    chapter_number = chapter.order.toFloat()
+                    scanlator = chapter.team?.name ?: "Unknown"
                 }
             }
     }

--- a/src/vi/yurigarden/src/eu/kanade/tachiyomi/extension/vi/yurigarden/YuriGardenDto.kt
+++ b/src/vi/yurigarden/src/eu/kanade/tachiyomi/extension/vi/yurigarden/YuriGardenDto.kt
@@ -44,9 +44,17 @@ class Author(
 class ChapterData(
     val id: Int,
     val order: Double,
-    val name: String? = null,
-    val volume: Int? = null,
+    val name: String = "",
+    val volume: Double? = null,
     val publishedAt: Long = 0L,
+    val lastUpdated: Long? = null,
+    val team: Team? = null,
+)
+
+@Serializable
+class Team(
+    val id: Int? = null,
+    val name: String = "",
 )
 
 @Serializable

--- a/src/vi/yurigarden/src/eu/kanade/tachiyomi/extension/vi/yurigarden/YuriGardenFilters.kt
+++ b/src/vi/yurigarden/src/eu/kanade/tachiyomi/extension/vi/yurigarden/YuriGardenFilters.kt
@@ -150,6 +150,8 @@ private val genres = arrayOf(
     Pair("Zombie", "zombie"),
 )
 
+val genreMap = genres.associate { it.second to it.first }
+
 private val statuses = arrayOf(
     Pair("Tất cả", ""),
     Pair("Sắp ra mắt", "upcoming"),


### PR DESCRIPTION
- Map genre slugs to their exact display names
- Fix and update data types for JSON parsing
- Improve chapter sorting accuracy
- Fix chapter WebView URLs
- Handle chapter naming for Oneshots (`Chapter -1`)
- Include volume and sub-title in chapter names
- Add scanlator group to each chapter

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
