### PR TITLE
Greed Scans: Update domain and rewrite as custom API source

### DIFF
--- a/src/en/greedscans/build.gradle
+++ b/src/en/greedscans/build.gradle
@@ -1,9 +1,7 @@
 ext {
     extName = 'Greed Scans'
     extClass = '.GreedScans'
-    themePkg = 'mangathemesia'
-    baseUrl = 'https://greedscans.com'
-    overrideVersionCode = 1
+    extVersionCode = 32
     isNsfw = false
 }
 

--- a/src/en/greedscans/src/eu/kanade/tachiyomi/extension/en/greedscans/Dto.kt
+++ b/src/en/greedscans/src/eu/kanade/tachiyomi/extension/en/greedscans/Dto.kt
@@ -1,0 +1,74 @@
+package eu.kanade.tachiyomi.extension.en.greedscans
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+class SeriesListResponse(
+    val data: PaginatedData,
+)
+
+@Serializable
+class PaginatedData(
+    val data: List<BrowseSeries>,
+    @SerialName("current_page") val currentPage: Int,
+    @SerialName("last_page") val lastPage: Int,
+) {
+    fun hasNextPage() = currentPage < lastPage
+}
+
+@Serializable
+class BrowseSeries(
+    val title: String,
+    val slug: String,
+    @SerialName("cover_image") val coverImage: String? = null,
+    val status: String? = null,
+)
+
+@Serializable
+class SeriesDetailResponse(
+    val data: SeriesDetail,
+)
+
+@Serializable
+class SeriesDetail(
+    val title: String,
+    val slug: String,
+    val synopsis: String? = null,
+    val author: String? = null,
+    val studio: String? = null,
+    @SerialName("cover_image") val coverImage: String? = null,
+    val status: String? = null,
+    val genres: List<String> = emptyList(),
+    @SerialName("alternative_titles") val alternativeTitles: List<String> = emptyList(),
+    val chapters: List<Chapter> = emptyList(),
+)
+
+@Serializable
+class Chapter(
+    val title: String,
+    val slug: String,
+    @SerialName("chapter_number") val chapterNumber: Float,
+    @SerialName("created_at") val createdAt: String? = null,
+    @SerialName("published_at") val publishedAt: String? = null,
+)
+
+@Serializable
+class ChapterDetailResponse(
+    val data: ChapterDetail,
+)
+
+@Serializable
+class ChapterDetail(
+    val chapter: ChapterImages,
+)
+
+@Serializable
+class ChapterImages(
+    val images: List<PageImage> = emptyList(),
+)
+
+@Serializable
+class PageImage(
+    @SerialName("image_url") val imageUrl: String,
+)

