### PR TITLE
Zeruelscan: fixed NullPointerException

### DIFF
--- a/src/it/zeurelscan/build.gradle
+++ b/src/it/zeurelscan/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ZeurelScan'
     extClass = '.ZeurelScan'
-    extVersionCode = 3
+    extVersionCode = 4
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/it/zeurelscan/src/eu/kanade/tachiyomi/extension/it/zeurelscan/ZeurelScan.kt
+++ b/src/it/zeurelscan/src/eu/kanade/tachiyomi/extension/it/zeurelscan/ZeurelScan.kt
@@ -118,7 +118,7 @@ class ZeurelScan : HttpSource() {
         .map(::pageListParse)
 
     override fun chapterListParse(response: Response): List<SChapter> {
-        val list = response.asJsoup().select("div.chapter")
+        val list = response.asJsoup().select("div.chapter:has(a)")
         var lastChapter = 0f
         return list.map {
             val str = it.selectFirst("a")!!.wholeOwnText().substringAfter("#")


### PR DESCRIPTION
The website added "fakes chapters" that are not yet published, without an `a` element and with "Coming Soon" appended to the (expected) publish date

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through ~~Android Studio~~ gradle and my mobile phone
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
