### PR TITLE
MangaMoins (FR): unescape HTML, ch titles redundancy filter

### DIFF
--- a/src/fr/mangamoins/build.gradle
+++ b/src/fr/mangamoins/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaMoins'
     extClass = '.MangaMoins'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = false
 }
 

--- a/src/fr/mangamoins/src/eu/kanade/tachiyomi/extension/fr/mangamoins/Dto.kt
+++ b/src/fr/mangamoins/src/eu/kanade/tachiyomi/extension/fr/mangamoins/Dto.kt
@@ -3,11 +3,14 @@ package eu.kanade.tachiyomi.extension.fr.mangamoins
 import eu.kanade.tachiyomi.source.model.SManga
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import org.jsoup.parser.Parser
 import java.util.Locale
 
 internal fun String.toMangaSlug(): String = this.lowercase(Locale.ROOT)
     .replace(Regex("[^a-z0-9]+"), "_")
     .trim('_')
+
+internal fun String.unescapeHtml(): String = Parser.unescapeEntities(this, false)
 
 @Serializable
 class MangaListResponse(
@@ -30,7 +33,7 @@ class MangaListItem(
     @SerialName("slug") val trendSlug: String? = null,
 ) {
     fun toSManga(): SManga = SManga.create().apply {
-        title = this@MangaListItem.title
+        title = this@MangaListItem.title.unescapeHtml()
         url = this@MangaListItem.slug ?: this@MangaListItem.trendSlug ?: title.toMangaSlug()
         thumbnail_url = this@MangaListItem.cover
     }

--- a/src/fr/mangamoins/src/eu/kanade/tachiyomi/extension/fr/mangamoins/MangaMoins.kt
+++ b/src/fr/mangamoins/src/eu/kanade/tachiyomi/extension/fr/mangamoins/MangaMoins.kt
@@ -103,10 +103,10 @@ class MangaMoins : HttpSource() {
         val result = response.parseAs<MangaDetailsResponse>()
         val info = result.info
         return SManga.create().apply {
-            title = info.title
-            author = info.author
-            artist = info.author
-            description = info.description.ifBlank { null }
+            title = info.title.unescapeHtml()
+            author = info.author.unescapeHtml()
+            artist = info.author.unescapeHtml()
+            description = info.description.unescapeHtml().ifBlank { null }
             status = when {
                 info.status.lowercase(Locale.FRENCH).contains("en cours") -> SManga.ONGOING
                 info.status.lowercase(Locale.FRENCH).contains("termin") -> SManga.COMPLETED
@@ -127,11 +127,12 @@ class MangaMoins : HttpSource() {
         return result.chapters.map { ch ->
             SChapter.create().apply {
                 name = buildString {
-                    append("Chapitre ")
-                    append(ch.num.toString().removeSuffix(".0"))
-                    if (ch.title.isNotBlank()) {
+                    val chapterName = "Chapitre ${ch.num.toString().removeSuffix(".0")}"
+                    append(chapterName)
+                    val title = ch.title.unescapeHtml()
+                    if (title.isNotBlank() && !title.equals(chapterName, ignoreCase = true)) {
                         append(" - ")
-                        append(ch.title)
+                        append(title)
                     }
                 }
                 url = ch.slug


### PR DESCRIPTION
Closes #15083

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
