### PR TITLE
Jeaz Scans (ES): Rewrite as custom source (formerly Madara)

### DIFF
--- a/src/es/jeazscans/build.gradle
+++ b/src/es/jeazscans/build.gradle
@@ -1,9 +1,7 @@
 ext {
     extName = 'Jeaz Scans'
     extClass = '.JeazScans'
-    themePkg = 'madara'
-    baseUrl = 'https://lectorhub.j5z.xyz'
-    overrideVersionCode = 18
+    extVersionCode = 66
     isNsfw = false
 }
 

--- a/src/es/jeazscans/src/eu/kanade/tachiyomi/extension/es/jeazscans/Dto.kt
+++ b/src/es/jeazscans/src/eu/kanade/tachiyomi/extension/es/jeazscans/Dto.kt
@@ -1,0 +1,35 @@
+package eu.kanade.tachiyomi.extension.es.jeazscans
+
+import eu.kanade.tachiyomi.source.model.SManga
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+class ApiLectorResponse(
+    val success: Boolean = false,
+    val paginas: List<ApiLectorPage> = emptyList(),
+)
+
+@Serializable
+class ApiLectorPage(
+    val orden: Int = 0,
+    @SerialName("data_verify") val dataVerify: String = "",
+)
+
+@Serializable
+class SearchResponseItem(
+    private val id: Int = -1,
+    private val titulo: String = "",
+    private val portada: String = "",
+) {
+    fun toSManga(baseUrl: String): SManga? {
+        if (id == -1 || titulo.isBlank()) return null
+        return SManga.create().apply {
+            url = "/manga.php?id=$id"
+            title = titulo
+            if (portada.isNotBlank()) {
+                thumbnail_url = if (portada.startsWith("http")) portada else "$baseUrl/${portada.trimStart('/')}"
+            }
+        }
+    }
+}

