### PR TITLE
Softkomik(ID): fix session api changed again & better error handling ```unknown cdn host```

### DIFF
--- a/src/id/softkomik/build.gradle
+++ b/src/id/softkomik/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Softkomik'
     extClass = '.Softkomik'
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = false
 }
 

--- a/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
+++ b/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
@@ -305,7 +305,7 @@ class Softkomik : HttpSource() {
                 client.newCall(GET("$baseUrl/api/me", apiHeaders)).execute().close()
             }
 
-            val response = client.newCall(GET("$baseUrl/api/me", apiHeaders)).execute()
+            val response = client.newCall(GET("$baseUrl/api/sessions", apiHeaders)).execute()
 
             if (!response.isSuccessful) {
                 val code = response.code

--- a/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
+++ b/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
@@ -232,10 +232,16 @@ class Softkomik : HttpSource() {
         }
 
         if (response?.isSuccessful == true) return response
-        response?.close()
 
         val currentHost = cdnUrls.firstOrNull { request.url.toString().startsWith(it) }
-            ?: return throw java.net.UnknownHostException("Unknown CDN host: ${request.url.host}")
+
+        // Only chapter CDN URLs should use retry host fallback.
+        // Non-CDN hosts (e.g. cover URL) should return the original response or throw if it failed, without trying other hosts.
+        if (currentHost == null) {
+            return response ?: throw (java.net.UnknownHostException(request.url.host))
+        }
+
+        response?.close()
 
         val imagePath = request.url.toString().removePrefix(currentHost).removePrefix("/")
         val otherHosts = cdnUrls.filter { it != currentHost }
@@ -299,7 +305,7 @@ class Softkomik : HttpSource() {
                 client.newCall(GET("$baseUrl/api/me", apiHeaders)).execute().close()
             }
 
-            val response = client.newCall(GET("$baseUrl/api/se", apiHeaders)).execute()
+            val response = client.newCall(GET("$baseUrl/api/me", apiHeaders)).execute()
 
             if (!response.isSuccessful) {
                 val code = response.code


### PR DESCRIPTION
close https://github.com/keiyoushi/extensions-source/issues/14401

session api changed again from ```/api/se``` to ~~/api/me~~ ```/api/sessions```

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
