### PR TITLE
Softkomik(ID): Add support manga/manhwa with login required

### DIFF
--- a/src/id/softkomik/build.gradle
+++ b/src/id/softkomik/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Softkomik'
     extClass = '.Softkomik'
-    extVersionCode = 9
+    extVersionCode = 10
     isNsfw = false
 }
 

--- a/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
+++ b/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
@@ -199,6 +199,7 @@ class Softkomik : HttpSource() {
             }
         }
 
+        // for manga/manhwa that requires login, the API still returns 200 but with empty image list.
         if (imageSrc.isEmpty()) {
             throw Exception("Chapter kosong atau memerlukan login di WebView")
         }

--- a/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
+++ b/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
@@ -319,7 +319,7 @@ class Softkomik : HttpSource() {
             .build()
 
         var response = chain.proceed(newRequest)
-        if (response.code == 403 || response.code == 401) {
+        if (response.code != 200) { // they now change the response status code
             response.close()
 
             // retry once with session from WebView, in case the session from api is invalid but WebView has valid session

--- a/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
+++ b/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
@@ -1,5 +1,13 @@
 package eu.kanade.tachiyomi.extension.id.softkomik
 
+import android.annotation.SuppressLint
+import android.app.Application
+import android.os.Handler
+import android.os.Looper
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import android.webkit.WebViewClient
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
@@ -15,7 +23,11 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import java.net.URLDecoder
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class Softkomik : HttpSource() {
     override val name = "Softkomik"
@@ -138,19 +150,29 @@ class Softkomik : HttpSource() {
 
     // ======================== Chapters ========================
     override fun chapterListRequest(manga: SManga): Request {
-        val url = "$apiUrl/komik/${manga.url}/chapter?limit=9999999"
+        // isRequiredLogin manga with genre ecchi or mature
+        val isRequiredLogin = manga.genre.orEmpty().lowercase().contains("ecchi") || manga.genre.orEmpty().lowercase().contains("mature")
+        var url = "$apiUrl/komik/${manga.url}/chapter?limit=9999999"
+        if (isRequiredLogin) {
+            url += requiredLoginSuffix
+        }
         return GET(url, headers)
     }
 
     override fun chapterListParse(response: Response): List<SChapter> {
         val dto = response.parseAs<ChapterListDto>()
         val slug = response.request.url.pathSegments[1]
+        val isRequiredLogin = response.request.url.toString().contains(requiredLoginSuffix)
         return dto.chapter.map { chapter ->
             val chapterNumStr = chapter.chapter
             val chapterNum = chapterNumStr.substringBefore(".").toFloatOrNull() ?: -1f
             val displayNum = formatChapterDisplay(chapterNumStr)
+            var chapterUrl = "/$slug/chapter/$chapterNumStr"
+            if (isRequiredLogin) {
+                chapterUrl += requiredLoginSuffix
+            }
             SChapter.create().apply {
-                url = "/$slug/chapter/$chapterNumStr"
+                url = chapterUrl
                 name = "Chapter $displayNum"
                 chapter_number = chapterNum
             }
@@ -176,6 +198,7 @@ class Softkomik : HttpSource() {
     override fun pageListRequest(chapter: SChapter): Request = GET("$baseUrl${chapter.url}", rscHeaders)
 
     override fun pageListParse(response: Response): List<Page> {
+        val isRequiredLogin = response.request.url.toString().contains(requiredLoginSuffix)
         val data = response.extractNextJs<ChapterPageDataDto>()
             ?: throw Exception("Could not find chapter data")
 
@@ -185,6 +208,9 @@ class Softkomik : HttpSource() {
             val urlApi = "$apiUrl/komik/$slug/chapter/$chapter/img/${data._id}"
 
             val token = getBearerTokenFromCookie()
+            if (token == null && isRequiredLogin) {
+                throw Exception("Chapter memerlukan login di WebView")
+            }
             val authHeaders = if (token != null) {
                 headersBuilder()
                     .addAll(headers)
@@ -276,10 +302,9 @@ class Softkomik : HttpSource() {
     private fun apiAuthInterceptor(chain: Interceptor.Chain): Response {
         val request = chain.request()
 
-        if (!request.url.host.endsWith("softdevices.my.id") || request.url.toString().startsWith(coverUrl)) {
+        if (!request.url.toString().startsWith(apiUrl)) {
             return chain.proceed(request)
         }
-
         val sessionResult = getSession()
         val newRequest = request.newBuilder()
             .header("X-Token", sessionResult.token)
@@ -291,7 +316,21 @@ class Softkomik : HttpSource() {
             response.close()
 
             // retry once with session from cookie, in case the session from api is invalid but cookie has valid session
-            val cookieSession = getSessionFromCookie()
+            // get manga slug from url, e.g. https://v2.softdevices.my.id/komik/one-piece/chapter/123/img/456 -> slug = one-piece
+            // only get slug if request contains /komik/{slug}/chapter, to avoid intercepting other API calls that don't require auth (e.g. search)
+            val slug = request.url.pathSegments.let { segments ->
+                val komikIndex = segments.indexOf("komik")
+                if (komikIndex != -1 && segments.size > komikIndex + 2 && segments[komikIndex + 2] == "chapter") {
+                    segments[komikIndex + 1]
+                } else {
+                    null
+                }
+            }
+            if (slug == null) {
+                // if slug is not found, return original 403 response
+                return chain.proceed(request)
+            }
+            val cookieSession = getSessionViaWebView(slug)
             val retryRequest = request.newBuilder()
                 .header("X-Token", cookieSession.token)
                 .header("X-Sign", cookieSession.sign)
@@ -318,25 +357,6 @@ class Softkomik : HttpSource() {
             val ex = cookieToken.expiresAt
             bearerToken = BearerTokenDto(token = token, ex = ex)
             return bearerToken
-        }
-    }
-
-    // because softkomik often changes their api session url,
-    // if the request fails, we can try to get session from cookies but the user needs to open manga details in WebView first to get the session cookies.
-    private fun getSessionFromCookie(): SessionDto {
-        synchronized(this) {
-            val cookies = client.cookieJar.loadForRequest(baseUrl.toHttpUrl())
-
-            val rawValue = cookies.firstOrNull { it.name == "x-m" }?.value ?: throw Exception("Buka manga detail di WebView untuk mendapatkan session, lalu refresh.")
-            val decodedValue = runCatching { URLDecoder.decode(rawValue, Charsets.UTF_8.name()) }
-                .getOrDefault(rawValue)
-
-            val cookieSession = runCatching { decodedValue.parseAs<SessionDto>() }.getOrNull()
-            if (cookieSession == null) {
-                throw Exception("Buka manga detail di WebView untuk mendapatkan session, lalu refresh.")
-            }
-            session = cookieSession
-            return cookieSession
         }
     }
 
@@ -381,6 +401,65 @@ class Softkomik : HttpSource() {
         }
     }
 
+    // because softkomik often changes their api session url,
+    // if the request fails, we can try to get session from WebView by loading the manga detail page, 
+    // which will automatically trigger the chapter list API that carries the session token in the header, and we can intercept that request to get the session token.
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun getSessionViaWebView(slug: String): SessionDto {
+        synchronized(this) {
+            val latch = CountDownLatch(1)
+            var capturedToken: String? = null
+            var capturedSign: String? = null
+
+            val handler = Handler(Looper.getMainLooper())
+            var webView: WebView? = null
+
+            handler.post {
+                val wv = WebView(Injekt.get<Application>())
+                webView = wv
+
+                wv.settings.javaScriptEnabled = true
+                wv.settings.domStorageEnabled = true
+                wv.settings.userAgentString = headers["User-Agent"]
+
+                wv.webViewClient = object : WebViewClient() {
+                    override fun shouldInterceptRequest(
+                        view: WebView,
+                        request: WebResourceRequest,
+                    ): WebResourceResponse? {
+                        val url = request.url.toString()
+
+                        // Intercept the chapter list API call — it always carries X-Token & X-Sign
+                        if (url.contains(apiUrl)) {
+                            val token = request.requestHeaders["X-Token"]
+                            val sign = request.requestHeaders["X-Sign"]
+
+                            if (!token.isNullOrEmpty() && !sign.isNullOrEmpty()) {
+                                capturedToken = token
+                                capturedSign = sign
+                                latch.countDown()
+                            }
+                        }
+                        return super.shouldInterceptRequest(view, request)
+                    }
+                }
+
+                // Load manga detail page, JS will automatically fire the chapter list API
+                wv.loadUrl("$baseUrl/$slug")
+            }
+
+            latch.await(15, TimeUnit.SECONDS)
+            handler.post { webView?.destroy() }
+
+            val token = capturedToken ?: throw Exception("Gagal mendapatkan session. Coba lagi.")
+            val sign = capturedSign ?: throw Exception("Gagal mendapatkan session. Coba lagi.")
+
+            // Based on response session API, expire the session in 2 hours.
+            session = SessionDto(token = token, sign = sign, ex = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(2))
+            return session!!
+        }
+    }
+
     // Normalizes the User-Agent by removing "Mobile Safari" because it can cause 401 errors.
     private fun normalizeUserAgent(userAgent: String?): String? {
         if (userAgent.isNullOrBlank()) return null
@@ -400,13 +479,14 @@ class Softkomik : HttpSource() {
         GenreFilter(),
         MinChapterFilter(),
     )
-
+    private val requiredLoginSuffix = "#login-required"
     private val apiUrl = "https://v2.softdevices.my.id"
     private val coverUrl = "https://cover.softdevices.my.id/softkomik-cover"
     private val userAgentMobileSafariRegex = Regex("""\s*Mobile Safari/\d+(?:\.\d+)*""", RegexOption.IGNORE_CASE)
     private val cdnUrls = listOf(
         "https://psy1.komik.im",
         "https://image.komik.im/softkomik",
+        "https://cdn1.softkomik.online/softkomik",
         "https://cd1.softkomik.online/softkomik",
         "https://f1.softkomik.com/file/softkomik-image",
         "https://img.softdevices.my.id/softkomik-image",

--- a/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
+++ b/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
@@ -387,7 +387,7 @@ class Softkomik : HttpSource() {
                 client.newCall(GET("$baseUrl/api/me", apiHeaders)).execute().close()
             }
 
-            val response = client.newCall(GET("$baseUrl/api/sessions/oqiw918pa", apiHeaders)).execute()
+            val response = client.newCall(GET("$baseUrl/api/sessions/kajskjas", apiHeaders)).execute()
 
             if (!response.isSuccessful) {
                 val code = response.code

--- a/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
+++ b/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
@@ -19,6 +19,7 @@ import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.utils.extractNextJs
 import keiyoushi.utils.parseAs
 import okhttp3.Headers
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.Request
@@ -26,6 +27,7 @@ import okhttp3.Response
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.net.URLDecoder
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -35,7 +37,8 @@ class Softkomik : HttpSource() {
     override val lang = "id"
     override val supportsLatest = true
 
-    private var session: SessionDto? = null
+    // session cache by URL/page route.
+    private val sessionsByUrlKey = ConcurrentHashMap<String, SessionDto>()
     private var bearerToken: BearerTokenDto? = null
 
     private val rscHeaders = headersBuilder()
@@ -307,32 +310,25 @@ class Softkomik : HttpSource() {
         if (!request.url.toString().startsWith(apiUrl)) {
             return chain.proceed(request)
         }
-        val sessionResult = getSession()
+
+        val route = resolveSessionRoute(request.url)
+        val sessionResult = getSession(route)
         val newRequest = request.newBuilder()
             .header("X-Token", sessionResult.token)
             .header("X-Sign", sessionResult.sign)
             .build()
 
         var response = chain.proceed(newRequest)
-        if (response.code == 403) {
+        if (response.code == 403 || response.code == 401) {
             response.close()
 
             // retry once with session from WebView, in case the session from api is invalid but WebView has valid session
-            // get manga slug from url, e.g. https://v2.softdevices.my.id/komik/one-piece/chapter/123/img/456 -> slug = one-piece
-            // only get slug if request contains /komik/{slug}/chapter, to avoid intercepting other API calls that don't require auth (e.g. search)
-            val slug = request.url.pathSegments.let { segments ->
-                val komikIndex = segments.indexOf("komik")
-                if (komikIndex != -1 && segments.size > komikIndex + 2 && segments[komikIndex + 2] == "chapter") {
-                    segments[komikIndex + 1]
-                } else {
-                    null
-                }
-            }
-            if (slug == null) {
-                // if slug is not found, return original 403 response
+            if (!route.isChapterListRequest || route.slug == null) {
+                // if this route is not chapter-based, return the original request response
                 return chain.proceed(request)
             }
-            val cookieSession = getSessionViaWebView(slug)
+
+            val cookieSession = getSessionViaWebView(route, request.url)
             val retryRequest = request.newBuilder()
                 .header("X-Token", cookieSession.token)
                 .header("X-Sign", cookieSession.sign)
@@ -362,18 +358,46 @@ class Softkomik : HttpSource() {
         }
     }
 
-    private fun getSession(): SessionDto {
-        val currentSession = session
-        if (currentSession != null && currentSession.ex > System.currentTimeMillis()) {
-            return currentSession
+    private data class SessionRoute(
+        val key: String,
+        val sessionApiUrl: String,
+        val slug: String?,
+        val isChapterListRequest: Boolean,
+        val isChapterImageRequest: Boolean,
+    )
+
+    private fun resolveSessionRoute(url: HttpUrl): SessionRoute {
+        val segments = url.pathSegments
+        val komikIndex = segments.indexOf("komik")
+        // slug is always the segment after "komik" in both chapter list and chapter image API
+        val slug = if (komikIndex != -1) segments.getOrNull(komikIndex + 1) else null
+        // chapter list API $apiUrl/komik/${manga.url}/chapter?limit=9999999
+        val isChapterListRequest = komikIndex != -1 && segments.getOrNull(komikIndex + 2) == "chapter"
+        // chapter image API $apiUrl/komik/${manga.url}/chapter/${chapter}/img/${data._id}
+        val isChapterImageRequest = isChapterListRequest && segments.contains("img")
+
+        val sessionKey = if (isChapterImageRequest) sessionKeyChapterImage else sessionKeyChapterList
+
+        val sessionApiUrl = if (isChapterImageRequest) {
+            "$baseUrl/api/sessions/chapter"
+        } else {
+            "$baseUrl/api/sessions/kajsijas"
         }
 
-        synchronized(this) {
-            val currentSessionSync = session
-            if (currentSessionSync != null && currentSessionSync.ex > System.currentTimeMillis()) {
-                return currentSessionSync
-            }
+        return SessionRoute(
+            key = sessionKey,
+            sessionApiUrl = sessionApiUrl,
+            slug = slug,
+            isChapterListRequest = isChapterListRequest,
+            isChapterImageRequest = isChapterImageRequest,
+        )
+    }
 
+    private fun getSession(route: SessionRoute): SessionDto {
+        sessionsByUrlKey[route.key]?.takeIf { it.ex > System.currentTimeMillis() }?.let { return it }
+
+        synchronized(this) {
+            sessionsByUrlKey[route.key]?.takeIf { it.ex > System.currentTimeMillis() }?.let { return it }
             val apiHeaders = headersBuilder()
                 .set("Accept", "application/json")
                 .set("Content-Type", "application/json")
@@ -389,7 +413,7 @@ class Softkomik : HttpSource() {
                 client.newCall(GET("$baseUrl/api/me", apiHeaders)).execute().close()
             }
 
-            val response = client.newCall(GET("$baseUrl/api/sessions/kajskjas", apiHeaders)).execute()
+            val response = client.newCall(GET(route.sessionApiUrl, apiHeaders)).execute()
 
             if (!response.isSuccessful) {
                 val code = response.code
@@ -398,8 +422,21 @@ class Softkomik : HttpSource() {
             }
 
             val newSession = response.use { it.parseAs<SessionDto>() }
-            session = newSession
+            sessionsByUrlKey[route.key] = newSession
             return newSession
+        }
+    }
+
+    private fun resolveWebViewChapterSegment(url: HttpUrl): String? {
+        val segments = url.pathSegments
+        val chapterIndex = segments.indexOf("chapter")
+        val rawChapter = if (chapterIndex != -1) segments.getOrNull(chapterIndex + 1) else return null
+
+        val chapterNumber = rawChapter?.toIntOrNull()
+        return if (chapterNumber != null && chapterNumber < 100) {
+            chapterNumber.toString().padStart(3, '0')
+        } else {
+            rawChapter
         }
     }
 
@@ -407,7 +444,19 @@ class Softkomik : HttpSource() {
     // if the request fails, we can try to get session from WebView by loading the manga detail page,
     // which will automatically trigger the chapter list API that carries the session token in the header, and we can intercept that request to get the session token.
     @SuppressLint("SetJavaScriptEnabled")
-    private fun getSessionViaWebView(slug: String): SessionDto {
+    private fun getSessionViaWebView(route: SessionRoute, url: HttpUrl): SessionDto {
+        val slug = route.slug ?: throw Exception("Gagal mendapatkan session. Coba lagi.")
+
+        // load sesion via WebView if url is for chapter list API or page chapter API
+        // chapter list API url: $baseUrl/{slug}
+        // page chapter API url: $baseUrl/{slug}/chapter/{chapter}
+        var webViewUrl = "$baseUrl/$slug"
+        if (route.isChapterImageRequest) {
+            val chapterSegment = resolveWebViewChapterSegment(url)
+            if (chapterSegment != null) {
+                webViewUrl = "$baseUrl/$slug/chapter/$chapterSegment"
+            }
+        }
         synchronized(this) {
             val latch = CountDownLatch(1)
             var capturedToken: String? = null
@@ -449,7 +498,7 @@ class Softkomik : HttpSource() {
                 }
 
                 // Load manga detail page, JS will automatically fire the chapter list API
-                wv.loadUrl("$baseUrl/$slug")
+                wv.loadUrl(webViewUrl)
             }
 
             latch.await(15, TimeUnit.SECONDS)
@@ -459,8 +508,9 @@ class Softkomik : HttpSource() {
             val sign = capturedSign ?: throw Exception("Gagal mendapatkan session. Coba lagi.")
 
             // Based on response session API, expire the session in 2 hours.
-            session = SessionDto(token = token, sign = sign, ex = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(2))
-            return session!!
+            val newSession = SessionDto(token = token, sign = sign, ex = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(2))
+            sessionsByUrlKey[route.key] = newSession
+            return newSession
         }
     }
 
@@ -486,6 +536,8 @@ class Softkomik : HttpSource() {
     private val requiredLoginSuffix = "login-required"
     private val requiredLoginFragment = "#$requiredLoginSuffix"
     private val requiredLoginGenres = listOf("ecchi", "mature")
+    private val sessionKeyChapterList = "chapter-list"
+    private val sessionKeyChapterImage = "chapter-image"
     private val apiUrl = "https://v2.softdevices.my.id"
     private val coverUrl = "https://cover.softdevices.my.id/softkomik-cover"
     private val userAgentMobileSafariRegex = Regex("""\s*Mobile Safari/\d+(?:\.\d+)*""", RegexOption.IGNORE_CASE)

--- a/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
+++ b/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
@@ -402,7 +402,7 @@ class Softkomik : HttpSource() {
     }
 
     // because softkomik often changes their api session url,
-    // if the request fails, we can try to get session from WebView by loading the manga detail page, 
+    // if the request fails, we can try to get session from WebView by loading the manga detail page,
     // which will automatically trigger the chapter list API that carries the session token in the header, and we can intercept that request to get the session token.
     @SuppressLint("SetJavaScriptEnabled")
     private fun getSessionViaWebView(slug: String): SessionDto {

--- a/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
+++ b/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
@@ -151,10 +151,12 @@ class Softkomik : HttpSource() {
     // ======================== Chapters ========================
     override fun chapterListRequest(manga: SManga): Request {
         // isRequiredLogin manga with genre ecchi or mature
-        val isRequiredLogin = manga.genre.orEmpty().lowercase().contains("ecchi") || manga.genre.orEmpty().lowercase().contains("mature")
+        val isRequiredLogin = requiredLoginGenres.any { keyword ->
+            manga.genre.orEmpty().contains(keyword, ignoreCase = true)
+        }
         var url = "$apiUrl/komik/${manga.url}/chapter?limit=9999999"
         if (isRequiredLogin) {
-            url += requiredLoginSuffix
+            url += requiredLoginFragment
         }
         return GET(url, headers)
     }
@@ -162,14 +164,14 @@ class Softkomik : HttpSource() {
     override fun chapterListParse(response: Response): List<SChapter> {
         val dto = response.parseAs<ChapterListDto>()
         val slug = response.request.url.pathSegments[1]
-        val isRequiredLogin = response.request.url.toString().contains(requiredLoginSuffix)
+        val isRequiredLogin = response.request.url.fragment?.contains(requiredLoginSuffix) == true
         return dto.chapter.map { chapter ->
             val chapterNumStr = chapter.chapter
             val chapterNum = chapterNumStr.substringBefore(".").toFloatOrNull() ?: -1f
             val displayNum = formatChapterDisplay(chapterNumStr)
             var chapterUrl = "/$slug/chapter/$chapterNumStr"
             if (isRequiredLogin) {
-                chapterUrl += requiredLoginSuffix
+                chapterUrl += requiredLoginFragment
             }
             SChapter.create().apply {
                 url = chapterUrl
@@ -198,7 +200,7 @@ class Softkomik : HttpSource() {
     override fun pageListRequest(chapter: SChapter): Request = GET("$baseUrl${chapter.url}", rscHeaders)
 
     override fun pageListParse(response: Response): List<Page> {
-        val isRequiredLogin = response.request.url.toString().contains(requiredLoginSuffix)
+        val isRequiredLogin = response.request.url.fragment?.contains(requiredLoginSuffix) == true
         val data = response.extractNextJs<ChapterPageDataDto>()
             ?: throw Exception("Could not find chapter data")
 
@@ -315,7 +317,7 @@ class Softkomik : HttpSource() {
         if (response.code == 403) {
             response.close()
 
-            // retry once with session from cookie, in case the session from api is invalid but cookie has valid session
+            // retry once with session from WebView, in case the session from api is invalid but WebView has valid session
             // get manga slug from url, e.g. https://v2.softdevices.my.id/komik/one-piece/chapter/123/img/456 -> slug = one-piece
             // only get slug if request contains /komik/{slug}/chapter, to avoid intercepting other API calls that don't require auth (e.g. search)
             val slug = request.url.pathSegments.let { segments ->
@@ -420,6 +422,8 @@ class Softkomik : HttpSource() {
 
                 wv.settings.javaScriptEnabled = true
                 wv.settings.domStorageEnabled = true
+                wv.settings.loadsImagesAutomatically = false
+                wv.settings.blockNetworkImage = true
                 wv.settings.userAgentString = headers["User-Agent"]
 
                 wv.webViewClient = object : WebViewClient() {
@@ -479,7 +483,9 @@ class Softkomik : HttpSource() {
         GenreFilter(),
         MinChapterFilter(),
     )
-    private val requiredLoginSuffix = "#login-required"
+    private val requiredLoginSuffix = "login-required"
+    private val requiredLoginFragment = "#$requiredLoginSuffix"
+    private val requiredLoginGenres = listOf("ecchi", "mature")
     private val apiUrl = "https://v2.softdevices.my.id"
     private val coverUrl = "https://cover.softdevices.my.id/softkomik-cover"
     private val userAgentMobileSafariRegex = Regex("""\s*Mobile Safari/\d+(?:\.\d+)*""", RegexOption.IGNORE_CASE)

--- a/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
+++ b/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
@@ -323,12 +323,7 @@ class Softkomik : HttpSource() {
             response.close()
 
             // retry once with session from WebView, in case the session from api is invalid but WebView has valid session
-            if (!route.isChapterListRequest || route.slug == null) {
-                // if this route is not chapter-based, return the original request response
-                return chain.proceed(request)
-            }
-
-            val cookieSession = getSessionViaWebView(route, request.url)
+            val cookieSession = getSessionViaWebView(route)
             val retryRequest = request.newBuilder()
                 .header("X-Token", cookieSession.token)
                 .header("X-Sign", cookieSession.sign)
@@ -361,6 +356,7 @@ class Softkomik : HttpSource() {
     private data class SessionRoute(
         val key: String,
         val sessionApiUrl: String,
+        val webViewUrl: String,
         val slug: String?,
         val isChapterListRequest: Boolean,
         val isChapterImageRequest: Boolean,
@@ -383,6 +379,18 @@ class Softkomik : HttpSource() {
         } else {
             "$baseUrl/api/sessions/kajsijas"
         }
+        val webViewUrl = if (isChapterImageRequest) {
+            val chapterSegment = resolveWebViewChapterSegment(url)
+            if (chapterSegment != null) {
+                "$baseUrl/$slug/chapter/$chapterSegment"
+            } else {
+                "$baseUrl/$slug/chapter/001"
+            }
+        } else if (isChapterListRequest) {
+            "$baseUrl/$slug"
+        } else {
+            "$baseUrl/komik/list" // this for manga list with filters.
+        }
 
         return SessionRoute(
             key = sessionKey,
@@ -390,6 +398,7 @@ class Softkomik : HttpSource() {
             slug = slug,
             isChapterListRequest = isChapterListRequest,
             isChapterImageRequest = isChapterImageRequest,
+            webViewUrl = webViewUrl,
         )
     }
 
@@ -444,19 +453,8 @@ class Softkomik : HttpSource() {
     // if the request fails, we can try to get session from WebView by loading the manga detail page,
     // which will automatically trigger the chapter list API that carries the session token in the header, and we can intercept that request to get the session token.
     @SuppressLint("SetJavaScriptEnabled")
-    private fun getSessionViaWebView(route: SessionRoute, url: HttpUrl): SessionDto {
-        val slug = route.slug ?: throw Exception("Gagal mendapatkan session. Coba lagi.")
-
-        // load sesion via WebView if url is for chapter list API or page chapter API
-        // chapter list API url: $baseUrl/{slug}
-        // page chapter API url: $baseUrl/{slug}/chapter/{chapter}
-        var webViewUrl = "$baseUrl/$slug"
-        if (route.isChapterImageRequest) {
-            val chapterSegment = resolveWebViewChapterSegment(url)
-            if (chapterSegment != null) {
-                webViewUrl = "$baseUrl/$slug/chapter/$chapterSegment"
-            }
-        }
+    private fun getSessionViaWebView(route: SessionRoute): SessionDto {
+        val webViewUrl = route.webViewUrl
         synchronized(this) {
             val latch = CountDownLatch(1)
             var capturedToken: String? = null

--- a/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
+++ b/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
@@ -24,6 +24,7 @@ class Softkomik : HttpSource() {
     override val supportsLatest = true
 
     private var session: SessionDto? = null
+    private var bearerToken: BearerTokenDto? = null
 
     private val rscHeaders = headersBuilder()
         .add("rsc", "1")
@@ -178,19 +179,28 @@ class Softkomik : HttpSource() {
         val data = response.extractNextJs<ChapterPageDataDto>()
             ?: throw Exception("Could not find chapter data")
 
-        val imageSrc = if (data.imageSrc.isEmpty()) {
+        val imageSrc = data.imageSrc.ifEmpty {
             val slug = response.request.url.pathSegments[0]
             val chapter = response.request.url.pathSegments[2]
-            val url = "$apiUrl/komik/$slug/chapter/$chapter/img/${data._id}"
-            client.newCall(GET(url, headers)).execute().use {
+            val urlApi = "$apiUrl/komik/$slug/chapter/$chapter/img/${data._id}"
+
+            val token = getBearerTokenFromCookie()
+            val authHeaders = if (token != null) {
+                headersBuilder()
+                    .addAll(headers)
+                    .set("Authorization", token.token)
+                    .build()
+            } else {
+                headers
+            }
+
+            client.newCall(GET(urlApi, authHeaders)).execute().use {
                 it.parseAs<ChapterPageImagesDto>().imageSrc
             }
-        } else {
-            data.imageSrc
         }
 
         if (imageSrc.isEmpty()) {
-            throw Exception("No pages found")
+            throw Exception("Chapter kosong atau memerlukan login di WebView")
         }
 
         val imageBaseUrl = if (data.storageInter2 == true) cdnUrls[2] else cdnUrls[0]
@@ -288,6 +298,26 @@ class Softkomik : HttpSource() {
             response = chain.proceed(retryRequest)
         }
         return response
+    }
+
+    private fun getBearerTokenFromCookie(): BearerTokenDto? {
+        synchronized(this) {
+            val currentToken = bearerToken
+            if (currentToken != null && currentToken.ex > System.currentTimeMillis()) {
+                return currentToken
+            }
+
+            val cookies = client.cookieJar.loadForRequest(baseUrl.toHttpUrl())
+            val cookieToken = cookies.firstOrNull { it.name == "tokkey" }
+            if (cookieToken == null) return null
+
+            val rawValue = cookieToken.value
+            val token = runCatching { URLDecoder.decode(rawValue, Charsets.UTF_8.name()) }
+                .getOrDefault(rawValue)
+            val ex = cookieToken.expiresAt
+            bearerToken = BearerTokenDto(token = token, ex = ex)
+            return bearerToken
+        }
     }
 
     // because softkomik often changes their api session url,

--- a/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/SoftkomikDto.kt
+++ b/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/SoftkomikDto.kt
@@ -59,7 +59,7 @@ data class SessionDto(
 )
 
 @Serializable
-data class BearerTokenDto(
+class BearerTokenDto(
     val token: String,
     val ex: Long,
 )

--- a/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/SoftkomikDto.kt
+++ b/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/SoftkomikDto.kt
@@ -57,3 +57,9 @@ data class SessionDto(
     val sign: String,
     val token: String,
 )
+
+@Serializable
+data class BearerTokenDto(
+    val token: String,
+    val ex: Long,
+)


### PR DESCRIPTION
- some manga/manhwa with genre ecchi or mature required login.
- session api changed again, now they have different session for chapter list & chapter page
- replace get session from cookie to webview because the cookie encrypted xD

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