--- a/src/es/jeazscans/src/eu/kanade/tachiyomi/extension/es/jeazscans/Dto.kt
+++ b/src/es/jeazscans/src/eu/kanade/tachiyomi/extension/es/jeazscans/Dto.kt
@@ -12,22 +12,22 @@ class ApiLectorResponse(
 
 @Serializable
 class ApiLectorPage(
-    val orden: Int = 0,
-    @SerialName("data_verify") val dataVerify: String = "",
+    val orden: Int,
+    @SerialName("data_verify") val dataVerify: String,
 )
 
 @Serializable
 class SearchResponseItem(
-    private val id: Int = -1,
-    private val titulo: String = "",
-    private val portada: String = "",
+    private val id: Int,
+    private val titulo: String,
+    private val portada: String?,
 ) {
     fun toSManga(baseUrl: String): SManga? {
         if (id == -1 || titulo.isBlank()) return null
         return SManga.create().apply {
             url = "/manga.php?id=$id"
             title = titulo
-            if (portada.isNotBlank()) {
+            if (!portada.isNullOrBlank()) {
                 thumbnail_url = if (portada.startsWith("http")) portada else "$baseUrl/${portada.trimStart('/')}"
             }
         }

--- a/src/es/jeazscans/src/eu/kanade/tachiyomi/extension/es/jeazscans/JeazScans.kt
+++ b/src/es/jeazscans/src/eu/kanade/tachiyomi/extension/es/jeazscans/JeazScans.kt
@@ -1,23 +1,328 @@
 package eu.kanade.tachiyomi.extension.es.jeazscans
 
-import eu.kanade.tachiyomi.multisrc.madara.Madara
+import android.util.Base64
+import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.parseAs
+import keiyoushi.utils.tryParse
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.jsoup.nodes.Document
 import java.text.SimpleDateFormat
+import java.util.Calendar
 import java.util.Locale
 
-class JeazScans :
-    Madara(
-        "Jeaz Scans",
-        "https://lectorhub.j5z.xyz",
-        "es",
-        dateFormat = SimpleDateFormat("MMM dd, yyyy", Locale("es")),
-    ) {
+class JeazScans : HttpSource() {
+
+    override val name = "Jeaz Scans"
+
+    override val baseUrl = "https://lectorhub.j5z.xyz"
+
+    override val lang = "es"
+
+    override val supportsLatest = true
+
     override val id = 5292079548510508306
 
-    override val useNewChapterEndpoint = true
-
-    override val client: OkHttpClient = super.client.newBuilder()
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .rateLimit(2)
         .build()
+
+    private val dateFormat by lazy {
+        SimpleDateFormat("MMM dd, yyyy", Locale("es"))
+    }
+
+    // The site migrated to custom home sections and PHP routes for search.
+    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/", headers)
+
+    override fun popularMangaParse(response: Response): MangasPage {
+        val document = response.asJsoup()
+        val mangas = document.select("section:has(h3:matchesOwn((?i)Top Rankings)) a[href*='manga.php?id=']").map { element ->
+            val manga = SManga.create()
+            val link = element.attr("abs:href")
+            val title = element.selectFirst("h4, h5")?.text().orEmpty()
+            val thumb = element.selectFirst("img")?.attr("abs:src").orEmpty()
+
+            manga.setUrlWithoutDomain(link)
+            manga.title = title
+            if (thumb.isNotBlank()) manga.thumbnail_url = thumb
+            manga
+        }
+        return MangasPage(mangas, false)
+    }
+
+    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/", headers)
+
+    override fun latestUpdatesParse(response: Response): MangasPage {
+        val document = response.asJsoup()
+        val mangas = document.select("section:has(h3:contains(Lanzamientos)) .manga-card")
+            .map { element ->
+                val manga = SManga.create()
+                val linkElement = element.selectFirst("a[href*='manga.php?id=']")
+                val title = element.selectFirst("figcaption")?.text().orEmpty()
+                val thumb = element.selectFirst("img")?.attr("abs:src").orEmpty()
+
+                manga.setUrlWithoutDomain(linkElement?.attr("abs:href").orEmpty())
+                manga.title = title
+                if (thumb.isNotBlank()) manga.thumbnail_url = thumb
+                manga
+            }
+            .filter { it.url.isNotEmpty() && it.title.isNotEmpty() }
+            .distinctBy { it.url }
+
+        return MangasPage(mangas, false)
+    }
+
+    override fun mangaDetailsParse(response: Response): SManga {
+        val document = response.asJsoup()
+        return SManga.create().apply {
+            val titleText = document.selectFirst("h1.blood-title")?.text().orEmpty()
+            if (titleText.isNotEmpty()) title = titleText
+
+            val descriptionBlock = document.selectFirst("div.text-gray-200:has(h3:matchesOwn((?i)SINOPSIS))")
+                ?: document.selectFirst("div.text-gray-200")
+            descriptionBlock?.let {
+                val synopsis = it.ownText().ifEmpty { it.text().replace(SINOPSIS_REGEX, "") }
+                if (synopsis.isNotEmpty()) description = synopsis
+            }
+
+            val thumbnail = document.selectFirst("div.lg\\:col-span-3 div.cultivation-panel img")
+                ?.attr("abs:src")
+                .orEmpty()
+            if (thumbnail.isNotEmpty()) thumbnail_url = thumbnail
+
+            val genres = document.select("a[href*='directorio.php?genero=']")
+                .map { it.text() }
+                .filter { it.isNotEmpty() }
+                .distinct()
+            if (genres.isNotEmpty()) genre = genres.joinToString()
+
+            val statusText = document.selectFirst("span.status-badge")?.text().orEmpty()
+            if (statusText.isNotEmpty()) {
+                status = when {
+                    statusText.contains("complet", ignoreCase = true) -> SManga.COMPLETED
+                    statusText.contains("pausa", ignoreCase = true) || statusText.contains("hiato", ignoreCase = true) -> SManga.ON_HIATUS
+                    statusText.contains("cancel", ignoreCase = true) || statusText.contains("aband", ignoreCase = true) -> SManga.CANCELLED
+                    statusText.contains("cultivo", ignoreCase = true) || statusText.contains("curso", ignoreCase = true) ||
+                        statusText.contains("ongoing", ignoreCase = true) || statusText.contains("emision", ignoreCase = true) -> SManga.ONGOING
+                    else -> SManga.UNKNOWN
+                }
+            }
+        }
+    }
+
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val document = response.asJsoup()
+        return document.select("#chaptersContainer a.chapter-item").map { element ->
+            val chapter = SChapter.create()
+
+            val chapterUrl = element.attr("abs:href")
+            chapter.setUrlWithoutDomain(chapterUrl)
+
+            val chapterNumber = element.attr("data-chapter-number")
+                .toFloatOrNull()
+                ?: CHAPTER_NUMBER_REGEX
+                    .find(chapterUrl)
+                    ?.groupValues
+                    ?.getOrNull(1)
+                    ?.toFloatOrNull()
+                ?: -1f
+            chapter.chapter_number = chapterNumber
+
+            val chapterTitle = element.selectFirst(".chapter-title")?.text().orEmpty()
+            chapter.name = if (chapterTitle.isNotEmpty()) {
+                chapterTitle
+            } else {
+                "Chapter ${chapterNumber.toString().removeSuffix(".0")}"
+            }
+
+            val dateText = element.selectFirst("span:has(i.ph-clock)")?.text()
+            chapter.date_upload = parseChapterDate(dateText)
+
+            chapter
+        }
+    }
+
+    private fun parseChapterDate(date: String?): Long {
+        if (date.isNullOrEmpty()) return 0L
+        val lowercaseDate = date.lowercase()
+        return when {
+            lowercaseDate.contains("hace") -> {
+                val number = NUMBER_REGEX.find(lowercaseDate)?.value?.toIntOrNull() ?: return 0L
+                val cal = Calendar.getInstance()
+                when {
+                    lowercaseDate.contains("segundo") -> cal.apply { add(Calendar.SECOND, -number) }.timeInMillis
+                    lowercaseDate.contains("minuto") -> cal.apply { add(Calendar.MINUTE, -number) }.timeInMillis
+                    lowercaseDate.contains("hora") -> cal.apply { add(Calendar.HOUR, -number) }.timeInMillis
+                    lowercaseDate.contains("día") || lowercaseDate.contains("dia") -> cal.apply { add(Calendar.DAY_OF_MONTH, -number) }.timeInMillis
+                    lowercaseDate.contains("semana") -> cal.apply { add(Calendar.WEEK_OF_YEAR, -number) }.timeInMillis
+                    lowercaseDate.contains("mes") -> cal.apply { add(Calendar.MONTH, -number) }.timeInMillis
+                    lowercaseDate.contains("año") -> cal.apply { add(Calendar.YEAR, -number) }.timeInMillis
+                    else -> 0L
+                }
+            }
+            lowercaseDate.contains("ayer") -> {
+                Calendar.getInstance().apply { add(Calendar.DAY_OF_MONTH, -1) }.timeInMillis
+            }
+            lowercaseDate.contains("hoy") -> {
+                Calendar.getInstance().timeInMillis
+            }
+            else -> dateFormat.tryParse(date)
+        }
+    }
+
+    override fun pageListParse(response: Response): List<Page> {
+        val document = response.asJsoup()
+        val imageElements = document.select(
+            "img.protected-img[src], .page-container img.protected-img[src], " +
+                "img.mv-secure-img[data-sec-src], .reader-body img[data-sec-src], " +
+                ".reader-body img[data-src], .reader-body img[src], " +
+                ".reading-content img[data-src], .reading-content img[src]",
+        )
+
+        val htmlPages = imageElements.mapNotNull { element ->
+            val imageUrl = when {
+                element.hasAttr("data-sec-src") -> element.attr("abs:data-sec-src")
+                element.hasAttr("data-src") -> element.attr("abs:data-src")
+                element.hasAttr("src") -> element.attr("abs:src")
+                else -> ""
+            }
+
+            if (imageUrl.isEmpty()) return@mapNotNull null
+
+            imageUrl
+        }.distinct().mapIndexed { index, imageUrl ->
+            Page(index, imageUrl = imageUrl)
+        }
+
+        if (htmlPages.isNotEmpty()) return htmlPages
+
+        return fetchPagesFromApi(document)
+    }
+
+    private fun fetchPagesFromApi(document: Document): List<Page> {
+        val (slug, cap) = extractSlugAndCap(document) ?: throw Exception("Could not extract slug/cap for API")
+        val apiUrl = buildApiUrl(document.location(), slug, cap) ?: throw Exception("Could not build API URL")
+
+        val requestHeaders = headers.newBuilder()
+            .set("Referer", document.location())
+            .build()
+
+        val payload = client.newCall(GET(apiUrl, requestHeaders)).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw Exception("HTTP error ${response.code}")
+            }
+
+            val apiResponse = response.parseAs<ApiLectorResponse>()
+            if (!apiResponse.success) throw Exception("API returned error")
+
+            apiResponse
+        }
+
+        val pages = payload.paginas
+
+        return pages.filter { it.dataVerify.isNotBlank() }
+            .sortedBy { it.orden }
+            .mapNotNull { decodeVerifyToUrl(it.dataVerify) }
+            .distinct()
+            .mapIndexed { idx, imageUrl -> Page(idx, imageUrl = imageUrl) }
+    }
+
+    private fun decodeVerifyToUrl(dataVerify: String): String? {
+        val decoded = runCatching {
+            String(Base64.decode(dataVerify, Base64.DEFAULT))
+        }.getOrNull() ?: return null
+
+        val url = decoded.reversed().trim()
+        if (!url.startsWith("http")) return null
+        return url
+    }
+
+    private fun extractSlugAndCap(document: Document): Pair<String, String>? {
+        val locationUrl = document.location().toHttpUrlOrNull()
+        val slugFromQuery = locationUrl?.queryParameter("manga")?.trim().orEmpty()
+        val capFromQuery = locationUrl?.queryParameter("cap")?.trim().orEmpty()
+        if (slugFromQuery.isNotBlank() && capFromQuery.isNotBlank()) {
+            return slugFromQuery to capFromQuery
+        }
+
+        val fromPath = PATH_SLUG_CAP_REGEX
+            .find(document.location())
+            ?.groupValues
+        if (fromPath != null && fromPath.size >= 3) {
+            return fromPath[1] to fromPath[2]
+        }
+
+        val scriptContent = document.select("script").joinToString("\n") { it.data() + "\n" + it.html() }
+        val slugFromScript = MANGA_SLUG_REGEX
+            .find(scriptContent)
+            ?.groupValues
+            ?.getOrNull(1)
+            .orEmpty()
+        val capFromScript = CAP_INICIAL_REGEX
+            .find(scriptContent)
+            ?.groupValues
+            ?.getOrNull(1)
+            .orEmpty()
+
+        if (slugFromScript.isNotEmpty() && capFromScript.isNotEmpty()) {
+            return slugFromScript to capFromScript
+        }
+
+        return null
+    }
+
+    private fun buildApiUrl(location: String, slug: String, cap: String): String? {
+        val current = location.toHttpUrlOrNull() ?: return null
+
+        return runCatching {
+            current.newBuilder()
+                .encodedPath("/api_lector.php")
+                .setQueryParameter("slug", slug)
+                .setQueryParameter("cap", cap)
+                .build()
+                .toString()
+        }.getOrNull()
+    }
+
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request = if (query.isBlank()) {
+        latestUpdatesRequest(page)
+    } else {
+        val url = "$baseUrl/ajax_search.php".toHttpUrl().newBuilder()
+            .addQueryParameter("q", query.trim())
+            .build()
+        GET(url, headers)
+    }
+
+    override fun searchMangaParse(response: Response): MangasPage {
+        if (!response.request.url.encodedPath.endsWith("/ajax_search.php")) {
+            return latestUpdatesParse(response)
+        }
+
+        val items = response.parseAs<List<SearchResponseItem>>()
+        val mangas = items.mapNotNull { it.toSManga(baseUrl) }
+
+        return MangasPage(mangas.distinctBy { it.url }, false)
+    }
+
+    override fun imageUrlParse(response: Response) = throw UnsupportedOperationException()
+
+    companion object {
+        private val SINOPSIS_REGEX = Regex("^SINOPSIS:?\\s*", RegexOption.IGNORE_CASE)
+        private val CHAPTER_NUMBER_REGEX = Regex("capitulo-([0-9.]+)", RegexOption.IGNORE_CASE)
+        private val NUMBER_REGEX = Regex("""\d+""")
+        private val PATH_SLUG_CAP_REGEX = Regex("/leer/([^/]+)/capitulo-([0-9.]+)", RegexOption.IGNORE_CASE)
+        private val MANGA_SLUG_REGEX = Regex("""MANGA_SLUG\s*=\s*["']([^"']+)["']""")
+        private val CAP_INICIAL_REGEX = Regex("""CAP_INICIAL\s*=\s*["']([^"']+)["']""")
+    }
 }

--- a/src/es/jeazscans/src/eu/kanade/tachiyomi/extension/es/jeazscans/JeazScans.kt
+++ b/src/es/jeazscans/src/eu/kanade/tachiyomi/extension/es/jeazscans/JeazScans.kt
@@ -32,7 +32,7 @@ class JeazScans : HttpSource() {
 
     override val supportsLatest = true
 
-    override val id = 5292079548510508306
+    override val versionId = 2
 
     override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .rateLimit(2)
@@ -48,15 +48,13 @@ class JeazScans : HttpSource() {
     override fun popularMangaParse(response: Response): MangasPage {
         val document = response.asJsoup()
         val mangas = document.select("section:has(h3:matchesOwn((?i)Top Rankings)) a[href*='manga.php?id=']").map { element ->
-            val manga = SManga.create()
-            val link = element.attr("abs:href")
-            val title = element.selectFirst("h4, h5")?.text().orEmpty()
-            val thumb = element.selectFirst("img")?.attr("abs:src").orEmpty()
+            SManga.create().apply {
+                setUrlWithoutDomain(element.attr("abs:href"))
+                title = element.selectFirst("h4, h5")!!.text()
 
-            manga.setUrlWithoutDomain(link)
-            manga.title = title
-            if (thumb.isNotBlank()) manga.thumbnail_url = thumb
-            manga
+                val thumb = element.selectFirst("img")?.attr("abs:src").orEmpty()
+                if (thumb.isNotEmpty()) thumbnail_url = thumb
+            }
         }
         return MangasPage(mangas, false)
     }
@@ -67,17 +65,15 @@ class JeazScans : HttpSource() {
         val document = response.asJsoup()
         val mangas = document.select("section:has(h3:contains(Lanzamientos)) .manga-card")
             .map { element ->
-                val manga = SManga.create()
-                val linkElement = element.selectFirst("a[href*='manga.php?id=']")
-                val title = element.selectFirst("figcaption")?.text().orEmpty()
-                val thumb = element.selectFirst("img")?.attr("abs:src").orEmpty()
+                SManga.create().apply {
+                    setUrlWithoutDomain(element.selectFirst("a[href*='manga.php?id=']")?.attr("abs:href").orEmpty())
+                    title = element.selectFirst("figcaption")!!.text()
 
-                manga.setUrlWithoutDomain(linkElement?.attr("abs:href").orEmpty())
-                manga.title = title
-                if (thumb.isNotBlank()) manga.thumbnail_url = thumb
-                manga
+                    val thumb = element.selectFirst("img")?.attr("abs:src").orEmpty()
+                    if (thumb.isNotEmpty()) thumbnail_url = thumb
+                }
             }
-            .filter { it.url.isNotEmpty() && it.title.isNotEmpty() }
+            .filter { it.url.isNotEmpty() }
             .distinctBy { it.url }
 
         return MangasPage(mangas, false)
@@ -86,8 +82,7 @@ class JeazScans : HttpSource() {
     override fun mangaDetailsParse(response: Response): SManga {
         val document = response.asJsoup()
         return SManga.create().apply {
-            val titleText = document.selectFirst("h1.blood-title")?.text().orEmpty()
-            if (titleText.isNotEmpty()) title = titleText
+            title = document.selectFirst("h1.blood-title")!!.text()
 
             val descriptionBlock = document.selectFirst("div.text-gray-200:has(h3:matchesOwn((?i)SINOPSIS))")
                 ?: document.selectFirst("div.text-gray-200")
@@ -107,14 +102,13 @@ class JeazScans : HttpSource() {
                 .distinct()
             if (genres.isNotEmpty()) genre = genres.joinToString()
 
-            val statusText = document.selectFirst("span.status-badge")?.text().orEmpty()
+            val statusText = document.selectFirst("span.status-badge")?.text().orEmpty().lowercase()
             if (statusText.isNotEmpty()) {
                 status = when {
-                    statusText.contains("complet", ignoreCase = true) -> SManga.COMPLETED
-                    statusText.contains("pausa", ignoreCase = true) || statusText.contains("hiato", ignoreCase = true) -> SManga.ON_HIATUS
-                    statusText.contains("cancel", ignoreCase = true) || statusText.contains("aband", ignoreCase = true) -> SManga.CANCELLED
-                    statusText.contains("cultivo", ignoreCase = true) || statusText.contains("curso", ignoreCase = true) ||
-                        statusText.contains("ongoing", ignoreCase = true) || statusText.contains("emision", ignoreCase = true) -> SManga.ONGOING
+                    statusText.contains("complet") -> SManga.COMPLETED
+                    arrayOf("pausa", "hiato").any { statusText.contains(it) } -> SManga.ON_HIATUS
+                    arrayOf("cancel", "aband").any { statusText.contains(it) } -> SManga.CANCELLED
+                    arrayOf("cultivo", "curso", "ongoing", "emision").any { statusText.contains(it) } -> SManga.ONGOING
                     else -> SManga.UNKNOWN
                 }
             }
@@ -124,32 +118,30 @@ class JeazScans : HttpSource() {
     override fun chapterListParse(response: Response): List<SChapter> {
         val document = response.asJsoup()
         return document.select("#chaptersContainer a.chapter-item").map { element ->
-            val chapter = SChapter.create()
+            SChapter.create().apply {
+                val chapterUrl = element.attr("abs:href")
+                setUrlWithoutDomain(chapterUrl)
 
-            val chapterUrl = element.attr("abs:href")
-            chapter.setUrlWithoutDomain(chapterUrl)
+                val parsedChapterNumber = element.attr("data-chapter-number")
+                    .toFloatOrNull()
+                    ?: CHAPTER_NUMBER_REGEX
+                        .find(chapterUrl)
+                        ?.groupValues
+                        ?.getOrNull(1)
+                        ?.toFloatOrNull()
+                    ?: -1f
+                chapter_number = parsedChapterNumber
 
-            val chapterNumber = element.attr("data-chapter-number")
-                .toFloatOrNull()
-                ?: CHAPTER_NUMBER_REGEX
-                    .find(chapterUrl)
-                    ?.groupValues
-                    ?.getOrNull(1)
-                    ?.toFloatOrNull()
-                ?: -1f
-            chapter.chapter_number = chapterNumber
+                val chapterTitle = element.selectFirst(".chapter-title")?.text().orEmpty()
+                name = if (chapterTitle.isNotEmpty()) {
+                    chapterTitle
+                } else {
+                    "Chapter ${parsedChapterNumber.toString().removeSuffix(".0")}"
+                }
 
-            val chapterTitle = element.selectFirst(".chapter-title")?.text().orEmpty()
-            chapter.name = if (chapterTitle.isNotEmpty()) {
-                chapterTitle
-            } else {
-                "Chapter ${chapterNumber.toString().removeSuffix(".0")}"
+                val dateText = element.selectFirst("span:has(i.ph-clock)")?.text()
+                date_upload = parseChapterDate(dateText)
             }
-
-            val dateText = element.selectFirst("span:has(i.ph-clock)")?.text()
-            chapter.date_upload = parseChapterDate(dateText)
-
-            chapter
         }
     }
 

--- a/src/es/jeazscans/src/eu/kanade/tachiyomi/extension/es/jeazscans/JeazScans.kt
+++ b/src/es/jeazscans/src/eu/kanade/tachiyomi/extension/es/jeazscans/JeazScans.kt
@@ -39,7 +39,7 @@ class JeazScans : HttpSource() {
         .build()
 
     private val dateFormat by lazy {
-        SimpleDateFormat("MMM dd, yyyy", Locale("es"))
+        SimpleDateFormat("dd MMM, yyyy", Locale.US)
     }
 
     // The site migrated to custom home sections and PHP routes for search.
@@ -51,9 +51,7 @@ class JeazScans : HttpSource() {
             SManga.create().apply {
                 setUrlWithoutDomain(element.attr("abs:href"))
                 title = element.selectFirst("h4, h5")!!.text()
-
-                val thumb = element.selectFirst("img")?.attr("abs:src").orEmpty()
-                if (thumb.isNotEmpty()) thumbnail_url = thumb
+                thumbnail_url = element.selectFirst("img")?.attr("abs:src")
             }
         }
         return MangasPage(mangas, false)
@@ -66,15 +64,11 @@ class JeazScans : HttpSource() {
         val mangas = document.select("section:has(h3:contains(Lanzamientos)) .manga-card")
             .map { element ->
                 SManga.create().apply {
-                    setUrlWithoutDomain(element.selectFirst("a[href*='manga.php?id=']")?.attr("abs:href").orEmpty())
+                    setUrlWithoutDomain(element.selectFirst("a[href*='manga.php?id=']")!!.attr("abs:href"))
                     title = element.selectFirst("figcaption")!!.text()
-
-                    val thumb = element.selectFirst("img")?.attr("abs:src").orEmpty()
-                    if (thumb.isNotEmpty()) thumbnail_url = thumb
+                    thumbnail_url = element.selectFirst("img")?.attr("abs:src")
                 }
             }
-            .filter { it.url.isNotEmpty() }
-            .distinctBy { it.url }
 
         return MangasPage(mangas, false)
     }
@@ -84,23 +78,17 @@ class JeazScans : HttpSource() {
         return SManga.create().apply {
             title = document.selectFirst("h1.blood-title")!!.text()
 
-            val descriptionBlock = document.selectFirst("div.text-gray-200:has(h3:matchesOwn((?i)SINOPSIS))")
-                ?: document.selectFirst("div.text-gray-200")
-            descriptionBlock?.let {
-                val synopsis = it.ownText().ifEmpty { it.text().replace(SINOPSIS_REGEX, "") }
-                if (synopsis.isNotEmpty()) description = synopsis
+            description = buildString {
+                val descriptionBlock = document.selectFirst("div.text-gray-200:has(h3:matchesOwn((?i)SINOPSIS))")
+                    ?: document.selectFirst("div.text-gray-200")
+                descriptionBlock?.let {
+                    append(it.ownText().ifEmpty { it.text().replace(SINOPSIS_REGEX, "") })
+                }
             }
 
-            val thumbnail = document.selectFirst("div.lg\\:col-span-3 div.cultivation-panel img")
-                ?.attr("abs:src")
-                .orEmpty()
-            if (thumbnail.isNotEmpty()) thumbnail_url = thumbnail
+            thumbnail_url = document.selectFirst("div.lg\\:col-span-3 div.cultivation-panel img")?.attr("abs:src")
 
-            val genres = document.select("a[href*='directorio.php?genero=']")
-                .map { it.text() }
-                .filter { it.isNotEmpty() }
-                .distinct()
-            if (genres.isNotEmpty()) genre = genres.joinToString()
+            genre = document.select("a[href*='directorio.php?genero=']").joinToString { it.text() }
 
             val statusText = document.selectFirst("span.status-badge")?.text().orEmpty().lowercase()
             if (statusText.isNotEmpty()) {
@@ -176,24 +164,16 @@ class JeazScans : HttpSource() {
     override fun pageListParse(response: Response): List<Page> {
         val document = response.asJsoup()
         val imageElements = document.select(
-            "img.protected-img[src], .page-container img.protected-img[src], " +
-                "img.mv-secure-img[data-sec-src], .reader-body img[data-sec-src], " +
-                ".reader-body img[data-src], .reader-body img[src], " +
-                ".reading-content img[data-src], .reading-content img[src]",
+            ".page-container img.protected-img, .reader-body img, .reading-content img",
         )
 
-        val htmlPages = imageElements.mapNotNull { element ->
+        val htmlPages = imageElements.mapIndexed { index, element ->
             val imageUrl = when {
                 element.hasAttr("data-sec-src") -> element.attr("abs:data-sec-src")
                 element.hasAttr("data-src") -> element.attr("abs:data-src")
-                element.hasAttr("src") -> element.attr("abs:src")
-                else -> ""
+                else -> element.attr("abs:src")
             }
 
-            if (imageUrl.isEmpty()) return@mapNotNull null
-
-            imageUrl
-        }.distinct().mapIndexed { index, imageUrl ->
             Page(index, imageUrl = imageUrl)
         }
 
@@ -304,7 +284,7 @@ class JeazScans : HttpSource() {
         val items = response.parseAs<List<SearchResponseItem>>()
         val mangas = items.mapNotNull { it.toSManga(baseUrl) }
 
-        return MangasPage(mangas.distinctBy { it.url }, false)
+        return MangasPage(mangas, false)
     }
 
     override fun imageUrlParse(response: Response) = throw UnsupportedOperationException()


### PR DESCRIPTION
Closes #13005 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension


### Changes made:
- **Migration:** Removed Madara multi-source dependency and rewrote the extension as a standalone custom `HttpSource`.