### PR TITLE
Happymh: match current reader API request

### DIFF
--- a/src/zh/happymh/build.gradle
+++ b/src/zh/happymh/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Happymh'
     extClass = '.Happymh'
-    extVersionCode = 20
+    extVersionCode = 21
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/zh/happymh/src/eu/kanade/tachiyomi/extension/zh/happymh/Happymh.kt
+++ b/src/zh/happymh/src/eu/kanade/tachiyomi/extension/zh/happymh/Happymh.kt
@@ -174,13 +174,16 @@ class Happymh :
     // Chapters
 
     private fun fetchChapterByPage(comicId: String, page: Int): ChapterByPageResponseData {
+        val requestId = System.currentTimeMillis().toString()
         val url = "$baseUrl/v2.0/apis/manga/chapterByPage".toHttpUrl().newBuilder()
             .addQueryParameter("code", comicId)
             .addQueryParameter("lang", "cn")
             .addQueryParameter("order", "asc")
             .addQueryParameter("page", "$page")
+            .addQueryParameter("_t", requestId)
             .build()
-        return client.newCall(GET(url, headers)).execute().parseAs<ChapterByPageResponse>().data
+        return client.newCall(GET(url, ajaxHeadersBuilder(requestId).build())).execute()
+            .parseAs<ChapterByPageResponse>().data
     }
 
     private fun fetchChapterByPage(manga: SManga, page: Int): ChapterByPageResponseData {
@@ -235,14 +238,18 @@ class Happymh :
             // Old format is detected
             throw Exception("请刷新章节列表")
         }
+        val requestId = System.currentTimeMillis().toString()
         val chapterUrl = "$baseUrl${chapter.url}".toHttpUrl()
         val comicId = chapterUrl.pathSegments[0]
         val chapterId = chapterUrl.pathSegments[2]
 
-        val url = "$baseUrl/v2.0/apis/manga/reading?code=$comicId&cid=$chapterId&v=v3.1919111"
-        // Some chapters return 403 without this header
-        val headers = headersBuilder()
-            .add("X-Requested-With", "XMLHttpRequest")
+        val url = "$baseUrl/v2.0/apis/manga/reading".toHttpUrl().newBuilder()
+            .addQueryParameter("code", comicId)
+            .addQueryParameter("cid", chapterId)
+            .addQueryParameter("v", "v4.203411")
+            .addQueryParameter("_t", requestId)
+            .build()
+        val headers = ajaxHeadersBuilder(requestId, accept = "application/json")
             .set("Referer", "$baseUrl/mangaread/$comicId/$chapterId")
             .build()
         return GET(url, headers)
@@ -294,6 +301,14 @@ class Happymh :
     private inline fun <reified T> Response.parseAs(): T = use {
         json.decodeFromStream(it.body.byteStream())
     }
+
+    private fun ajaxHeadersBuilder(
+        requestId: String,
+        accept: String = "application/json, text/plain, */*",
+    ): Headers.Builder = headersBuilder()
+        .set("Accept", accept)
+        .add("X-Requested-With", "XMLHttpRequest")
+        .add("X-Requested-Id", requestId)
 
     private fun ChapterByPageResponseData.isPageEnd(): Boolean = isEnd == 1 || items.isEmpty()
 


### PR DESCRIPTION
Closes https://github.com/keiyoushi/extensions-source/issues/14896

A successful HAR captured on April 19, 2026 shows the current reader API now expects a different request signature. The extension was still calling `/v2.0/apis/manga/reading` with `v=v3.1919111`, while the site now uses:
- `v=v4.203411`
- `_t=<timestamp>`
- `Accept: application/json`
- `X-Requested-Id: <timestamp>`

This PR updates the chapter and reader requests to match the current API shape and bumps `extVersionCode` to `21`.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
