### PR TITLE
Hive Scans: fix Missing FieldException

### DIFF
--- a/src/en/infernalvoidscans/build.gradle
+++ b/src/en/infernalvoidscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.HiveScans'
     themePkg = 'iken'
     baseUrl = 'https://hivetoons.org'
-    overrideVersionCode = 41
+    overrideVersionCode = 42
     isNsfw = false
 }
 

--- a/src/en/infernalvoidscans/src/eu/kanade/tachiyomi/extension/en/infernalvoidscans/HiveScans.kt
+++ b/src/en/infernalvoidscans/src/eu/kanade/tachiyomi/extension/en/infernalvoidscans/HiveScans.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.extension.en.infernalvoidscans
 
 import eu.kanade.tachiyomi.multisrc.iken.Iken
+import okhttp3.ResponseBody.Companion.toResponseBody
 
 class HiveScans :
     Iken(
@@ -17,7 +18,28 @@ class HiveScans :
             val headers = request.headers.newBuilder()
                 .set("Cache-Control", "max-age=0")
                 .build()
-            chain.proceed(request.newBuilder().headers(headers).build())
+
+            val response = chain.proceed(request.newBuilder().headers(headers).build())
+
+            if (request.url.encodedPath.endsWith("/api/query")) {
+                val body = response.body ?: return@addInterceptor response
+                val contentType = body.contentType()
+                val bodyString = body.string()
+
+                // The API removed the `isNovel` field from the /api/query endpoint which crashes the parser.
+                // We inject it manually right before the `postTitle` property inside the SearchResponse mapping.
+                val newBody = if (!bodyString.contains("\"isNovel\"")) {
+                    bodyString.replace("\"postTitle\":", "\"isNovel\":false,\"postTitle\":")
+                } else {
+                    bodyString
+                }
+
+                return@addInterceptor response.newBuilder()
+                    .body(newBody.toResponseBody(contentType))
+                    .build()
+            }
+
+            response
         }
         .build()
 


### PR DESCRIPTION
Closes #14657

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
