### PR TITLE
Valir Scans: update domain to .org

### DIFF
--- a/src/en/valirscans/build.gradle
+++ b/src/en/valirscans/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Valir Scans'
     extClass = '.ValirScans'
     themePkg = 'keyoapp'
-    baseUrl = 'https://valirscans.com'
-    overrideVersionCode = 0
+    baseUrl = 'https://valirscans.org'
+    overrideVersionCode = 1
     isNsfw = false
 }
 

--- a/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
+++ b/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
@@ -5,7 +5,7 @@ import eu.kanade.tachiyomi.multisrc.keyoapp.Keyoapp
 class ValirScans :
     Keyoapp(
         "Valir Scans",
-        "https://valirscans.com",
+        "https://valirscans.org",
         "en",
     ) {
     override val descriptionSelector: String = "div.grid > div.overflow-hidden > p"


### PR DESCRIPTION
### Summary
Updated Valir Scans URL from `.com` to `.org` as confirmed by source staff. Incremented `overrideVersionCode` to push the update to users.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

Fixes #14416