### PR TITLE
Comikey (ALL): Fix empty reason message when authorized

### DIFF
--- a/src/all/comikey/build.gradle
+++ b/src/all/comikey/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = "Comikey"
     extClass = ".ComikeyFactory"
-    extVersionCode = 3
+    extVersionCode = 4
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/comikey/src/eu/kanade/tachiyomi/extension/all/comikey/Comikey.kt
+++ b/src/all/comikey/src/eu/kanade/tachiyomi/extension/all/comikey/Comikey.kt
@@ -312,7 +312,7 @@ open class Comikey(
                     val url = request?.url
                         ?: return super.shouldInterceptRequest(view, request)
 
-                    if (url.host != "relay-us.epub.rocks" || url.path?.endsWith("/manifest") != true) {
+                    if (url.host?.matches(Regex("""relay-\w+\.epub\.rocks""")) != true || url.path?.endsWith("/manifest") != true) {
                         return super.shouldInterceptRequest(view, request)
                     }
 
@@ -331,7 +331,7 @@ open class Comikey(
                         response.headers["Content-Type"] ?: "application/divina+json+vnd.e4p.drm",
                         null,
                         response.code,
-                        response.message,
+                        response.message?.takeIf { it.isNotEmpty() } ?: "OK",
                         response.headers.toMap(),
                         response.body.byteStream(),
                     )


### PR DESCRIPTION
Closes #14445, Closes #13214, Closes #4710

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
