### PR TITLE
Beauty3600000: Fix browsing/searching, backward compatibility, add `genres` and  support related entries

### DIFF
--- a/src/all/beauty3600000/build.gradle
+++ b/src/all/beauty3600000/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = '3600000 Beauty'
     extClass = '.Beauty3600000'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Beauty3600000.kt
+++ b/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Beauty3600000.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.extension.all.beauty3600000
 
 import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
@@ -12,6 +13,11 @@ import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.utils.firstInstance
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.tryParse
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -123,7 +129,46 @@ class Beauty3600000 : HttpSource() {
         headers,
     )
 
-    override fun mangaDetailsParse(response: Response): SManga = response.parseAs<PostDto>().toSManga()
+    override fun mangaDetailsParse(response: Response): SManga = response.parseAs<PostDto>().toSManga().apply {
+        runCatching {
+            runBlocking {
+                getTags(url)
+                    .takeIf { it.isNotEmpty() }
+                    ?.let { tags -> genre = tags.joinToString { it.name } }
+            }
+        }
+    }
+
+    private suspend fun getTags(mangaId: String): List<TermDto> {
+        val request = GET(
+            baseUrl.toHttpUrlOrNull()!!.newBuilder()
+                .addPathSegments(API_BASE)
+                .addPathSegment("tags")
+                .addQueryParameter("post", mangaId)
+                .build(),
+            headers,
+        )
+        return client.newCall(request).awaitSuccess()
+            .parseAs<List<TermDto>>()
+    }
+
+    override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> {
+        val tags = getTags(manga.url)
+
+        return tags.parallelCatchingFlatMap { tag ->
+            val url = baseUrl.toHttpUrlOrNull()!!.newBuilder()
+                .addPathSegments(API_BASE)
+                .addPathSegment("posts")
+                .apply {
+                    addQueryParameter("page", "1")
+                    addQueryParameter("per_page", PER_PAGE.toString())
+                    addQueryParameter("tags", tag.id.toString())
+                }.build()
+
+            client.newCall(GET(url, headers)).awaitSuccess()
+                .use { searchMangaParse(it) }.mangas
+        }
+    }
 
     override fun getMangaUrl(manga: SManga): String = "$baseUrl/?p=${manga.url}"
 
@@ -173,10 +218,26 @@ class Beauty3600000 : HttpSource() {
         return MangasPage(mangas, currentPage < totalPages)
     }
 
+    /**
+     * Parallel implementation of [Iterable.flatMap], but running
+     * the transformation function inside a try-catch block.
+     */
+    private suspend inline fun <A, B> Iterable<A>.parallelCatchingFlatMap(crossinline f: suspend (A) -> Iterable<B>): List<B> = withContext(Dispatchers.IO) {
+        map {
+            async {
+                try {
+                    f(it)
+                } catch (e: Throwable) {
+                    e.printStackTrace()
+                    emptyList()
+                }
+            }
+        }.awaitAll().flatten()
+    }
+
     // disable suggested mangas on Komikku
     // site doesn't support keyword search and too slow
     override val disableRelatedMangasBySearch = true
