### PR TITLE
Ezmanhwa fix chapter name parsing

### DIFF
--- a/lib-multisrc/ezmanhwa/build.gradle.kts
+++ b/lib-multisrc/ezmanhwa/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 1
+baseVersionCode = 2

--- a/lib-multisrc/ezmanhwa/src/eu/kanade/tachiyomi/multisrc/ezmanhwa/EZManhwaDto.kt
+++ b/lib-multisrc/ezmanhwa/src/eu/kanade/tachiyomi/multisrc/ezmanhwa/EZManhwaDto.kt
@@ -16,6 +16,8 @@ internal val EZMANHWA_DATE_FORMAT by lazy {
     }
 }
 
+internal val CHAPTER_PREFIX_REGEX = Regex("^(?i)(chapter|ch\\.?|episode|ep\\.?)\\s*.*")
+
 @Serializable
 data class EZManhwaSeriesListDto(
     val data: List<EZManhwaSeriesDto>,
@@ -92,28 +94,14 @@ data class EZManhwaChapterDto(
 
         val parsedTitle = title?.trim()?.takeIf { it.isNotBlank() }
 
-        val chapterName = buildString {
-            if (numStr.isNotBlank()) {
-                if (parsedTitle == null) {
-                    append("Chapter $numStr")
-                } else if (parsedTitle == numStr) {
-                    append("Chapter $numStr")
-                } else if (
-                    parsedTitle.contains(numStr) &&
-                    parsedTitle.matches(Regex("^(?i)(chapter|ch\\.?|episode|ep\\.?)\\s*.*"))
-                ) {
-                    append(parsedTitle)
-                } else {
-                    append("Chapter $numStr")
-                    if (parsedTitle.startsWith("-") || parsedTitle.startsWith(":")) {
-                        append(" ")
-                    } else {
-                        append(" - ")
-                    }
-                    append(parsedTitle)
-                }
-            } else {
-                append(parsedTitle ?: "Chapter")
+        val chapterName = if (numStr.isBlank()) {
+            parsedTitle ?: "Chapter"
+        } else {
+            when {
+                parsedTitle == null || parsedTitle == numStr -> "Chapter $numStr"
+                isChapterTitle(parsedTitle, numStr) -> parsedTitle
+                parsedTitle.startsWith("-") || parsedTitle.startsWith(":") -> "Chapter $numStr $parsedTitle"
+                else -> "Chapter $numStr - $parsedTitle"
             }
         }
 
@@ -121,6 +109,8 @@ data class EZManhwaChapterDto(
         chapter_number = number?.toFloat() ?: -1f
         date_upload = EZMANHWA_DATE_FORMAT.tryParse(createdAt)
     }
+
+    private fun isChapterTitle(title: String, numStr: String): Boolean = title.contains(numStr) && CHAPTER_PREFIX_REGEX.matches(title)
 }
 
 @Serializable

--- a/lib-multisrc/ezmanhwa/src/eu/kanade/tachiyomi/multisrc/ezmanhwa/EZManhwaDto.kt
+++ b/lib-multisrc/ezmanhwa/src/eu/kanade/tachiyomi/multisrc/ezmanhwa/EZManhwaDto.kt
@@ -89,8 +89,35 @@ data class EZManhwaChapterDto(
         val numStr = number?.let {
             if (it % 1.0 == 0.0) it.toInt().toString() else it.toString()
         } ?: ""
-        val chapterTitle = title?.takeIf { it.isNotBlank() } ?: "Chapter $numStr".trim()
-        name = prefix + chapterTitle
+
+        val parsedTitle = title?.trim()?.takeIf { it.isNotBlank() }
+
+        val chapterName = buildString {
+            if (numStr.isNotBlank()) {
+                if (parsedTitle == null) {
+                    append("Chapter $numStr")
+                } else if (parsedTitle == numStr) {
+                    append("Chapter $numStr")
+                } else if (
+                    parsedTitle.contains(numStr) &&
+                    parsedTitle.matches(Regex("^(?i)(chapter|ch\\.?|episode|ep\\.?)\\s*.*"))
+                ) {
+                    append(parsedTitle)
+                } else {
+                    append("Chapter $numStr")
+                    if (parsedTitle.startsWith("-") || parsedTitle.startsWith(":")) {
+                        append(" ")
+                    } else {
+                        append(" - ")
+                    }
+                    append(parsedTitle)
+                }
+            } else {
+                append(parsedTitle ?: "Chapter")
+            }
+        }
+
+        name = prefix + chapterName
         chapter_number = number?.toFloat() ?: -1f
         date_upload = EZMANHWA_DATE_FORMAT.tryParse(createdAt)
     }


### PR DESCRIPTION
Closes #14875

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
