### PR TITLE
Softkomik/ID: Fix Unknown CDN host and 401 error

### DIFF
--- a/src/id/softkomik/build.gradle
+++ b/src/id/softkomik/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Softkomik'
     extClass = '.Softkomik'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = false
 }
 

--- a/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
+++ b/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
@@ -213,7 +213,17 @@ class Softkomik : HttpSource() {
     // ============================= Utilities ==============================
 
     private fun imageInterceptor(chain: Interceptor.Chain): Response {
-        val request = chain.request()
+        val originalRequest = chain.request()
+        val userAgent = originalRequest.header("User-Agent")
+        val normalizedUserAgent = normalizeUserAgent(userAgent)
+
+        val request = if (normalizedUserAgent != userAgent) {
+            originalRequest.newBuilder()
+                .header("User-Agent", normalizedUserAgent.orEmpty())
+                .build()
+        } else {
+            originalRequest
+        }
 
         val response = try {
             chain.proceed(request)
@@ -303,6 +313,16 @@ class Softkomik : HttpSource() {
         }
     }
 
+    // Normalizes the User-Agent by removing "Mobile Safari" because it can cause 401 errors.
+    private fun normalizeUserAgent(userAgent: String?): String? {
+        if (userAgent.isNullOrBlank()) return null
+
+        return userAgent
+            .replace(userAgentMobileSafariRegex, "")
+            .trim()
+            .ifEmpty { null }
+    }
+
     override fun getFilterList() = FilterList(
         Filter.Header("Filter tidak bisa digabungkan dengan pencarian teks."),
         Filter.Separator(),
@@ -315,6 +335,7 @@ class Softkomik : HttpSource() {
 
     private val apiUrl = "https://v2.softdevices.my.id"
     private val coverUrl = "https://cover.softdevices.my.id/softkomik-cover"
+    private val userAgentMobileSafariRegex = Regex("""\s*Mobile Safari/\d+(?:\.\d+)*""", RegexOption.IGNORE_CASE)
     private val cdnUrls = listOf(
         "https://psy1.komik.im",
         "https://image.komik.im/softkomik",

--- a/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
+++ b/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
@@ -248,7 +248,7 @@ class Softkomik : HttpSource() {
     private fun apiAuthInterceptor(chain: Interceptor.Chain): Response {
         val request = chain.request()
 
-        if (!request.url.host.endsWith("softdevices.my.id")) {
+        if (!request.url.host.endsWith("softdevices.my.id") || request.url.toString().startsWith(coverUrl)) {
             return chain.proceed(request)
         }
 
@@ -289,7 +289,7 @@ class Softkomik : HttpSource() {
                 client.newCall(GET("$baseUrl/api/me", apiHeaders)).execute().close()
             }
 
-            val response = client.newCall(GET("$baseUrl/api/sessions", apiHeaders)).execute()
+            val response = client.newCall(GET("$baseUrl/api/se", apiHeaders)).execute()
 
             if (!response.isSuccessful) {
                 val code = response.code


### PR DESCRIPTION
close https://github.com/keiyoushi/extensions-source/issues/14025

- Changed the API session endpoint from ```/api/sessions``` to ```/api/se```
- Prevented the apiAuthInterceptor from being applied to image cover request (this  causing 401 error)
- remove user agent ```Mobile Safari``` if any, because it was also triggering 401 error

when the session or cover image requests got a 401 error, the code continued to the retry logic CDN URLs. which then caused "Unknown CDN host" errors

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