--- a/src/en/greedscans/src/eu/kanade/tachiyomi/extension/en/greedscans/Filters.kt
+++ b/src/en/greedscans/src/eu/kanade/tachiyomi/extension/en/greedscans/Filters.kt
@@ -1,0 +1,159 @@
+package eu.kanade.tachiyomi.extension.en.greedscans
+
+import eu.kanade.tachiyomi.source.model.Filter
+import eu.kanade.tachiyomi.source.model.FilterList
+import okhttp3.HttpUrl
+
+interface UrlFilter {
+    fun addToUrl(url: HttpUrl.Builder)
+}
+
+abstract class SelectFilter(
+    name: String,
+    private val options: List<Pair<String, String>>,
+    private val queryParam: String,
+    defaultValue: String? = null,
+) : Filter.Select<String>(
+    name,
+    options.map { it.first }.toTypedArray(),
+    options.indexOfFirst { it.second == defaultValue }.takeIf { it != -1 } ?: 0,
+),
+    UrlFilter {
+    override fun addToUrl(url: HttpUrl.Builder) {
+        val value = options[state].second
+        if (value.isNotEmpty()) url.addQueryParameter(queryParam, value)
+    }
+}
+
+class CheckBoxFilter(name: String, val value: String) : Filter.CheckBox(name)
+
+abstract class CheckBoxGroup(
+    name: String,
+    options: List<Pair<String, String>>,
+    private val queryParam: String,
+) : Filter.Group<CheckBoxFilter>(
+    name,
+    options.map { CheckBoxFilter(it.first, it.second) },
+),
+    UrlFilter {
+    override fun addToUrl(url: HttpUrl.Builder) {
+        state.filter { it.state }.forEach {
+            url.addQueryParameter(queryParam, it.value)
+        }
+    }
+}
+
+class SortFilter(defaultValue: String? = null) :
+    SelectFilter(
+        name = "Sort By",
+        options = listOf(
+            "Popular" to "popular",
+            "Latest Update" to "latest_update",
+            "Rating" to "rating",
+            "A-Z" to "a_z",
+            "Newest" to "newest",
+        ),
+        queryParam = "sort_by",
+        defaultValue = defaultValue,
+    ) {
+    companion object {
+        val popular = FilterList(SortFilter("popular"))
+        val latest = FilterList(SortFilter("latest_update"))
+    }
+}
+
+class StatusFilter :
+    CheckBoxGroup(
+        name = "Status",
+        options = listOf(
+            "Ongoing" to "ongoing",
+            "Completed" to "completed",
+            "Hiatus" to "hiatus",
+        ),
+        queryParam = "status",
+    )
+
+class TypeFilter :
+    CheckBoxGroup(
+        name = "Type",
+        options = listOf(
+            "Free" to "free",
+            "Coin" to "coin",
+            "VIP" to "vip",
+        ),
+        queryParam = "type",
+    )
+
+class MinChaptersFilter :
+    Filter.Text("Minimum Chapters"),
+    UrlFilter {
+    override fun addToUrl(url: HttpUrl.Builder) {
+        if (state.isNotEmpty()) url.addQueryParameter("min_chapters", state)
+    }
+}
+
+class GenreFilter :
+    CheckBoxGroup(
+        name = "Genres",
+        options = listOf(
+            "Action" to "action",
+            "Fantasy" to "fantasy",
+            "Adventure" to "adventure",
+            "Drama" to "drama",
+            "Comedy" to "comedy",
+            "Romance" to "romance",
+            "Shounen" to "shounen",
+            "Isekai" to "isekai",
+            "Murim" to "murim",
+            "Reincarnation" to "reincarnation",
+            "Manhwa" to "manhwa",
+            "Mystery" to "mystery",
+            "Tragedy" to "tragedy",
+            "Webtoons" to "webtoons",
+            "Revenge" to "revenge",
+            "Slice of Life" to "slice-of-life",
+            "Martial Arts" to "martial-arts",
+            "School Life" to "school-life",
+            "Regression" to "regression",
+            "Overpowered" to "overpowered",
+            "Historical" to "historical",
+            "Supernatural" to "supernatural",
+            "Game" to "game",
+            "Genius MC" to "genius-mc",
+            "System" to "system",
+            "Magic" to "magic",
+            "Shoujo" to "shoujo",
+            "Sci-Fi" to "sci-fi",
+            "Wuxia" to "wuxia",
+            "Horror" to "horror",
+            "Seinen" to "seinen",
+            "Psychological" to "psychological",
+            "Manhua" to "manhua",
+            "Sports" to "sports",
+            "Thriller" to "thriller",
+            "Dungeons" to "dungeons",
+            "Crime" to "crime",
+            "Demon" to "demon",
+            "Superhero" to "superhero",
+            "Crazy MC" to "crazy-mc",
+            "Sci Fi" to "sci-fi",
+            "Harem" to "harem",
+            "Necromancer" to "necromancer",
+            "Tower" to "tower",
+            "Full Color" to "full-color",
+            "Violence" to "violence",
+            "Ecchi" to "ecchi",
+            "Adaptation" to "adaptation",
+            "Long Strip" to "long-strip",
+            "Villain" to "villain",
+            "Mature" to "mature",
+            "Comic" to "comic",
+            "Monsters" to "monsters",
+            "Medical" to "medical",
+            "Manga" to "manga",
+            "Time Travel" to "time-travel",
+            "Cooking" to "cooking",
+            "One Shot" to "one-shot",
+        ),
+        queryParam = "genres[]",
+    )

--- a/src/en/greedscans/src/eu/kanade/tachiyomi/extension/en/greedscans/GreedScans.kt
+++ b/src/en/greedscans/src/eu/kanade/tachiyomi/extension/en/greedscans/GreedScans.kt
@@ -1,30 +1,145 @@
 package eu.kanade.tachiyomi.extension.en.greedscans
 
-import android.content.SharedPreferences
-import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
-import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesiaPaidChapterHelper
-import eu.kanade.tachiyomi.source.ConfigurableSource
-import keiyoushi.utils.getPreferences
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.parseAs
+import keiyoushi.utils.tryParse
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Request
+import okhttp3.Response
+import java.text.SimpleDateFormat
+import java.util.Locale
 
