### PR TITLE
Ikiru (ID): Update domain to 03.ikiru.wtf

### DIFF
--- a/src/id/mangatale/build.gradle
+++ b/src/id/mangatale/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Ikiru'
     extClass = '.Ikiru'
     themePkg = 'natsuid'
-    baseUrl = 'https://02.ikiru.wtf'
-    overrideVersionCode = 44
+    baseUrl = 'https://03.ikiru.wtf'
+    overrideVersionCode = 45
     isNsfw = false
 }
 

--- a/src/id/mangatale/src/eu/kanade/tachiyomi/extension/id/mangatale/Ikiru.kt
+++ b/src/id/mangatale/src/eu/kanade/tachiyomi/extension/id/mangatale/Ikiru.kt
@@ -8,7 +8,7 @@ class Ikiru :
     NatsuId(
         "Ikiru",
         "id",
-        "https://02.ikiru.wtf",
+        "https://03.ikiru.wtf",
     ) {
     // Formerly "MangaTale"
     override val id = 1532456597012176985


### PR DESCRIPTION
Closes #14860

The old domain `02.ikiru.wtf` now 302-redirects to `03.ikiru.wtf`. Updated `baseUrl` in `build.gradle` and the `Ikiru.kt` source, bumped `overrideVersionCode` 44 → 45.

Verified `03.ikiru.wtf` serves the WordPress-style API the `natsuid` template expects (`/wp-json/wp/v2/manga`, `/wp-admin/admin-ajax.php`) — all endpoints return 200 with real content.

## Checklist

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension