### PR TITLE
Valir Scans: fix new site routes and parser

### DIFF
--- a/src/en/valirscans/build.gradle
+++ b/src/en/valirscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ValirScans'
     themePkg = 'keyoapp'
     baseUrl = 'https://valirscans.org'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
 }
 

--- a/src/en/valirscans/build.gradle
+++ b/src/en/valirscans/build.gradle
@@ -1,9 +1,8 @@
 ext {
     extName = 'Valir Scans'
     extClass = '.ValirScans'
-    themePkg = 'keyoapp'
     baseUrl = 'https://valirscans.org'
-    overrideVersionCode = 2
+    extVersionCode = 20
     isNsfw = false
 }
 

--- a/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
+++ b/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
@@ -54,7 +54,7 @@ class ValirScans :
 
     private val baseHttpUrl by lazy { "$baseUrl/".toHttpUrl() }
 
-    override fun headersBuilder() = Headers.Builder()
+    override fun headersBuilder() = super.headersBuilder()
         .add("Referer", "$baseUrl/")
 
     override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/series?sort=views&order=desc&page=$page", headers)

--- a/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
+++ b/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
@@ -35,7 +35,7 @@ class ValirScans :
     HttpSource(),
     ConfigurableSource {
 
-    override val versionId = 2
+    override val versionId = 3
 
     override val name = "Valir Scans"
 
@@ -81,9 +81,9 @@ class ValirScans :
 
     override fun getFilterList() = FilterList()
 
-    override fun getMangaUrl(manga: SManga): String = baseUrl + normalizeSeriesPath(manga.url)
+    override fun getMangaUrl(manga: SManga): String = baseUrl + manga.url
 
-    override fun mangaDetailsRequest(manga: SManga): Request = GET(baseUrl + normalizeSeriesPath(manga.url), headers)
+    override fun mangaDetailsRequest(manga: SManga): Request = GET(getMangaUrl(manga), headers)
 
     override fun mangaDetailsParse(response: Response): SManga {
         val html = response.use { it.body.string() }
@@ -122,7 +122,7 @@ class ValirScans :
     override fun chapterListParse(response: Response): List<SChapter> {
         val html = response.use { it.body.string() }
         val document = Jsoup.parse(html, response.request.url.toString())
-        val seriesPath = normalizeSeriesPath(response.request.url.encodedPath)
+        val seriesPath = response.request.url.encodedPath
         val firstPageData = document.extractSeriesPageData() ?: return emptyList()
         val chapters = buildList {
             addAll(firstPageData.chapters)
@@ -156,9 +156,9 @@ class ValirScans :
             .reversed()
     }
 
-    override fun getChapterUrl(chapter: SChapter): String = baseUrl + normalizeChapterPath(chapter.url)
+    override fun getChapterUrl(chapter: SChapter): String = baseUrl + chapter.url
 
-    override fun pageListRequest(chapter: SChapter): Request = GET(baseUrl + normalizeChapterPath(chapter.url), rscHeaders)
+    override fun pageListRequest(chapter: SChapter): Request = GET(getChapterUrl(chapter), rscHeaders)
 
     override fun pageListParse(response: Response): List<Page> {
         val chapter = response.extractNextJs<ChapterPageDto> { element ->
@@ -218,7 +218,7 @@ class ValirScans :
 
         return SManga.create().apply {
             this.title = title
-            setUrlWithoutDomain(detailLink.absUrl("href"))
+            setUrlWithoutDomain(detailLink.absUrl("href").substringBefore("?"))
             thumbnail_url = selectFirst("img[src], img[srcset]")?.extractThumbnailUrl()
         }
     }
@@ -238,41 +238,6 @@ class ValirScans :
 
     private fun String.toAbsoluteUrl(base: String = baseUrl): String = resolveUrl(this, base.toHttpUrlOrNull() ?: baseHttpUrl)?.toString() ?: this
 
-    // Normalize old saved library URLs from the pre-migration route formats.
-    private fun normalizeSeriesPath(path: String): String {
-        val resolvedUrl = resolveUrl(path)
-        val segments = resolvedUrl?.pathSegments.orEmpty().filter(String::isNotBlank)
-
-        return when {
-            segments.size >= 3 && segments[0] == "series" && segments[1] == "comic" ->
-                "/series/comic/${segments[2]}"
-            segments.size >= 2 && segments[0] == "comic" ->
-                "/series/comic/${segments[1]}"
-            segments.size >= 2 && segments[0] == "series" ->
-                "/series/comic/${segments[1]}"
-            segments.isNotEmpty() ->
-                "/series/comic/${segments.last()}"
-            else ->
-                sanitizeRelativePath(path)
-        }.trimEnd('/')
-    }
-
-    private fun normalizeChapterPath(path: String): String {
-        val resolvedUrl = resolveUrl(path)
-        val segments = resolvedUrl?.pathSegments.orEmpty().filter(String::isNotBlank)
-
-        return when {
-            segments.size >= 5 && segments[0] == "series" && segments[1] == "comic" && segments[3] == "chapter" ->
-                "/series/comic/${segments[2]}/chapter/${segments[4]}"
-            segments.size >= 4 && segments[0] == "comic" && segments[2] == "chapter" ->
-                "/series/comic/${segments[1]}/chapter/${segments[3]}"
-            segments.size >= 4 && segments[0] == "series" && segments[2] == "chapter" ->
-                "/series/comic/${segments[1]}/chapter/${segments[3]}"
-            else ->
-                sanitizeRelativePath(path).substringBefore("?")
-        }
-    }
-
     private fun resolveUrl(path: String, base: HttpUrl = baseHttpUrl): HttpUrl? {
         path.toHttpUrlOrNull()?.let { return it }
 
@@ -281,11 +246,6 @@ class ValirScans :
         }
 
         return base.resolve(path)
-    }
-
-    private fun sanitizeRelativePath(path: String): String {
-        val cleanPath = path.substringBefore('#')
-        return "/" + cleanPath.removePrefix("/")
     }
 
     private fun parseStatus(status: String?): Int = when (status?.uppercase(Locale.ENGLISH)) {

--- a/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
+++ b/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
@@ -51,6 +51,10 @@ class ValirScans :
 
     private val baseHttpUrl = "$baseUrl/".toHttpUrl()
 
+    private val rscHeaders = headersBuilder()
+        .set("rsc", "1")
+        .build()
+
     override fun headersBuilder() = super.headersBuilder()
         .add("Referer", "$baseUrl/")
 
@@ -154,12 +158,10 @@ class ValirScans :
 
     override fun getChapterUrl(chapter: SChapter): String = baseUrl + normalizeChapterPath(chapter.url)
 
-    override fun pageListRequest(chapter: SChapter): Request = GET(baseUrl + normalizeChapterPath(chapter.url), headers)
+    override fun pageListRequest(chapter: SChapter): Request = GET(baseUrl + normalizeChapterPath(chapter.url), rscHeaders)
 
     override fun pageListParse(response: Response): List<Page> {
-        val html = response.use { it.body.string() }
-        val document = Jsoup.parse(html, response.request.url.toString())
-        val chapter = document.extractNextJs<ChapterPageDto> { element ->
+        val chapter = response.extractNextJs<ChapterPageDto> { element ->
             element is JsonObject && "chapter" in element
         }?.chapter ?: error("Could not find chapter data")
 

--- a/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
+++ b/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
@@ -13,10 +13,11 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
-import kotlinx.serialization.decodeFromString
+import keiyoushi.utils.tryParse
 import kotlinx.serialization.json.Json
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.Jsoup
@@ -249,12 +250,18 @@ class ValirScans :
     }
 
     private fun sanitizePath(path: String): String {
-        val withoutDomain = path
-            .removePrefix(baseUrl)
-            .removePrefix("https://valirscans.com")
-            .removePrefix("https://valirscans.org")
+        path.toHttpUrlOrNull()?.let { url ->
+            return buildString {
+                append(url.encodedPath)
+                url.encodedQuery?.let {
+                    append('?')
+                    append(it)
+                }
+            }
+        }
 
-        return "/" + withoutDomain.removePrefix("/").substringBefore("#")
+        // Stored library URLs can still be relative, so keep a small string fallback.
+        return "/" + path.removePrefix("/").substringBefore("#")
     }
 
     private fun extractEscapedJsonValue(html: String, marker: String, openChar: Char): String {
@@ -294,7 +301,7 @@ class ValirScans :
 
     private fun formatChapterNumber(number: Float): String = chapterNumberFormatter.format(number)
 
-    private fun String?.parseDate(): Long = this?.let { dateFormat.parse(it)?.time } ?: 0L
+    private fun String?.parseDate(): Long = dateFormat.tryParse(this)
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         SwitchPreferenceCompat(screen.context).apply {

--- a/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
+++ b/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
@@ -193,7 +193,7 @@ class ValirScans :
 
         return SManga.create().apply {
             this.title = title
-            url = normalizeSeriesPath(detailLink.attr("href"))
+            setUrlWithoutDomain(detailLink.absUrl("href"))
             thumbnail_url = selectFirst("img[src], img[srcset]")?.extractThumbnailUrl()
         }
     }
@@ -282,7 +282,7 @@ class ValirScans :
         error("Could not find JSON end for marker: $marker")
     }
 
-    private fun String.unescapeJson(): String = json.decodeFromString("\"$this\"")
+    private fun String.unescapeJson(): String = "\"$this\"".parseAs<String>()
 
     private fun parseStatus(status: String?): Int = when (status?.uppercase(Locale.ENGLISH)) {
         "ONGOING" -> SManga.ONGOING

--- a/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
+++ b/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
@@ -99,7 +99,7 @@ class ValirScans :
         }.getOrNull()
 
         return SManga.create().apply {
-            title = schema?.name ?: document.selectFirst("h1")?.text().orEmpty()
+            title = schema?.name ?: document.selectFirst("h1")!!.text()
             description = detailData?.description ?: schema?.description
             author = schema?.author?.name ?: detailData?.author
             artist = detailData?.artist

--- a/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
+++ b/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
@@ -139,7 +139,7 @@ class ValirScans :
                         append(chapter.title.ifBlank { "Chapter ${formatChapterNumber(chapter.number)}" })
                     }
                     chapter_number = chapter.number
-                    date_upload = chapter.publishedAt.parseDate()
+                    date_upload = dateFormat.tryParse(chapter.publishedAt)
                 }
             }
             .toList()
@@ -156,9 +156,11 @@ class ValirScans :
             .unescapeJson()
             .parseAs<ReaderChapterDto>()
 
-        return chapter.pages.map { page ->
-            Page(page.pageNumber - 1, imageUrl = page.imageUrl.toAbsoluteUrl())
-        }
+        return chapter.pages
+            .sortedBy { it.pageNumber }
+            .mapIndexed { index, page ->
+                Page(index, imageUrl = page.imageUrl.toAbsoluteUrl())
+            }
     }
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
@@ -302,8 +304,6 @@ class ValirScans :
     }
 
     private fun formatChapterNumber(number: Float): String = chapterNumberFormatter.format(number)
-
-    private fun String?.parseDate(): Long = dateFormat.tryParse(this)
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         SwitchPreferenceCompat(screen.context).apply {

--- a/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
+++ b/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
@@ -16,6 +16,7 @@ import keiyoushi.utils.parseAs
 import keiyoushi.utils.tryParse
 import kotlinx.serialization.json.Json
 import okhttp3.Headers
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Request
@@ -50,6 +51,8 @@ class ValirScans :
     private val json: Json by injectLazy()
 
     private val preferences: SharedPreferences by getPreferencesLazy()
+
+    private val baseHttpUrl by lazy { "$baseUrl/".toHttpUrl() }
 
     override fun headersBuilder() = Headers.Builder()
         .add("Referer", "$baseUrl/")
@@ -101,8 +104,8 @@ class ValirScans :
             author = schema?.author?.name ?: detailData?.author
             artist = detailData?.artist
             status = parseStatus(detailData?.status)
-            thumbnail_url = detailData?.coverImage?.toAbsoluteUrl()
-                ?: schema?.image?.toAbsoluteUrl()
+            thumbnail_url = detailData?.coverImage?.toAbsoluteUrl(response.request.url.toString())
+                ?: schema?.image?.toAbsoluteUrl(response.request.url.toString())
             genre = buildList {
                 detailData?.type
                     ?.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.ENGLISH) else it.toString() }
@@ -209,59 +212,58 @@ class ValirScans :
 
         val encodedUrl = candidate.substringAfter("url=", "").substringBefore("&")
         val decodedUrl = URLDecoder.decode(encodedUrl, StandardCharsets.UTF_8)
-        return decodedUrl.toAbsoluteUrl()
+        return decodedUrl.toAbsoluteUrl(ownerDocument()?.location() ?: baseUrl)
     }
 
