### PR TITLE
AllManga: Fix page loading by decrypting encrypted API response

### DIFF
--- a/src/en/allanime/build.gradle
+++ b/src/en/allanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AllManga'
     extClass = '.AllManga'
-    extVersionCode = 11
+    extVersionCode = 12
     isNsfw = true
 }
 

--- a/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/AllManga.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/AllManga.kt
@@ -221,8 +221,8 @@ class AllManga :
     }
 
     override fun pageListParse(response: Response): List<Page> {
-        val result = response.parseAs<ApiPageListResponse>()
-        val pages = result.data.pageList?.edges?.get(0) ?: return emptyList()
+        val pageListData = response.parsePageList()
+        val pages = pageListData.pageList?.edges?.get(0) ?: return emptyList()
 
         val imageDomain = pages.serverUrl?.let { server ->
             if (server.matches(urlRegex)) {

--- a/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/Dto.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/Dto.kt
@@ -132,6 +132,12 @@ class DateDto(
     val sub: String? = null,
 )
 
+// page list - encrypted response wrapper
+@Serializable
+class EncryptedOrPageListData(
+    val tobeparsed: String? = null,
+)
+
 // page list
 @Serializable
 class PageListData(

--- a/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/Utils.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/Utils.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.extension.en.allanime
 
+import android.util.Base64
 import eu.kanade.tachiyomi.source.model.SManga
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -8,8 +9,12 @@ import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import org.jsoup.Jsoup
+import java.security.MessageDigest
 import java.text.SimpleDateFormat
 import java.util.Locale
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
 
 val json: Json = Json {
     ignoreUnknownKeys = true
@@ -49,6 +54,41 @@ fun String?.parseDate(): Long = runCatching {
 }.getOrDefault(0L)
 
 inline fun <reified T> Response.parseAs(): T = json.decodeFromString(body.string())
+
+fun Response.parsePageList(): PageListData {
+    val rawBody = body.string()
+    val wrapper = json.decodeFromString<Data<EncryptedOrPageListData>>(rawBody)
+
+    val encrypted = wrapper.data.tobeparsed
+    if (encrypted != null) {
+        val decrypted = decryptAesGcm(encrypted)
+        return json.decodeFromString<PageListData>(decrypted)
+    }
+
+    // Fallback: unencrypted response (old format)
+    return json.decodeFromString<ApiPageListResponse>(rawBody).data
+}
+
+private fun decryptAesGcm(encoded: String): String {
+    val keyBytes = MessageDigest.getInstance("SHA-256")
+        .digest(AES_KEY.toByteArray(Charsets.UTF_8))
+
+    val data = Base64.decode(encoded, Base64.DEFAULT)
+    val iv = data.copyOfRange(0, 12)
+    val ciphertext = data.copyOfRange(12, data.size)
+
+    val cipher = Cipher.getInstance("AES/GCM/NoPadding").apply {
+        init(
+            Cipher.DECRYPT_MODE,
+            SecretKeySpec(keyBytes, "AES"),
+            GCMParameterSpec(128, iv),
+        )
+    }
+
+    return cipher.doFinal(ciphertext).toString(Charsets.UTF_8)
+}
+
+private const val AES_KEY = "SimtVuagFbGR2K7P"
 
 inline fun <reified T> List<*>.firstInstanceOrNull(): T? = filterIsInstance<T>().firstOrNull()
 


### PR DESCRIPTION
## Summary

The AllManga API changed its `chapterPages` endpoint to return page data encrypted with AES-256-GCM under a `tobeparsed` field, instead of the previous plaintext JSON. This broke all chapter page loading ("no page found").

Closes #14817

This PR adds decryption support so pages load correctly again. The decrypted payload is structurally identical to the old response, so no other parsing changes were needed.

### Changes
- Added `parsePageList()` in `Utils.kt` that detects and decrypts the encrypted response
- Added `EncryptedOrPageListData` DTO for the new response shape
- Updated `pageListParse` in `AllManga.kt` to use the new parser
- Includes fallback for unencrypted responses in case the API reverts
- Bumped `extVersionCode` to 12

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension