### PR TITLE
EvaScans: Fix date format

### DIFF
--- a/src/en/evascans/build.gradle
+++ b/src/en/evascans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.EvaScans'
     themePkg = 'mangathemesia'
     baseUrl = 'https://evascans.org'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
 }
 

--- a/src/en/evascans/src/eu/kanade/tachiyomi/extension/en/evascans/EvaScans.kt
+++ b/src/en/evascans/src/eu/kanade/tachiyomi/extension/en/evascans/EvaScans.kt
@@ -3,6 +3,8 @@ package eu.kanade.tachiyomi.extension.en.evascans
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import eu.kanade.tachiyomi.source.model.SManga
 import org.jsoup.nodes.Element
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 class EvaScans :
     MangaThemesia(
@@ -10,6 +12,7 @@ class EvaScans :
         "https://evascans.org",
         "en",
         "/series",
+        SimpleDateFormat("yyyy/MM/dd", Locale.ENGLISH),
     ) {
     // Fix search/listing - site uses custom card layout (div elements, not article)
     override fun searchMangaSelector() = "div.manga-card-v, .listupd .bs .bsx"

--- a/src/en/evascans/src/eu/kanade/tachiyomi/extension/en/evascans/EvaScans.kt
+++ b/src/en/evascans/src/eu/kanade/tachiyomi/extension/en/evascans/EvaScans.kt
@@ -12,7 +12,7 @@ class EvaScans :
         "https://evascans.org",
         "en",
         "/series",
-        SimpleDateFormat("yyyy/MM/dd", Locale.ENGLISH),
+        SimpleDateFormat("yyyy/MM/dd", Locale.ROOT),
     ) {
     // Fix search/listing - site uses custom card layout (div elements, not article)
     override fun searchMangaSelector() = "div.manga-card-v, .listupd .bs .bsx"


### PR DESCRIPTION
Fixes parsing for the date format used on EvaScans

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
