### PR TITLE
MANGA/in/UA: Fix chapters, HttpSource

### DIFF
--- a/src/uk/mangainua/build.gradle
+++ b/src/uk/mangainua/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaInUa'
     extClass = '.Mangainua'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = true
 }
 

--- a/src/uk/mangainua/src/eu/kanade/tachiyomi/extension/uk/mangainua/Mangainua.kt
+++ b/src/uk/mangainua/src/eu/kanade/tachiyomi/extension/uk/mangainua/Mangainua.kt
@@ -37,6 +37,10 @@ class Mangainua : ParsedHttpSource() {
     override fun headersBuilder() = super.headersBuilder()
         .add("Referer", baseUrl)
 
+    private fun ajaxHeaders() = headersBuilder()
+        .add("X-Requested-With", "XMLHttpRequest")
+        .build()
+
     // ============================== Popular ===============================
     override fun popularMangaRequest(page: Int) = GET(baseUrl)
 
@@ -150,6 +154,7 @@ class Mangainua : ParsedHttpSource() {
             }
         }
     }
+
     override fun chapterListParse(response: Response): List<SChapter> {
         val document = response.asJsoup()
         val userHash = document.parseUserHash()
@@ -157,13 +162,14 @@ class Mangainua : ParsedHttpSource() {
         val userHashQuery = document.parseUserHashQuery(endpoint)
         val metaElement = document.selectFirst(Evaluator.Id("linkstocomics"))!!
         val body = FormBody.Builder()
-            .addEncoded("action", "show")
-            .addEncoded("news_id", metaElement.attr("data-news_id"))
-            .addEncoded("news_category", metaElement.attr("data-news_category"))
-            .addEncoded("this_link", metaElement.attr("data-this_link"))
-            .addEncoded(userHashQuery, userHash)
+            .add("action", "show")
+            .add("news_id", metaElement.attr("data-news_id"))
+            .add("news_category", metaElement.attr("data-news_category"))
+            .add("this_link", metaElement.attr("data-this_link"))
+            .add(userHashQuery, userHash)
             .build()
-        val request = POST("$baseUrl/$endpoint", headers, body)
+
+        val request = POST("$baseUrl/$endpoint", ajaxHeaders(), body)
 
         val chaptersDoc = client.newCall(request).execute().use { it.asJsoup() }
         return parseChapterElements(chaptersDoc.body().children()).asReversed()
@@ -176,7 +182,8 @@ class Mangainua : ParsedHttpSource() {
         val userHashQuery = document.parseUserHashQuery(endpoint)
         val newsId = document.selectFirst(Evaluator.Id("comics"))!!.attr("data-news_id")
         val url = "$baseUrl/$endpoint&news_id=$newsId&action=show&$userHashQuery=$userHash"
-        val pagesDoc = client.newCall(GET(url, headers)).execute()
+
+        val pagesDoc = client.newCall(GET(url, ajaxHeaders())).execute()
             .use { it.asJsoup() }
         return pagesDoc.getElementsByTag("img").mapIndexed { index, img ->
             Page(index, imageUrl = img.attr("data-src"))
@@ -202,18 +209,14 @@ class Mangainua : ParsedHttpSource() {
             return hash.ifEmpty { throw Exception("Couldn't find user hash") }
         }
 
+        private val userHashQueryRegex = Regex("""(\w+)\s*:\s*site_login_hash""")
+
         private fun Document.parseUserHashQuery(endpoint: String): String {
             val script = selectFirst("script:containsData($endpoint)")?.data()
-            val queries = script?.run {
-                substringAfter(endpoint).substringAfter('{').substringBefore('}')
-            }
-            val query = queries.orEmpty()
-                .substringBefore(SITE_LOGIN_HASH, "")
-                .substringBeforeLast(':')
-                .trimEnd()
-                .substringAfterLast(' ')
+                ?: throw Exception("Couldn't find user hash query script!")
 
-            return query.ifEmpty { throw Exception("Couldn't find user hash query!") }
+            return userHashQueryRegex.find(script)?.groupValues?.get(1)
+                ?: throw Exception("Couldn't find user hash query!")
         }
     }
 }

--- a/src/uk/mangainua/src/eu/kanade/tachiyomi/extension/uk/mangainua/Mangainua.kt
+++ b/src/uk/mangainua/src/eu/kanade/tachiyomi/extension/uk/mangainua/Mangainua.kt
@@ -4,10 +4,11 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
 import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.ParsedHttpSource
+import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
 import okhttp3.FormBody
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -20,7 +21,7 @@ import org.jsoup.select.Evaluator
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class Mangainua : ParsedHttpSource() {
+class Mangainua : HttpSource() {
 
     // Info
     override val name = "MANGA/in/UA"
@@ -44,9 +45,13 @@ class Mangainua : ParsedHttpSource() {
     // ============================== Popular ===============================
     override fun popularMangaRequest(page: Int) = GET(baseUrl)
 
-    override fun popularMangaSelector() = "div.owl-carousel div.card--big"
+    override fun popularMangaParse(response: Response): MangasPage {
+        val document = response.asJsoup()
+        val mangas = document.select("div.owl-carousel div.card--big").map(::mangaFromElement)
+        return MangasPage(mangas, false)
+    }
 
-    override fun popularMangaFromElement(element: Element) = SManga.create().apply {
+    private fun mangaFromElement(element: Element) = SManga.create().apply {
         element.selectFirst("h3.card__title a")!!.run {
             setUrlWithoutDomain(attr("href"))
             title = text()
@@ -56,16 +61,15 @@ class Mangainua : ParsedHttpSource() {
         }
     }
 
-    override fun popularMangaNextPageSelector() = null
-
     // =============================== Latest ===============================
     override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/page/$page/")
 
-    override fun latestUpdatesSelector() = "main.main article.item"
-
-    override fun latestUpdatesFromElement(element: Element) = popularMangaFromElement(element)
-
-    override fun latestUpdatesNextPageSelector() = "a:contains(Наступна)"
+    override fun latestUpdatesParse(response: Response): MangasPage {
+        val document = response.asJsoup()
+        val mangas = document.select("main.main article.item").map(::mangaFromElement)
+        val hasNextPage = document.selectFirst("a:contains(Наступна)") != null
+        return MangasPage(mangas, hasNextPage)
+    }
 
     // =============================== Search ===============================
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request = if (query.length > 2) {
@@ -83,14 +87,11 @@ class Mangainua : ParsedHttpSource() {
         throw Exception("Запит має містити щонайменше 3 символи / The query must contain at least 3 characters")
     }
 
-    override fun searchMangaSelector() = latestUpdatesSelector()
-
-    override fun searchMangaFromElement(element: Element) = popularMangaFromElement(element)
-
-    override fun searchMangaNextPageSelector() = latestUpdatesNextPageSelector()
+    override fun searchMangaParse(response: Response) = latestUpdatesParse(response)
 
     // =========================== Manga Details ============================
-    override fun mangaDetailsParse(document: Document) = SManga.create().apply {
+    override fun mangaDetailsParse(response: Response) = SManga.create().apply {
+        val document = response.asJsoup()
         title = document.selectFirst("span.UAname")!!.text()
         description = document.selectFirst("div.item__full-description")!!.text()
         thumbnail_url = document.selectFirst("div.item__full-sidebar--poster img")?.absUrl("src")
@@ -120,10 +121,6 @@ class Mangainua : ParsedHttpSource() {
     private fun Document.getInfoElement(text: String): Element? = selectFirst("div.item__full-sideba--header:has(div:containsOwn($text)) span.item__full-sidebar--description")
 
     // ============================== Chapters ==============================
-    override fun chapterListSelector() = throw UnsupportedOperationException()
-
-    override fun chapterFromElement(element: Element): SChapter = throw UnsupportedOperationException()
-
     private fun parseChapterElements(elements: Elements): List<SChapter> {
         var previousChapterName: String? = null
         var previousChapterNumber: Float = 0F
@@ -176,7 +173,8 @@ class Mangainua : ParsedHttpSource() {
     }
 
     // =============================== Pages ================================
-    override fun pageListParse(document: Document): List<Page> {
+    override fun pageListParse(response: Response): List<Page> {
+        val document = response.asJsoup()
         val userHash = document.parseUserHash()
         val endpoint = "engine/ajax/controller.php?mod=load_chapters_image"
         val userHashQuery = document.parseUserHashQuery(endpoint)
@@ -190,7 +188,7 @@ class Mangainua : ParsedHttpSource() {
         }
     }
 
-    override fun imageUrlParse(document: Document): String = throw UnsupportedOperationException()
+    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
 
     // ============================= Utilities ==============================
     companion object {


### PR DESCRIPTION
Close: #15036 
Ai assisted 

Other than the new header `ajaxHeaders` in `chapterListParse` and `pageListParse` which is needed to fix the chapter list and page list bug, the other changes are optional improvements.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
