### PR TITLE
[skip ci] Add capture group to the issue moderator

### DIFF
--- a/.github/workflows/issue_moderator.yml
+++ b/.github/workflows/issue_moderator.yml
@@ -53,7 +53,7 @@ jobs:
               },
               {
                 "type": "both",
-                "regex": "remanga\\.org|nhentai(\\.net)?|e([x-])?hentai(\\.org)?|hitomi\\.la|pururin(\\.me)?|hentai2read(\\.com)?|hentai20\\.io",
+                "regex": "(remanga\\.org|nhentai(\\.net)?|e([x-])?hentai(\\.org)?|hitomi\\.la|pururin(\\.me)?|hentai2read(\\.com)?|hentai20\\.io)",
                 "ignoreCase": true,
                 "labels": ["invalid"],
                 "message": "{match} will not be added back as it has been removed [due to legal reasons](https://github.com/github/dmca)."


### PR DESCRIPTION
Fixed issues when the comment from the bot shows that there is no match. For example, https://github.com/keiyoushi/extensions-source/issues/14347#issuecomment-4149312017

Also related: https://github.com/keiyoushi/issue-moderator-action/pull/126