### PR TITLE
Comix : Updated chapter deduplication to prioritise "Official?" group

### DIFF
--- a/src/en/comix/build.gradle
+++ b/src/en/comix/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comix'
     extClass = '.Comix'
-    extVersionCode = 8
+    extVersionCode = 9
     isNsfw = true
 }
 

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
@@ -219,13 +219,20 @@ class Comix :
             if (current == null) {
                 chapterMap[key] = ch
             } else {
-                // Prefer official scan group
-                val officialNew = (ch.scanlationGroupId == 9275 || ch.isOfficial == 1)
-                val officialCurrent = (current.scanlationGroupId == 9275 || current.isOfficial == 1)
-                val better = when {
-                    officialNew && !officialCurrent -> true
+                // Prefer official flag first, then "Official?" group, then votes/updatedAt
+                val newIsOfficial = ch.isOfficial == 1
+                val currentIsOfficial = current.isOfficial == 1
+                val newIsGroup10702 = ch.scanlationGroupId == 10702
+                val currentIsGroup10702 = current.scanlationGroupId == 10702
 
-                    !officialNew && officialCurrent -> false
+                val better = when {
+                    // Prefer official-marked chapters
+                    newIsOfficial && !currentIsOfficial -> true
+                    !newIsOfficial && currentIsOfficial -> false
+
+                    // If neither official, prefer group "Official?"
+                    newIsGroup10702 && !currentIsGroup10702 -> true
+                    !newIsGroup10702 && currentIsGroup10702 -> false
 
                     // compare votes then updatedAt
                     else -> when {


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

Closes #13160

Note : It will prioritise the boolean first, and then the "Official?" group, so for manga with both, the group name will be the publisher.