### PR TITLE
Japscan: Fix hard code chapter honeypot filter

### DIFF
--- a/src/fr/japscan/build.gradle
+++ b/src/fr/japscan/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Japscan'
     extClass = '.Japscan'
-    extVersionCode = 64
+    extVersionCode = 65
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -252,13 +252,14 @@ class Japscan :
             }
             .distinctBy { it.second }
 
-        // Filter out known anti-scraping honeypots (e.g. "Chapitre Love You MikeZeDev Volume").
-        // Real chapter URLs end with a numeric segment (e.g. /manga/one-piece/1100/).
-        // Honeypots either have non-numeric URL segments or contain tell-tale strings in their name.
+        // Filter out anti-scraping honeypots by binding name and URL together:
+        // a real chapter URL ends in a numeric segment (e.g. /manga/one-piece/1100/)
+        // and that same number appears in the chapter's name ("Chapitre 1100: ...").
+        // Stripping non-digits from the name handles half-chapters like "Chapitre 1100.5" + /11005/.
         val filtered = allUrlPairs
             .filter { (name, url, _) ->
-                !name.contains("MikeZeDev", ignoreCase = true) &&
-                    url.trimEnd('/').substringAfterLast('/').all { it.isDigit() }
+                val urlNum = url.trimEnd('/').substringAfterLast('/')
+                urlNum.all { it.isDigit() } && name.filter { it.isDigit() }.contains(urlNum)
             }
 
         // Fall back to the unfiltered list in case the heuristics are too aggressive.


### PR DESCRIPTION
The previous honeypot filter relied on a hardcoded `"MikeZeDev"` string match. Japscan renamed the trap text to `"Mike.ZeDev"` shortly after, which trivially bypassed the check and brought the regression back (every chapter container collapsed to the same fake URL again, leaving 1 chapter per manga).

This swaps the string match for a structural heuristic that doesn't depend on the trap's wording.

Changes:

- Replaced the `name.contains("MikeZeDev")` check with a name/URL binding: the URL's numeric segment (e.g. `1100` from `/manga/one-piece/1100/`) must appear within the chapter name's digits. Honeypots either lack a digit in the name, or have a URL number that doesn't match the name's number — both fail the new check.
- Stripping non-digits from the name before comparing keeps half-chapters like `"Chapitre 1100.5"` working when the URL is `/11005/`.
- Kept the URL-must-end-in-digits check, since the user confirmed honeypots can have numeric URLs and removing it lets them slip through.
- Kept the fallback to the unfiltered list as a safety net in case Japscan changes URL conventions.
- Bumped `extVersionCode` to 65.

Closes #15130 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
