### PR TITLE
Luscious Fix 1000+ Image Chapter Merging

### DIFF
--- a/src/all/luscious/build.gradle
+++ b/src/all/luscious/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Luscious'
     extClass = '.LusciousFactory'
-    extVersionCode = 29
+    extVersionCode = 30
     isNsfw = true
 }
 

--- a/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/Luscious.kt
+++ b/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/Luscious.kt
@@ -26,6 +26,7 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.asResponseBody
 import rx.Observable
+import kotlin.math.ceil
 
 abstract class Luscious(
     final override val lang: String,
@@ -84,6 +85,7 @@ abstract class Luscious(
             Input(
                 display = sortByFilter.selected,
                 page = page,
+                itemsPerPage = 50,
                 filters = mutableListOf<Filter>().apply {
                     if (contentTypeFilter.selected != FILTER_VALUE_IGNORE) {
                         add(contentTypeFilter.toJsonObject("content_id"))
@@ -216,9 +218,60 @@ abstract class Luscious(
     override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> {
         val id = manga.url.substringAfterLast("_").removeSuffix("/")
 
-        return client.newCall(GET(buildAlbumPicturesPageUrl(id, 1)))
+        return client.newCall(buildAlbumInfoRequest(id))
             .asObservableSuccess()
-            .map { parseAlbumPicturesResponse(it, manga.url) }
+            .map { response ->
+                val album = response.parseAs<AlbumGetResponse>().data.album.get
+                val totalPictures = album.numberOfPictures
+
+                if (getMergeChapterPref()) {
+                    val chapters = mutableListOf<SChapter>()
+                    val chunkCount = ceil(totalPictures / 1000.0).toInt().coerceAtLeast(1)
+
+                    for (i in 1..chunkCount) {
+                        val chapter = SChapter.create()
+                        chapter.url = "${manga.url}?chunk=$i"
+                        chapter.name = if (chunkCount == 1) "Merged Chapter" else "Merged Chapter (Part $i)"
+                        chapter.chapter_number = i.toFloat()
+                        chapter.date_upload = (album.created?.toLong() ?: 0L) * 1000L
+                        chapters.add(chapter)
+                    }
+                    chapters.reversed()
+                } else {
+                    val chapters = mutableListOf<SChapter>()
+                    var page = 1
+                    var hasMore = true
+
+                    while (hasMore) {
+                        val newPage = client.newCall(GET(buildAlbumPicturesPageUrl(id, page))).execute()
+                        val data = newPage.parseAs<AlbumListOwnPicturesResponse>()
+                        val pictureItems = parsePictures(data)
+
+                        if (pictureItems.isEmpty()) {
+                            hasMore = false
+                        } else {
+                            pictureItems.forEach {
+                                val chapter = SChapter.create().apply {
+                                    chapter_number = it.index.toFloat()
+                                    name = "${it.index} - ${it.title}"
+                                    date_upload = (it.created ?: 0L) * 1000L
+                                }
+                                chapter.setUrlWithoutDomain(it.url)
+                                chapters.add(chapter)
+                            }
+
+                            // API natively caps `total_items` tracking to 1000 so we override that by
+                            // directly tracking standard math iteration against the true `numberOfPictures`
+                            if (page * 50 >= totalPictures || data.data.picture.list.items.isEmpty()) {
+                                hasMore = false
+                            } else {
+                                page++
+                            }
+                        }
+                    }
+                    chapters.reversed()
+                }
+            }
     }
 
     private fun getPictureUrl(picture: Picture) = when {
@@ -254,52 +307,6 @@ abstract class Luscious(
         return items
     }
 
-    private fun parseAlbumPicturesResponse(response: Response, mangaUrl: String): List<SChapter> {
-        val chapters = mutableListOf<SChapter>()
-
-        val id = response.request.url.queryParameter("variables").toString().parseAs<Variables>().input.filters
-            .first { it.name == "album_id" }.value
-
-        var data = response.parseAs<AlbumListOwnPicturesResponse>()
-
-        when (getMergeChapterPref()) {
-            true -> {
-                val chapter = SChapter.create()
-                chapter.url = mangaUrl
-                chapter.name = "Merged Chapter"
-                chapter.date_upload = data.data.picture.list.items[0].created.toLong()
-                chapter.chapter_number = 1F
-                chapters.add(chapter)
-            }
-
-            false -> {
-                var nextPage = true
-                var page = 2
-
-                while (nextPage) {
-                    nextPage = data.data.picture.list.info.hasNextPage
-                    val pictureItems = parsePictures(data)
-                    pictureItems.forEach {
-                        val chapter = SChapter.create().apply {
-                            chapter_number = it.index.toFloat()
-                            name = "${it.index} - ${it.title}"
-                            date_upload = (it.created ?: 0) * 1000
-                        }
-                        chapter.setUrlWithoutDomain(it.url)
-                        chapters.add(chapter)
-                    }
-                    if (nextPage) {
-                        val newPage = client.newCall(GET(buildAlbumPicturesPageUrl(id, page))).execute()
-                        data = newPage.parseAs<AlbumListOwnPicturesResponse>()
-                    }
-                    page++
-                }
-            }
-        }
-
-        return chapters.reversed()
-    }
-
     override fun chapterListParse(response: Response): List<SChapter> = throw UnsupportedOperationException()
 
     // Pages
@@ -311,6 +318,7 @@ abstract class Luscious(
             ),
             display = getSortPref(),
             page = page,
+            itemsPerPage = 50,
         ),
     )
 
@@ -323,40 +331,32 @@ abstract class Luscious(
             .build()
     }
 
-    private fun parseAlbumPicturesResponseMergeChapter(response: Response): List<Page> {
-        val pages = mutableListOf<Page>()
-        var nextPage = true
-        var page = 2
-        val id = response.request.url.queryParameter("variables").toString().parseAs<Variables>().input.filters
-            .first { it.name == "album_id" }.value
+    override fun fetchPageList(chapter: SChapter): Observable<List<Page>> = if (chapter.url.startsWith("/albums/")) {
+        val chunk = chapter.url.substringAfter("?chunk=", "1").substringBefore("#").toIntOrNull() ?: 1
+        val id = chapter.url.substringBefore("?").substringAfterLast("_").removeSuffix("/")
 
-        var data = response.parseAs<AlbumListOwnPicturesResponse>()
+        Observable.fromCallable {
+            val pages = mutableListOf<Page>()
+            val startPage = (chunk - 1) * 20 + 1
+            val endPage = chunk * 20
 
-        while (nextPage) {
-            nextPage = data.data.picture.list.info.hasNextPage
-            val pictureItems = parsePictures(data)
-            pages.addAll(pictureItems.map { Page(it.index, "", it.url.toHttpUrl().newBuilder().host(cdnHost).build().toString()) })
-            if (nextPage) {
-                val newPage = client.newCall(GET(buildAlbumPicturesPageUrl(id, page))).execute()
-                data = newPage.parseAs<AlbumListOwnPicturesResponse>()
+            for (page in startPage..endPage) {
+                val response = client.newCall(GET(buildAlbumPicturesPageUrl(id, page))).execute()
+                val data = response.parseAs<AlbumListOwnPicturesResponse>()
+                val pictureItems = parsePictures(data)
+
+                if (pictureItems.isEmpty()) break
+
+                pictureItems.forEach {
+                    pages.add(Page(pages.size, imageUrl = it.url.toHttpUrl().newBuilder().host(cdnHost).build().toString()))
+                }
+
+                if (pictureItems.size < 50) break
             }
-            page++
+            pages
         }
-        return pages
-    }
-
-    override fun fetchPageList(chapter: SChapter): Observable<List<Page>> = when (getMergeChapterPref()) {
-        true -> {
-            val id = chapter.url.substringAfterLast("_").removeSuffix("/")
-
-            client.newCall(GET(buildAlbumPicturesPageUrl(id, 1)))
-                .asObservableSuccess()
-                .map { parseAlbumPicturesResponseMergeChapter(it) }
-        }
-
-        false -> {
-            Observable.just(listOf(Page(0, "", "https://$cdnHost${chapter.url}")))
-        }
+    } else {
+        Observable.just(listOf(Page(0, imageUrl = "https://$cdnHost${chapter.url}")))
     }
 
     override fun pageListParse(response: Response): List<Page> = throw UnsupportedOperationException()
@@ -365,14 +365,10 @@ abstract class Luscious(
 
     override fun fetchImageUrl(page: Page): Observable<String> = throw UnsupportedOperationException()
 
-    override fun getChapterUrl(chapter: SChapter): String = when (getMergeChapterPref()) {
-        true -> {
-            "$baseUrl${chapter.url}"
-        }
-
-        else -> {
-            "https://$cdnHost${chapter.url}"
-        }
+    override fun getChapterUrl(chapter: SChapter): String = if (chapter.url.startsWith("/albums/")) {
+        "$baseUrl${chapter.url.substringBefore("?")}"
+    } else {
+        "https://$cdnHost${chapter.url}"
     }
 
     // Details

--- a/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/LusciousConstants.kt
+++ b/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/LusciousConstants.kt
@@ -66,7 +66,7 @@ fragment AlbumStandard on Album {
 
 const val MERGE_CHAPTER_PREF_KEY = "MERGE_CHAPTER"
 const val MERGE_CHAPTER_PREF_TITLE = "Merge Chapter"
-const val MERGE_CHAPTER_PREF_SUMMARY = "If checked, merges all content of one Album into one Chapter"
+const val MERGE_CHAPTER_PREF_SUMMARY = "If checked, merges all content of one album into chapters of up to 1000 images each, labeled as 'Merged Chapter (Part 1)', 'Merged Chapter (Part 2)', and so on. Note: you must be logged into the WebView to access more than 1000 images."
 const val MERGE_CHAPTER_PREF_DEFAULT_VALUE = false
 
 const val RESOLUTION_PREF_KEY = "RESOLUTION"

--- a/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/LusciousDTO.kt
+++ b/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/LusciousDTO.kt
@@ -60,6 +60,7 @@ class FullAlbum(
     @SerialName("number_of_animated_pictures")
     val numberOfAnimatedPictures: Int,
     val content: ItemWithTitle,
+    val created: Double? = null,
 )
 
 @Serializable
@@ -89,6 +90,8 @@ class Variables(
 class Input(
     val display: String?,
     val page: Int,
+    @SerialName("items_per_page")
+    val itemsPerPage: Int = 50,
     val filters: List<Filter>,
 )
 


### PR DESCRIPTION
Closes #14194


<img width="400" alt="image" src="https://github.com/user-attachments/assets/456c2a14-87e1-4b4d-88fa-3333e6f6335b" />

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
