### PR TITLE
MangaTaro: Unescape HTML entities in manga title, description and chapter title

### DIFF
--- a/src/all/mangataro/build.gradle
+++ b/src/all/mangataro/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaTaro'
     extClass = '.MangaTaroFactory'
-    extVersionCode = 9
+    extVersionCode = 10
     isNsfw = false
 }
 

--- a/src/all/mangataro/src/eu/kanade/tachiyomi/extension/all/mangataro/Dto.kt
+++ b/src/all/mangataro/src/eu/kanade/tachiyomi/extension/all/mangataro/Dto.kt
@@ -150,7 +150,7 @@ class ProjectList(
         val cover: String,
     ) {
         fun toSManga() = SManga.create().apply {
-            title = this@MangaDto.title
+            title = this@MangaDto.title.unescapeHtml()
             url = MangaUrl(id.toString(), slug, group).toJsonString()
             thumbnail_url = cover
         }

--- a/src/all/mangataro/src/eu/kanade/tachiyomi/extension/all/mangataro/MangaTaro.kt
+++ b/src/all/mangataro/src/eu/kanade/tachiyomi/extension/all/mangataro/MangaTaro.kt
@@ -90,9 +90,9 @@ open class MangaTaro(
                     .map {
                         SManga.create().apply {
                             url = MangaUrl(it.id.toString(), it.slug).toJsonString()
-                            title = it.title
+                            title = it.title.unescapeHtml()
                             thumbnail_url = it.thumbnail
-                            description = it.description
+                            description = it.description.unescapeHtml()
                             status = when (it.status) {
                                 "Ongoing" -> SManga.ONGOING
                                 "Completed" -> SManga.COMPLETED
@@ -147,9 +147,9 @@ open class MangaTaro(
             .map {
                 SManga.create().apply {
                     url = MangaUrl(id = it.id, slug = it.url.toSlug()).toJsonString()
-                    title = it.title
+                    title = it.title.unescapeHtml()
                     thumbnail_url = it.cover
-                    description = it.description
+                    description = it.description.unescapeHtml()
                     status = when (it.status) {
                         "Ongoing" -> SManga.ONGOING
                         "Completed" -> SManga.COMPLETED
@@ -215,8 +215,8 @@ open class MangaTaro(
 
         return SManga.create().apply {
             url = MangaUrl(data.id.toString(), data.slug).toJsonString()
-            title = Parser.unescapeEntities(data.title.rendered, false)
-            description = Jsoup.parseBodyFragment(data.content.rendered).wholeText()
+            title = data.title.rendered.unescapeHtml()
+            description = Jsoup.parseBodyFragment(data.content.rendered).wholeText().unescapeHtml()
             genre = buildSet {
                 addAll(data.embedded.getTerms("post_tag"))
                 if (listOf("Manhwa", "Manhua", "Manga").none { this.contains(it) }) {
@@ -277,10 +277,8 @@ open class MangaTaro(
                 name = buildString {
                     append("Chapter ")
                     append(it.chapter)
-                    it.title.also { title ->
-                        if (title !in placeholders) {
-                            append(": ", title)
-                        }
+                    it.title?.takeIf { it !in placeholders }?.let { title ->
+                        append(": ", title.unescapeHtml())
                     }
                 }
                 it.groupName.let { group ->
@@ -460,4 +458,13 @@ class MangaTaroGroup(lang: String, val groups: List<Long>) :
         private const val GROUP_PREF = "groupPref"
         private const val RESTART_APP = "Restart app to apply new setting."
     }
+}
+
+internal fun String.unescapeHtml(): String {
+    var decoded = this
+    do {
+        val previous = decoded
+        decoded = Parser.unescapeEntities(decoded, false)
+    } while (decoded != previous)
+    return decoded
 }


### PR DESCRIPTION
Close: #14231

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
