### PR TITLE
Japscan: handle transform-positioned chapter honeypots

### DIFF
--- a/src/fr/japscan/build.gradle
+++ b/src/fr/japscan/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Japscan'
     extClass = '.Japscan'
-    extVersionCode = 68
+    extVersionCode = 69
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -91,10 +91,21 @@ class Japscan :
             "text-indent:-",
         )
 
-        // Match a large absolute offset (3+ digits, positive or negative) on any side.
+        // Match styles that visually remove an element while leaving it in the DOM:
+        //  - large absolute offset (3+ digits) via top/bottom/left/right or `inset:` shorthand
+        //  - `transform: translate / translateX / translateY / translate3d` with a 3+ digit offset
+        //  - `transform: scale(0)` / `scale3d(0,...)` (collapsed to nothing)
+        //  - `transform: matrix(0,0,0,0,...)` (also collapsed)
+        //  - `max-width:0` / `max-height:0` (mirror of the existing width:0/height:0 tokens)
         // 3 digits is enough to be off-screen even with viewport units (200vh, 999vw, …)
         // while still tolerating fine adjustments like top:-1px or right:99px.
-        private val OFFSCREEN_OFFSET_REGEX = Regex("""(?:top|bottom|left|right):-?\d{3,}""")
+        private val OFFSCREEN_OFFSET_REGEX = Regex(
+            """(?:top|bottom|left|right|inset):-?\d{3,}""" +
+                """|transform:translate(?:3d|x|y)?\([^)]*-?\d{3,}""" +
+                """|transform:scale(?:3d)?\(0[,)]""" +
+                """|transform:matrix\(0,0,0,0""" +
+                """|max-(?:width|height):0""",
+        )
         val dateFormat by lazy {
             SimpleDateFormat("dd MMM yyyy", Locale.US)
         }
@@ -253,9 +264,34 @@ class Japscan :
     override fun chapterListParse(response: Response): List<SChapter> {
         val document = response.asJsoup()
         val mangaSlug = extractMangaSlug(response.request.url)
-        return document.select(chapterListSelector()).mapNotNull { el ->
+        val chapters = document.select(chapterListSelector()).mapNotNull { el ->
             runCatching { parseChapter(el, mangaSlug) }.getOrNull()
         }
+        return filterOutlierChapters(chapters)
+    }
+
+    // Defense in depth: if a honeypot ever slips past the per-row hidden-style
+    // heuristics, its URL number is wildly out of range (e.g. 483181 vs. real 1181).
+    // Drop the upper cluster when consecutive chapter numbers jump by more than 1000.
+    private fun filterOutlierChapters(chapters: List<SChapter>): List<SChapter> {
+        val withNum = chapters.mapNotNull { ch ->
+            val n = ch.url.trimEnd('/').substringAfterLast('/').toLongOrNull() ?: return@mapNotNull null
+            ch to n
+        }
+        if (withNum.size < 2) return chapters
+        val sorted = withNum.sortedBy { it.second }
+        var gapIdx = -1
+        var gapSize = 0L
+        for (i in 1 until sorted.size) {
+            val g = sorted[i].second - sorted[i - 1].second
+            if (g > gapSize) {
+                gapSize = g
+                gapIdx = i
+            }
+        }
+        if (gapSize <= 1000) return chapters
+        val keep = sorted.take(gapIdx).map { it.first }.toSet()
+        return chapters.filter { it in keep }
     }
 
     private fun extractMangaSlug(url: okhttp3.HttpUrl): String? {


### PR DESCRIPTION
## Summary

- Japscan rotated their chapter-list honeypot trick: real chapter rows are now intermixed with `<a>`/`<span>`/`<p>` decoys positioned off-screen via `style="position:absolute;transform:translate(-99999px,-99999px)"` instead of `top/left:-99999px`. The previous `OFFSCREEN_OFFSET_REGEX` only matched positional offsets, so the decoys survived the hidden-element filter and won the URL tie-break (their 6-digit fake numbers like `/manga/one-piece/483181/` are longer than the real `/manga/one-piece/1181/`).
- Extended `OFFSCREEN_OFFSET_REGEX` to also match `transform:translate(...)` / `translateX/Y/3d`, `transform:scale(0)` / `scale3d(0,...)`, `transform:matrix(0,0,0,0,...)`, the `inset:` shorthand with a 3+ digit offset, and `max-width:0` / `max-height:0`. Pre-empts a few obvious adjacent variants without risking regressions on legitimate styles.
- Added `filterOutlierChapters` as defense in depth: after parsing, if consecutive chapter URL numbers jump by more than 1000, drop the upper cluster. Catches the symptom even if a future hide-trick slips past the per-row check.
- Bumped `extVersionCode` 68 → 69.


Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
