### PR TITLE
Fix LibGroup summary double parse.

### DIFF
--- a/lib-multisrc/libgroup/build.gradle.kts
+++ b/lib-multisrc/libgroup/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 39
+baseVersionCode = 40

--- a/lib-multisrc/libgroup/src/eu/kanade/tachiyomi/multisrc/libgroup/LibGroupDto.kt
+++ b/lib-multisrc/libgroup/src/eu/kanade/tachiyomi/multisrc/libgroup/LibGroupDto.kt
@@ -7,7 +7,6 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonArray
@@ -216,16 +215,16 @@ class Manga(
                         }
                         result.append("\n")
                     }
-                }
-
-                // Recurse into content array for other node types
-                node["content"]?.jsonArray?.forEach { child ->
-                    extractTextFromNode(child, result)
+                    // Recurse into content array for other node types
+                    else -> {
+                        node["content"]?.jsonArray?.forEach { child ->
+                            extractTextFromNode(child, result)
+                        }
+                    }
                 }
             }
             is JsonArray -> node.forEach { extractTextFromNode(it, result) }
             is JsonPrimitive -> result.append(node.content)
-            is JsonNull -> { /* do nothing */ }
         }
     }
 }


### PR DESCRIPTION
Small fix for #14824 (prev pull req https://github.com/keiyoushi/extensions-source/pull/14828).
After previous change summary object start parse twice, so here i fix it.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
