### PR TITLE
MangaMoins: Fix 403 error on API calls

### DIFF
--- a/src/fr/mangamoins/build.gradle
+++ b/src/fr/mangamoins/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaMoins'
     extClass = '.MangaMoins'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = false
 }
 

--- a/src/fr/mangamoins/src/eu/kanade/tachiyomi/extension/fr/mangamoins/MangaMoins.kt
+++ b/src/fr/mangamoins/src/eu/kanade/tachiyomi/extension/fr/mangamoins/MangaMoins.kt
@@ -27,19 +27,16 @@ class MangaMoins : HttpSource() {
 
     private val apiUrl = "$baseUrl/api/v1"
 
-    override val client: OkHttpClient = super.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .addInterceptor { chain ->
             val request = chain.request()
             val response = chain.proceed(request)
 
             if (response.code == 403 && request.url.toString().contains("/api/v1/")) {
-                val responseBody = response.peekBody(1024L).string()
-                if (responseBody.contains("\"code\":101")) {
-                    response.close()
-                    val homeRequest = GET(baseUrl, headers)
-                    super.client.newCall(homeRequest).execute().close()
-                    return@addInterceptor chain.proceed(request)
-                }
+                response.close()
+                val homeRequest = GET(baseUrl, headers)
+                super.client.newCall(homeRequest).execute().close()
+                return@addInterceptor chain.proceed(request)
             }
             response
         }

--- a/src/fr/mangamoins/src/eu/kanade/tachiyomi/extension/fr/mangamoins/MangaMoins.kt
+++ b/src/fr/mangamoins/src/eu/kanade/tachiyomi/extension/fr/mangamoins/MangaMoins.kt
@@ -10,6 +10,7 @@ import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.utils.parseAs
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import java.util.Locale
@@ -25,6 +26,24 @@ class MangaMoins : HttpSource() {
     override val supportsLatest = true
 
     private val apiUrl = "$baseUrl/api/v1"
+
+    override val client: OkHttpClient = super.client.newBuilder()
+        .addInterceptor { chain ->
+            val request = chain.request()
+            val response = chain.proceed(request)
+
+            if (response.code == 403 && request.url.toString().contains("/api/v1/")) {
+                val responseBody = response.peekBody(1024L).string()
+                if (responseBody.contains("\"code\":101")) {
+                    response.close()
+                    val homeRequest = GET(baseUrl, headers)
+                    super.client.newCall(homeRequest).execute().close()
+                    return@addInterceptor chain.proceed(request)
+                }
+            }
+            response
+        }
+        .build()
 
     override fun headersBuilder(): Headers.Builder = super.headersBuilder()
         .add("Referer", "$baseUrl/")


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
