### PR TITLE
MangaCloud (EN): Fix request headers

### DIFF
--- a/src/en/mangacloud/build.gradle
+++ b/src/en/mangacloud/build.gradle
@@ -1,7 +1,7 @@
 ext {
 	extName = 'MangaCloud'
 	extClass = '.MangaCloud'
-	extVersionCode = 2
+	extVersionCode = 3
 	isNsfw = false
 }
 

--- a/src/en/mangacloud/src/eu/kanade/tachiyomi/extension/en/mangacloud/Filters.kt
+++ b/src/en/mangacloud/src/eu/kanade/tachiyomi/extension/en/mangacloud/Filters.kt
@@ -54,8 +54,8 @@ class SortFilter :
         name = "Sort by",
         options = listOf(
             "None" to null,
-            "Latest Upload" to "updated_date-DESC",
-            "Oldest Upload" to "updated_date-ASC",
+            "Latest Chapter" to "chapter_date-DESC",
+            "Oldest Chapter" to "chapter_date-ASC",
             "Title Ascending" to "title-ASC",
             "Title Descending" to "title-DESC",
             "Recently Added" to "created_date-DESC",

--- a/src/en/mangacloud/src/eu/kanade/tachiyomi/extension/en/mangacloud/MangaCloud.kt
+++ b/src/en/mangacloud/src/eu/kanade/tachiyomi/extension/en/mangacloud/MangaCloud.kt
@@ -47,6 +47,7 @@ class MangaCloud : HttpSource() {
 
     override fun headersBuilder() = super.headersBuilder()
         .set("Referer", "$baseUrl/")
+        .set("Key", generateKey())
 
     override fun popularMangaRequest(page: Int): Request {
         return if (page > 3) {
@@ -58,7 +59,7 @@ class MangaCloud : HttpSource() {
                 else -> "month"
             }
 
-            return GET("$API_URL/comic-popular-view/$time", headers)
+            return GET("$API_URL/comic-popular-view/$time", headersBuilder().build())
         }
     }
 
@@ -78,7 +79,7 @@ class MangaCloud : HttpSource() {
             .toJsonString()
             .toRequestBody(jsonMediaType)
 
-        return POST(url, headers, payload)
+        return POST(url, headersBuilder().build(), payload)
     }
 
     override fun latestUpdatesParse(response: Response): MangasPage {
@@ -119,7 +120,7 @@ class MangaCloud : HttpSource() {
     private fun fetchOnlineTags(tagsFile: File) {
         if (!fetchingOnlineTags.compareAndSet(false, true)) return
 
-        val request = GET("$API_URL/tag/list", headers)
+        val request = GET("$API_URL/tag/list", headersBuilder().build())
 
         client.newCall(request).enqueue(
             object : Callback {
@@ -138,6 +139,7 @@ class MangaCloud : HttpSource() {
                         fetchingOnlineTags.set(false)
                     }
                 }
+
                 override fun onFailure(call: Call, e: IOException) {
                     Log.e(name, "Failed to fetch tags", e)
                     fetchingOnlineTags.set(false)
@@ -204,7 +206,7 @@ class MangaCloud : HttpSource() {
             .toJsonString()
             .toRequestBody(jsonMediaType)
 
-        return POST(url, headers, payload)
+        return POST(url, headersBuilder().build(), payload)
     }
 
     override fun searchMangaParse(response: Response): MangasPage {
@@ -238,7 +240,7 @@ class MangaCloud : HttpSource() {
 
     override fun mangaDetailsRequest(manga: SManga) = mangaDetailsRequest(manga.url)
 
-    private fun mangaDetailsRequest(comicId: String) = GET("$API_URL/comic/$comicId", headers)
+    private fun mangaDetailsRequest(comicId: String) = GET("$API_URL/comic/$comicId", headersBuilder().build())
 
     override fun getMangaUrl(manga: SManga): String = "$baseUrl/comic/${manga.url}"
 
@@ -247,11 +249,11 @@ class MangaCloud : HttpSource() {
     override fun chapterListRequest(manga: SManga) = mangaDetailsRequest(manga)
 
     override fun chapterListParse(response: Response): List<SChapter> {
-        val data = response.parseAs<Data<Manga>>()
+        val data = response.parseAs<Data<Manga>>().data
 
-        return data.data.chapters.map { chapter ->
+        return data.chapters.map { chapter ->
             SChapter.create().apply {
-                url = ChapterUrl(data.data.id, chapter.id).toJsonString()
+                url = ChapterUrl(data.id, chapter.id).toJsonString()
                 name = buildString {
                     append("Chapter ")
                     append(chapter.number.toString().substringBefore(".0"))
@@ -269,7 +271,7 @@ class MangaCloud : HttpSource() {
     override fun pageListRequest(chapter: SChapter): Request {
         val chapterId = chapter.url.parseAs<ChapterUrl>().chapterId
 
-        return GET("$API_URL/chapter/$chapterId", headers)
+        return GET("$API_URL/chapter/$chapterId", headersBuilder().build())
     }
 
     override fun getChapterUrl(chapter: SChapter): String {
@@ -287,6 +289,11 @@ class MangaCloud : HttpSource() {
     }
 
     override fun imageUrlParse(response: Response) = throw UnsupportedOperationException()
+
+    private fun generateKey(): String {
+        val timestamp = (System.currentTimeMillis() / 1000).toString().reversed()
+        return timestamp.map { "${(0..9).random()}$it" }.joinToString("")
+    }
 }
 
 private val jsonMediaType = "application/json".toMediaType()


### PR DESCRIPTION
Closes #15578

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
