### PR TITLE
HDoujin: fix language code

### DIFF
--- a/src/all/hdoujin/build.gradle
+++ b/src/all/hdoujin/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'HDoujin'
     extClass = '.HDoujinFactory'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/all/hdoujin/src/eu/kanade/tachiyomi/extension/all/hdoujin/HDoujin.kt
+++ b/src/all/hdoujin/src/eu/kanade/tachiyomi/extension/all/hdoujin/HDoujin.kt
@@ -48,7 +48,7 @@ class HDoujin(
     override val name = "HDoujin"
 
     override val id: Long = when (lang) {
-        "ko" -> 1528745830L
+        "ko" -> 8377507648400729012L
         else -> super.id
     }
 

--- a/src/all/hdoujin/src/eu/kanade/tachiyomi/extension/all/hdoujin/HDoujin.kt
+++ b/src/all/hdoujin/src/eu/kanade/tachiyomi/extension/all/hdoujin/HDoujin.kt
@@ -47,6 +47,11 @@ class HDoujin(
 
     override val name = "HDoujin"
 
+    override val id: Long = when (lang) {
+        "ko" -> 1528745830L
+        else -> super.id
+    }
+
     override val supportsLatest = true
     private val preferences = getPreferences()
     private fun quality() = preferences.getString(PREF_IMAGE_RES, "1280")!!

--- a/src/all/hdoujin/src/eu/kanade/tachiyomi/extension/all/hdoujin/HDoujinFactory.kt
+++ b/src/all/hdoujin/src/eu/kanade/tachiyomi/extension/all/hdoujin/HDoujinFactory.kt
@@ -8,7 +8,7 @@ class HDoujinFactory : SourceFactory {
         HDoujin("en", "english"),
         HDoujin("es", "spanish"),
         HDoujin("ja", "japanese"),
-        HDoujin("kr", "korean"),
+        HDoujin("ko", "korean"),
         HDoujin("zh", "chinese"),
     )
 }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
