### PR TITLE
HDoujin: Add spanish lang

### DIFF
--- a/src/all/hdoujin/build.gradle
+++ b/src/all/hdoujin/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'HDoujin'
     extClass = '.HDoujinFactory'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/all/hdoujin/src/eu/kanade/tachiyomi/extension/all/hdoujin/HDoujinFactory.kt
+++ b/src/all/hdoujin/src/eu/kanade/tachiyomi/extension/all/hdoujin/HDoujinFactory.kt
@@ -6,6 +6,7 @@ class HDoujinFactory : SourceFactory {
     override fun createSources() = listOf(
         HDoujin("all"),
         HDoujin("en", "english"),
+        HDoujin("es", "spanish"),
         HDoujin("ja", "japanese"),
         HDoujin("kr", "korean"),
         HDoujin("zh", "chinese"),


### PR DESCRIPTION
Closes #14516

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
