### PR TITLE
Update issue moderator to use URL sections

### DIFF
--- a/.github/workflows/issue_moderator.yml
+++ b/.github/workflows/issue_moderator.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Moderate issues
-        uses: keiyoushi/issue-moderator-action@9597245ba176cf43ed82edccc40a7479d0d8d050
+        uses: keiyoushi/issue-moderator-action@ad49a28cf962db967f92d9cf974f797597460012
         with:
           repo-token: ${{ github.token }}
           member-token: ${{ secrets.MEMBER_TOKEN }}
@@ -41,6 +41,9 @@ jobs:
           existing-check-labels: |
             ["Source request", "Domain changed"]
           existing-check-repo-url: https://raw.githubusercontent.com/keiyoushi/extensions/repo/index.min.json
+
+          url-search-sections: |
+            ["Source link", "Source new URL"]
 
           auto-close-rules: |
             [


### PR DESCRIPTION
Follow-up to https://github.com/keiyoushi/issue-moderator-action/pull/319

This will make the issue moderator to search for URLs only in the "Source link" and "Source new URL" sections of the issue.

Fixes the issue when the source name contains a domain or when the user mentions a different source/URL in a different section for whatever reason.