### PR TITLE
Ninegrid: FIX thumbnails not loading in series list

### DIFF
--- a/src/ru/ninegrid/build.gradle
+++ b/src/ru/ninegrid/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'NineGrid'
     extClass = '.NineGrid'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = false
 }
 

--- a/src/ru/ninegrid/src/eu/kanade/tachiyomi/extension/ru/ninegrid/Dto.kt
+++ b/src/ru/ninegrid/src/eu/kanade/tachiyomi/extension/ru/ninegrid/Dto.kt
@@ -19,9 +19,10 @@ class SeriesDto(
     val genres: List<String> = emptyList(),
     val status: String? = null,
 ) {
-    fun toSManga(): SManga = SManga.create().apply {
+    fun toSManga(apiBase: String): SManga = SManga.create().apply {
         url = id.toString()
         title = name
+        thumbnail_url = "$apiBase/series/${this@SeriesDto.id}/thumbnail"
         description = this@SeriesDto.description
         author = publisherName
         genre = genres.joinToString()

--- a/src/ru/ninegrid/src/eu/kanade/tachiyomi/extension/ru/ninegrid/NineGrid.kt
+++ b/src/ru/ninegrid/src/eu/kanade/tachiyomi/extension/ru/ninegrid/NineGrid.kt
@@ -68,11 +68,7 @@ class NineGrid :
 
     override fun popularMangaParse(response: Response): MangasPage {
         val data = response.parseAs<SeriesListResponse>()
-        val mangas = data.content.map {
-            it.toSManga().apply {
-                thumbnail_url = "$apiBase/series/$id/thumbnail"
-            }
-        }
+        val mangas = data.content.map { it.toSManga(apiBase) }
         return MangasPage(mangas, data.page + 1 < data.totalPages)
     }
 
@@ -128,10 +124,7 @@ class NineGrid :
 
     override fun mangaDetailsParse(response: Response): SManga {
         val s = response.parseAs<SeriesDto>()
-        return s.toSManga().apply {
-            thumbnail_url = "$apiBase/series/${s.id}/thumbnail"
-            initialized = true
-        }
+        return s.toSManga(apiBase).apply { initialized = true }
     }
 
     // Chapter List


### PR DESCRIPTION
## Bug

Thumbnails don't load in the Popular/Latest/Search series list. They only appear after opening a series detail page.

## Cause

In `popularMangaParse`, the thumbnail URL was constructed inside `SManga.apply {}`:

```kotlin
it.toSManga().apply {
    thumbnail_url = "$apiBase/series/$id/thumbnail"  // $id = SManga.id (hash), not series ID!
}
```

`$id` resolved to `SManga.id` (a hash-based Long) instead of the actual series integer ID from the API.

## Fix

Moved `thumbnail_url` construction into `SeriesDto.toSManga(apiBase)` where `this@SeriesDto.id` correctly references the API series ID:

```kotlin
fun toSManga(apiBase: String): SManga = SManga.create().apply {
    thumbnail_url = "$apiBase/series/${this@SeriesDto.id}/thumbnail"
    // ...
}
```