### PR TITLE
cosmicscansid: Fix IllegalArgumentException when encountering data UR…

### DIFF
--- a/src/id/cosmicscansid/build.gradle
+++ b/src/id/cosmicscansid/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.CosmicScansID'
     themePkg = 'mangathemesia'
     baseUrl = 'https://lc5.cosmicscans.asia'
-    overrideVersionCode = 18
+    overrideVersionCode = 19
     isNsfw = false
 }
 

--- a/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/CosmicScansID.kt
+++ b/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/CosmicScansID.kt
@@ -16,6 +16,7 @@ import keiyoushi.utils.getPreferences
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import org.jsoup.nodes.Element
 import org.jsoup.select.Elements
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -91,6 +92,12 @@ class CosmicScansID :
 
     // manga details
     override val seriesDescriptionSelector = ".entry-content[itemprop=description] :not(a,p:has(a))"
+
+    override fun Element.imgAttr(): String = sequenceOf("data-lazy-src", "data-src", "data-cfsrc", "src")
+        .map { attr("abs:$it") }
+        .find { it.isNotEmpty() && !it.startsWith("data:") }
+        ?: ""
+
     override fun Elements.imgAttr(): String = this.first()?.imgAttr() ?: ""
 
     // pages


### PR DESCRIPTION
…I placeholders

This commit overrides  in  to filter out any image attributes that start with . This prevents the  which occurs when a placeholder Base64 image is present in lazy-loaded  tags.

Fix IllegalArgumentException: expected URL scheme 'http'or'https'but was 'data'

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