-    override val supportsRelatedMangas = false
 
     companion object {
         private const val API_BASE = "wp-json/wp/v2"

--- a/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Beauty3600000.kt
+++ b/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Beauty3600000.kt
@@ -131,11 +131,9 @@ class Beauty3600000 : HttpSource() {
 
     override fun mangaDetailsParse(response: Response): SManga = response.parseAs<PostDto>().toSManga().apply {
         runCatching {
-            runBlocking {
-                getTags(url)
-                    .takeIf { it.isNotEmpty() }
-                    ?.let { tags -> genre = tags.joinToString { it.name } }
-            }
+            runBlocking { getTags(url) }
+                .takeIf { it.isNotEmpty() }
+                ?.let { tags -> genre = tags.joinToString { it.name } }
         }
     }
 
@@ -154,6 +152,7 @@ class Beauty3600000 : HttpSource() {
 
     override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> {
         val tags = getTags(manga.url)
+            .sortedBy { it.name.startsWith('[') }
 
         return tags.parallelCatchingFlatMap { tag ->
             val url = baseUrl.toHttpUrlOrNull()!!.newBuilder()

--- a/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Beauty3600000.kt
+++ b/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Beauty3600000.kt
@@ -130,18 +130,19 @@ class Beauty3600000 : HttpSource() {
     )
 
     override fun mangaDetailsParse(response: Response): SManga = response.parseAs<PostDto>().toSManga().apply {
-        runCatching {
-            runBlocking { getTags(url) }
-                .takeIf { it.isNotEmpty() }
-                ?.let { tags -> genre = tags.joinToString { it.name } }
-        }
+        genre = runBlocking {
+            listOf("categories", "tags").parallelCatchingFlatMap { term ->
+                getTerms(url, term)
+            }
+        }.takeIf { it.isNotEmpty() }
+            ?.joinToString { it.name }
     }
 
-    private suspend fun getTags(mangaId: String): List<TermDto> {
+    private suspend fun getTerms(mangaId: String, term: String): List<TermDto> {
         val request = GET(
             baseUrl.toHttpUrlOrNull()!!.newBuilder()
                 .addPathSegments(API_BASE)
-                .addPathSegment("tags")
+                .addPathSegment(term)
                 .addQueryParameter("post", mangaId)
                 .build(),
             headers,
@@ -151,7 +152,7 @@ class Beauty3600000 : HttpSource() {
     }
 
     override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> {
-        val tags = getTags(manga.url)
+        val tags = getTerms(manga.url, "tags")
             .sortedBy { it.name.startsWith('[') }
 
         return tags.parallelCatchingFlatMap { tag ->

--- a/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Beauty3600000.kt
+++ b/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Beauty3600000.kt
@@ -211,7 +211,11 @@ class Beauty3600000 : HttpSource() {
     // ========================= Helpers =========================
 
     private fun parseMangasPage(response: Response): MangasPage {
-        val posts = response.parseAs<List<PostDto>>()
+        val body = response.body.string()
+        val posts = jsonArrayRegex.find(body)
+            ?.value
+            ?.parseAs<List<PostDto>>()
+            ?: return MangasPage(emptyList(), false)
         val mangas = posts.map { it.toSManga() }
         val totalPages = response.header("X-WP-TotalPages")?.toIntOrNull() ?: 0
         val currentPage = response.request.url.queryParameter("page")?.toIntOrNull() ?: 1
@@ -242,6 +246,7 @@ class Beauty3600000 : HttpSource() {
     companion object {
         private const val API_BASE = "wp-json/wp/v2"
         private const val PER_PAGE = 100
+        private val jsonArrayRegex by lazy { Regex("""\[.*]\s*$""") }
 
         private val DATE_FORMAT by lazy {
             SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US).apply {

--- a/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Beauty3600000.kt
+++ b/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Beauty3600000.kt
@@ -91,6 +91,10 @@ class Beauty3600000 : HttpSource() {
         val categoryFilter = filterList.firstInstance<CategoryFilter>()
         val tagFilter = filterList.firstInstance<TagFilter>()
 
+        if (categoryFilter.state == 0 && tagFilter.state == 0) {
+            throw IllegalArgumentException("No filters selected")
+        }
+
         val url = baseUrl.toHttpUrlOrNull()!!.newBuilder()
             .addPathSegments(API_BASE)
             .addPathSegment("posts")

--- a/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Beauty3600000.kt
+++ b/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Beauty3600000.kt
@@ -72,7 +72,7 @@ class Beauty3600000 : HttpSource() {
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         val queryUrl = query.toHttpUrlOrNull()
         if (queryUrl != null && queryUrl.host == baseUrl.toHttpUrlOrNull()?.host) {
-            val id = queryUrl.queryParameter("p")
+            val id = queryUrl.queryParameter("p")?.trim()
             val slug = if (id == null) queryUrl.pathSegments.lastOrNull { it.isNotBlank() }?.removeSuffix(".html") else null
             val url = baseUrl.toHttpUrlOrNull()!!.newBuilder()
                 .addPathSegments(API_BASE)
@@ -94,6 +94,9 @@ class Beauty3600000 : HttpSource() {
         val tagFilter = filterList.firstInstance<TagFilter>()
 
         if (categoryFilter.state == 0 && tagFilter.state == 0) {
+            if (query.isBlank()) {
+                return popularMangaRequest(page)
+            }
             throw IllegalArgumentException("No filters selected")
         }
 
@@ -131,7 +134,7 @@ class Beauty3600000 : HttpSource() {
             addPathSegments(API_BASE)
             addPathSegment("posts")
             manga.url.toIntOrNull()?.let { addPathSegment(manga.url) }
-                ?: addQueryParameter("slug", manga.url.removeSuffix("/").substringAfterLast('/'))
+                ?: addQueryParameter("slug", manga.url.removeSurrounding("/"))
         }
             .build(),
         headers,
@@ -189,7 +192,9 @@ class Beauty3600000 : HttpSource() {
         }
     }
 
-    override fun getMangaUrl(manga: SManga): String = "$baseUrl/?p=${manga.url}"
+    override fun getMangaUrl(manga: SManga): String = manga.url.toIntOrNull()
+        ?.let { "$baseUrl/?p=${manga.url}" }
+        ?: "$baseUrl${manga.url}"
 
     private fun Response.toPost(): PostDto {
         val url = request.url.toString()
@@ -198,7 +203,8 @@ class Beauty3600000 : HttpSource() {
             jsonArrayRegex.find(body)
                 ?.value
                 ?.parseAs<List<PostDto>>()
-                ?.firstOrNull()!!
+                ?.firstOrNull()
+                ?: throw IllegalArgumentException("Post not found")
         } else {
             parseAs<PostDto>()
         }

--- a/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Beauty3600000.kt
+++ b/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Beauty3600000.kt
@@ -92,12 +92,16 @@ class Beauty3600000 : HttpSource() {
         val filterList = filters.ifEmpty { getFilterList() }
         val categoryFilter = filterList.firstInstance<CategoryFilter>()
         val tagFilter = filterList.firstInstance<TagFilter>()
+        var tagSearch: Int? = null
 
         if (categoryFilter.state == 0 && tagFilter.state == 0) {
             if (query.isBlank()) {
                 return popularMangaRequest(page)
             }
-            throw IllegalArgumentException("No filters selected")
+
+            val tags = runCatching { runBlocking { searchTag(query) } }.getOrNull()
+            tagSearch = tags?.firstOrNull()?.id
+                ?: throw IllegalArgumentException("No filters selected")
         }
 
         val url = baseUrl.toHttpUrlOrNull()!!.newBuilder()
@@ -110,6 +114,7 @@ class Beauty3600000 : HttpSource() {
                 when {
                     categoryFilter.state != 0 -> addQueryParameter("categories", categoryFilter.toUriPart())
                     tagFilter.state != 0 -> addQueryParameter("tags", tagFilter.toUriPart())
+                    tagSearch != null -> addQueryParameter("tags", tagSearch.toString())
                 }
             }.build()
 
@@ -159,6 +164,19 @@ class Beauty3600000 : HttpSource() {
                 .addPathSegments(API_BASE)
                 .addPathSegment(term)
                 .addQueryParameter("post", mangaId.toString())
+                .build(),
+            headers,
+        )
+        return client.newCall(request).awaitSuccess()
+            .parseAs<List<TermDto>>()
+    }
+
+    private suspend fun searchTag(slug: String): List<TermDto> {
+        val request = GET(
+            baseUrl.toHttpUrlOrNull()!!.newBuilder()
+                .addPathSegments(API_BASE)
+                .addPathSegment("tags")
+                .addQueryParameter("slug", slug)
                 .build(),
             headers,
         )

--- a/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Beauty3600000.kt
+++ b/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Beauty3600000.kt
@@ -79,7 +79,9 @@ class Beauty3600000 : HttpSource() {
                 .addPathSegment("posts")
                 .apply {
                     if (id != null) {
-                        addQueryParameter("include", id)
+                        id.toIntOrNull()?.let { addQueryParameter("include", it.toString()) }
+                            // Allow copy old entry's `manga.url` to search for old entry for migration which is in format "https://3600000.xyz/?p=/{slug}/"
+                            ?: addQueryParameter("slug", id.removeSurrounding("/"))
                     } else if (slug != null) {
                         addQueryParameter("slug", slug)
                     }

--- a/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Beauty3600000.kt
+++ b/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Beauty3600000.kt
@@ -124,30 +124,36 @@ class Beauty3600000 : HttpSource() {
 
     // ========================= Details =========================
 
-    override fun mangaDetailsRequest(manga: SManga): Request = GET(
-        baseUrl.toHttpUrlOrNull()!!.newBuilder()
-            .addPathSegments(API_BASE)
-            .addPathSegment("posts")
-            .addPathSegment(manga.url)
+    override fun mangaDetailsRequest(manga: SManga) = GET(
+        baseUrl.toHttpUrlOrNull()!!.newBuilder().apply {
+            addPathSegments(API_BASE)
+            addPathSegment("posts")
+            manga.url.toIntOrNull()?.let { addPathSegment(manga.url) }
+                ?: addQueryParameter("slug", manga.url.removeSuffix("/").substringAfterLast('/'))
+        }
             .build(),
         headers,
     )
 
-    override fun mangaDetailsParse(response: Response): SManga = response.parseAs<PostDto>().toSManga().apply {
-        genre = runBlocking {
-            listOf("categories", "tags").parallelCatchingFlatMap { term ->
-                getTerms(url, term)
-            }
-        }.takeIf { it.isNotEmpty() }
-            ?.joinToString { it.name }
+    override fun mangaDetailsParse(response: Response): SManga {
+        val post = response.toPost()
+
+        return post.toSManga().apply {
+            genre = runBlocking {
+                listOf("categories", "tags").parallelCatchingFlatMap { term ->
+                    getTerms(post.id, term)
+                }
+            }.takeIf { it.isNotEmpty() }
+                ?.joinToString { it.name }
+        }
     }
 
-    private suspend fun getTerms(mangaId: String, term: String): List<TermDto> {
+    private suspend fun getTerms(mangaId: Int, term: String): List<TermDto> {
         val request = GET(
             baseUrl.toHttpUrlOrNull()!!.newBuilder()
                 .addPathSegments(API_BASE)
                 .addPathSegment(term)
-                .addQueryParameter("post", mangaId)
+                .addQueryParameter("post", mangaId.toString())
                 .build(),
             headers,
         )
@@ -156,7 +162,14 @@ class Beauty3600000 : HttpSource() {
     }
 
     override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> {
-        val tags = getTerms(manga.url, "tags")
+        val mangaId = manga.url.toIntOrNull() ?: run {
+            val request = mangaDetailsRequest(manga)
+            client.newCall(request).awaitSuccess()
+                .use { mangaDetailsParse(it) }
+                .url.toIntOrNull()
+                ?: return emptyList()
+        }
+        val tags = getTerms(mangaId, "tags")
             .sortedBy { it.name.startsWith('[') }
 
         return tags.parallelCatchingFlatMap { tag ->
@@ -176,12 +189,25 @@ class Beauty3600000 : HttpSource() {
 
     override fun getMangaUrl(manga: SManga): String = "$baseUrl/?p=${manga.url}"
 
+    private fun Response.toPost(): PostDto {
+        val url = request.url.toString()
+        return if (url.contains("slug=")) {
+            val body = body.string()
+            jsonArrayRegex.find(body)
+                ?.value
+                ?.parseAs<List<PostDto>>()
+                ?.firstOrNull()!!
+        } else {
+            parseAs<PostDto>()
+        }
+    }
+
     // ========================= Chapters =========================
 
     override fun chapterListRequest(manga: SManga): Request = mangaDetailsRequest(manga)
 
     override fun chapterListParse(response: Response): List<SChapter> {
-        val post = response.parseAs<PostDto>()
+        val post = response.toPost()
         return listOf(
             post.toSChapter().apply {
                 date_upload = DATE_FORMAT.tryParse(post.date)

--- a/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Beauty3600000.kt
+++ b/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Beauty3600000.kt
@@ -23,6 +23,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.Jsoup
+import rx.Observable
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
@@ -42,6 +43,10 @@ class Beauty3600000 : HttpSource() {
         .connectTimeout(120, TimeUnit.SECONDS)
         .readTimeout(120, TimeUnit.SECONDS)
         .rateLimit(1)
+        .build()
+
+    private val searchingClient: OkHttpClient = client.newBuilder()
+        .rateLimit(1, 30)
         .build()
 
     override fun headersBuilder() = super.headersBuilder()
@@ -69,6 +74,19 @@ class Beauty3600000 : HttpSource() {
 
     // ========================= Search =========================
 
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        val request = searchMangaRequest(page, query, filters)
+        val requestUrl = request.url
+        val searchParams = requestUrl.queryParameter("search")
+        return Observable.fromCallable {
+            if (searchParams != null) {
+                searchingClient.newCall(request).execute()
+            } else {
+                client.newCall(request).execute()
+            }
+        }.map { searchMangaParse(it) }
+    }
+
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         val queryUrl = query.toHttpUrlOrNull()
         if (queryUrl != null && queryUrl.host == baseUrl.toHttpUrlOrNull()?.host) {
@@ -94,14 +112,13 @@ class Beauty3600000 : HttpSource() {
         val tagFilter = filterList.firstInstance<TagFilter>()
         var tagSearch: Int? = null
 
-        if (categoryFilter.state == 0 && tagFilter.state == 0) {
+        if (categoryFilter.state <= 0 && tagFilter.state <= 0) {
             if (query.isBlank()) {
                 return popularMangaRequest(page)
             }
 
-            val tags = runCatching { runBlocking { searchTag(query) } }.getOrNull()
-            tagSearch = tags?.firstOrNull()?.id
-                ?: throw IllegalArgumentException("No filters selected")
+            val tags = runCatching { runBlocking { getTag(query.trim()) } }.getOrNull()
+            tagSearch = tags?.firstOrNull { it.name.equals(query.trim(), ignoreCase = true) }?.id
         }
 
         val url = baseUrl.toHttpUrlOrNull()!!.newBuilder()
@@ -111,9 +128,13 @@ class Beauty3600000 : HttpSource() {
                 addQueryParameter("page", page.toString())
                 addQueryParameter("per_page", PER_PAGE.toString())
 
+                if (query.isNotBlank() && tagSearch == null) {
+                    addQueryParameter("search", query.trim())
+                }
+
                 when {
-                    categoryFilter.state != 0 -> addQueryParameter("categories", categoryFilter.toUriPart())
-                    tagFilter.state != 0 -> addQueryParameter("tags", tagFilter.toUriPart())
+                    categoryFilter.state > 0 -> addQueryParameter("categories", categoryFilter.toUriPart())
+                    tagFilter.state > 0 -> addQueryParameter("tags", tagFilter.toUriPart())
                     tagSearch != null -> addQueryParameter("tags", tagSearch.toString())
                 }
             }.build()
@@ -171,7 +192,7 @@ class Beauty3600000 : HttpSource() {
             .parseAs<List<TermDto>>()
     }
 
-    private suspend fun searchTag(slug: String): List<TermDto> {
+    private suspend fun getTag(slug: String): List<TermDto> {
         val request = GET(
             baseUrl.toHttpUrlOrNull()!!.newBuilder()
                 .addPathSegments(API_BASE)
@@ -215,8 +236,8 @@ class Beauty3600000 : HttpSource() {
         ?: "$baseUrl${manga.url}"
 
     private fun Response.toPost(): PostDto {
-        val url = request.url.toString()
-        return if (url.contains("slug=")) {
+        val slugParam = request.url.queryParameter("slug")
+        return if (slugParam != null) {
             val body = body.string()
             jsonArrayRegex.find(body)
                 ?.value
@@ -296,7 +317,6 @@ class Beauty3600000 : HttpSource() {
     }
 
     // disable suggested mangas on Komikku
-    // site doesn't support keyword search and too slow
     override val disableRelatedMangasBySearch = true
 
     companion object {

--- a/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Dto.kt
+++ b/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Dto.kt
@@ -20,7 +20,6 @@ class PostDto(
         thumbnail_url = Jsoup.parseBodyFragment(content.rendered).selectFirst("img")?.attr("src")
         status = SManga.COMPLETED
         update_strategy = UpdateStrategy.ONLY_FETCH_ONCE
-        initialized = true
     }
 
     fun toSChapter() = SChapter.create().apply {

--- a/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Dto.kt
+++ b/src/all/beauty3600000/src/eu/kanade/tachiyomi/extension/all/beauty3600000/Dto.kt
@@ -5,6 +5,7 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
 import kotlinx.serialization.Serializable
 import org.jsoup.Jsoup
+import org.jsoup.parser.Parser
 
 @Serializable
 class PostDto(
@@ -16,7 +17,9 @@ class PostDto(
 ) {
     fun toSManga() = SManga.create().apply {
         url = id.toString()
-        title = this@PostDto.title.rendered.takeIf { it.isNotBlank() } ?: throw Exception("Title is mandatory")
+        title = this@PostDto.title.rendered.decodeHtmlEntities()
+            .takeIf { it.isNotBlank() }
+            ?: throw Exception("Title is mandatory")
         thumbnail_url = Jsoup.parseBodyFragment(content.rendered).selectFirst("img")?.attr("src")
         status = SManga.COMPLETED
         update_strategy = UpdateStrategy.ONLY_FETCH_ONCE
@@ -32,6 +35,8 @@ class PostDto(
 class RenderedDto(
     val rendered: String,
 )
+
+private fun String.decodeHtmlEntities(): String = Parser.unescapeEntities(this, false)
 
 @Serializable
 class TermDto(


### PR DESCRIPTION
* Fix browsing/searching failed due to HTML error:
```html
br />
<b>Warning</b>:  gethostbyaddr(): Address is not a valid IPv4 or IPv6 address in <b>/www/wwwroot/360/wp-content/plugins/search-limiter-blocker/search-limiter-blocker.php</b> on line <b>163</b><br />
```

* Add categories & tags to entries' genres
* Support related entries by parsing tags
* Don't return the popular list if no filters are selected while searching (prevent false results when text searching)
* Fix HTML entities decoding in post titles
* Backward compatible for existing in-library entries
* Allow copy old entry's `manga.url` to search for old entry for migration
* Fallback to tag search
* Support query searching

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
