### PR TITLE
Fix CI

### DIFF
--- a/src/en/arvenscans/build.gradle
+++ b/src/en/arvenscans/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Vortex Scans'
     extClass = '.VortexScans'
     themePkg = 'iken'
-    baseUrl = 'https://vortexscans.io'
-    overrideVersionCode = 40
+    baseUrl = 'https://vortexscans.org'
+    overrideVersionCode = 39
     isNsfw = false
 }
 

--- a/src/en/arvenscans/src/eu/kanade/tachiyomi/extension/en/arvenscans/VortexScans.kt
+++ b/src/en/arvenscans/src/eu/kanade/tachiyomi/extension/en/arvenscans/VortexScans.kt
@@ -10,8 +10,8 @@ class VortexScans :
     Iken(
         "Vortex Scans",
         "en",
-        "https://vortexscans.io",
-        "https://api.vortexscans.io",
+        "https://vortexscans.org",
+        "https://api.vortexscans.org",
     ) {
 
     override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> = client.newCall(chapterListRequest(manga))

--- a/src/vi/toptruyen/build.gradle
+++ b/src/vi/toptruyen/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Top Truyen'
     extClass = '.TopTruyen'
     themePkg = 'wpcomics'
-    baseUrl = 'https://www.toptruyenssi.com'
-    overrideVersionCode = 23
+    baseUrl = 'https://www.toptruyenssz.com'
+    overrideVersionCode = 22
     isNsfw = true
 }
 

--- a/src/vi/toptruyen/src/eu/kanade/tachiyomi/extension/vi/toptruyen/TopTruyen.kt
+++ b/src/vi/toptruyen/src/eu/kanade/tachiyomi/extension/vi/toptruyen/TopTruyen.kt
@@ -23,7 +23,7 @@ import java.util.TimeZone
 class TopTruyen :
     WPComics(
         "Top Truyen",
-        "https://www.toptruyenssi.com",
+        "https://www.toptruyenssz.com",
         "vi",
         dateFormat = SimpleDateFormat("dd-MM-yyyy", Locale.ROOT).apply {
             timeZone = TimeZone.getTimeZone("Asia/Ho_Chi_Minh")


### PR DESCRIPTION
I doubt the issue is related to the change at hand, but it is causing issues for other extensions.


See https://github.com/keiyoushi/extensions-source/actions/runs/23870593105/job/69602809427
```
21:10:47.334 [main] INFO  inspector.Main - Found 17 extensions
21:10:47.359 [DefaultDispatcher-worker-2] DEBUG inspector.Main - Installing repo/apk/tachiyomi-en.arvenscans-v1.4.57.apk
21:10:47.359 [DefaultDispatcher-worker-4] DEBUG inspector.Main - Installing repo/apk/tachiyomi-id.softkomik-v1.4.8.apk
21:10:47.358 [DefaultDispatcher-worker-1] DEBUG inspector.Main - Installing repo/apk/tachiyomi-en.azcomic-v1.4.2.apk
21:10:47.359 [DefaultDispatcher-worker-3] DEBUG inspector.Main - Installing repo/apk/tachiyomi-vi.toptruyen-v1.4.30.apk
21:10:48.971 [DefaultDispatcher-worker-1] DEBUG inspector.Main - Installing repo/apk/tachiyomi-pt.mediocretoons-v1.4.17.apk
21:10:48.971 [DefaultDispatcher-worker-4] DEBUG inspector.Main - Installing repo/apk/tachiyomi-vi.vcomycs-v1.4.6.apk
Exception in thread "main" java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:481)
	at inspector.util.PackageTools.loadExtensionSources(PackageTools.kt:136)
	at inspector.util.Extension.installApk(Extension.kt:65)
	at inspector.MainKt$main$extensionsInfo$1$1$1.invokeSuspend(Main.kt:61)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:829)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
	Suppressed: java.lang.reflect.InvocationTargetException
		... 14 more
	Caused by: java.lang.IncompatibleClassChangeError: Expecting non-static method 'kotlinx.coroutines.CoroutineDispatcher kotlinx.coroutines.Dispatchers.getIO()'
		at eu.kanade.tachiyomi.multisrc.iken.Iken.<init>(Unknown Source)
		at eu.kanade.tachiyomi.extension.en.arvenscans.VortexScans.<init>(Unknown Source)
		... 14 more
Caused by: java.lang.IncompatibleClassChangeError: Expecting non-static method 'kotlinx.coroutines.CoroutineDispatcher kotlinx.coroutines.Dispatchers.getIO()'
	at eu.kanade.tachiyomi.multisrc.wpcomics.WPComics.<init>(Unknown Source)
	at eu.kanade.tachiyomi.extension.vi.toptruyen.TopTruyen.<init>(Unknown Source)
	... 14 more
Error: Process completed with exit code 1.

```

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
