### PR TITLE
fixed Atsumaru genres

### DIFF
--- a/src/en/atsumaru/build.gradle
+++ b/src/en/atsumaru/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Atsumaru'
     extClass = '.Atsumaru'
-    extVersionCode = 13
+    extVersionCode = 14
     isNsfw = true
 }
 

--- a/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/Dto.kt
+++ b/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/Dto.kt
@@ -56,7 +56,7 @@ class MangaDto(
     // Details
     private val authors: List<AuthorDto>? = null,
     private val synopsis: String? = null,
-    private val tags: List<TagDto>? = null,
+    private val genres: List<TagDto>? = null,
     private val status: String? = null,
     private val type: String? = null,
     val scanlators: List<ScanlatorDto>? = null,
@@ -87,7 +87,7 @@ class MangaDto(
         description = synopsis
         genre = buildList {
             type?.let { add(it) }
-            tags?.forEach { add(it.name) }
+            genres?.forEach { add(it.name) }
         }.joinToString()
         authors?.let {
             author = it.joinToString { author -> author.name }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

API endpoint returns genres in a list called "genres" and not "tags". Previously tags always returned null
