### PR TITLE
Spicy Scan (ES): Fix receiving json array

### DIFF
--- a/lib-multisrc/spicytheme/build.gradle.kts
+++ b/lib-multisrc/spicytheme/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 1
+baseVersionCode = 2

--- a/lib-multisrc/spicytheme/src/eu/kanade/tachiyomi/multisrc/spicytheme/Dto.kt
+++ b/lib-multisrc/spicytheme/src/eu/kanade/tachiyomi/multisrc/spicytheme/Dto.kt
@@ -5,13 +5,11 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
 import keiyoushi.utils.tryParse
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonTransformingSerializer
 import kotlinx.serialization.serializer
 import java.text.SimpleDateFormat
 
@@ -86,19 +84,8 @@ data class ChapterImagesDto(
 
 // Get first item only in case of JsonArray
 
-object FirstobjOrObj : KSerializer<ChapterImagesDto> {
-
-    override val descriptor = ChapterImagesDto.serializer().descriptor
-
-    override fun deserialize(decoder: Decoder): ChapterImagesDto {
-        val el = (decoder as JsonDecoder).decodeJsonElement()
-        val obj = if (el is JsonArray) el[0] else el
-        return decoder.json.decodeFromJsonElement(ChapterImagesDto.serializer(), el)
-    }
-
-    override fun serialize(encoder: Encoder, value: ChapterImagesDto) {
-        encoder.encodeSerializableValue(serializer(), value)
-    }
+object FirstobjOrObj : JsonTransformingSerializer<ChapterImagesDto>(ChapterImagesDto.serializer()) {
+    override fun transformDeserialize(element: JsonElement): JsonElement = if (element is JsonArray) element[0] else element
 }
 
 fun MangaDto.toSManga() = SManga.create().apply {

--- a/lib-multisrc/spicytheme/src/eu/kanade/tachiyomi/multisrc/spicytheme/Dto.kt
+++ b/lib-multisrc/spicytheme/src/eu/kanade/tachiyomi/multisrc/spicytheme/Dto.kt
@@ -5,8 +5,14 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
 import keiyoushi.utils.tryParse
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.serializer
 import java.text.SimpleDateFormat
 
 @Serializable
@@ -28,7 +34,9 @@ data class PagesResponseDto(
     val slug: String,
     val hasNext: Boolean,
     val hasPrevious: Boolean,
-    @SerialName("pageches") val pages: ChapterImagesDto,
+    @SerialName("pageches")
+    @Serializable(FirstobjOrObj::class)
+    val pages: ChapterImagesDto,
 )
 
 @Serializable
@@ -75,6 +83,23 @@ data class ChapterImagesDto(
     @SerialName("urlImg") val rawImages: String,
     val chapterId: Int,
 )
+
+// Get first item only in case of JsonArray
+
+object FirstobjOrObj : KSerializer<ChapterImagesDto> {
+
+    override val descriptor = ChapterImagesDto.serializer().descriptor
+
+    override fun deserialize(decoder: Decoder): ChapterImagesDto {
+        val el = (decoder as JsonDecoder).decodeJsonElement()
+        val obj = if (el is JsonArray) el[0] else el
+        return decoder.json.decodeFromJsonElement(ChapterImagesDto.serializer(), el)
+    }
+
+    override fun serialize(encoder: Encoder, value: ChapterImagesDto) {
+        encoder.encodeSerializableValue(serializer(), value)
+    }
+}
 
 fun MangaDto.toSManga() = SManga.create().apply {
     url = slug


### PR DESCRIPTION
Closes #13341

Checklist:

- [] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
