### PR TITLE
Nyx Scans: update domain to nyxmanga.org

### DIFF
--- a/src/en/nyxscans/build.gradle
+++ b/src/en/nyxscans/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Nyx Scans'
     extClass = '.NyxScans'
     themePkg = 'iken'
-    baseUrl = 'https://nyxscans.com'
-    overrideVersionCode = 1
+    baseUrl = 'https://nyxmanga.org'
+    overrideVersionCode = 2
     isNsfw = false
 }
 

--- a/src/en/nyxscans/src/eu/kanade/tachiyomi/extension/en/nyxscans/NyxScans.kt
+++ b/src/en/nyxscans/src/eu/kanade/tachiyomi/extension/en/nyxscans/NyxScans.kt
@@ -6,6 +6,6 @@ class NyxScans :
     Iken(
         "Nyx Scans",
         "en",
-        "https://nyxscans.com",
-        "https://api.nyxscans.com",
+        "https://nyxmanga.org",
+        "https://api.nyxmanga.org",
     )


### PR DESCRIPTION
### Summary
Updated Nyx Scans URL to `https://nyxmanga.org` as confirmed by recent site migrations. Incremented version code to push update to users.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

Fixes #14408