### PR TITLE
Zonatmo.to (ES) : various fixes

### DIFF
--- a/src/es/zonatmoto/build.gradle
+++ b/src/es/zonatmoto/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = "Zonatmo.to (unoriginal)"
     extClass = '.ZonatmoTo'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/es/zonatmoto/src/eu/kanade/tachiyomi/extension/es/zonatmoto/Dto.kt
+++ b/src/es/zonatmoto/src/eu/kanade/tachiyomi/extension/es/zonatmoto/Dto.kt
@@ -76,12 +76,13 @@ class AuthorDto(
 
 @Serializable
 class ChapterItemDto(
+    val id: Int,
     @SerialName("chapter_number")
     val chapterNumber: String,
     val title: String,
     val slug: String,
     @SerialName("release_date")
-    val releaseDate: String,
+    val releaseDate: String? = null,
 )
 
 @Serializable

--- a/src/es/zonatmoto/src/eu/kanade/tachiyomi/extension/es/zonatmoto/ZonatmoTo.kt
+++ b/src/es/zonatmoto/src/eu/kanade/tachiyomi/extension/es/zonatmoto/ZonatmoTo.kt
@@ -206,9 +206,8 @@ class ZonatmoTo : HttpSource() {
         val pathSegments = chapterUrl.pathSegments
         val mangaSlug = pathSegments[pathSegments.size - 2]
         val chapterSlug = pathSegments[pathSegments.size - 1]
-        val id = chapterUrl.queryParameter("id")
 
-        return GET(singleChapterApiUrl(mangaSlug, chapterSlug, id), apiHeaders)
+        return GET(singleChapterApiUrl(mangaSlug, chapterSlug), apiHeaders)
     }
 
     override fun pageListParse(response: Response): List<Page> {
@@ -281,16 +280,12 @@ class ZonatmoTo : HttpSource() {
         .build()
         .toString()
 
-    private fun singleChapterApiUrl(mangaSlug: String, chapterSlug: String, id: String? = null): String {
+    private fun singleChapterApiUrl(mangaSlug: String, chapterSlug: String): String {
         val url = apiUrl.newBuilder()
             .addPathSegment("single")
             .addPathSegment("manga")
             .addPathSegment(mangaSlug)
             .addPathSegment(chapterSlug)
-
-        if (id != null) {
-            url.addQueryParameter("id", id)
-        }
 
         return url.build().toString()
     }

--- a/src/es/zonatmoto/src/eu/kanade/tachiyomi/extension/es/zonatmoto/ZonatmoTo.kt
+++ b/src/es/zonatmoto/src/eu/kanade/tachiyomi/extension/es/zonatmoto/ZonatmoTo.kt
@@ -337,7 +337,7 @@ class ZonatmoTo : HttpSource() {
     }
 
     private fun ChapterItemDto.toSChapter(mangaSlug: String): SChapter = SChapter.create().apply {
-        url = "$mangaSlug/$slug?id=$id"
+        url = "$mangaSlug/$slug#$id"
         val cleanTitle = title.trim()
         name = "#$chapterNumber" + if (cleanTitle.isNotBlank()) " - $cleanTitle" else ""
         chapter_number = chapterNumber.toFloatOrNull() ?: -1f

--- a/src/es/zonatmoto/src/eu/kanade/tachiyomi/extension/es/zonatmoto/ZonatmoTo.kt
+++ b/src/es/zonatmoto/src/eu/kanade/tachiyomi/extension/es/zonatmoto/ZonatmoTo.kt
@@ -192,17 +192,23 @@ class ZonatmoTo : HttpSource() {
             }
         }
 
-        return chapters.map { it.toSChapter(mangaSlug) }.reversed()
+        return chapters
+            .distinctBy { item -> item.id }
+            .sortedByDescending { item -> item.chapterNumber.toFloatOrNull() ?: -1f }
+            .map { item -> item.toSChapter(mangaSlug) }
     }
 
     // ========================= Pages =========================
 
     override fun pageListRequest(chapter: SChapter): Request {
-        val slugs = chapter.url.split("/", limit = 2)
-            .takeIf { it.size == 2 }
-            ?: throw Exception("Invalid chapter url")
+        val chapterUrl = baseUrl.toHttpUrl().resolve(chapter.url)!!
 
-        return GET(singleChapterApiUrl(mangaSlug = slugs[0], chapterSlug = slugs[1]), apiHeaders)
+        val pathSegments = chapterUrl.pathSegments
+        val mangaSlug = pathSegments[pathSegments.size - 2]
+        val chapterSlug = pathSegments[pathSegments.size - 1]
+        val id = chapterUrl.queryParameter("id")
+
+        return GET(singleChapterApiUrl(mangaSlug, chapterSlug, id), apiHeaders)
     }
 
     override fun pageListParse(response: Response): List<Page> {
@@ -275,13 +281,19 @@ class ZonatmoTo : HttpSource() {
         .build()
         .toString()
 
-    private fun singleChapterApiUrl(mangaSlug: String, chapterSlug: String): String = apiUrl.newBuilder()
-        .addPathSegment("single")
-        .addPathSegment("manga")
-        .addPathSegment(mangaSlug)
-        .addPathSegment(chapterSlug)
-        .build()
-        .toString()
+    private fun singleChapterApiUrl(mangaSlug: String, chapterSlug: String, id: String? = null): String {
+        val url = apiUrl.newBuilder()
+            .addPathSegment("single")
+            .addPathSegment("manga")
+            .addPathSegment(mangaSlug)
+            .addPathSegment(chapterSlug)
+
+        if (id != null) {
+            url.addQueryParameter("id", id)
+        }
+
+        return url.build().toString()
+    }
 
     private fun cdnImageUrl(jit: String, imageName: String): String = CDN_URL.toHttpUrl().newBuilder()
         .addPathSegment("manga")
@@ -325,8 +337,9 @@ class ZonatmoTo : HttpSource() {
     }
 
     private fun ChapterItemDto.toSChapter(mangaSlug: String): SChapter = SChapter.create().apply {
-        url = "$mangaSlug/$slug"
-        name = title.trim().ifEmpty { "Capitulo $chapterNumber" }
+        url = "$mangaSlug/$slug?id=$id"
+        val cleanTitle = title.trim()
+        name = "#$chapterNumber" + if (cleanTitle.isNotBlank()) " - $cleanTitle" else ""
         chapter_number = chapterNumber.toFloatOrNull() ?: -1f
         date_upload = dateFormat.tryParse(releaseDate)
     }


### PR DESCRIPTION
Related to #14374

* handle chapters with no release_date
* use chapters id instead of deduplicating by slug to handle some edge cases 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
