### PR TITLE
MyHentaiGallery (EN): add Artists / Parodies filters

### DIFF
--- a/src/en/myhentaigallery/build.gradle
+++ b/src/en/myhentaigallery/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MyHentaiGallery'
     extClass = '.MyHentaiGallery'
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = true
 }
 

--- a/src/en/myhentaigallery/src/eu/kanade/tachiyomi/extension/en/myhentaigallery/Filters.kt
+++ b/src/en/myhentaigallery/src/eu/kanade/tachiyomi/extension/en/myhentaigallery/Filters.kt
@@ -130,3 +130,9 @@ internal class GenreFilter :
             Pair("Weight Gain", "66"),
         ),
     )
+
+internal open class TagLookupFilter(displayName: String, val uriPart: String) : Filter.Text(displayName)
+
+internal class ArtistFilter : TagLookupFilter("Artists", "artist")
+
+internal class ParodyFilter : TagLookupFilter("Parodies", "parody")

--- a/src/en/myhentaigallery/src/eu/kanade/tachiyomi/extension/en/myhentaigallery/MyHentaiGallery.kt
+++ b/src/en/myhentaigallery/src/eu/kanade/tachiyomi/extension/en/myhentaigallery/MyHentaiGallery.kt
@@ -15,6 +15,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
+import org.jsoup.nodes.Element
 import rx.Observable
 
 class MyHentaiGallery : HttpSource() {
@@ -61,10 +62,19 @@ class MyHentaiGallery : HttpSource() {
             return GET(url, headers)
         }
 
-        val categoryFilter = filters.firstInstanceOrNull<GenreFilter>()
-        val sortFilter = filters.firstInstanceOrNull<SortFilter>()
+        val filterList = if (filters.isEmpty()) getFilterList() else filters
+        val categoryFilter = filterList.firstInstanceOrNull<GenreFilter>()
+        val sortFilter = filterList.firstInstanceOrNull<SortFilter>()
+        val tagLookupFilter = filterList
+            .filterIsInstance<TagLookupFilter>()
+            .firstOrNull { it.state.isNotBlank() }
 
-        if (categoryFilter != null && categoryFilter.toUriPart() != "---") {
+        if (tagLookupFilter != null) {
+            val tagId = tagLookupFilter.resolveTagId()
+            return GET("$baseUrl/a/${tagLookupFilter.uriPart}/$tagId/$page", headers)
+        }
+
+        if (categoryFilter != null && categoryFilter.toUriPart().isNotEmpty()) {
             val catId = categoryFilter.toUriPart()
             return GET("$baseUrl/g/category/$catId/$page", headers)
         }
@@ -83,6 +93,11 @@ class MyHentaiGallery : HttpSource() {
         SortFilter(),
         Filter.Separator(),
         GenreFilter(),
+        Filter.Separator(),
+        Filter.Header("Use one category/artist/parody filter at a time"),
+        Filter.Header("Artists/Parodies accept ID, tag URL, or exact name"),
+        ArtistFilter(),
+        ParodyFilter(),
     )
 
     // =========================== Comic Listing ==============================
@@ -108,30 +123,32 @@ class MyHentaiGallery : HttpSource() {
 
     override fun mangaDetailsParse(response: Response): SManga {
         val document = response.asJsoup()
+        val info: Element = document.selectFirst("div.comic-header")!!
+        val categories = info.select("div:containsOwn(categories) a").eachText()
+        val artists = info.select("div:containsOwn(artists) a").eachText()
+        val parodies = info.select("div:containsOwn(parodies) a").eachText()
 
-        return document.selectFirst("div.comic-header")!!.let { info ->
-            SManga.create().apply {
-                title = info.selectFirst("h1")!!.text()
-                genre = info.select("div:containsOwn(categories) a").joinToString { it.text() }
-                artist = info.select("div:containsOwn(artists) a").joinToString { it.text() }
-                thumbnail_url = document.selectFirst(".comic-listing .comic-inner img")?.absUrl("src")?.encodeSpaces()
-                status = SManga.COMPLETED
-                initialized = true
-                description = buildString {
-                    info.select("div:containsOwn(groups) a")
-                        .takeIf { it.isNotEmpty() }
-                        ?.also { if (isNotEmpty()) append("\n\n") }
-                        ?.also { appendLine("Groups:") }
-                        ?.joinToString("\n") { "- ${it.text()}" }
-                        ?.also { append(it) }
+        return SManga.create().apply {
+            title = info.selectFirst("h1")!!.text()
+            genre = (categories + artists + parodies).joinToString()
+            artist = artists.joinToString()
+            thumbnail_url = document.selectFirst(".comic-listing .comic-inner img")?.absUrl("src")?.encodeSpaces()
+            status = SManga.COMPLETED
+            initialized = true
+            description = buildString {
+                info.select("div:containsOwn(groups) a")
+                    .takeIf { it.isNotEmpty() }
+                    ?.also { if (isNotEmpty()) append("\n\n") }
+                    ?.also { appendLine("Groups:") }
+                    ?.joinToString("\n") { "- ${it.text()}" }
+                    ?.also { append(it) }
 
-                    info.select("div:containsOwn(parodies) a")
-                        .takeIf { it.isNotEmpty() }
-                        ?.also { if (isNotEmpty()) append("\n\n") }
-                        ?.also { appendLine("Parodies:") }
-                        ?.joinToString("\n") { "- ${it.text()}" }
-                        ?.also { append(it) }
-                }
+                info.select("div:containsOwn(parodies) a")
+                    .takeIf { it.isNotEmpty() }
+                    ?.also { if (isNotEmpty()) append("\n\n") }
+                    ?.also { appendLine("Parodies:") }
+                    ?.joinToString("\n") { "- ${it.text()}" }
+                    ?.also { append(it) }
             }
         }
     }
@@ -159,7 +176,52 @@ class MyHentaiGallery : HttpSource() {
 
     private fun String.encodeSpaces(): String = replace(" ", "%20")
 
+    private fun TagLookupFilter.resolveTagId(): String {
+        val value = state.trim()
+        value.toLongOrNull()?.let { return it.toString() }
+
+        TAG_URL_REGEX.find(value)?.let { match ->
+            val namespace = match.groupValues[1].lowercase()
+            if (namespace != uriPart) {
+                throw Exception("Expected a $uriPart URL, got a $namespace URL")
+            }
+
+            return match.groupValues[2]
+        }
+
+        return lookupTagId(uriPart, value)
+            ?: throw Exception("No $uriPart \"$value\" was found. Use the exact tag name, numeric ID, or full MyHentaiGallery tag URL.")
+    }
+
+    private fun lookupTagId(uriPart: String, name: String): String? {
+        val lookup = tagLookupCache.getOrPut(uriPart) { loadTagLookup(uriPart) }
+        return lookup[name.normalizeTagName()]
+    }
+
+    private fun loadTagLookup(uriPart: String): Map<String, String> {
+        val tagUrlRegex = Regex("""/$uriPart/(\d+)(?:[/?#]|$)""", RegexOption.IGNORE_CASE)
+
+        return client.newCall(GET("$baseUrl/tag/$uriPart", headers)).execute().use { response ->
+            response.asJsoup()
+                .select("a[href*='/$uriPart/']")
+                .mapNotNull { element ->
+                    val id = tagUrlRegex.find(element.attr("href"))?.groupValues?.get(1)
+                        ?: return@mapNotNull null
+                    val name = element.text().normalizeTagName()
+                    if (name.isBlank()) null else name to id
+                }
+                .toMap()
+        }
+    }
+
+    private fun String.normalizeTagName(): String = replace(TAG_COUNT_SUFFIX, "").trim().lowercase().replace(WHITESPACE_REGEX, " ")
+
     companion object {
         const val PREFIX_ID_SEARCH = "id:"
+        private val TAG_URL_REGEX = Regex("""/(artist|parody)/(\d+)(?:[/?#]|$)""", RegexOption.IGNORE_CASE)
+        private val WHITESPACE_REGEX = Regex("""\s+""")
+        private val TAG_COUNT_SUFFIX = Regex("""\s*\(\d+\)\s*$""")
     }
+
+    private val tagLookupCache = mutableMapOf<String, Map<String, String>>()
 }


### PR DESCRIPTION
Adds support for filtering on MHG by a single artist or parody.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
