### PR TITLE
Japscan: fix chapter list after new hidden-element honeypots

### DIFF
--- a/src/fr/japscan/build.gradle
+++ b/src/fr/japscan/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Japscan'
     extClass = '.Japscan'
-    extVersionCode = 67
+    extVersionCode = 68
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -78,6 +78,23 @@ class Japscan :
 
     companion object {
         private val CHAPTER_PATH_TYPES = setOf("manga", "manhua", "manhwa", "bd", "comic")
+        private val HIDDEN_STYLE_TOKENS = listOf(
+            "display:none",
+            "visibility:hidden",
+            "opacity:0",
+            "width:0",
+            "height:0",
+            "pointer-events:none",
+            "clip-path:inset(100%",
+            "clip:rect(0,0,0,0",
+            "font-size:0",
+            "text-indent:-",
+        )
+
+        // Match a large absolute offset (3+ digits, positive or negative) on any side.
+        // 3 digits is enough to be off-screen even with viewport units (200vh, 999vw, …)
+        // while still tolerating fine adjustments like top:-1px or right:99px.
+        private val OFFSCREEN_OFFSET_REGEX = Regex("""(?:top|bottom|left|right):-?\d{3,}""")
         val dateFormat by lazy {
             SimpleDateFormat("dd MMM yyyy", Locale.US)
         }
@@ -250,9 +267,34 @@ class Japscan :
 
     override fun chapterFromElement(element: Element): SChapter = throw UnsupportedOperationException()
 
+    private fun isHidden(el: Element): Boolean {
+        if (el.hasClass("d-none")) return true
+        if (el.hasAttr("hidden")) return true
+        if (el.attr("aria-hidden").equals("true", ignoreCase = true)) return true
+        val style = el.attr("style").replace(" ", "").lowercase()
+        if (HIDDEN_STYLE_TOKENS.any { style.contains(it) }) return true
+        if (OFFSCREEN_OFFSET_REGEX.containsMatchIn(style)) return true
+        return false
+    }
+
+    private fun isHiddenWithin(el: Element, root: Element): Boolean {
+        var cur: Element? = el
+        while (cur != null && cur !== root) {
+            if (isHidden(cur)) return true
+            cur = cur.parent()
+        }
+        return false
+    }
+
     private fun parseChapter(element: Element, mangaSlug: String?): SChapter {
-        // Only search for a tag with any attribute containing manga/manhua/manhwa
+        // Only search for a tag with any attribute containing manga/manhua/manhwa.
+        // Skip elements that are visually hidden — Japscan hides honeypots with
+        // class="d-none", inline display/visibility/opacity:0, zero size, or by
+        // positioning them way off-screen. The visible chapter row never carries
+        // any of these, so to evade detection Japscan would have to make the
+        // honeypots visible to humans too.
         val allUrlPairs = (element.getElementsContainingText("Chapitre") + element.getElementsContainingText("Volume"))
+            .filterNot { isHiddenWithin(it, element) }
             .mapNotNull { el ->
                 // Find the first attribute whose value matches the chapter URL pattern
                 val attrMatch = el.attributes().asList().firstOrNull { attr ->


### PR DESCRIPTION
## Summary

- Japscan changed their anti-scraping markup. Honeypot chapter entries now reuse the real manga slug (e.g. `/manga/one-piece/999121/`) and use a fake "Chapitre N" label whose number matches the URL's trailing digits. This defeats the existing slug + name-digit + URL-segment filter (added in 5f4c63735), so the chapter list comes back full of `999xxx` entries.
- Real chapters are visible `<div style="cursor:pointer" vxxx="/manga/<slug>/<num>/">…`; honeypots are `<a>/<span>/<p>` hidden via class `d-none`, inline `opacity:0`/`width:0`/`height:0`/`pointer-events:none`, or off-screen positioning (`left:-9999px`).
- `parseChapter` now prunes any candidate whose self-or-ancestor is hidden, before running the existing matching logic. Hidden = class `d-none`, attribute `hidden` / `aria-hidden="true"`, an inline-style "hidden" token (`display:none`, `visibility:hidden`, `opacity:0`, `width:0`, `height:0`, `pointer-events:none`, `clip-path:inset(100%`, `clip:rect(0,0,0,0`, `font-size:0`, `text-indent:-`), or a 3+ digit offset on `top`/`bottom`/`left`/`right` (sign- and unit-agnostic, so `-9999px`, `999vw`, `-200vh` all trigger while `top:-1px` stays tolerated).
- Existing slug + name-digit + URL-segment bind is kept as a defence-in-depth fallback for older honeypot variants.
- Bumped `extVersionCode` 67 → 68.

Closes: #15444 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
