### PR TITLE
Madara multi-src: add related manga support

### DIFF
--- a/lib-multisrc/madara/build.gradle.kts
+++ b/lib-multisrc/madara/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 45
+baseVersionCode = 46
 
 dependencies {
     api(project(":lib:cryptoaes"))

--- a/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
+++ b/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
@@ -209,7 +209,7 @@ abstract class Madara(
                         title = it.ownText()
                     } ?: return@mapNotNull null
                     manga.selectFirst(".widget-thumbnail img")?.let {
-                        thumbnail_url = imageFromElement(it)
+                        thumbnail_url = processThumbnail(imageFromElement(it), true)
                     }
                 }
             }

--- a/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
+++ b/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
@@ -196,6 +196,25 @@ abstract class Madara(
         "div.nav-previous, nav.navigation-ajax, a.nextpostslink"
     }
 
+    // Related Manga
+    protected open fun relatedMangaSelector() = ".related-reading-wrap"
+
+    override fun relatedMangaListParse(response: Response): List<SManga> {
+        val document = response.asJsoup()
+        return document.select(relatedMangaSelector())
+            .mapNotNull { manga ->
+                SManga.create().apply {
+                    manga.selectFirst(".widget-title a")?.let {
+                        setUrlWithoutDomain(it.attr("abs:href"))
+                        title = it.ownText()
+                    } ?: return@mapNotNull null
+                    manga.selectFirst(".widget-thumbnail img")?.let {
+                        thumbnail_url = imageFromElement(it)
+                    }
+                }
+            }
+    }
+
     // Latest Updates
 
     override fun latestUpdatesSelector() = popularMangaSelector()


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension