### PR TITLE
Update domain for Komikindo

### DIFF
--- a/src/id/komikindo/build.gradle
+++ b/src/id/komikindo/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Komikindo'
     extClass = '.Komikindo'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://komikindo.club'
-    overrideVersionCode = 4
+    baseUrl = 'https://komikindo.bid'
+    overrideVersionCode = 5
     isNsfw = true
 }
 

--- a/src/id/komikindo/src/eu/kanade/tachiyomi/extension/id/komikindo/Komikindo.kt
+++ b/src/id/komikindo/src/eu/kanade/tachiyomi/extension/id/komikindo/Komikindo.kt
@@ -10,7 +10,7 @@ import org.jsoup.nodes.Document
 class Komikindo :
     MangaThemesia(
         "Komikindo",
-        "https://komikindo.club",
+        "https://komikindo.bid",
         "id",
     ) {
     // Some covers fail to load with no Accept header + no resize parameter.


### PR DESCRIPTION
Closes #11357 (unable to reproduce)

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
