### PR TITLE
Support related albums in Luscious extension

### DIFF
--- a/src/all/luscious/build.gradle
+++ b/src/all/luscious/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Luscious'
     extClass = '.LusciousFactory'
-    extVersionCode = 30
+    extVersionCode = 31
     isNsfw = true
 }
 

--- a/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/Luscious.kt
+++ b/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/Luscious.kt
@@ -207,6 +207,18 @@ abstract class Luscious(
         return GET(url, headers)
     }
 
+    private fun buildAlbumListRelatedRequestInput(id: String) = buildAlbumInfoRequestInput(id)
+
+    private fun buildAlbumListRelatedRequest(id: String): Request {
+        val input = buildAlbumListRelatedRequestInput(id)
+        val url = apiBaseUrl.toHttpUrl().newBuilder()
+            .addQueryParameter("operationName", "AlbumListRelated")
+            .addQueryParameter("query", albumListRelatedQuery)
+            .addQueryParameter("variables", input.toJsonString())
+            .build()
+        return GET(url, headers)
+    }
+
     // Latest
 
     override fun latestUpdatesRequest(page: Int): Request = buildAlbumListRequest(page, getSortFilters(LATEST_DEFAULT_SORT_STATE, lusLang))
@@ -407,6 +419,32 @@ abstract class Luscious(
     }
 
     override fun mangaDetailsParse(response: Response): SManga = throw UnsupportedOperationException()
+
+    // Related
+
+    override fun relatedMangaListRequest(manga: SManga): Request {
+        val id = manga.url.substringAfterLast("_").removeSuffix("/")
+        return buildAlbumListRelatedRequest(id)
+    }
+
+    override fun relatedMangaListParse(response: Response): List<SManga> {
+        val data = response.parseAs<AlbumRelatedResponse>()
+        with(data.data.album.listRelated) {
+            return listOfNotNull(
+                moreLikeThis,
+                itemsLikedLikeThis,
+                itemsCreatedByThisUser,
+            ).flatMap { relatedItems ->
+                relatedItems.map {
+                    SManga.create().apply {
+                        url = it.url
+                        title = it.title
+                        thumbnail_url = it.cover.url
+                    }
+                }
+            }
+        }
+    }
 
     // Popular
 

--- a/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/LusciousConstants.kt
+++ b/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/LusciousConstants.kt
@@ -64,6 +64,21 @@ fragment AlbumStandard on Album {
 }
 """.trimIndent()
 
+val albumListRelatedQuery = $$"""
+query AlbumListRelated($id: ID!) {
+    album {
+        list_related(id: $id) {
+            more_like_this { ...AlbumInSearchList }
+            items_liked_like_this { ...AlbumInSearchList }
+            items_created_by_this_user { ...AlbumInSearchList }
+        }
+    }
+}
+fragment AlbumInSearchList on Album {
+    title url cover { url }
+}
+""".trimIndent()
+
 const val MERGE_CHAPTER_PREF_KEY = "MERGE_CHAPTER"
 const val MERGE_CHAPTER_PREF_TITLE = "Merge Chapter"
 const val MERGE_CHAPTER_PREF_SUMMARY = "If checked, merges all content of one album into chapters of up to 1000 images each, labeled as 'Merged Chapter (Part 1)', 'Merged Chapter (Part 2)', and so on. Note: you must be logged into the WebView to access more than 1000 images."

--- a/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/LusciousDTO.kt
+++ b/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/LusciousDTO.kt
@@ -36,6 +36,33 @@ class AlbumList(
     val items: List<Album>,
 )
 
+// ALBUM RELATED
+@Serializable
+class AlbumRelatedResponse(
+    val data: AlbumRelatedData,
+)
+
+@Serializable
+class AlbumRelatedData(
+    val album: AlbumRelatedDataAlbum,
+)
+
+@Serializable
+class AlbumRelatedDataAlbum(
+    @SerialName("list_related")
+    val listRelated: AlbumRelated,
+)
+
+@Serializable
+class AlbumRelated(
+    @SerialName("more_like_this")
+    val moreLikeThis: List<Album>?,
+    @SerialName("items_liked_like_this")
+    val itemsLikedLikeThis: List<Album>?,
+    @SerialName("items_created_by_this_user")
+    val itemsCreatedByThisUser: List<Album>?,
+)
+
 // ALBUM
 @Serializable
 class Album(


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

This update introduces functionality to retrieve related albums, enhancing the user experience by providing more content recommendations.

