### PR TITLE
Manga Mura: Fix loading second page of Browse

### DIFF
--- a/src/ja/mangamura/build.gradle
+++ b/src/ja/mangamura/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaMura'
     themePkg = 'mangareader'
     baseUrl = 'https://mangamura.net'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/ja/mangamura/src/eu/kanade/tachiyomi/extension/ja/mangamura/MangaMura.kt
+++ b/src/ja/mangamura/src/eu/kanade/tachiyomi/extension/ja/mangamura/MangaMura.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.extension.ja.mangamura
 
 import eu.kanade.tachiyomi.multisrc.mangareader.MangaReader
 import eu.kanade.tachiyomi.source.model.FilterList
+import okhttp3.HttpUrl
 import okhttp3.Request
 
 class MangaMura :
@@ -11,6 +12,10 @@ class MangaMura :
         "ja",
     ) {
     override val chapterIdSelect = "ja-chaps"
+
+    override fun addPage(page: Int, builder: HttpUrl.Builder) {
+        builder.addQueryParameter("p", page.toString())
+    }
 
     override fun getAjaxUrl(id: String): String = "$baseUrl/json/chapter?mode=vertical&id=$id"
 


### PR DESCRIPTION
Closes #14761

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
