### PR TITLE
CosmicScans.id: update base URL to lc6 (#14898)

### DIFF
--- a/src/id/cosmicscansid/build.gradle
+++ b/src/id/cosmicscansid/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'CosmicScans.id'
     extClass = '.CosmicScansID'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://lc5.cosmicscans.asia'
-    overrideVersionCode = 19
+    baseUrl = 'https://lc6.cosmicscans.asia'
+    overrideVersionCode = 20
     isNsfw = false
 }
 

--- a/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/CosmicScansID.kt
+++ b/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/CosmicScansID.kt
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit
 class CosmicScansID :
     MangaThemesia(
         "CosmicScans.id",
-        "https://lc5.cosmicscans.asia",
+        "https://lc6.cosmicscans.asia",
         "id",
         dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("id")),
     ),


### PR DESCRIPTION
Closes https://github.com/keiyoushi/extensions-source/issues/14898
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