-    private fun String.toAbsoluteUrl(): String = when {
-        startsWith("http://") || startsWith("https://") -> this
-        startsWith("//") -> "https:$this"
-        startsWith("/") -> baseUrl + this
-        else -> "$baseUrl/$this"
-    }
+    private fun String.toAbsoluteUrl(base: String = baseUrl): String = resolveUrl(this, base.toHttpUrlOrNull() ?: baseHttpUrl)?.toString() ?: this
 
     private fun normalizeSeriesPath(path: String): String {
-        val cleanPath = sanitizePath(path)
+        val resolvedUrl = resolveUrl(path)
+        val segments = resolvedUrl?.pathSegments.orEmpty().filter(String::isNotBlank)
+
         return when {
-            cleanPath.startsWith("/series/comic/") -> cleanPath.substringBefore("/chapter/").substringBefore("?")
-            cleanPath.startsWith("/comic/") -> "/series$cleanPath".substringBefore("/chapter/").substringBefore("?")
-            cleanPath.startsWith("/series/") -> {
-                val slug = cleanPath.removePrefix("/series/").substringBefore("/").substringBefore("?")
-                "/series/comic/$slug"
-            }
-            else -> {
-                val slug = cleanPath.substringAfterLast("/").substringBefore("?")
-                "/series/comic/$slug"
-            }
+            segments.size >= 3 && segments[0] == "series" && segments[1] == "comic" ->
+                "/series/comic/${segments[2]}"
+            segments.size >= 2 && segments[0] == "comic" ->
+                "/series/comic/${segments[1]}"
+            segments.size >= 2 && segments[0] == "series" ->
+                "/series/comic/${segments[1]}"
+            segments.isNotEmpty() ->
+                "/series/comic/${segments.last()}"
+            else ->
+                sanitizeRelativePath(path)
         }.trimEnd('/')
     }
 
     private fun normalizeChapterPath(path: String): String {
-        val cleanPath = sanitizePath(path)
+        val resolvedUrl = resolveUrl(path)
+        val segments = resolvedUrl?.pathSegments.orEmpty().filter(String::isNotBlank)
+
         return when {
-            cleanPath.startsWith("/series/comic/") -> cleanPath
-            cleanPath.startsWith("/comic/") -> "/series$cleanPath"
-            cleanPath.startsWith("/series/") && cleanPath.contains("/chapter/") -> {
-                val slug = cleanPath.removePrefix("/series/").substringBefore("/")
-                val chapter = cleanPath.substringAfter("/chapter/")
-                "/series/comic/$slug/chapter/$chapter"
-            }
-            else -> cleanPath
-        }.substringBefore("?")
+            segments.size >= 5 && segments[0] == "series" && segments[1] == "comic" && segments[3] == "chapter" ->
+                "/series/comic/${segments[2]}/chapter/${segments[4]}"
+            segments.size >= 4 && segments[0] == "comic" && segments[2] == "chapter" ->
+                "/series/comic/${segments[1]}/chapter/${segments[3]}"
+            segments.size >= 4 && segments[0] == "series" && segments[2] == "chapter" ->
+                "/series/comic/${segments[1]}/chapter/${segments[3]}"
+            else ->
+                sanitizeRelativePath(path).substringBefore("?")
+        }
     }
 
