### PR TITLE
feat(fr/scanmanga): externalize scrapping markers

### DIFF
--- a/src/fr/scanmanga/build.gradle
+++ b/src/fr/scanmanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Scan-Manga'
     extClass = '.ScanManga'
-    extVersionCode = 18
+    extVersionCode = 19
     isNsfw = true
 }
 

--- a/src/fr/scanmanga/src/eu/kanade/tachiyomi/extension/fr/scanmanga/MarkerManager.kt
+++ b/src/fr/scanmanga/src/eu/kanade/tachiyomi/extension/fr/scanmanga/MarkerManager.kt
@@ -1,0 +1,123 @@
+package eu.kanade.tachiyomi.extension.fr.scanmanga
+
+import android.content.SharedPreferences
+import keiyoushi.utils.parseAs
+import kotlinx.serialization.Serializable
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+@Serializable
+class RemoteMarkersBasic(
+    val validVersion: List<Int>,
+)
+
+@Serializable
+class RemoteMarkers(
+    val validVersion: List<Int>,
+    val selectors: Selectors,
+    val regexes: Regexes,
+    val apiConfig: ApiConfig,
+) {
+    @Serializable
+    class Selectors(val packedScript: String)
+
+    @Serializable
+    class Regexes(
+        val hunterObfuscation: String,
+        val smlParam: String, // Split from parameters
+        val smeParam: String, // Split from parameters
+        val chapterInfo: String,
+    )
+
+    @Serializable
+    class ApiConfig(
+        val pageListUrl: String,
+        val requestBody: String,
+        val headers: Map<String, String>? = null,
+    )
+}
+
+class MarkerManager(
+    private val client: OkHttpClient,
+    private val preferences: SharedPreferences,
+) {
+    private var cachedMarkers: RemoteMarkers? = null
+
+    companion object {
+        private const val MARKER_URL = "https://github.com/Starmania/scan-manga/releases/latest/download/marker.json"
+        const val PREF_MARKERS_JSON = "external_markers_json"
+        const val PREF_MARKERS_LAST_UPDATE = "external_markers_last_update"
+        private const val CACHE_TTL_MS = 12 * 60 * 60 * 1000L // 12 hours
+
+        private const val PARSER_VERSION = 1
+
+        val DEFAULT_MARKERS = RemoteMarkers(
+            validVersion = listOf(1),
+            selectors = RemoteMarkers.Selectors(
+                packedScript = "script:containsData(eval\\(function \\()",
+            ),
+            regexes = RemoteMarkers.Regexes(
+                hunterObfuscation = """eval\(function \(\w,\w,\w,\w,\w,\w(?:,[^)]+)?\)\{.*?\}\("([^"]+)",\d+,"([^"]+)",(\d+),(\d+),\d+\)\)""",
+                smlParam = """sml\s*=\s*'([^']+)'""",
+                smeParam = """sme\s*=\s*'([^']+)'""",
+                chapterInfo = """const idc = (\d+)""",
+            ),
+            apiConfig = RemoteMarkers.ApiConfig(
+                pageListUrl = "https://bqj.{topDomain}/lel/{chapterId}.json",
+                requestBody = """{"a":"{sme}","b":"{sml}","c":"{fingerprint}"}""",
+                headers = mapOf("Token" to "yf"),
+            ),
+        )
+    }
+
+    fun getMarkers(): RemoteMarkers {
+        val lastUpdate = preferences.getString(PREF_MARKERS_LAST_UPDATE, "0")?.toLongOrNull() ?: 0L
+        val cachedJson = preferences.getString(PREF_MARKERS_JSON, null)
+        val cacheExpired = (System.currentTimeMillis() - lastUpdate) >= CACHE_TTL_MS
+
+        cachedMarkers?.let {
+            if (PARSER_VERSION in it.validVersion && cacheExpired) return it
+        }
+
+        if (cachedJson != null && !cacheExpired) {
+            // Populate the class with the cached JSON
+            try {
+                val markers = cachedJson.parseAs<RemoteMarkersBasic>()
+                if (PARSER_VERSION in markers.validVersion) {
+                    cachedMarkers = cachedJson.parseAs<RemoteMarkers>()
+                    return cachedMarkers!!
+                }
+            } catch (_: Exception) {
+            }
+        }
+
+        return fetchWithRetry()
+    }
+
+    private fun fetchWithRetry(): RemoteMarkers {
+        return (1..3).firstNotNullOfOrNull {
+            runCatching {
+                val request = Request.Builder().url(MARKER_URL).build()
+                client.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) return@runCatching null
+
+                    val bodyString = response.body.string()
+                    val basic = bodyString.parseAs<RemoteMarkersBasic>()
+
+                    if (PARSER_VERSION !in basic.validVersion) {
+                        // No need to retry if the version is not compatible, 10ms won't make a difference
+                        return DEFAULT_MARKERS
+                    }
+
+                    bodyString.parseAs<RemoteMarkers>().also { markers ->
+                        cachedMarkers = markers
+                        preferences.edit()
+                            .putString(PREF_MARKERS_JSON, bodyString)
+                            .putString(PREF_MARKERS_LAST_UPDATE, System.currentTimeMillis().toString())
+                            .apply()
+                    }
+                }
+            }.getOrNull()
+        } ?: DEFAULT_MARKERS
+    }
+}

