### PR TITLE
MangasBrasuka: Fix pages

### DIFF
--- a/src/pt/mangasbrasuka/build.gradle
+++ b/src/pt/mangasbrasuka/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangasBrasuka'
     themePkg = 'madara'
     baseUrl = 'https://mangasbrasuka.com.br'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/pt/mangasbrasuka/src/eu/kanade/tachiyomi/extension/pt/mangasbrasuka/MangasBrasuka.kt
+++ b/src/pt/mangasbrasuka/src/eu/kanade/tachiyomi/extension/pt/mangasbrasuka/MangasBrasuka.kt
@@ -1,7 +1,12 @@
 package eu.kanade.tachiyomi.extension.pt.mangasbrasuka
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.util.asJsoup
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.jsoup.nodes.Document
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -19,4 +24,18 @@ class MangasBrasuka :
     override val useLoadMoreRequest = LoadMoreStrategy.Never
 
     override val useNewChapterEndpoint = true
+
+    override fun pageListParse(document: Document): List<Page> {
+        val redirectUrl = document.selectFirst("div.page-break a")!!.absUrl("href")
+        val pageUrl = redirectUrl.toHttpUrl().queryParameter("t")!!.toHttpUrl().toUrl()
+
+        val url = "$baseUrl/campanha.php".toHttpUrl().newBuilder()
+            .addQueryParameter("auth", pageUrl.toString())
+            .build()
+
+        return client.newCall(GET(url, headers)).execute().asJsoup()
+            .select(".manga-content img").mapIndexed { index, elemet ->
+                Page(index, imageUrl = elemet.absUrl("src"))
+            }
+    }
 }

--- a/src/pt/mangasbrasuka/src/eu/kanade/tachiyomi/extension/pt/mangasbrasuka/MangasBrasuka.kt
+++ b/src/pt/mangasbrasuka/src/eu/kanade/tachiyomi/extension/pt/mangasbrasuka/MangasBrasuka.kt
@@ -15,7 +15,7 @@ class MangasBrasuka :
         "Mangas Brasuka",
         "https://mangasbrasuka.com.br",
         "pt-BR",
-        SimpleDateFormat("MM dd, yyyy", Locale("pt", "BR")),
+        SimpleDateFormat("MM/dd/yyyy", Locale.ROOT),
     ) {
     override val client = super.client.newBuilder()
         .rateLimit(2)


### PR DESCRIPTION
Closes #14794

this is the second time I've seen this protection(#14748)

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
