### PR TITLE
HentaiEra: Fix language selection

### DIFF
--- a/src/all/hentaiera/build.gradle
+++ b/src/all/hentaiera/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.HentaiEraFactory'
     themePkg = 'galleryadults'
     baseUrl = 'https://hentaiera.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/all/hentaiera/src/eu/kanade/tachiyomi/extension/all/hentaiera/HentaiEra.kt
+++ b/src/all/hentaiera/src/eu/kanade/tachiyomi/extension/all/hentaiera/HentaiEra.kt
@@ -39,15 +39,13 @@ class HentaiEra(
         ?: mangaLang
 
     private val langFlags by lazy {
-        mapOf(
-            "us" to LANGUAGE_ENGLISH,
-            "jp" to LANGUAGE_JAPANESE,
-            "es" to LANGUAGE_SPANISH,
-            "fr" to LANGUAGE_FRENCH,
-            "kr" to LANGUAGE_KOREAN,
-            "de" to LANGUAGE_GERMAN,
-            "ru" to LANGUAGE_RUSSIAN,
-        )
+        getLanguageURIs()
+            .associate { it.uri to it.name }
+            .toMutableMap()
+            .apply {
+                // Keep the existing English flag alias in case the site uses `flag-us`
+                putIfAbsent("us", LANGUAGE_ENGLISH)
+            }
     }
 
     override fun popularMangaRequest(page: Int): Request = if (mangaLang.isBlank()) {

--- a/src/all/hentaiera/src/eu/kanade/tachiyomi/extension/all/hentaiera/HentaiEra.kt
+++ b/src/all/hentaiera/src/eu/kanade/tachiyomi/extension/all/hentaiera/HentaiEra.kt
@@ -40,7 +40,7 @@ class HentaiEra(
 
     private val langFlags by lazy {
         getLanguageURIs()
-            .associate { it.uri to it.name }
+            .associate { it.second to it.first }
             .toMutableMap()
             .apply {
                 // Keep the existing English flag alias in case the site uses `flag-us`

--- a/src/all/hentaiera/src/eu/kanade/tachiyomi/extension/all/hentaiera/HentaiEra.kt
+++ b/src/all/hentaiera/src/eu/kanade/tachiyomi/extension/all/hentaiera/HentaiEra.kt
@@ -33,7 +33,7 @@ class HentaiEra(
             if (it == LANGUAGE_SPEECHLESS) mangaLang else null
         }
         ?: selectFirst(".g_flag")?.classNames()
-            ?.firstOrNull { it != "g_flag" }
+            ?.firstOrNull { it.startsWith("flag-") }
             ?.substringAfter("flag-")
             ?.let { langFlags[it] }
         ?: mangaLang

--- a/src/all/hentaiera/src/eu/kanade/tachiyomi/extension/all/hentaiera/HentaiEra.kt
+++ b/src/all/hentaiera/src/eu/kanade/tachiyomi/extension/all/hentaiera/HentaiEra.kt
@@ -30,8 +30,25 @@ class HentaiEra(
         .removeSuffix("/").substringAfterLast("/")
         .let {
             // Include Speechless in search results
-            if (it == LANGUAGE_SPEECHLESS) mangaLang else it
+            if (it == LANGUAGE_SPEECHLESS) mangaLang else null
         }
+        ?: selectFirst(".g_flag")?.classNames()
+            ?.firstOrNull { it != "g_flag" }
+            ?.substringAfter("flag-")
+            ?.let { langFlags[it] }
+        ?: mangaLang
+
+    private val langFlags by lazy {
+        mapOf(
+            "us" to LANGUAGE_ENGLISH,
+            "jp" to LANGUAGE_JAPANESE,
+            "es" to LANGUAGE_SPANISH,
+            "fr" to LANGUAGE_FRENCH,
+            "kr" to LANGUAGE_KOREAN,
+            "de" to LANGUAGE_GERMAN,
+            "ru" to LANGUAGE_RUSSIAN,
+        )
+    }
 
     override fun popularMangaRequest(page: Int): Request = if (mangaLang.isBlank()) {
         // Popular browsing for LANGUAGE_MULTI


### PR DESCRIPTION
Entries might be put under `translated` URL so we use flag instead

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