-class GreedScans :
-    MangaThemesia(
-        "Greed Scans",
-        "https://greedscans.com",
-        "en",
-    ),
-    ConfigurableSource {
+class GreedScans : HttpSource() {
 
-    private val preferences: SharedPreferences = getPreferences()
+    override val name = "Greed Scans"
+    override val baseUrl = "https://gojoscans.com"
+    private val apiUrl = "https://api.gojoscans.com/api"
+    override val lang = "en"
+    override val supportsLatest = true
 
-    private val paidChapterHelper = MangaThemesiaPaidChapterHelper()
+    // ==================== POPULAR ====================
 
-    override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        paidChapterHelper.addHidePaidChaptersPreferenceToScreen(screen, intl)
+    override fun popularMangaRequest(page: Int) = searchMangaRequest(page, "", SortFilter.popular)
+
+    override fun popularMangaParse(response: Response) = searchMangaParse(response)
+
+    // ==================== LATEST ====================
+
+    override fun latestUpdatesRequest(page: Int) = searchMangaRequest(page, "", SortFilter.latest)
+
+    override fun latestUpdatesParse(response: Response) = searchMangaParse(response)
+
+    // ==================== SEARCH ====================
+
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+        val url = "$apiUrl/series".toHttpUrl().newBuilder().apply {
+            addQueryParameter("page", page.toString())
+            addQueryParameter("per_page", "24")
+            addQueryParameter("sort_order", "desc")
+            if (query.isNotEmpty()) addQueryParameter("search", query)
+            filters.filterIsInstance<UrlFilter>().forEach { it.addToUrl(this) }
+        }.build()
+
+        return GET(url, headers)
     }
 
-    override fun chapterListSelector(): String = paidChapterHelper.getChapterListSelectorBasedOnHidePaidChaptersPref(
-        super.chapterListSelector(),
-        preferences,
+    override fun searchMangaParse(response: Response): MangasPage {
+        val data = response.parseAs<SeriesListResponse>().data
+
+        val mangas = data.data.map { series ->
+            SManga.create().apply {
+                url = "/series/${series.slug}"
+                title = series.title
+                thumbnail_url = series.coverImage
+                status = series.status.toStatus()
+            }
+        }
+
+        return MangasPage(mangas, data.hasNextPage())
+    }
+
+    override fun getFilterList() = FilterList(
+        SortFilter(),
+        StatusFilter(),
+        TypeFilter(),
+        MinChaptersFilter(),
+        GenreFilter(),
     )
+
+    // ==================== MANGA DETAILS ====================
+
+    override fun mangaDetailsRequest(manga: SManga): Request {
+        val compatibleUrl = manga.url.replace("/manga/", "/series/")
+        return GET("$apiUrl$compatibleUrl", headers)
+    }
+
+    override fun mangaDetailsParse(response: Response): SManga {
+        val data = response.parseAs<SeriesDetailResponse>().data
+
+        return SManga.create().apply {
+            url = "/series/${data.slug}"
+            title = data.title
+            author = data.author
+            artist = data.studio
+            thumbnail_url = data.coverImage
+            status = data.status.toStatus()
+            genre = data.genres.joinToString(", ")
+            description = buildString {
+                data.synopsis?.let { append(it) }
+                if (data.alternativeTitles.isNotEmpty()) {
+                    append("\n\nAlternative Titles:\n")
+                    append(data.alternativeTitles.joinToString("\n"))
+                }
+            }
+        }
+    }
+
+    // ==================== CHAPTER LIST ====================
+
+    override fun chapterListRequest(manga: SManga): Request = mangaDetailsRequest(manga)
+
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val data = response.parseAs<SeriesDetailResponse>().data
+
+        return data.chapters.sortedByDescending { it.chapterNumber }.map { chapter ->
+            SChapter.create().apply {
+                url = "/series/${data.slug}/chapters/${chapter.slug}"
+                name = chapter.title
+                date_upload = (chapter.publishedAt ?: chapter.createdAt)?.let {
+                    DATE_FORMAT.tryParse(it)
+                } ?: 0L
+            }
+        }
+    }
+
+    companion object {
+        val DATE_FORMAT = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'", Locale.ENGLISH)
+    }
+
+    // ==================== PAGE LIST ====================
+
+    override fun pageListRequest(chapter: SChapter): Request = GET("$apiUrl${chapter.url}", headers)
+
+    override fun pageListParse(response: Response): List<Page> {
+        val images = response.parseAs<ChapterDetailResponse>().data.chapter.images
+
+        return images.mapIndexed { i, img -> Page(i, imageUrl = img.imageUrl) }
+    }
+
+    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException("Not used")
+
+    // ==================== HELPERS ====================
+
+    private fun String?.toStatus() = when (this?.lowercase()) {
+        "ongoing" -> SManga.ONGOING
+        "completed" -> SManga.COMPLETED
+        "hiatus" -> SManga.ON_HIATUS
+        else -> SManga.UNKNOWN
+    }
 }


### PR DESCRIPTION
closes #15223

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

The scanlation group rebranded from Greed Scans to Gojo Scans (`gojoscans.com`). However, during this migration, they completely dropped the MangaThemesia CMS and moved to a custom headless JSON API (`api.gojoscans.com`).

A simple domain update in the multisrc theme no longer works. Therefore, I have:
1. Removed GreedScans from the mangathemesia multisrc.
2. Rewritten the extension from scratch as a standalone HttpSource to consume their new JSON API.
3. Implemented Latest, Popular, and Search functionalities.
4. Added support for their dynamic filters (Sort, Status, Type, Genres, Min Chapters).