### PR TITLE
Japscan: Fix chapter anti-scraping honeypots

### DIFF
--- a/src/fr/japscan/build.gradle
+++ b/src/fr/japscan/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Japscan'
     extClass = '.Japscan'
-    extVersionCode = 63
+    extVersionCode = 64
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -234,7 +234,7 @@ class Japscan :
 
     override fun chapterFromElement(element: Element): SChapter {
         // Only search for a tag with any attribute containing manga/manhua/manhwa
-        val urlPairs = (element.getElementsContainingText("Chapitre") + element.getElementsContainingText("Volume"))
+        val allUrlPairs = (element.getElementsContainingText("Chapitre") + element.getElementsContainingText("Volume"))
             .mapNotNull { el ->
                 // Find the first attribute whose value matches the chapter URL pattern
                 val attrMatch = el.attributes().asList().firstOrNull { attr ->
@@ -251,6 +251,18 @@ class Japscan :
                 }
             }
             .distinctBy { it.second }
+
+        // Filter out known anti-scraping honeypots (e.g. "Chapitre Love You MikeZeDev Volume").
+        // Real chapter URLs end with a numeric segment (e.g. /manga/one-piece/1100/).
+        // Honeypots either have non-numeric URL segments or contain tell-tale strings in their name.
+        val filtered = allUrlPairs
+            .filter { (name, url, _) ->
+                !name.contains("MikeZeDev", ignoreCase = true) &&
+                    url.trimEnd('/').substringAfterLast('/').all { it.isDigit() }
+            }
+
+        // Fall back to the unfiltered list in case the heuristics are too aggressive.
+        val urlPairs = (filtered.ifEmpty { allUrlPairs })
             .sortedWith(
                 compareByDescending<Triple<String, String, Boolean>> { it.third }
                     .thenBy { it.second.length },


### PR DESCRIPTION
The existing parsing logic in chapterFromElement was systematically picking this fake entry over real chapters because it used a non-href attribute (preferred by the current sort) and had a shorter URL (also preferred). Since every chapter container returned the same fake URL, deduplication collapsed the entire list into a single fake chapter.
Changes:

Added a two-layer filter before sorting: exclude elements whose name contains "MikeZeDev" (case-insensitive), and exclude URLs whose last path segment is not a pure number (real chapter URLs always end with a chapter number, e.g. /manga/one-piece/1100/)
Added a fallback to the unfiltered list in case the heuristics are too aggressive, to avoid breaking the extension entirely if Japscan changes the honeypot format
Bumped extVersionCode to 64

Closes #14728

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
