### PR TITLE
BaoTangTruyen missing getMangaUrl and getChapterUrl

### DIFF
--- a/src/vi/baotangtruyen/build.gradle
+++ b/src/vi/baotangtruyen/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'BaoTangTruyen'
     extClass = '.BaoTangTruyen'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = false
 }
 

--- a/src/vi/baotangtruyen/src/eu/kanade/tachiyomi/extension/vi/baotangtruyen/BaoTangTruyen.kt
+++ b/src/vi/baotangtruyen/src/eu/kanade/tachiyomi/extension/vi/baotangtruyen/BaoTangTruyen.kt
@@ -108,6 +108,8 @@ class BaoTangTruyen : HttpSource() {
 
     private fun extractMangaSlug(url: String): String? = MANGA_SLUG_REGEX.find(url)?.groupValues?.getOrNull(1)
 
+    override fun getMangaUrl(manga: SManga): String = baseUrl + manga.url
+
     override fun mangaDetailsRequest(manga: SManga): Request {
         val slug = extractMangaSlug(manga.url)
             ?: throw Exception("Không tìm thấy truyện")
@@ -180,6 +182,14 @@ class BaoTangTruyen : HttpSource() {
     }
 
     // ============================== Chapters ==============================
+
+    override fun getChapterUrl(chapter: SChapter): String {
+        val segments = chapter.url.substringBefore("?").removeSuffix("/").split("/")
+        val chapterSlug = segments.lastOrNull() ?: return baseUrl
+        val mangaSlug = segments.getOrNull(segments.size - 2) ?: return baseUrl
+
+        return "$baseUrl/truyen-tranh/$mangaSlug/$chapterSlug"
+    }
 
     override fun chapterListRequest(manga: SManga): Request {
         val slug = extractMangaSlug(manga.url)


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
