### PR TITLE
Vortex Scans: Revert API URL to `api.vortexscans.org`

### DIFF
--- a/src/en/arvenscans/build.gradle
+++ b/src/en/arvenscans/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Vortex Scans'
     extClass = '.VortexScans'
     themePkg = 'iken'
-    baseUrl = 'https://vortexcomics.org'
+    baseUrl = 'https://vortexscans.org'
     overrideVersionCode = 42
     isNsfw = false
 }

--- a/src/en/arvenscans/build.gradle
+++ b/src/en/arvenscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.VortexScans'
     themePkg = 'iken'
     baseUrl = 'https://vortexcomics.org'
-    overrideVersionCode = 41
+    overrideVersionCode = 42
     isNsfw = false
 }
 

--- a/src/en/arvenscans/src/eu/kanade/tachiyomi/extension/en/arvenscans/VortexScans.kt
+++ b/src/en/arvenscans/src/eu/kanade/tachiyomi/extension/en/arvenscans/VortexScans.kt
@@ -11,7 +11,7 @@ class VortexScans :
         "Vortex Scans",
         "en",
         "https://vortexcomics.org",
-        "https://api.vortexcomics.org",
+        "https://api.vortexscans.org",
     ) {
 
     override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> = client.newCall(chapterListRequest(manga))

--- a/src/en/arvenscans/src/eu/kanade/tachiyomi/extension/en/arvenscans/VortexScans.kt
+++ b/src/en/arvenscans/src/eu/kanade/tachiyomi/extension/en/arvenscans/VortexScans.kt
@@ -10,7 +10,7 @@ class VortexScans :
     Iken(
         "Vortex Scans",
         "en",
-        "https://vortexcomics.org",
+        "https://vortexscans.org",
         "https://api.vortexscans.org",
     ) {
 


### PR DESCRIPTION
Closes #14497

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
