### PR TITLE
Emperor Scan (ES): update mangaDetailsSelectorDescription

### DIFF
--- a/src/es/emperorscan/build.gradle
+++ b/src/es/emperorscan/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.EmperorScan'
     themePkg = 'madara'
     baseUrl = 'https://imperiomanhua.com'
-    overrideVersionCode = 10
+    overrideVersionCode = 11
     isNsfw = false
 }
 

--- a/src/es/emperorscan/src/eu/kanade/tachiyomi/extension/es/emperorscan/EmperorScan.kt
+++ b/src/es/emperorscan/src/eu/kanade/tachiyomi/extension/es/emperorscan/EmperorScan.kt
@@ -32,7 +32,7 @@ class EmperorScan :
 
     override fun getMangaUrl(manga: SManga) = "$baseUrl${manga.url}"
 
-    override val mangaDetailsSelectorDescription = "div.summary__content p:not(p:has(a))"
+    override val mangaDetailsSelectorDescription = "div.summary_content div.post-content_item:has(h5:contains(Sinopsis)) div"
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         screen.addRandomUAPreference()


### PR DESCRIPTION
Closes #15070

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