--- a/src/fr/scanmanga/src/eu/kanade/tachiyomi/extension/fr/scanmanga/ScanManga.kt
+++ b/src/fr/scanmanga/src/eu/kanade/tachiyomi/extension/fr/scanmanga/ScanManga.kt
@@ -203,7 +203,8 @@ class ScanManga :
 
     // Pages
     private fun decodeHunter(obfuscatedJs: String): String {
-        val regex = Regex("""eval\(function\(\w,\w,\w,\w,\w,\w(?:,[^)]+)?\)\{.*?\}\("([^"]+)",\d+,"([^"]+)",(\d+),(\d+),\d+\)\)""")
+        val markers = markerManager.getMarkers()
+        val regex = Regex(markers.regexes.hunterObfuscation)
         val (encoded, mask, intervalStr, optionStr) = regex.find(obfuscatedJs)?.destructured
             ?: error("Failed to match obfuscation pattern: $obfuscatedJs")
 
@@ -264,37 +265,57 @@ class ScanManga :
 
     override fun pageListParse(response: Response): List<Page> {
         val document = response.asJsoup()
-        val packedScript = document.selectFirst("script:containsData(eval\\(function\\()")!!.data()
+        val markers = markerManager.getMarkers()
 
+        val packedScript = document.selectFirst(markers.selectors.packedScript)!!.data()
         val unpackedScript = decodeHunter(packedScript)
-        val parametersRegex = Regex("""sml = '([^']+)';\n?.*var sme = '([^']+)'""")
 
-        val (sml, sme) = parametersRegex.find(unpackedScript)?.destructured
-            ?: error("Failed to extract parameters from script.")
+        // parametersRegex
+        val smlRegex = Regex(markers.regexes.smlParam)
+        val (sml) = smlRegex.find(unpackedScript)?.destructured
+            ?: error("Failed to extract sml parameter.")
 
-        val chapterInfoRegex = Regex("""const idc = (\d+)""")
+        val smeRegex = Regex(markers.regexes.smeParam)
+        val (sme) = smeRegex.find(unpackedScript)?.destructured
+            ?: error("Failed to extract sme parameter.")
+
+        val chapterInfoRegex = Regex(markers.regexes.chapterInfo)
         val (chapterId) = chapterInfoRegex.find(packedScript)?.destructured
             ?: error("Failed to extract chapter ID.")
 
+        val availableVariables = mapOf(
+            "sme" to sme,
+            "sml" to sml,
+            "fingerprint" to getFingerprint(),
+            "chapterId" to chapterId,
+            "topDomain" to (baseUrl.toHttpUrl().topPrivateDomain() ?: ""),
+        )
+
         val mediaType = "application/json; charset=UTF-8".toMediaType()
-        val requestBody = """{"a":"$sme","b":"$sml","c":"${getFingerprint()}"}"""
+        val requestBody = injectVariables(markers.apiConfig.requestBody, availableVariables)
+        val pageListUrl = injectVariables(markers.apiConfig.pageListUrl, availableVariables)
 
         val documentUrl = document.baseUri().toHttpUrl()
+        val requestHeaders = headers.newBuilder()
+            .add("Origin", "${documentUrl.scheme}://${documentUrl.host}")
+            .add("Referer", documentUrl.toString())
+            .apply {
+                markers.apiConfig.headers?.forEach { (key, value) ->
+                    add(key, injectVariables(value, availableVariables))
+                }
+            }
+            .build()
 
         val pageListRequest = POST(
-            "https://bqj.${baseUrl.toHttpUrl().topPrivateDomain()}/lel/$chapterId.json",
-            headers.newBuilder()
-                .add("Origin", "${documentUrl.scheme}://${documentUrl.host}")
-                .add("Referer", documentUrl.toString())
-                .add("Token", "yf")
-                .build(),
-            requestBody.toRequestBody(mediaType),
+            url = pageListUrl,
+            headers = requestHeaders,
+            body = requestBody.toRequestBody(mediaType),
         )
 
         val lelResponse = client.newBuilder().cookieJar(CookieJar.NO_COOKIES).build()
             .newCall(pageListRequest).execute().use { response ->
                 if (!response.isSuccessful) {
-                    error("Unexpected error while fetching lel.")
+                    error("Unexpected error while fetching lel. HTTP ${response.code}")
                 }
                 dataAPI(response.body.string(), chapterId.toInt())
             }
@@ -385,5 +406,47 @@ class ScanManga :
                 preferences.edit().putString(key, newValue as String).commit()
             }
         }.also { screen.addPreference(it) }
+
+        EditTextPreference(screen.context).apply {
+            key = MarkerManager.PREF_MARKERS_LAST_UPDATE
+            title = "Markers Last Update"
+            summary = "Last update timestamp (in milliseconds since epoch) of the markers."
+
+            setDefaultValue("0") // Keep as String
+            dialogTitle = "Markers Last Update"
+
+            setOnPreferenceChangeListener { _, newValue ->
+                val input = newValue as? String
+                val isLong = input?.toLongOrNull() != null
+
+                isLong
+            }
+        }.also { screen.addPreference(it) }
+        EditTextPreference(screen.context).apply {
+            key = MarkerManager.PREF_MARKERS_JSON
+            title = "Debug: Markers JSON"
+            summary =
+                "For debugging purposes. Displays the raw JSON string of the markers used for decoding obfuscated scripts. Automatically updated when markers are refreshed."
+
+            setDefaultValue(null)
+            dialogTitle = "Markers JSON"
+            dialogMessage =
+                "This is the raw JSON string of the markers used for decoding obfuscated scripts. It is automatically updated when markers are refreshed. You can use this information for debugging purposes."
+
+            setOnPreferenceChangeListener { _, newValue ->
+                // Do not allow manual changes, this is for display only
+                false
+            }
+        }.also { screen.addPreference(it) }
+    }
+
+    private val markerManager by lazy { MarkerManager(client, preferences) }
+
+    private fun injectVariables(template: String, variables: Map<String, String>): String {
+        var result = template
+        for ((key, value) in variables) {
+            result = result.replace("{$key}", value)
+        }
+        return result
     }
 }


### PR DESCRIPTION
Also fix new space added :)

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