-    private fun sanitizePath(path: String): String {
-        path.toHttpUrlOrNull()?.let { url ->
-            return buildString {
-                append(url.encodedPath)
-                url.encodedQuery?.let {
-                    append('?')
-                    append(it)
-                }
-            }
+    private fun resolveUrl(path: String, base: HttpUrl = baseHttpUrl): HttpUrl? {
+        path.toHttpUrlOrNull()?.let { return it }
+
+        if (path.startsWith("//")) {
+            return "${base.scheme}:$path".toHttpUrlOrNull()
         }
 
-        // Stored library URLs can still be relative, so keep a small string fallback.
-        return "/" + path.removePrefix("/").substringBefore("#")
+        return base.resolve(path)
+    }
+
+    private fun sanitizeRelativePath(path: String): String {
+        val cleanPath = path.substringBefore('#')
+        return "/" + cleanPath.removePrefix("/")
     }
 
     private fun extractEscapedJsonValue(html: String, marker: String, openChar: Char): String {

--- a/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
+++ b/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
@@ -1,16 +1,331 @@
 package eu.kanade.tachiyomi.extension.en.valirscans
 
-import eu.kanade.tachiyomi.multisrc.keyoapp.Keyoapp
+import android.content.SharedPreferences
+import androidx.preference.PreferenceScreen
+import androidx.preference.SwitchPreferenceCompat
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.source.ConfigurableSource
+import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Request
+import okhttp3.Response
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import uy.kohesive.injekt.injectLazy
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
 
 class ValirScans :
-    Keyoapp(
-        "Valir Scans",
-        "https://valirscans.org",
-        "en",
-    ) {
-    override val descriptionSelector: String = "div.grid > div.overflow-hidden > p"
-    override val statusSelector: String = "div[alt=Status]"
-    override val authorSelector: String = "div[alt=Author]"
-    override val artistSelector: String = "div[alt=Artist]"
-    override val typeSelector: String = "div[alt='Series Type']"
+    HttpSource(),
+    ConfigurableSource {
+
+    override val versionId = 2
+
+    override val name = "Valir Scans"
+
+    override val baseUrl = "https://valirscans.org"
+
+    override val lang = "en"
+
+    override val supportsLatest = true
+
+    override val client = network.cloudflareClient
+
+    private val json: Json by injectLazy()
+
+    private val preferences: SharedPreferences by getPreferencesLazy()
+
+    override fun headersBuilder() = Headers.Builder()
+        .add("Referer", "$baseUrl/")
+
+    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/series?sort=views&order=desc&page=$page", headers)
+
+    override fun popularMangaParse(response: Response): MangasPage = response.parseBrowsePage()
+
+    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/series?sort=updated&order=desc&page=$page", headers)
+
+    override fun latestUpdatesParse(response: Response): MangasPage = response.parseBrowsePage()
+
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+        val url = "$baseUrl/series".toHttpUrl().newBuilder().apply {
+            addQueryParameter("page", page.toString())
+            if (query.isNotBlank()) {
+                addQueryParameter("q", query.trim())
+            }
+        }.build()
+
+        return GET(url, headers)
+    }
+
+    override fun searchMangaParse(response: Response): MangasPage = response.parseBrowsePage()
+
+    override fun getFilterList() = FilterList()
+
+    override fun getMangaUrl(manga: SManga): String = baseUrl + normalizeSeriesPath(manga.url)
+
+    override fun mangaDetailsRequest(manga: SManga): Request = GET(baseUrl + normalizeSeriesPath(manga.url), headers)
+
+    override fun mangaDetailsParse(response: Response): SManga {
+        val html = response.use { it.body.string() }
+        val document = Jsoup.parse(html, response.request.url.toString())
+        val schema = document.select("script[type=application/ld+json]")
+            .asSequence()
+            .map { runCatching { it.data().parseAs<BookSchema>() }.getOrNull() }
+            .firstOrNull { it?.type == "Book" }
+
+        val detailData = runCatching {
+            extractEscapedJsonValue(html, ESCAPED_SERIES_MARKER, '{')
+                .unescapeJson()
+                .parseAs<SeriesDetailsDto>()
+        }.getOrNull()
+
+        return SManga.create().apply {
+            title = schema?.name ?: document.selectFirst("h1")?.text().orEmpty()
+            description = detailData?.description ?: schema?.description
+            author = schema?.author?.name ?: detailData?.author
+            artist = detailData?.artist
+            status = parseStatus(detailData?.status)
+            thumbnail_url = detailData?.coverImage?.toAbsoluteUrl()
+                ?: schema?.image?.toAbsoluteUrl()
+            genre = buildList {
+                detailData?.type
+                    ?.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.ENGLISH) else it.toString() }
+                    ?.also(::add)
+                addAll(detailData?.genres.orEmpty().map { it.name })
+                if (isEmpty()) {
+                    addAll(schema?.genre.orEmpty())
+                }
+            }.distinct().joinToString()
+            initialized = true
+        }
+    }
+
+    override fun chapterListRequest(manga: SManga): Request = mangaDetailsRequest(manga)
+
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val html = response.use { it.body.string() }
+        val seriesPath = normalizeSeriesPath(response.request.url.encodedPath)
+        val chapters = extractEscapedJsonValue(html, ESCAPED_CHAPTERS_MARKER, '[')
+            .unescapeJson()
+            .parseAs<List<ChapterDto>>()
+
+        return chapters
+            .asSequence()
+            .filter { preferences.showPaidChapters || !it.isLocked }
+            .map { chapter ->
+                SChapter.create().apply {
+                    url = "$seriesPath/chapter/${formatChapterNumber(chapter.number)}"
+                    name = buildString {
+                        if (chapter.isLocked) append("🔒 ")
+                        append(chapter.title.ifBlank { "Chapter ${formatChapterNumber(chapter.number)}" })
+                    }
+                    chapter_number = chapter.number
+                    date_upload = chapter.publishedAt.parseDate()
+                }
+            }
+            .toList()
+            .reversed()
+    }
+
+    override fun getChapterUrl(chapter: SChapter): String = baseUrl + normalizeChapterPath(chapter.url)
+
+    override fun pageListRequest(chapter: SChapter): Request = GET(baseUrl + normalizeChapterPath(chapter.url), headers)
+
+    override fun pageListParse(response: Response): List<Page> {
+        val html = response.use { it.body.string() }
+        val chapter = extractEscapedJsonValue(html, ESCAPED_CHAPTER_MARKER, '{')
+            .unescapeJson()
+            .parseAs<ReaderChapterDto>()
+
+        return chapter.pages.map { page ->
+            Page(page.pageNumber - 1, imageUrl = page.imageUrl.toAbsoluteUrl())
+        }
+    }
+
+    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
+
+    override fun imageRequest(page: Page): Request {
+        val imageHeaders = headersBuilder()
+            .add("Accept", "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8")
+            .build()
+
+        return GET(page.imageUrl!!, imageHeaders)
+    }
+
+    private fun Response.parseBrowsePage(): MangasPage {
+        val page = request.url.queryParameter("page")?.toIntOrNull() ?: 1
+        val html = use { it.body.string() }
+        val document = Jsoup.parse(html, request.url.toString())
+        val mangas = document.select("div[role=gridcell]").mapNotNull { it.toSManga() }
+
+        val totalResults = TOTAL_RESULTS_REGEX.find(html)?.groupValues?.get(2)?.toIntOrNull()
+        val hasNextPage = totalResults?.let { page * BROWSE_PAGE_SIZE < it } ?: false
+
+        return MangasPage(mangas, hasNextPage)
+    }
+
+    private fun Element.toSManga(): SManga? {
+        val detailLink = selectFirst("a[href*='?ref=browse']")
+            ?: select("a[href*='/series/comic/']")
+                .firstOrNull { !it.attr("href").contains("/chapter/") }
+            ?: return null
+
+        val title = selectFirst("h3")?.text()
+            ?.ifBlank { null }
+            ?: selectFirst("img[alt]")?.attr("alt")
+                ?.ifBlank { null }
+            ?: return null
+
+        return SManga.create().apply {
+            this.title = title
+            url = normalizeSeriesPath(detailLink.attr("href"))
+            thumbnail_url = selectFirst("img[src], img[srcset]")?.extractThumbnailUrl()
+        }
+    }
+
+    private fun Element.extractThumbnailUrl(): String {
+        val candidate = attr("abs:src")
+            .ifBlank { attr("abs:srcset").substringBefore(" ") }
+
+        if (!candidate.contains("/_next/image?url=")) {
+            return candidate
+        }
+
+        val encodedUrl = candidate.substringAfter("url=", "").substringBefore("&")
+        val decodedUrl = URLDecoder.decode(encodedUrl, StandardCharsets.UTF_8)
+        return decodedUrl.toAbsoluteUrl()
+    }
+
+    private fun String.toAbsoluteUrl(): String = when {
+        startsWith("http://") || startsWith("https://") -> this
+        startsWith("//") -> "https:$this"
+        startsWith("/") -> baseUrl + this
+        else -> "$baseUrl/$this"
+    }
+
+    private fun normalizeSeriesPath(path: String): String {
+        val cleanPath = sanitizePath(path)
+        return when {
+            cleanPath.startsWith("/series/comic/") -> cleanPath.substringBefore("/chapter/").substringBefore("?")
+            cleanPath.startsWith("/comic/") -> "/series$cleanPath".substringBefore("/chapter/").substringBefore("?")
+            cleanPath.startsWith("/series/") -> {
+                val slug = cleanPath.removePrefix("/series/").substringBefore("/").substringBefore("?")
+                "/series/comic/$slug"
+            }
+            else -> {
+                val slug = cleanPath.substringAfterLast("/").substringBefore("?")
+                "/series/comic/$slug"
+            }
+        }.trimEnd('/')
+    }
+
+    private fun normalizeChapterPath(path: String): String {
+        val cleanPath = sanitizePath(path)
+        return when {
+            cleanPath.startsWith("/series/comic/") -> cleanPath
+            cleanPath.startsWith("/comic/") -> "/series$cleanPath"
+            cleanPath.startsWith("/series/") && cleanPath.contains("/chapter/") -> {
+                val slug = cleanPath.removePrefix("/series/").substringBefore("/")
+                val chapter = cleanPath.substringAfter("/chapter/")
+                "/series/comic/$slug/chapter/$chapter"
+            }
+            else -> cleanPath
+        }.substringBefore("?")
+    }
+
+    private fun sanitizePath(path: String): String {
+        val withoutDomain = path
+            .removePrefix(baseUrl)
+            .removePrefix("https://valirscans.com")
+            .removePrefix("https://valirscans.org")
+
+        return "/" + withoutDomain.removePrefix("/").substringBefore("#")
+    }
+
+    private fun extractEscapedJsonValue(html: String, marker: String, openChar: Char): String {
+        val startIndex = html.indexOf(marker)
+        check(startIndex >= 0) { "Could not find marker: $marker" }
+
+        val valueStart = html.indexOf(openChar, startIndex + marker.length)
+        check(valueStart >= 0) { "Could not find JSON start for marker: $marker" }
+
+        val closeChar = if (openChar == '{') '}' else ']'
+        var depth = 0
+
+        for (index in valueStart until html.length) {
+            when (html[index]) {
+                openChar -> depth++
+                closeChar -> {
+                    depth--
+                    if (depth == 0) {
+                        return html.substring(valueStart, index + 1)
+                    }
+                }
+            }
+        }
+
+        error("Could not find JSON end for marker: $marker")
+    }
+
+    private fun String.unescapeJson(): String = json.decodeFromString("\"$this\"")
+
+    private fun parseStatus(status: String?): Int = when (status?.uppercase(Locale.ENGLISH)) {
+        "ONGOING" -> SManga.ONGOING
+        "COMPLETED" -> SManga.COMPLETED
+        "HIATUS" -> SManga.ON_HIATUS
+        "CANCELLED", "CANCELED", "DROPPED" -> SManga.CANCELLED
+        else -> SManga.UNKNOWN
+    }
+
+    private fun formatChapterNumber(number: Float): String = chapterNumberFormatter.format(number)
+
+    private fun String?.parseDate(): Long = this?.let { dateFormat.parse(it)?.time } ?: 0L
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        SwitchPreferenceCompat(screen.context).apply {
+            key = SHOW_PAID_CHAPTERS_PREF
+            title = "Show paid chapters"
+            summaryOn = "Paid chapters will be shown in the chapter list."
+            summaryOff = "Paid chapters will be hidden from the chapter list."
+            setDefaultValue(SHOW_PAID_CHAPTERS_DEFAULT)
+        }.also(screen::addPreference)
+    }
+
+    private val SharedPreferences.showPaidChapters: Boolean
+        get() = getBoolean(SHOW_PAID_CHAPTERS_PREF, SHOW_PAID_CHAPTERS_DEFAULT)
+
+    companion object {
+        private const val BROWSE_PAGE_SIZE = 24
+
+        private const val SHOW_PAID_CHAPTERS_PREF = "pref_show_paid_chap"
+        private const val SHOW_PAID_CHAPTERS_DEFAULT = false
+
+        private const val ESCAPED_SERIES_MARKER = "\\\"series\\\":"
+        private const val ESCAPED_CHAPTERS_MARKER = "\\\"chapters\\\":"
+        private const val ESCAPED_CHAPTER_MARKER = "\\\"chapter\\\":"
+
+        private val TOTAL_RESULTS_REGEX =
+            """Showing <!-- -->(\d+)<!-- --> of <!-- -->(\d+)<!-- --> results""".toRegex()
+
+        private val chapterNumberFormatter = DecimalFormat("#.##", DecimalFormatSymbols(Locale.US))
+
+        private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
+    }
 }

