### PR TITLE
Manga18: fix pagination

### DIFF
--- a/lib-multisrc/manga18/build.gradle.kts
+++ b/lib-multisrc/manga18/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 1
+baseVersionCode = 2

--- a/lib-multisrc/manga18/src/eu/kanade/tachiyomi/multisrc/manga18/Manga18.kt
+++ b/lib-multisrc/manga18/src/eu/kanade/tachiyomi/multisrc/manga18/Manga18.kt
@@ -48,7 +48,7 @@ abstract class Manga18(
     }
 
     override fun popularMangaSelector() = "div.story_item"
-    override fun popularMangaNextPageSelector() = ".pagination a[rel=next]"
+    override fun popularMangaNextPageSelector() = ".pagination > li:last-child:not(.active)"
 
     override fun popularMangaFromElement(element: Element) = SManga.create().apply {
         setUrlWithoutDomain(element.selectFirst("a")!!.absUrl("href"))


### PR DESCRIPTION
Closes #14630

Doesn't break any of the other (already working) extensions. Bumping regardless since it changes the underlying logic.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
