### PR TITLE
kiryuu: update domain

### DIFF
--- a/src/id/kiryuu/build.gradle
+++ b/src/id/kiryuu/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Kiryuu'
     extClass = '.Kiryuu'
     themePkg = 'natsuid'
-    baseUrl = 'https://v1.kiryuu.to'
-    overrideVersionCode = 46
+    baseUrl = 'https://v2.kiryuu.to'
+    overrideVersionCode = 47
     isNsfw = false
 }
 

--- a/src/id/kiryuu/src/eu/kanade/tachiyomi/extension/id/kiryuu/Kiryuu.kt
+++ b/src/id/kiryuu/src/eu/kanade/tachiyomi/extension/id/kiryuu/Kiryuu.kt
@@ -11,7 +11,7 @@ class Kiryuu :
     NatsuId(
         "Kiryuu",
         "id",
-        "https://v1.kiryuu.to",
+        "https://v2.kiryuu.to",
     ) {
     // Formerly "Kiryuu (WP Manga Stream)"
     override val id = 3639673976007021338


### PR DESCRIPTION
causing a 'Too many follow-up requests: 21' error in OkHttp due to a redirect loop. Updating the base URL to the latest version resolves this.

Closes #14512
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
