### PR TITLE
fix(fr/scanmanga): hide mihon

### DIFF
--- a/src/fr/scanmanga/build.gradle
+++ b/src/fr/scanmanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Scan-Manga'
     extClass = '.ScanManga'
-    extVersionCode = 15
+    extVersionCode = 16
     isNsfw = true
 }
 

--- a/src/fr/scanmanga/src/eu/kanade/tachiyomi/extension/fr/scanmanga/ScanManga.kt
+++ b/src/fr/scanmanga/src/eu/kanade/tachiyomi/extension/fr/scanmanga/ScanManga.kt
@@ -78,6 +78,8 @@ class ScanManga :
             .add("X-Requested-With", "")
     }
 
+    private fun fetchHeadersBuilder(): Headers.Builder = headersBuilder().removeAll("X-Requested-With")
+
     // Popular
     override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/TOP-Manga-Webtoon-45.html", headers)
 
@@ -268,7 +270,7 @@ class ScanManga :
 
         val pageListRequest = POST(
             "https://bqj.${baseUrl.toHttpUrl().topPrivateDomain()}/lel/$chapterId.json",
-            headers.newBuilder()
+            fetchHeadersBuilder()
                 .add("Origin", "${documentUrl.scheme}://${documentUrl.host}")
                 .add("Referer", documentUrl.toString())
                 .add("Token", "yf")

--- a/src/fr/scanmanga/src/eu/kanade/tachiyomi/extension/fr/scanmanga/ScanManga.kt
+++ b/src/fr/scanmanga/src/eu/kanade/tachiyomi/extension/fr/scanmanga/ScanManga.kt
@@ -48,6 +48,21 @@ class ScanManga :
 
     protected val preferences by getPreferencesLazy()
 
+    override val client = super.client.newBuilder()
+        .addNetworkInterceptor { chain ->
+            val originalRequest = chain.request()
+            val header = originalRequest.header("X-Requested-With")
+            if (header != null && header.isEmpty()) {
+                return@addNetworkInterceptor chain.proceed(
+                    originalRequest.newBuilder()
+                        .removeHeader("X-Requested-With")
+                        .build(),
+                )
+            }
+            return@addNetworkInterceptor chain.proceed(originalRequest)
+        }
+        .build()
+
     override fun headersBuilder(): Headers.Builder {
         val currentChromeVersion = super.headersBuilder().build().get("User-Agent")?.let {
             Regex("Chrome/(\\d+)").find(it)?.groupValues?.get(1)?.toIntOrNull()
@@ -77,8 +92,6 @@ class ScanManga :
 //            .add("priority", "u=0, i")
             .add("X-Requested-With", "")
     }
-
-    private fun fetchHeadersBuilder(): Headers.Builder = headersBuilder().removeAll("X-Requested-With")
 
     // Popular
     override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/TOP-Manga-Webtoon-45.html", headers)
@@ -270,7 +283,7 @@ class ScanManga :
 
         val pageListRequest = POST(
             "https://bqj.${baseUrl.toHttpUrl().topPrivateDomain()}/lel/$chapterId.json",
-            fetchHeadersBuilder()
+            headers.newBuilder()
                 .add("Origin", "${documentUrl.scheme}://${documentUrl.host}")
                 .add("Referer", documentUrl.toString())
                 .add("Token", "yf")


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension

Closes #14170