### PR TITLE
MangaOni (ES): Fix missing manga titles in search results

### DIFF
--- a/src/es/mangamx/build.gradle
+++ b/src/es/mangamx/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaOni'
     extClass = '.MangaOni'
-    extVersionCode = 18
+    extVersionCode = 19
     isNsfw = true
 }
 

--- a/src/es/mangamx/src/eu/kanade/tachiyomi/extension/es/mangamx/MangaOni.kt
+++ b/src/es/mangamx/src/eu/kanade/tachiyomi/extension/es/mangamx/MangaOni.kt
@@ -122,8 +122,9 @@ class MangaOni :
             document.select("#article-div > div").map { element ->
                 SManga.create().apply {
                     thumbnail_url = element.select("img").attr("abs:src")
-                    element.selectFirst("div a")?.also {
-                        title = it.text()
+                    title = element.select("a").firstOrNull { it.text().isNotBlank() }?.text()
+                        ?: throw Exception("Title not found")
+                    element.selectFirst("a")?.also {
                         setUrlWithoutDomain(it.attr("abs:href"))
                     }
                 }
@@ -139,6 +140,7 @@ class MangaOni :
         val document = response.asJsoup()
 
         return SManga.create().apply {
+            title = document.selectFirst("h1")?.text() ?: throw Exception("Title not found")
             thumbnail_url = document.select("img[src*=cover]").attr("abs:src")
             description = document.select("div#sinopsis").lastOrNull()?.ownText()
             author = document.select("div#info-i").text().let {


### PR DESCRIPTION
Closes #15584

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
