### PR TITLE
Softkomik (ID): Fall back to WebView when session API fails

### DIFF
--- a/src/id/softkomik/build.gradle
+++ b/src/id/softkomik/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Softkomik'
     extClass = '.Softkomik'
-    extVersionCode = 10
+    extVersionCode = 11
     isNsfw = false
 }
 

--- a/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
+++ b/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
@@ -422,17 +422,22 @@ class Softkomik : HttpSource() {
                 client.newCall(GET("$baseUrl/api/me", apiHeaders)).execute().close()
             }
 
-            val response = client.newCall(GET(route.sessionApiUrl, apiHeaders)).execute()
+            val response = runCatching {
+                client.newCall(GET(route.sessionApiUrl, apiHeaders)).execute()
+            }.getOrNull()
 
-            if (!response.isSuccessful) {
-                val code = response.code
-                response.close()
-                throw Exception("Gagal mendapatkan akses token dari Softkomik (HTTP $code).")
+            if (response?.isSuccessful == true) {
+                val newSession = response.use { it.parseAs<SessionDto>() }
+                sessionsByUrlKey[route.key] = newSession
+                return newSession
             }
+            response?.close()
 
-            val newSession = response.use { it.parseAs<SessionDto>() }
-            sessionsByUrlKey[route.key] = newSession
-            return newSession
+            // Softkomik frequently renames their session API endpoint. When the direct
+            // call fails (commonly with HTTP 404), fall back to capturing the session
+            // headers that the site's own JavaScript sends from a live WebView — that
+            // path survives URL changes without an extension update.
+            return getSessionViaWebView(route)
         }
     }
 


### PR DESCRIPTION
Closes #14851

## Root cause

The session endpoints the extension calls 404 again:

```
GET https://softkomik.co/api/sessions/kajsijas   → 404
GET https://softkomik.co/api/sessions/chapter    → 404
```

The site just renames its session path every few weeks — the last update was #14473 on 2026-04-03, and the one before that was #14352 on 2026-03-30. When `getSession` hits a non-successful response it throws `"Gagal mendapatkan akses token dari Softkomik (HTTP 404)"` before `apiAuthInterceptor` gets a chance to fall back.

## Fix

`getSessionViaWebView` already captures a valid `X-Token` / `X-Sign` pair by loading the manga detail page in a hidden WebView and intercepting the headers the site's own JavaScript sends on its API calls. This path survives URL renames because the site's JS always knows the current endpoint.

The fallback was only being exercised after a *subsequent* API call returned non-200 with the obtained token, not when the session endpoint itself failed. Route `getSession` through the WebView fallback on any failure from the direct call, so the next rename doesn't need another PR.

Also bumped `extVersionCode` 10 → 11.

## Testing

- Built with `./gradlew :src:id:softkomik:assembleDebug` — no warnings.
- Installed into Mihon on an Android 14 emulator — extension loads.
- Confirmed the user's reported condition reproduces on current `main`: both `/api/sessions/kajsijas` and `/api/sessions/chapter` return 404 to anonymous callers.

A reporter on the issue ([comment](https://github.com/keiyoushi/extensions-source/issues/14851#issuecomment-)) noted that accessing the site via the in-app WebView works fine — consistent with the WebView fallback being the reliable path.

## Checklist

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension