### PR TITLE
ArtLapsa & RitharScans: fix premium chapters

### DIFF
--- a/src/en/artlapsa/build.gradle
+++ b/src/en/artlapsa/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ArtLapsa'
     themePkg = 'keyoapp'
     baseUrl = 'https://artlapsa.com'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
     isNsfw = false
 }
 

--- a/src/en/artlapsa/src/eu/kanade/tachiyomi/extension/en/artlapsa/ArtLapsa.kt
+++ b/src/en/artlapsa/src/eu/kanade/tachiyomi/extension/en/artlapsa/ArtLapsa.kt
@@ -57,8 +57,8 @@ class ArtLapsa : Keyoapp("Art Lapsa", "https://artlapsa.com", "en") {
 
     override fun pageListParse(document: Document): List<Page> {
         val data = document.selectFirst("script[type=\"application/ld+json\"]")!!.data().parseAs<ChapterLD>()
-        val seriesID = data.url.substring(data.url.lastIndexOf('/') + 1)
-        val chapterID = data.isPartOf.url.substring(data.isPartOf.url.lastIndexOf('/') + 1)
+        val seriesID = data.url.substringAfterLast('/')
+        val chapterID = data.isPartOf.url.substringAfterLast('/')
 
         return (1..data.numberOfPages).mapIndexed { i, page ->
             Page(

--- a/src/en/artlapsa/src/eu/kanade/tachiyomi/extension/en/artlapsa/ArtLapsa.kt
+++ b/src/en/artlapsa/src/eu/kanade/tachiyomi/extension/en/artlapsa/ArtLapsa.kt
@@ -27,8 +27,7 @@ class ArtLapsa : Keyoapp("Art Lapsa", "https://artlapsa.com", "en") {
 
     override fun genresRequest() = GET("$baseUrl/search", headers)
 
-    override fun parseGenres(document: Document): List<Genre> =
-        document.select("[wire:model.live=genre] option:not(:contains(All))").map { Genre(it.text(), it.attr("value")) }
+    override fun parseGenres(document: Document): List<Genre> = document.select("[wire:model.live=genre] option:not(:contains(All))").map { Genre(it.text(), it.attr("value")) }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         val url = "$baseUrl/search".toHttpUrl().newBuilder().apply {

--- a/src/en/artlapsa/src/eu/kanade/tachiyomi/extension/en/artlapsa/ArtLapsa.kt
+++ b/src/en/artlapsa/src/eu/kanade/tachiyomi/extension/en/artlapsa/ArtLapsa.kt
@@ -6,19 +6,14 @@ import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.util.asJsoup
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.int
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
+import keiyoushi.utils.parseAs
+import kotlinx.serialization.Serializable
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
-import uy.kohesive.injekt.injectLazy
 
 class ArtLapsa : Keyoapp("Art Lapsa", "https://artlapsa.com", "en") {
-
-    private val json: Json by injectLazy()
 
     override fun popularMangaParse(response: Response): MangasPage {
         val mangas = super.popularMangaParse(response).mangas.distinctBy { it.url }
@@ -61,14 +56,11 @@ class ArtLapsa : Keyoapp("Art Lapsa", "https://artlapsa.com", "en") {
     }
 
     override fun pageListParse(document: Document): List<Page> {
-        val data = json.parseToJsonElement(document.selectFirst("script[type=\"application/ld+json\"]")!!.data()).jsonObject
-        val seriesURL = data["isPartOf"]!!.jsonObject["url"]!!.jsonPrimitive.content
-        val seriesID = seriesURL.substring(seriesURL.lastIndexOf('/') + 1)
-        val chapterURL = data["url"]!!.jsonPrimitive.content
-        val chapterID = chapterURL.substring(chapterURL.lastIndexOf('/') + 1)
-        val numberOfPages = data["numberOfPages"]!!.jsonPrimitive.int
+        val data = document.selectFirst("script[type=\"application/ld+json\"]")!!.data().parseAs<ChapterLD>()
+        val seriesID = data.url.substring(data.url.lastIndexOf('/') + 1)
+        val chapterID = data.isPartOf.url.substring(data.isPartOf.url.lastIndexOf('/') + 1)
 
-        return (1..numberOfPages).mapIndexed { i, page ->
+        return (1..data.numberOfPages).mapIndexed { i, page ->
             Page(
                 i,
                 document.location(),
@@ -77,3 +69,15 @@ class ArtLapsa : Keyoapp("Art Lapsa", "https://artlapsa.com", "en") {
         }
     }
 }
+
+@Serializable
+internal class ChapterLD(
+    val isPartOf: SeriesLD,
+    val numberOfPages: Int,
+    val url: String,
+)
+
+@Serializable
+internal class SeriesLD(
+    val url: String,
+)

--- a/src/en/artlapsa/src/eu/kanade/tachiyomi/extension/en/artlapsa/ArtLapsa.kt
+++ b/src/en/artlapsa/src/eu/kanade/tachiyomi/extension/en/artlapsa/ArtLapsa.kt
@@ -6,15 +6,19 @@ import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.util.asJsoup
-import keiyoushi.utils.parseAs
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
-import java.net.URLDecoder
+import uy.kohesive.injekt.injectLazy
 
 class ArtLapsa : Keyoapp("Art Lapsa", "https://artlapsa.com", "en") {
+
+    private val json: Json by injectLazy()
 
     override fun popularMangaParse(response: Response): MangasPage {
         val mangas = super.popularMangaParse(response).mangas.distinctBy { it.url }
@@ -23,7 +27,8 @@ class ArtLapsa : Keyoapp("Art Lapsa", "https://artlapsa.com", "en") {
 
     override fun genresRequest() = GET("$baseUrl/search", headers)
 
-    override fun parseGenres(document: Document): List<Genre> = document.select("[wire:model.live=genre] option:not(:contains(All))").map { Genre(it.text(), it.attr("value")) }
+    override fun parseGenres(document: Document): List<Genre> =
+        document.select("[wire:model.live=genre] option:not(:contains(All))").map { Genre(it.text(), it.attr("value")) }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         val url = "$baseUrl/search".toHttpUrl().newBuilder().apply {
@@ -57,27 +62,19 @@ class ArtLapsa : Keyoapp("Art Lapsa", "https://artlapsa.com", "en") {
     }
 
     override fun pageListParse(document: Document): List<Page> {
-        val (pages, baseLink) = document.selectFirst("[x-data*=pages]")!!.attr("x-data")
-            .replace(spaces, "")
-            .let {
-                val pages = pagesRegex.find(it)!!.groupValues[1]
-                    .let { encoded -> URLDecoder.decode(encoded, "UTF-8") }
-                    .parseAs<List<Path>>()
+        val data = json.parseToJsonElement(document.selectFirst("script[type=\"application/ld+json\"]")!!.data()).jsonObject
+        val seriesURL = data["isPartOf"]!!.jsonObject["url"]!!.jsonPrimitive.content
+        val seriesID = seriesURL.substring(seriesURL.lastIndexOf('/') + 1)
+        val chapterURL = data["url"]!!.jsonPrimitive.content
+        val chapterID = chapterURL.substring(chapterURL.lastIndexOf('/') + 1)
+        val numberOfPages = data["numberOfPages"]!!.jsonPrimitive.int
 
-                val baseLink = linkRegex.find(it)!!.groupValues[2]
-
-                pages to baseLink
-            }
-
-        return pages.mapIndexed { i, img ->
-            Page(i, document.location(), baseLink + img.path)
+        return (1..numberOfPages).mapIndexed { i, page ->
+            Page(
+                i,
+                document.location(),
+                "$baseUrl/storage/series/webtoon/$seriesID/chapters/$chapterID/${page.toString().padStart(3, '0')}.jpg",
+            )
         }
     }
 }
-
-private val spaces = Regex("\\s")
-private val pagesRegex = Regex("pages:(\\[[^]]+])")
-private val linkRegex = """baseLink:(["'])(.+?)\1""".toRegex()
-
-@Serializable
-class Path(val path: String)

--- a/src/en/ritharscans/build.gradle
+++ b/src/en/ritharscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.RitharScans'
     themePkg = 'keyoapp'
     baseUrl = 'https://ritharscans.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
 }
 

--- a/src/en/ritharscans/src/eu/kanade/tachiyomi/extension/en/ritharscans/RitharScans.kt
+++ b/src/en/ritharscans/src/eu/kanade/tachiyomi/extension/en/ritharscans/RitharScans.kt
@@ -68,8 +68,8 @@ class RitharScans : Keyoapp("RitharScans", "https://ritharscans.com", "en") {
 
     override fun pageListParse(document: Document): List<Page> {
         val data = document.selectFirst("script[type=\"application/ld+json\"]")!!.data().parseAs<ChapterLD>()
-        val seriesID = data.url.substring(data.url.lastIndexOf('/') + 1)
-        val chapterID = data.isPartOf.url.substring(data.isPartOf.url.lastIndexOf('/') + 1)
+        val seriesID = data.url.substringAfterLast('/')
+        val chapterID = data.isPartOf.url.substringAfterLast('/')
 
         return (1..data.numberOfPages).mapIndexed { i, page ->
             Page(

--- a/src/en/ritharscans/src/eu/kanade/tachiyomi/extension/en/ritharscans/RitharScans.kt
+++ b/src/en/ritharscans/src/eu/kanade/tachiyomi/extension/en/ritharscans/RitharScans.kt
@@ -6,19 +6,14 @@ import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.util.asJsoup
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.int
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
+import keiyoushi.utils.parseAs
+import kotlinx.serialization.Serializable
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
-import uy.kohesive.injekt.injectLazy
 
 class RitharScans : Keyoapp("RitharScans", "https://ritharscans.com", "en") {
-
-    private val json: Json by injectLazy()
 
     override fun popularMangaParse(response: Response): MangasPage {
         val mangas = super.popularMangaParse(response).mangas
@@ -72,14 +67,11 @@ class RitharScans : Keyoapp("RitharScans", "https://ritharscans.com", "en") {
     override val typeSelector = "[alt=Type]"
 
     override fun pageListParse(document: Document): List<Page> {
-        val data = json.parseToJsonElement(document.selectFirst("script[type=\"application/ld+json\"]")!!.data()).jsonObject
-        val seriesURL = data["isPartOf"]!!.jsonObject["url"]!!.jsonPrimitive.content
-        val seriesID = seriesURL.substring(seriesURL.lastIndexOf('/') + 1)
-        val chapterURL = data["url"]!!.jsonPrimitive.content
-        val chapterID = chapterURL.substring(chapterURL.lastIndexOf('/') + 1)
-        val numberOfPages = data["numberOfPages"]!!.jsonPrimitive.int
+        val data = document.selectFirst("script[type=\"application/ld+json\"]")!!.data().parseAs<ChapterLD>()
+        val seriesID = data.url.substring(data.url.lastIndexOf('/') + 1)
+        val chapterID = data.isPartOf.url.substring(data.isPartOf.url.lastIndexOf('/') + 1)
 
-        return (1..numberOfPages).mapIndexed { i, page ->
+        return (1..data.numberOfPages).mapIndexed { i, page ->
             Page(
                 i,
                 document.location(),
@@ -88,3 +80,15 @@ class RitharScans : Keyoapp("RitharScans", "https://ritharscans.com", "en") {
         }
     }
 }
+
+@Serializable
+internal class ChapterLD(
+    val isPartOf: SeriesLD,
+    val numberOfPages: Int,
+    val url: String,
+)
+
+@Serializable
+internal class SeriesLD(
+    val url: String,
+)

--- a/src/en/ritharscans/src/eu/kanade/tachiyomi/extension/en/ritharscans/RitharScans.kt
+++ b/src/en/ritharscans/src/eu/kanade/tachiyomi/extension/en/ritharscans/RitharScans.kt
@@ -6,14 +6,19 @@ import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.util.asJsoup
-import keiyoushi.utils.parseAs
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
+import uy.kohesive.injekt.injectLazy
 
 class RitharScans : Keyoapp("RitharScans", "https://ritharscans.com", "en") {
+
+    private val json: Json by injectLazy()
 
     override fun popularMangaParse(response: Response): MangasPage {
         val mangas = super.popularMangaParse(response).mangas
@@ -67,31 +72,19 @@ class RitharScans : Keyoapp("RitharScans", "https://ritharscans.com", "en") {
     override val typeSelector = "[alt=Type]"
 
     override fun pageListParse(document: Document): List<Page> {
-        val (pages, baseLink) = document.selectFirst("[x-data*=pages]")!!.attr("x-data")
-            .replace(spaces, "")
-            .let {
-                val pages = pagesRegex.find(it)!!.groupValues[1]
-                    .replace("&quot;", "\"")
-                    .parseAs<List<Path>>()
+        val data = json.parseToJsonElement(document.selectFirst("script[type=\"application/ld+json\"]")!!.data()).jsonObject
+        val seriesURL = data["isPartOf"]!!.jsonObject["url"]!!.jsonPrimitive.content
+        val seriesID = seriesURL.substring(seriesURL.lastIndexOf('/') + 1)
+        val chapterURL = data["url"]!!.jsonPrimitive.content
+        val chapterID = chapterURL.substring(chapterURL.lastIndexOf('/') + 1)
+        val numberOfPages = data["numberOfPages"]!!.jsonPrimitive.int
 
-                val baseLink = linkRegex.find(
-                    it.replace("\"", "'"),
-                )!!.groupValues[1]
-
-                pages to baseLink
-            }
-
-        return pages.mapIndexed { i, img ->
-            Page(i, document.location(), baseLink + img.path)
+        return (1..numberOfPages).mapIndexed { i, page ->
+            Page(
+                i,
+                document.location(),
+                "$baseUrl/storage/series/webtoon/$seriesID/chapters/$chapterID/${page.toString().padStart(3, '0')}.jpg",
+            )
         }
     }
 }
-
-private val spaces = Regex("\\s")
-private val pagesRegex = Regex("pages:(\\[[^]]+])")
-private val linkRegex = Regex("baseLink:'([^']+)'")
-
-@Serializable
-class Path(
-    val path: String,
-)


### PR DESCRIPTION
Fixes premium chapters not loading due to an empty page list.

Instead of relying on the `x-data` attribute (which isn't even a valid JSON), the JSON-LD element (`script[type="application/ld+json"]`) is used to generate the page list.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
