### PR TITLE
Zenko: update image storage domain (#14775)

### DIFF
--- a/src/uk/zenko/build.gradle
+++ b/src/uk/zenko/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Zenko'
     extClass = '.Zenko'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/uk/zenko/src/eu/kanade/tachiyomi/extension/uk/zenko/Zenko.kt
+++ b/src/uk/zenko/src/eu/kanade/tachiyomi/extension/uk/zenko/Zenko.kt
@@ -186,7 +186,7 @@ class Zenko : HttpSource() {
 
     companion object {
         private const val API_URL = "https://api.zenko.online"
-        private const val IMAGE_STORAGE_URL = "https://zenko.b-cdn.net"
+        private const val IMAGE_STORAGE_URL = "https://storage.zenko.online"
 
         private val json: Json by injectLazy()
     }


### PR DESCRIPTION
Closes [#14775](https://github.com/keiyoushi/extensions-source/issues/14775)

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
