### PR TITLE
Fix TheBlank

### DIFF
--- a/src/en/theblank/build.gradle
+++ b/src/en/theblank/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'The Blank'
     extClass = '.TheBlank'
-    extVersionCode = 53
+    extVersionCode = 54
     isNsfw = true
 }
 

--- a/src/en/theblank/src/eu/kanade/tachiyomi/extension/en/theblank/Dto.kt
+++ b/src/en/theblank/src/eu/kanade/tachiyomi/extension/en/theblank/Dto.kt
@@ -4,7 +4,6 @@ import eu.kanade.tachiyomi.source.model.SManga
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonNames
-import java.security.KeyPair
 
 @Serializable
 class Version(
@@ -88,18 +87,32 @@ class MangaResponse(
     }
 }
 
+/**
+ * Inertia response for `GET /serie/{slug}/chapter/{slug}`. The handshake
+ * material (chapter_token, server_pubkey, page_count) sits on `props`
+ * directly; `props.data` only carries the chapter/serie identity.
+ */
 @Serializable
 class PageListResponse(
     val props: Props,
 ) {
     @Serializable
     class Props(
-        @SerialName("signed_urls")
-        val signedUrls: List<String>,
-    )
+        @SerialName("page_count")
+        val pageCount: Int,
+        @SerialName("chapter_token")
+        val chapterToken: String,
+        @SerialName("server_pubkey")
+        val serverPubkey: String,
+        val data: Data,
+    ) {
+        @Serializable
+        class Data(
+            val slug: String,
+            val serie: Serie,
+        )
+
+        @Serializable
+        class Serie(val slug: String)
+    }
 }
-
-class KeyPairResult(val keyPair: KeyPair, val publicKeyBase64: String)
-
-@Serializable
-class SessionResponse(val sid: String)

--- a/src/en/theblank/src/eu/kanade/tachiyomi/extension/en/theblank/TheBlank.kt
+++ b/src/en/theblank/src/eu/kanade/tachiyomi/extension/en/theblank/TheBlank.kt
@@ -5,6 +5,7 @@ import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.extension.en.theblank.decryption.SecretStream
 import eu.kanade.tachiyomi.extension.en.theblank.decryption.State
+import eu.kanade.tachiyomi.extension.en.theblank.decryption.X25519
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
@@ -21,34 +22,26 @@ import keiyoushi.utils.firstInstance
 import keiyoushi.utils.firstInstanceOrNull
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
-import keiyoushi.utils.toJsonString
 import keiyoushi.utils.tryParse
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody
-import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.asResponseBody
 import okio.Buffer
 import okio.Timeout
 import okio.buffer
 import java.io.IOException
-import java.nio.charset.StandardCharsets
-import java.security.KeyPairGenerator
 import java.security.MessageDigest
-import java.security.PrivateKey
 import java.security.SecureRandom
-import java.security.spec.MGF1ParameterSpec
 import java.text.SimpleDateFormat
 import java.util.Locale
-import javax.crypto.Cipher
-import javax.crypto.spec.OAEPParameterSpec
-import javax.crypto.spec.PSource
+import java.util.concurrent.ConcurrentHashMap
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
 
 class TheBlank :
     HttpSource(),
@@ -316,7 +309,7 @@ class TheBlank :
                     }.build().encodedPath
                     name = buildString {
                         if (it.isPremium) {
-                            append("\uD83D\uDD12 ") // lock emoji
+                            append("\uD83D\uDD12 ")
                         }
                         append(it.title)
                     }
@@ -346,121 +339,165 @@ class TheBlank :
         )
     }
 
-    override fun pageListParse(response: Response): List<Page> {
-        val signedUrls = response.parseAs<PageListResponse>().props.signedUrls
-
-        val keyPair = generateKeyPair()
-        val sid = decodeUrlSafeBase64(
-            fetchSessionId(keyPair.publicKeyBase64),
-        )
-        val key = rsaDecrypt(keyPair.keyPair.private, sid)
-
-        return signedUrls.mapIndexed { idx, img ->
-            val httpUrl = img.toHttpUrl()
-
-            val fileName = httpUrl.queryParameter("path")
-                ?.substringAfterLast('/')
-                ?: throw IllegalStateException("Image URL missing 'path' parameter: $img")
-
-            Page(
-                index = idx,
-                imageUrl = httpUrl.newBuilder()
-                    .fragment(key + fileName)
-                    .build()
-                    .toString(),
-            )
-        }
-    }
-
-    private fun fetchSessionId(publicKeyBase64: String): String {
-        val url = "$baseUrl/checksum".toHttpUrl()
-        val body = buildJsonObject {
-            put("checksum", publicKeyBase64)
-            put("timestamp", generateNonce())
-        }.toJsonString().toRequestBody("application/json".toMediaType())
-
-        val request = apiRequest(
-            url,
-            body,
-            includeXSRFToken = false,
-            includeCSRFToken = true,
-            includeVersion = false,
-        )
-
-        return client.newCall(request).execute()
-            .parseAs<SessionResponse>().sid
-    }
-
-    private fun generateKeyPair(): KeyPairResult {
-        val generator = KeyPairGenerator.getInstance("RSA").apply {
-            initialize(2048)
-        }
-
-        val keyPair = generator.generateKeyPair()
-        val publicKeyBase64 = Base64.encodeToString(keyPair.public.encoded, Base64.NO_WRAP)
-
-        return KeyPairResult(keyPair, publicKeyBase64)
-    }
-
     private val secureRandom = SecureRandom()
 
