### PR TITLE
Nexus Scan (PT): Fix first and last page

### DIFF
--- a/src/pt/spectralscan/build.gradle
+++ b/src/pt/spectralscan/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Nexus Scan'
     extClass = '.NexusScan'
-    extVersionCode = 59
+    extVersionCode = 60
     isNsfw = true
 }
 

--- a/src/pt/spectralscan/src/eu/kanade/tachiyomi/extension/pt/spectralscan/NexusScan.kt
+++ b/src/pt/spectralscan/src/eu/kanade/tachiyomi/extension/pt/spectralscan/NexusScan.kt
@@ -236,11 +236,21 @@ class NexusScan :
 
     override fun pageListParse(response: Response): List<Page> {
         val readResponse = response.parseAs<ReadResponse>()
-        return readResponse.pages
-            .sortedBy { it.pageNumber }
-            .mapIndexed { index, page ->
-                Page(index, imageUrl = "$baseUrl/api/p/${readResponse.pageToken}/${page.pageNumber}")
+        val pages = readResponse.pages
+        if (pages.first().imageUrl != null) {
+            return pages.mapIndexed { index, page ->
+                Page(
+                    index,
+                    imageUrl = page.imageUrl!!,
+                )
             }
+        }
+        return pages.mapIndexed { index, _ ->
+            Page(
+                index,
+                imageUrl = "$baseUrl/api/p/${readResponse.pageToken}/$index",
+            )
+        }
     }
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()

--- a/src/pt/spectralscan/src/eu/kanade/tachiyomi/extension/pt/spectralscan/NexusScanDto.kt
+++ b/src/pt/spectralscan/src/eu/kanade/tachiyomi/extension/pt/spectralscan/NexusScanDto.kt
@@ -65,7 +65,8 @@ class ReadResponse(
 
 @Serializable
 class PageDto(
-    val pageNumber: Int,
+    val pageNumber: Int? = null,
+    val imageUrl: String? = null,
 )
 
 @Serializable


### PR DESCRIPTION
Following the site Js source
```js
function FA(e, t) {
    var a;
    // imageUrl field may still exist
    e[0].imageUrl ? e : t ? e.map((e, a) => ({
    id: e.id || a,
    pageNumber: e.pageNumber ?? a,
    imageUrl: `/api/p/${t}/${a}`, 
                             ^
               // a starts from 0
```

Closes #14640

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension