### PR TITLE
Collected Curios (EN) : Refactor into HttpSource

### DIFF
--- a/src/en/collectedcurios/build.gradle
+++ b/src/en/collectedcurios/build.gradle
@@ -1,7 +1,8 @@
 ext {
     extName = 'Collected Curios'
     extClass = '.Collectedcurios'
-    extVersionCode = 1
+    extVersionCode = 2
+	isNsfw = false
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/collectedcurios/src/eu/kanade/tachiyomi/extension/en/collectedcurios/Collectedcurios.kt
+++ b/src/en/collectedcurios/src/eu/kanade/tachiyomi/extension/en/collectedcurios/Collectedcurios.kt
@@ -5,15 +5,13 @@ import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.ParsedHttpSource
+import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
 import okhttp3.Request
 import okhttp3.Response
-import org.jsoup.nodes.Document
-import org.jsoup.nodes.Element
 import rx.Observable
 
-class Collectedcurios : ParsedHttpSource() {
+class Collectedcurios : HttpSource() {
 
     override val name = "Collected Curios"
 
@@ -23,6 +21,7 @@ class Collectedcurios : ParsedHttpSource() {
 
     override val supportsLatest = false
 
+    // ============================== Popular ===============================
     override fun fetchPopularManga(page: Int): Observable<MangasPage> = Observable.just(
         MangasPage(
             arrayListOf(
@@ -46,44 +45,60 @@ class Collectedcurios : ParsedHttpSource() {
                     thumbnail_url = "https://www.collectedcurios.com/images/CC_2011_Battle_Bunnies_Button.jpg"
                 },
 
-                    /*
-                    SManga.create().apply {
-                        title = "Spider and Scorpion"
-                        artist = "Jolly Jack aka Phillip M Jackson"
-                        author = "Jolly Jack aka Phillip M Jackson"
-                        status = SManga.ONGOING
-                        url = "/spiderandscorpion.php"
-                        description = "Spider and Scorpion webcomic."
-                        thumbnail_url = "https://www.collectedcurios.com/images/CC_2011_Spider_And_Scorpion_Button.jpg"
-                    },
-                     */
+                SManga.create().apply {
+                    title = "Spider and Scorpion"
+                    artist = "Jolly Jack aka Phillip M Jackson"
+                    author = "Jolly Jack aka Phillip M Jackson"
+                    status = SManga.ONGOING
+                    url = "/spiderandscorpion.php"
+                    description = "Spider and Scorpion webcomic."
+                    thumbnail_url = "https://www.collectedcurios.com/images/CC_2011_Spider_And_Scorpion_Button.jpg"
+                },
             ),
             false,
         ),
     )
 
+    override fun popularMangaRequest(page: Int): Request = throw UnsupportedOperationException()
+
+    override fun popularMangaParse(response: Response): MangasPage = throw UnsupportedOperationException()
+
+    // =============================== Latest ===============================
+    override fun latestUpdatesRequest(page: Int): Request = throw UnsupportedOperationException()
+
+    override fun latestUpdatesParse(response: Response): MangasPage = throw UnsupportedOperationException()
+
+    // =============================== Search ===============================
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = fetchPopularManga(1)
 
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request = throw UnsupportedOperationException()
+
+    override fun searchMangaParse(response: Response): MangasPage = throw UnsupportedOperationException()
+
+    // =========================== Manga Details ============================
     override fun fetchMangaDetails(manga: SManga): Observable<SManga> = Observable.just(manga)
 
+    override fun mangaDetailsParse(response: Response): SManga = throw UnsupportedOperationException()
+
+    // ============================== Chapters ==============================
     override fun chapterListParse(response: Response): List<SChapter> {
         val responseJs = response.asJsoup()
 
-        val chapters =
-            if (responseJs.selectFirst("img[title=Last]") == null) {
-                responseJs.selectFirst("input[title=Jump to number]")
-                    ?.attr("value")?.toInt()
-            } else {
-                responseJs.selectFirst("img[title=Last]")?.parent()
-                    ?.attr("href")?.substringAfter("=")?.toInt()
-            }
+        val chapters = responseJs.selectFirst("img[title=Last]")?.parent()
+            ?.attr("href")?.substringAfter("=")?.toIntOrNull()
+            ?: responseJs.selectFirst("input[title=Jump to number]")
+                ?.attr("value")?.toIntOrNull()
+            ?: responseJs.selectFirst("img[title=Back one]")?.parent()
+                ?.attr("href")?.substringAfter("=")?.toIntOrNull()?.plus(1)
+            ?: 1
 
-        var chapterList = mutableListOf<SChapter>()
+        val chapterList = mutableListOf<SChapter>()
+        val requestPath = response.request.url.encodedPath
 
-        for (i in chapters?.downTo(1)!!) {
+        for (i in chapters downTo 1) {
             chapterList.add(
                 SChapter.create().apply {
-                    url = "${response.request.url}?s=$i"
+                    url = "$requestPath?s=$i"
                     name = "Chapter - $i"
                     chapter_number = i.toFloat()
                     date_upload = 0L
@@ -93,15 +108,10 @@ class Collectedcurios : ParsedHttpSource() {
         return chapterList
     }
 
-    override fun chapterListSelector() = throw UnsupportedOperationException()
+    // =============================== Pages ================================
+    override fun fetchPageList(chapter: SChapter) = Observable.just(listOf(Page(0, baseUrl + chapter.url)))
 
-    override fun chapterFromElement(element: Element) = SChapter.create().apply {
-        name = element.selectFirst(".w3-round")?.attr("value") ?: "Chapter"
-    }
-
-    override fun pageListParse(document: Document): List<Page> = throw UnsupportedOperationException()
-
-    override fun fetchPageList(chapter: SChapter) = Observable.just(listOf(Page(0, chapter.url)))!!
+    override fun pageListParse(response: Response): List<Page> = throw UnsupportedOperationException()
 
     override fun imageUrlParse(response: Response): String {
         val url = response.request.url.toString()
@@ -117,32 +127,4 @@ class Collectedcurios : ParsedHttpSource() {
             else -> throw Exception("Could not find the image")
         }
     }
-
-    override fun imageUrlParse(document: Document) = throw UnsupportedOperationException()
-
-    override fun popularMangaSelector(): String = throw UnsupportedOperationException()
-
-    override fun searchMangaFromElement(element: Element): SManga = throw UnsupportedOperationException()
-
-    override fun searchMangaNextPageSelector(): String? = throw UnsupportedOperationException()
-
-    override fun searchMangaSelector(): String = throw UnsupportedOperationException()
-
-    override fun popularMangaRequest(page: Int): Request = throw UnsupportedOperationException()
-
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request = throw UnsupportedOperationException()
-
-    override fun popularMangaNextPageSelector(): String? = throw UnsupportedOperationException()
-
-    override fun popularMangaFromElement(element: Element): SManga = throw UnsupportedOperationException()
-
-    override fun mangaDetailsParse(document: Document): SManga = throw UnsupportedOperationException()
-
-    override fun latestUpdatesNextPageSelector(): String? = throw UnsupportedOperationException()
-
-    override fun latestUpdatesFromElement(element: Element): SManga = throw UnsupportedOperationException()
-
-    override fun latestUpdatesRequest(page: Int): Request = throw UnsupportedOperationException()
-
-    override fun latestUpdatesSelector(): String = throw UnsupportedOperationException()
 }


### PR DESCRIPTION
Not related to any issue
Moved from deprecated ParsedHttpSource to HttpSource and updated parsing, fixing  "Spider and Scorpion"

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