--- a/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
+++ b/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScans.kt
@@ -11,11 +11,11 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.extractNextJs
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.tryParse
-import kotlinx.serialization.json.Json
-import okhttp3.Headers
+import kotlinx.serialization.json.JsonObject
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
@@ -23,7 +23,6 @@ import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
-import uy.kohesive.injekt.injectLazy
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 import java.text.DecimalFormat
@@ -48,11 +47,9 @@ class ValirScans :
 
     override val client = network.cloudflareClient
 
-    private val json: Json by injectLazy()
-
     private val preferences: SharedPreferences by getPreferencesLazy()
 
-    private val baseHttpUrl by lazy { "$baseUrl/".toHttpUrl() }
+    private val baseHttpUrl = "$baseUrl/".toHttpUrl()
 
     override fun headersBuilder() = super.headersBuilder()
         .add("Referer", "$baseUrl/")
@@ -87,16 +84,13 @@ class ValirScans :
     override fun mangaDetailsParse(response: Response): SManga {
         val html = response.use { it.body.string() }
         val document = Jsoup.parse(html, response.request.url.toString())
+        val pageData = document.extractSeriesPageData()
         val schema = document.select("script[type=application/ld+json]")
             .asSequence()
             .map { runCatching { it.data().parseAs<BookSchema>() }.getOrNull() }
             .firstOrNull { it?.type == "Book" }
 
-        val detailData = runCatching {
-            extractEscapedJsonValue(html, ESCAPED_SERIES_MARKER, '{')
-                .unescapeJson()
-                .parseAs<SeriesDetailsDto>()
-        }.getOrNull()
+        val detailData = pageData?.series
 
         return SManga.create().apply {
             title = schema?.name ?: document.selectFirst("h1")!!.text()
@@ -123,10 +117,22 @@ class ValirScans :
 
     override fun chapterListParse(response: Response): List<SChapter> {
         val html = response.use { it.body.string() }
+        val document = Jsoup.parse(html, response.request.url.toString())
         val seriesPath = normalizeSeriesPath(response.request.url.encodedPath)
-        val chapters = extractEscapedJsonValue(html, ESCAPED_CHAPTERS_MARKER, '[')
-            .unescapeJson()
-            .parseAs<List<ChapterDto>>()
+        val firstPageData = document.extractSeriesPageData() ?: return emptyList()
+        val chapters = buildList {
+            addAll(firstPageData.chapters)
+
+            for (page in (firstPageData.currentPage + 1)..firstPageData.totalPages) {
+                val pageUrl = response.request.url.newBuilder()
+                    .setQueryParameter("page", page.toString())
+                    .build()
+                val pageData = client.newCall(GET(pageUrl, headers)).execute().use { pageResponse ->
+                    pageResponse.asSeriesPageData()
+                } ?: continue
+                addAll(pageData.chapters)
+            }
+        }
 
         return chapters
             .asSequence()
@@ -152,9 +158,10 @@ class ValirScans :
 
     override fun pageListParse(response: Response): List<Page> {
         val html = response.use { it.body.string() }
-        val chapter = extractEscapedJsonValue(html, ESCAPED_CHAPTER_MARKER, '{')
-            .unescapeJson()
-            .parseAs<ReaderChapterDto>()
+        val document = Jsoup.parse(html, response.request.url.toString())
+        val chapter = document.extractNextJs<ChapterPageDto> { element ->
+            element is JsonObject && "chapter" in element
+        }?.chapter ?: error("Could not find chapter data")
 
         return chapter.pages
             .sortedBy { it.pageNumber }
@@ -171,6 +178,16 @@ class ValirScans :
             .build()
 
         return GET(page.imageUrl!!, imageHeaders)
+    }
+
+    private fun Response.asSeriesPageData(): SeriesPageDto? {
+        val html = body.string()
+        val document = Jsoup.parse(html, request.url.toString())
+        return document.extractSeriesPageData()
+    }
+
+    private fun org.jsoup.nodes.Document.extractSeriesPageData(): SeriesPageDto? = extractNextJs<SeriesPageDto> { element ->
+        element is JsonObject && "series" in element && "chapters" in element
     }
 
     private fun Response.parseBrowsePage(): MangasPage {
@@ -212,13 +229,14 @@ class ValirScans :
             return candidate
         }
 
-        val encodedUrl = candidate.substringAfter("url=", "").substringBefore("&")
+        val encodedUrl = candidate.toHttpUrlOrNull()?.queryParameter("url") ?: return candidate
         val decodedUrl = URLDecoder.decode(encodedUrl, StandardCharsets.UTF_8)
         return decodedUrl.toAbsoluteUrl(ownerDocument()?.location() ?: baseUrl)
     }
 
     private fun String.toAbsoluteUrl(base: String = baseUrl): String = resolveUrl(this, base.toHttpUrlOrNull() ?: baseHttpUrl)?.toString() ?: this
 
+    // Normalize old saved library URLs from the pre-migration route formats.
     private fun normalizeSeriesPath(path: String): String {
         val resolvedUrl = resolveUrl(path)
         val segments = resolvedUrl?.pathSegments.orEmpty().filter(String::isNotBlank)
@@ -268,33 +286,6 @@ class ValirScans :
         return "/" + cleanPath.removePrefix("/")
     }
 
-    private fun extractEscapedJsonValue(html: String, marker: String, openChar: Char): String {
-        val startIndex = html.indexOf(marker)
-        check(startIndex >= 0) { "Could not find marker: $marker" }
-
-        val valueStart = html.indexOf(openChar, startIndex + marker.length)
-        check(valueStart >= 0) { "Could not find JSON start for marker: $marker" }
-
-        val closeChar = if (openChar == '{') '}' else ']'
-        var depth = 0
-
-        for (index in valueStart until html.length) {
-            when (html[index]) {
-                openChar -> depth++
-                closeChar -> {
-                    depth--
-                    if (depth == 0) {
-                        return html.substring(valueStart, index + 1)
-                    }
-                }
-            }
-        }
-
-        error("Could not find JSON end for marker: $marker")
-    }
-
-    private fun String.unescapeJson(): String = "\"$this\"".parseAs<String>()
-
     private fun parseStatus(status: String?): Int = when (status?.uppercase(Locale.ENGLISH)) {
         "ONGOING" -> SManga.ONGOING
         "COMPLETED" -> SManga.COMPLETED
@@ -323,10 +314,6 @@ class ValirScans :
 
         private const val SHOW_PAID_CHAPTERS_PREF = "pref_show_paid_chap"
         private const val SHOW_PAID_CHAPTERS_DEFAULT = false
-
-        private const val ESCAPED_SERIES_MARKER = "\\\"series\\\":"
-        private const val ESCAPED_CHAPTERS_MARKER = "\\\"chapters\\\":"
-        private const val ESCAPED_CHAPTER_MARKER = "\\\"chapter\\\":"
 
         private val TOTAL_RESULTS_REGEX =
             """Showing <!-- -->(\d+)<!-- --> of <!-- -->(\d+)<!-- --> results""".toRegex()

--- a/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScansDto.kt
+++ b/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScansDto.kt
@@ -14,12 +14,12 @@ class BookSchema(
 )
 
 @Serializable
-data class AuthorSchema(
+class AuthorSchema(
     val name: String? = null,
 )
 
 @Serializable
-data class SeriesDetailsDto(
+class SeriesDetailsDto(
     val title: String,
     val slug: String,
     val author: String? = null,
@@ -32,12 +32,12 @@ data class SeriesDetailsDto(
 )
 
 @Serializable
-data class GenreDto(
+class GenreDto(
     val name: String,
 )
 
 @Serializable
-data class ChapterDto(
+class ChapterDto(
     val number: Float,
     val title: String = "",
     val isLocked: Boolean = false,
@@ -45,12 +45,12 @@ data class ChapterDto(
 )
 
 @Serializable
-data class ReaderChapterDto(
+class ReaderChapterDto(
     val pages: List<ReaderPageDto> = emptyList(),
 )
 
 @Serializable
-data class ReaderPageDto(
+class ReaderPageDto(
     val pageNumber: Int,
     val imageUrl: String,
 )

--- a/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScansDto.kt
+++ b/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScansDto.kt
@@ -32,6 +32,14 @@ class SeriesDetailsDto(
 )
 
 @Serializable
+class SeriesPageDto(
+    val series: SeriesDetailsDto,
+    val chapters: List<ChapterDto> = emptyList(),
+    val currentPage: Int = 1,
+    val totalPages: Int = 1,
+)
+
+@Serializable
 class GenreDto(
     val name: String,
 )
@@ -47,6 +55,11 @@ class ChapterDto(
 @Serializable
 class ReaderChapterDto(
     val pages: List<ReaderPageDto> = emptyList(),
+)
+
+@Serializable
+class ChapterPageDto(
+    val chapter: ReaderChapterDto,
 )
 
 @Serializable

--- a/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScansDto.kt
+++ b/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScansDto.kt
@@ -1,0 +1,56 @@
+package eu.kanade.tachiyomi.extension.en.valirscans
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BookSchema(
+    @SerialName("@type") val type: String? = null,
+    val name: String = "",
+    val author: AuthorSchema? = null,
+    val image: String? = null,
+    val description: String? = null,
+    val genre: List<String> = emptyList(),
+)
+
+@Serializable
+data class AuthorSchema(
+    val name: String? = null,
+)
+
+@Serializable
+data class SeriesDetailsDto(
+    val title: String,
+    val slug: String,
+    val author: String? = null,
+    val artist: String? = null,
+    val description: String? = null,
+    val coverImage: String? = null,
+    val status: String? = null,
+    val type: String? = null,
+    val genres: List<GenreDto> = emptyList(),
+)
+
+@Serializable
+data class GenreDto(
+    val name: String,
+)
+
+@Serializable
+data class ChapterDto(
+    val number: Float,
+    val title: String = "",
+    val isLocked: Boolean = false,
+    val publishedAt: String? = null,
+)
+
+@Serializable
+data class ReaderChapterDto(
+    val pages: List<ReaderPageDto> = emptyList(),
+)
+
+@Serializable
+data class ReaderPageDto(
+    val pageNumber: Int,
+    val imageUrl: String,
+)

--- a/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScansDto.kt
+++ b/src/en/valirscans/src/eu/kanade/tachiyomi/extension/en/valirscans/ValirScansDto.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class BookSchema(
+class BookSchema(
     @SerialName("@type") val type: String? = null,
     val name: String = "",
     val author: AuthorSchema? = null,


### PR DESCRIPTION
The previous PR for valir scans only changed the URL/domain to the new one but the actual structure of the page has changed when they migrated to the new domain which this PR fixes

Closes #14436

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