-    private fun generateNonce(): String {
-        val timestampHex = (System.currentTimeMillis() / 1000)
-            .toString(16)
-            .padStart(16, '0')
+    private class ChapterSession(
+        val chapterToken: String,
+        val sharedSecret: ByteArray,
+        val clientPubkeyB64: String,
+    )
 
-        val randomHex = ByteArray(24).apply {
-            secureRandom.nextBytes(this)
-        }.joinToString("") { "%02x".format(it) }
+    private val sessions = ConcurrentHashMap<String, ChapterSession>()
+    private val sessionLocks = ConcurrentHashMap<String, Any>()
 
-        return timestampHex + randomHex
+    private fun sessionKey(serieSlug: String, chapterSlug: String) = "tb-$serieSlug--$chapterSlug"
+
+    private fun handshakeFrom(props: PageListResponse.Props): ChapterSession {
+        val serverPub = Base64.decode(props.serverPubkey, Base64.DEFAULT)
+        require(serverPub.size == 32) { "server pubkey must be 32 bytes" }
+
+        val priv = ByteArray(32).also(secureRandom::nextBytes)
+        val clientPub = X25519.publicKey(priv)
+        val shared = X25519.scalarMult(priv, serverPub)
+        priv.fill(0)
+
+        return ChapterSession(
+            chapterToken = props.chapterToken,
+            sharedSecret = shared,
+            clientPubkeyB64 = Base64.encodeToString(clientPub, Base64.NO_WRAP),
+        )
     }
 
-    private fun rsaDecrypt(privateKey: PrivateKey, encryptedData: ByteArray): String {
-        val cipher = Cipher.getInstance("RSA/ECB/OAEPPadding").apply {
-            val oaepSpec = OAEPParameterSpec(
-                "SHA-256",
-                "MGF1",
-                MGF1ParameterSpec.SHA256,
-                PSource.PSpecified.DEFAULT,
-            )
+    // Refetches the chapter page to rebuild the handshake on cache miss —
+    // hit after a process restart when Tachiyomi rehydrates Page objects
+    // from disk but the in-memory session map is empty.
+    private fun ensureSession(serieSlug: String, chapterSlug: String): ChapterSession {
+        val id = sessionKey(serieSlug, chapterSlug)
+        sessions[id]?.let { return it }
 
-            init(Cipher.DECRYPT_MODE, privateKey, oaepSpec)
+        val lock = sessionLocks[id] ?: Any().let { fresh ->
+            sessionLocks.putIfAbsent(id, fresh) ?: fresh
         }
+        synchronized(lock) {
+            sessions[id]?.let { return it }
 
-        val decryptedBytes = cipher.doFinal(encryptedData)
+            val url = baseHttpUrl.newBuilder()
+                .addPathSegment("serie").addPathSegment(serieSlug)
+                .addPathSegment("chapter").addPathSegment(chapterSlug)
+                .build()
+            val req = apiRequest(
+                url,
+                includeXSRFToken = true,
+                includeCSRFToken = false,
+                includeVersion = true,
+            )
+            val props = client.newCall(req).execute().use { resp ->
+                if (!resp.isSuccessful) {
+                    throw IOException("Could not rebuild chapter session: HTTP ${resp.code}")
+                }
+                resp.parseAs<PageListResponse>().props
+            }
 
-        return String(decryptedBytes, StandardCharsets.UTF_8)
+            val sess = handshakeFrom(props)
+            sessions[id] = sess
+            return sess
+        }
     }
 
-    private fun decodeUrlSafeBase64(data: String): ByteArray {
-        val normalized = data
-            .replace('-', '+')
-            .replace('_', '/')
-            .let { it + "=".repeat((4 - it.length % 4) % 4) }
+    override fun pageListParse(response: Response): List<Page> {
+        val props = response.parseAs<PageListResponse>().props
+        val sess = handshakeFrom(props)
+        val id = sessionKey(props.data.serie.slug, props.data.slug)
+        sessions[id] = sess
 
-        return Base64.decode(normalized, Base64.DEFAULT)
+        return (1..props.pageCount).map { idx ->
+            Page(
+                index = idx - 1,
+                url = "$id#$idx",
+                imageUrl = "$baseUrl/serie/${props.data.serie.slug}/chapter/${props.data.slug}/page/$idx#$id",
+            )
+        }
+    }
+
+    private fun hexNonce(byteCount: Int = 16): String {
+        val b = ByteArray(byteCount).also(secureRandom::nextBytes)
+        return b.joinToString("") { "%02x".format(it) }
+    }
+
+    private fun hmacSha256Hex(key: String, msg: String): String {
+        val mac = Mac.getInstance("HmacSHA256").apply {
+            init(SecretKeySpec(key.toByteArray(Charsets.US_ASCII), "HmacSHA256"))
+        }
+        return mac.doFinal(msg.toByteArray(Charsets.US_ASCII))
+            .joinToString("") { "%02x".format(it) }
+    }
+
+    override fun imageRequest(page: Page): Request {
+        val parsed = page.imageUrl!!.toHttpUrl()
+        val seg = parsed.pathSegments
+        require(seg.size >= 6 && seg[0] == "serie" && seg[2] == "chapter" && seg[4] == "page") {
+            "unexpected page URL shape: ${parsed.encodedPath}"
+        }
+        val serieSlug = seg[1]
+        val chapterSlug = seg[3]
+        val pageIndex = seg[5].toInt()
+
+        val session = ensureSession(serieSlug, chapterSlug)
+        val sessionId = sessionKey(serieSlug, chapterSlug)
+
+        val ts = (System.currentTimeMillis() / 1000).toString()
+        val nonce = hexNonce()
+        val sig = hmacSha256Hex(session.chapterToken, "$pageIndex$ts$nonce")
+
+        val url = baseHttpUrl.newBuilder()
+            .addPathSegment("serie").addPathSegment(serieSlug)
+            .addPathSegment("chapter").addPathSegment(chapterSlug)
+            .addPathSegment("page").addPathSegment(pageIndex.toString())
+            .addQueryParameter("token", session.chapterToken)
+            .addQueryParameter("ts", ts)
+            .addQueryParameter("nonce", nonce)
+            .addQueryParameter("sig", sig)
+            .fragment(sessionId)
+            .build()
+
+        val h = headersBuilder()
+            .set("X-Client-Pubkey", session.clientPubkeyB64)
+            .build()
+
+        return GET(url, h)
     }
 
     private fun imageInterceptor(chain: Interceptor.Chain): Response {
         val request = chain.request()
         val response = chain.proceed(request)
 
-        val fragment = request.url.fragment
-            ?.takeIf { it != THUMBNAIL_FRAGMENT }
-            ?: return response
+        val sessionId = request.url.fragment ?: return response
+        val session = sessions[sessionId] ?: return response
+
+        val pageNameRaw = response.header("X-Page-Name") ?: return response
+        val keyHintB64 = response.header("X-Key-Hint") ?: return response
+        val keyHint = Base64.decode(keyHintB64, Base64.DEFAULT)
+        require(keyHint.size >= 32) { "X-Key-Hint must decode to >= 32 bytes" }
+
+        // streamKey = SHA-256(sharedSecret || filename) XOR keyHint[:32]
+        // — KDF recovered from pam.wasm; not a documented derivation.
+        val streamKey = run {
+            val sha = MessageDigest.getInstance("SHA-256").run {
+                update(session.sharedSecret)
+                update(pageNameRaw.toByteArray(Charsets.UTF_8))
+                digest()
+            }
+            ByteArray(32) { i -> (sha[i].toInt() xor keyHint[i].toInt()).toByte() }
+        }
 
         val networkSource = response.body.source()
         networkSource.skip(PREFIX_LENGTH.toLong())
-
-        val nonce = networkSource.readByteArray(IMAGE_HEADER_LENGTH.toLong())
-        val key = MessageDigest.getInstance("SHA-256")
-            .digest(fragment.toByteArray(Charsets.UTF_8))
+        val ssHeader = networkSource.readByteArray(STREAM_HEADER_LENGTH.toLong())
 
         val decryptedSource = object : okio.Source {
             private val secretStream = SecretStream()
             private val state = State().apply {
-                secretStream.initPull(this, nonce, key)
+                secretStream.initPull(this, ssHeader, streamKey)
             }
             private val decryptedBuffer = Buffer()
             private var isFinished = false
@@ -510,6 +547,6 @@ class TheBlank :
 
 private const val THUMBNAIL_FRAGMENT = "thumbnail"
 private const val HIDE_PREMIUM_PREF = "pref_hide_premium_chapters"
-private const val CHUNK_SIZE = 65536 + 17 // Data size + ABYTES
+private const val CHUNK_SIZE = 65536 + 17 // libsodium secretstream chunk + ABYTES
 private const val PREFIX_LENGTH = 128
-private const val IMAGE_HEADER_LENGTH = 24
+private const val STREAM_HEADER_LENGTH = 24

--- a/src/en/theblank/src/eu/kanade/tachiyomi/extension/en/theblank/decryption/X25519.kt
+++ b/src/en/theblank/src/eu/kanade/tachiyomi/extension/en/theblank/decryption/X25519.kt
@@ -1,0 +1,113 @@
+package eu.kanade.tachiyomi.extension.en.theblank.decryption
+
+import java.math.BigInteger
+
+/**
+ * Self-contained X25519 (RFC 7748) using BigInteger.
+ *
+ * Used once per chapter to derive the ECDH shared secret with the server's
+ * static public key. Not constant-time — acceptable here because the
+ * private scalar is freshly generated, used once, then wiped.
+ */
+internal object X25519 {
+    private val P = BigInteger.ONE.shiftLeft(255).subtract(BigInteger.valueOf(19))
+    private val A24 = BigInteger.valueOf(121665)
+    private val TWO = BigInteger.valueOf(2)
+
+    private val BASE = ByteArray(32).also { it[0] = 9 }
+
+    fun publicKey(privateKey: ByteArray): ByteArray = scalarMult(privateKey, BASE)
+
+    fun scalarMult(scalar: ByteArray, u: ByteArray): ByteArray {
+        require(scalar.size == 32) { "scalar must be 32 bytes" }
+        require(u.size == 32) { "u must be 32 bytes" }
+        val k = clamp(scalar)
+        val x = decodeU(u)
+        return encodeU(ladder(k, x))
+    }
+
+    private fun clamp(s: ByteArray): BigInteger {
+        val k = s.copyOf()
+        k[0] = (k[0].toInt() and 248).toByte()
+        k[31] = ((k[31].toInt() and 127) or 64).toByte()
+        return leToBig(k)
+    }
+
+    private fun decodeU(u: ByteArray): BigInteger {
+        val u2 = u.copyOf()
+        u2[31] = (u2[31].toInt() and 127).toByte()
+        return leToBig(u2).mod(P)
+    }
+
+    private fun encodeU(x: BigInteger): ByteArray = bigToLe(x.mod(P), 32)
+
+    private fun leToBig(le: ByteArray): BigInteger {
+        val be = ByteArray(le.size + 1) // leading 0x00 to keep positive
+        for (i in le.indices) be[le.size - i] = le[i]
+        return BigInteger(be)
+    }
+
+    private fun bigToLe(x: BigInteger, len: Int): ByteArray {
+        val out = ByteArray(len)
+        var v = x
+        var i = 0
+        while (i < len && v.signum() > 0) {
+            out[i] = v.toInt().and(0xff).toByte()
+            v = v.shiftRight(8)
+            i++
+        }
+        return out
+    }
+
+    private fun ladder(k: BigInteger, u: BigInteger): BigInteger {
+        var x1 = u
+        var x2 = BigInteger.ONE
+        var z2 = BigInteger.ZERO
+        var x3 = u
+        var z3 = BigInteger.ONE
+        var swap = 0
+
+        for (t in 254 downTo 0) {
+            val kt = if (k.testBit(t)) 1 else 0
+            swap = swap xor kt
+            if (swap == 1) {
+                val tx = x2
+                x2 = x3
+                x3 = tx
+                val tz = z2
+                z2 = z3
+                z3 = tz
+            }
+            swap = kt
+
+            val a = x2.add(z2).mod(P)
+            val aa = a.multiply(a).mod(P)
+            val b = x2.subtract(z2).mod(P)
+            val bb = b.multiply(b).mod(P)
+            val e = aa.subtract(bb).mod(P)
+            val c = x3.add(z3).mod(P)
+            val d = x3.subtract(z3).mod(P)
+            val da = d.multiply(a).mod(P)
+            val cb = c.multiply(b).mod(P)
+
+            val nx3 = da.add(cb).mod(P).modPow(TWO, P)
+            val nz3 = x1.multiply(da.subtract(cb).mod(P).modPow(TWO, P)).mod(P)
+            val nx2 = aa.multiply(bb).mod(P)
+            val nz2 = e.multiply(aa.add(A24.multiply(e)).mod(P)).mod(P)
+
+            x2 = nx2
+            z2 = nz2
+            x3 = nx3
+            z3 = nz3
+        }
+        if (swap == 1) {
+            val tx = x2
+            x2 = x3
+            x3 = tx
+            val tz = z2
+            z2 = z3
+            z3 = tz
+        }
+        return x2.multiply(z2.modInverse(P)).mod(P)
+    }
+}


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

Closes #14936

Expand for details
<details>
 The Blank replaced its old RSA-OAEP / signed-URL page delivery with an
  ECDH-keyed libsodium secretstream. The previous implementation no longer
  decodes any pages; this PR replaces the whole decryption path.

  ## What the site does now

  Each chapter page response is a binary stream encrypted with
  `crypto_secretstream_xchacha20poly1305`. The per-page key is derived
  client-side from material the site mints per chapter, and the page request
  itself is HMAC-signed.

  The chapter HTML embeds an Inertia `data-page` blob with three new fields
  on `props` (not on `props.data`):

  - `chapter_token` — 64-hex-char HMAC key, scoped to one chapter
  - `server_pubkey` — 32-byte X25519 static public key, base64
  - `page_count`

  `props.data` retains the old chapter/serie identity (`slug`, `serie.slug`).
  The dead `cek_wrapped` / `cek_epoch` fields under `props.data` are not
  referenced by the live site and are ignored here.

  ### End-to-end decryption flow

  1. **Per-chapter ECDH (once).** Generate an ephemeral X25519 keypair,
     compute `shared = X25519(clientPriv, serverPub)`. Store `shared` keyed
     by `(serieSlug, chapterSlug)`; wipe `clientPriv`.

  2. **Per-page signed request.**
      ```
      GET /serie/{s}/chapter/{c}/page/{i}
          ?token={chapter_token}&ts={unix_seconds}&nonce={hex16}
          &sig={HMAC-SHA256(chapter_token, "{i}{ts}{nonce}")}
      X-Client-Pubkey: base64(clientPub)
      ```

  3. **Response layout.** `application/octet-stream` body of
     `[128-byte preamble][24-byte secretstream header][AEAD chunks…]`,
     plus two custom headers used as KDF inputs:
      - `X-Page-Name`: original filename (e.g. `1.jpg`)
      - `X-Key-Hint`: base64, ≥32 bytes; one-time XOR pad

  4. **Stream-key derivation.** Recovered by reverse-engineering the
     `_initPageDecryption` export of `pam.wasm`:
      ```
      streamKey = SHA-256(shared || filename) XOR keyHint[:32]
      ```

  5. **Decrypt.** `crypto_secretstream_xchacha20poly1305_init_pull(state,
     header, streamKey)` then `pull` 65 553-byte chunks (libsodium's 65 536
     plaintext + 17 ABYTES) until `tag == TAG_FINAL`. Output streamed
     straight into the OkHttp response body as `image/jpg`.

  ## What changed in the extension

  - **`Dto.kt` — `PageListResponse`**: handshake fields moved to
    `props.{chapter_token, server_pubkey, page_count}`. `props.data` keeps
    only `slug` and `serie.slug`.
  - **`TheBlank.kt`** — full rewrite of the page path:
      - `pageListParse` performs the X25519 handshake once, stores a
        `ChapterSession` keyed by `tb-{serie}--{chapter}`.
      - `imageRequest` parses the slug/index from the `Page.imageUrl` path,
        calls `ensureSession` (refetches the chapter HTML and re-handshakes
        on cache miss — handles process restart with rehydrated `Page`s),
        then signs a fresh `?token&ts&nonce&sig` URL and attaches
        `X-Client-Pubkey`. Per-chapter `sessionLocks` provide
        double-checked locking around the rebuild.
      - `imageInterceptor` reads `X-Page-Name` + `X-Key-Hint`, applies the
        KDF, and streams the decrypted body via the existing libsodium-style
        `decryption/{ChaCha20,Poly1305,SecretStream,State}.java`.
      - Removed: RSA keypair generation, `/checksum` POST, session-id flow,
        `signed_urls`, `rsaDecrypt`, `decodeUrlSafeBase64`, the timestamp
        nonce builder.
  - **`decryption/X25519.kt` (new)** — pure-Kotlin RFC 7748 X25519 via
    BigInteger Montgomery ladder. Used once per chapter on a freshly
    generated, immediately-wiped private scalar; non-constant-time is
    acceptable for that profile.
</details>