### PR TITLE
Japscan: Fix chapter list honeypot bypass

### DIFF
--- a/src/fr/japscan/build.gradle
+++ b/src/fr/japscan/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Japscan'
     extClass = '.Japscan'
-    extVersionCode = 66
+    extVersionCode = 67
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -279,7 +279,9 @@ class Japscan :
         val filtered = allUrlPairs
             .filter { (name, url, _) ->
                 val segments = url.split('/').filter { it.isNotEmpty() }
-                if (mangaSlug != null && segments.getOrNull(1) != mangaSlug) return@filter false
+                if (segments.size != 3) return@filter false
+                if (segments[0] !in CHAPTER_PATH_TYPES) return@filter false
+                if (mangaSlug != null && segments[1] != mangaSlug) return@filter false
                 val urlNum = url.trimEnd('/').substringAfterLast('/')
                 if (!urlNum.all { it.isDigit() }) return@filter false
                 val chapterNum = Regex("""(?i)chapitre\s+([\d.]+)""").find(name)


### PR DESCRIPTION
Sorry for the spam of MR but they are making change to counter it

## Summary
- Japscan changed its chapter list honeypot pattern: instead of using a different slug (e.g. `/manga/cv/N/`), the new honeypots reuse the real manga slug but insert an extra junk segment (e.g. `/manga/one-piece/fxc/1/`). The existing slug bind still passed, and since the honeypot URL is longer than the real one, the length-based tiebreaker selected it — so every row resolved to a honeypot.
- Tighten the filter in `parseChapter` to require exactly three path segments (`<type>/<slug>/<digits>`) with `<type>` in `CHAPTER_PATH_TYPES`. Existing slug and name/number binds are kept as additional defenses.
- Bump `extVersionCode` 66 → 67.

Closes: #15412 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
