### PR TITLE
ManhuaRock (VI): Fix chapter URL

### DIFF
--- a/src/vi/manhuarock/build.gradle
+++ b/src/vi/manhuarock/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = "ManhuaRock"
     extClass = ".ManhuaRock"
-    extVersionCode = 16
+    extVersionCode = 17
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/vi/manhuarock/src/eu/kanade/tachiyomi/extension/vi/manhuarock/ManhuaRock.kt
+++ b/src/vi/manhuarock/src/eu/kanade/tachiyomi/extension/vi/manhuarock/ManhuaRock.kt
@@ -14,6 +14,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
+import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferences
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.tryParse
@@ -127,14 +128,37 @@ class ManhuaRock :
 
     override fun chapterFromElement(element: Element) = SChapter.create().apply {
         val a = element.selectFirst("a")!!
-
         setUrlWithoutDomain(a.attr("abs:href"))
         name = a.text()
         date_upload = dateFormat.tryParse(element.select("span.chapter-time").attr("data-last-update"))
     }
 
+    // old: /truyen-tranh/slug/chap-0.html
+    // new: /truyen/slug/chapter-0/<ChapterId>
+    override fun getChapterUrl(chapter: SChapter): String {
+        if (!chapter.url.endsWith(".html")) {
+            return baseUrl + chapter.url.replace("truyen-tranh", "truyen").removeSuffix("/")
+                .substringBeforeLast("/")
+        }
+        return baseUrl + chapter.url
+    }
+
+    private fun getChapterId(url: String): String {
+        val lastSegment = url.toHttpUrl().pathSegments.last()
+        return if (lastSegment.all { it.isDigit() }) {
+            lastSegment
+        } else {
+            val response = client.newCall(GET(url, headers)).execute()
+            val doc = response.asJsoup()
+            val scriptContent = doc.selectFirst("script:containsData(chapter_id)")!!.data()
+            scriptContent.substringAfter("chapter_id = ")
+                .substringBefore(",")
+                .trim()
+        }
+    }
+
     override fun pageListRequest(chapter: SChapter): Request {
-        val chapterId = chapter.url.split('/').last()
+        val chapterId = getChapterId(baseUrl + chapter.url)
 
         return GET("$baseUrl/ajax/image/list/chap/$chapterId?mode=vertical&quality=high")
     }


### PR DESCRIPTION
Closes #14644

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension

