### PR TITLE
BloomScans: Update selectors

### DIFF
--- a/src/es/bloomscans/build.gradle
+++ b/src/es/bloomscans/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Bloom Scans'
     extClass = '.Bloomscans'
     themePkg = "mangathemesia"
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     baseUrl = "https://bloomscans.com"
     isNsfw = true
 }

--- a/src/es/bloomscans/src/eu/kanade/tachiyomi/extension/es/bloomscans/Bloomscans.kt
+++ b/src/es/bloomscans/src/eu/kanade/tachiyomi/extension/es/bloomscans/Bloomscans.kt
@@ -1,5 +1,22 @@
 package eu.kanade.tachiyomi.extension.es.bloomscans
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import java.text.SimpleDateFormat
+import java.util.Locale
 
-class Bloomscans : MangaThemesia("Bloom Scans", "https://bloomscans.com", "es", mangaUrlDirectory = "/series")
+class Bloomscans :
+    MangaThemesia(
+        "Bloom Scans",
+        "https://bloomscans.com",
+        "es",
+        mangaUrlDirectory = "/series",
+        dateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("es")),
+    ) {
+    override val seriesTitleSelector = ".lrs-title"
+    override val seriesThumbnailSelector = "img.lrs-cover"
+    override val seriesDescriptionSelector = ".lrs-syn-wrap"
+    override val seriesStatusSelector = ".lrs-infotable tr:contains(Status) td:last-child"
+    override val seriesGenreSelector = ".lrs-genre"
+
+    override fun chapterListSelector() = "#lrs-native-chapterlist li"
+}


### PR DESCRIPTION
Closes #14809

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
