### PR TITLE
[PT-BR] - Mediocretoons api modify and fix popular mangas

### DIFF
--- a/src/pt/mediocretoons/build.gradle
+++ b/src/pt/mediocretoons/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Mediocre Toons'
     extClass = '.MediocreToons'
     baseUrl = 'https://mediocrescan.com'
-    extVersionCode = 16
+    extVersionCode = 17
     isNsfw = true
 }
 

--- a/src/pt/mediocretoons/src/eu/kanade/tachiyomi/extension/pt/mediocretoons/MediocreToons.kt
+++ b/src/pt/mediocretoons/src/eu/kanade/tachiyomi/extension/pt/mediocretoons/MediocreToons.kt
@@ -33,7 +33,7 @@ class MediocreToons :
     override val baseUrl = "https://mediocrescan.com"
     override val lang = "pt-BR"
     override val supportsLatest = true
-    private val apiUrl = "https://api.mediocretoons.site"
+    private val apiUrl = "https://api.mediocretoons.net"
 
     private val preferences: SharedPreferences by getPreferencesLazy()
 
@@ -160,33 +160,21 @@ class MediocreToons :
 
     // ============================== Popular ================================
     override fun popularMangaRequest(page: Int): Request {
-        val url = "$apiUrl/obras/ranking".toHttpUrl().newBuilder()
+        val url = "$apiUrl/obras/buscar".toHttpUrl().newBuilder()
+            .addQueryParameter("limite", "24")
+            .addQueryParameter("pagina", page.toString())
+            .addQueryParameter("temCapitulo", "true")
+            .addQueryParameter("formato", POPULAR_FORMATOS)
             .addQueryParameter("ordenarPor", "view_geral")
-            .addQueryParameter("limite", "100")
             .build()
         return GET(url, headers)
     }
 
     override fun popularMangaParse(response: Response): MangasPage {
-        val rankingList = response.parseAs<List<MediocreRankingDto>>()
-
-        val mangas = rankingList.map { rankingDto ->
-            SManga.create().apply {
-                title = rankingDto.name
-                thumbnail_url = rankingDto.image?.let { img ->
-                    when {
-                        img.startsWith("http") -> img
-                        else -> "${MediocreToons.CDN_URL}/obras/${rankingDto.id}/$img"
-                    }
-                }
-                url = "/obra/${rankingDto.id}"
-                description = ""
-                status = SManga.UNKNOWN
-                initialized = false
-            }
-        }
-
-        return MangasPage(mangas, hasNextPage = false)
+        val dto = response.parseAs<MediocreListDto<List<MediocreMangaDto>>>()
+        val mangas = dto.data.map { it.toSManga() }
+        val hasNext = dto.pagination?.hasNextPage ?: false
+        return MangasPage(mangas, hasNextPage = hasNext)
     }
 
     // ============================= Latest Updates ==========================
@@ -463,7 +451,8 @@ class MediocreToons :
     }
 
     companion object {
-        const val CDN_URL = "https://cdn.mediocretoons.site"
+        const val CDN_URL = "https://api.mediocretoons.net/storage"
+        private const val POPULAR_FORMATOS = "1,3,4,5,8,9,13"
         private const val EMAIL_PREF = "email"
         private const val PASSWORD_PREF = "password"
     }

--- a/src/pt/mediocretoons/src/eu/kanade/tachiyomi/extension/pt/mediocretoons/MediocreToonsDto.kt
+++ b/src/pt/mediocretoons/src/eu/kanade/tachiyomi/extension/pt/mediocretoons/MediocreToonsDto.kt
@@ -42,16 +42,6 @@ data class MediocreFormatDto(
 )
 
 @Serializable
-data class MediocreRankingDto(
-    @SerialName("id") val id: Int = 0,
-    @SerialName("nome") val name: String = "",
-    @SerialName("imagem") val image: String? = null,
-    @SerialName("views_hoje") val viewsToday: Int = 0,
-    @SerialName("view_semana") val viewsWeek: Int = 0,
-    @SerialName("view_geral") val viewsTotal: Int = 0,
-)
-
-@Serializable
 data class MediocreStatusDto(
     val id: Int = 0,
     @SerialName("nome") val name: String = "",
@@ -84,6 +74,9 @@ data class MediocreMangaDto(
     val status: MediocreStatusDto? = null,
     @SerialName("total_capitulos") val totalChapters: Int = 0,
     @SerialName("capitulos") val chapters: List<MediocreChapterSimpleDto> = emptyList(),
+    @SerialName("criada_em") val createdAt: String? = null,
+    @SerialName("atualizada_em") val updatedAt: String? = null,
+    @SerialName("capitulo_numero") val homeChapterNumber: Float? = null,
 )
 
 @Serializable

--- a/src/pt/mediocretoons/src/eu/kanade/tachiyomi/extension/pt/mediocretoons/MediocreToonsDto.kt
+++ b/src/pt/mediocretoons/src/eu/kanade/tachiyomi/extension/pt/mediocretoons/MediocreToonsDto.kt
@@ -74,9 +74,6 @@ data class MediocreMangaDto(
     val status: MediocreStatusDto? = null,
     @SerialName("total_capitulos") val totalChapters: Int = 0,
     @SerialName("capitulos") val chapters: List<MediocreChapterSimpleDto> = emptyList(),
-    @SerialName("criada_em") val createdAt: String? = null,
-    @SerialName("atualizada_em") val updatedAt: String? = null,
-    @SerialName("capitulo_numero") val homeChapterNumber: Float? = null,
 )
 
 @Serializable


### PR DESCRIPTION
Update Mediocre Toons extension: bump version code to 17, change API URL, and refactor popular manga request parsing


closes: https://github.com/keiyoushi/extensions-source/issues/14388


Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
