### PR TITLE
WeLoveManga (JA): Fix image loading

### DIFF
--- a/lib-multisrc/fmreader/build.gradle.kts
+++ b/lib-multisrc/fmreader/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 10
+baseVersionCode = 11

--- a/lib-multisrc/fmreader/src/eu/kanade/tachiyomi/multisrc/fmreader/FMReader.kt
+++ b/lib-multisrc/fmreader/src/eu/kanade/tachiyomi/multisrc/fmreader/FMReader.kt
@@ -331,6 +331,7 @@ abstract class FMReader(
         fun Element.decoded(): String {
             val attr =
                 when {
+                    this.hasAttr("data-img") -> "data-img"
                     this.hasAttr("data-original") -> "data-original"
                     this.hasAttr("data-src") -> "data-src"
                     this.hasAttr("data-srcset") -> "data-srcset"

--- a/src/ja/rawlh/build.gradle
+++ b/src/ja/rawlh/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.WeLoveManga'
     themePkg = 'fmreader'
     baseUrl = 'https://weloma.art'
-    overrideVersionCode = 6
+    overrideVersionCode = 5
     isNsfw = true
 }
 

--- a/src/ja/rawlh/build.gradle
+++ b/src/ja/rawlh/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.WeLoveManga'
     themePkg = 'fmreader'
     baseUrl = 'https://weloma.art'
-    overrideVersionCode = 5
+    overrideVersionCode = 6
     isNsfw = true
 }
 

--- a/src/ja/rawlh/src/eu/kanade/tachiyomi/extension/ja/rawlh/WeLoveManga.kt
+++ b/src/ja/rawlh/src/eu/kanade/tachiyomi/extension/ja/rawlh/WeLoveManga.kt
@@ -13,13 +13,8 @@ class WeLoveManga : FMReader("WeLoveManga", "https://weloma.art", "ja") {
     override val id = 7595224096258102519
 
     override val chapterUrlSelector = ""
-    override fun pageListParse(document: Document): List<Page> {
-        fun Element.decoded(): String = this.attr("data-src").trimEnd()
 
-        return document.select(pageListImageSelector).mapIndexed { i, img ->
-            Page(i, document.location(), img.decoded())
-        }
-    }
+    override fun pageListParse(document: Document): List<Page> = base64PageListParse(document)
 
     // Referer needs to be chapter URL
     override fun imageRequest(page: Page): Request = GET(page.imageUrl!!, headersBuilder().set("Referer", page.url).build())


### PR DESCRIPTION
  Closes #12495 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
