### PR TITLE
Comix Fix API

### DIFF
--- a/src/en/comix/build.gradle
+++ b/src/en/comix/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comix'
     extClass = '.Comix'
-    extVersionCode = 11
+    extVersionCode = 12
     isNsfw = true
 }
 

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
@@ -174,10 +174,11 @@ class Comix :
 
     override fun chapterListRequest(manga: SManga): Request {
         val hid = manga.url.removePrefix("/").substringBefore("-")
-        return chapterListRequest(hid, 1)
+        val fullSlug = manga.url.removePrefix("/")
+        return chapterListRequest(hid, fullSlug, 1)
     }
 
-    private fun chapterListRequest(mangaHash: String, page: Int): Request {
+    private fun chapterListRequest(mangaHash: String, mangaSlug: String, page: Int): Request {
         val path = "/manga/$mangaHash/chapters"
         val hashToken = generateHash(path)
         val url = apiUrl.toHttpUrl().newBuilder()
@@ -188,6 +189,7 @@ class Comix :
             .addQueryParameter("limit", "100")
             .addQueryParameter("page", page.toString())
             .addQueryParameter("_", hashToken)
+            .addQueryParameter("mangaSlug", mangaSlug) // Add slug as query parameter
             .build()
 
         return GET(url, headers)
@@ -196,6 +198,7 @@ class Comix :
     override fun chapterListParse(response: Response): List<SChapter> {
         val deduplicate = preferences.deduplicateChapters()
         val mangaHash = response.request.url.pathSegments[3]
+        val mangaSlug = response.request.url.queryParameter("mangaSlug") ?: mangaHash // Extract slug
         var resp: ChapterDetailsResponse = response.parseAs()
 
         var chapterMap: LinkedHashMap<Number, Chapter>? = null
@@ -213,7 +216,7 @@ class Comix :
 
         while (hasNext) {
             resp = client
-                .newCall(chapterListRequest(mangaHash, page++))
+                .newCall(chapterListRequest(mangaHash, mangaSlug, page++))
                 .execute()
                 .parseAs()
 
@@ -234,7 +237,7 @@ class Comix :
                 chapterList!!
             }
 
-        return finalChapters.map { it.toSChapter(mangaHash) }
+        return finalChapters.map { it.toSChapter(mangaSlug) }
     }
 
     private fun deduplicateChapters(

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
@@ -14,7 +14,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
-import keiyoushi.utils.getPreferences
+import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
@@ -27,11 +27,12 @@ class Comix :
 
     override val name = "Comix"
     override val baseUrl = "https://comix.to"
-    private val apiUrl = "https://comix.to/api/v2"
+    private val apiUrl = "https://comix.to/api/v1"
     override val lang = "en"
     override val supportsLatest = true
 
-    private val preferences: SharedPreferences = getPreferences()
+    private val preferences: SharedPreferences by getPreferencesLazy()
+
     override val client = network.cloudflareClient.newBuilder()
         .rateLimit(5)
         .build()
@@ -40,17 +41,17 @@ class Comix :
 
     override fun imageUrlParse(response: Response) = throw UnsupportedOperationException()
 
-    // ========================= Popular =========================
+    // ============================== Popular ==============================
     override fun popularMangaRequest(page: Int): Request {
         val url = apiUrl.toHttpUrl().newBuilder().apply {
             addPathSegment("manga")
-            addQueryParameter("order[views_30d]", "desc")
-            addQueryParameter("limit", "50")
+            addQueryParameter("order[score]", "desc")
+            addQueryParameter("limit", "28")
             addQueryParameter("page", page.toString())
 
             if (preferences.hideNsfw()) {
                 NSFW_GENRE_IDS.forEach {
-                    addQueryParameter("genres[]", "-$it")
+                    addQueryParameter("genres_ex[]", it)
                 }
             }
         }.build()
@@ -60,17 +61,17 @@ class Comix :
 
     override fun popularMangaParse(response: Response) = searchMangaParse(response)
 
-    // ========================= Latest =========================
+    // ============================== Latest ===============================
     override fun latestUpdatesRequest(page: Int): Request {
         val url = apiUrl.toHttpUrl().newBuilder().apply {
             addPathSegment("manga")
             addQueryParameter("order[chapter_updated_at]", "desc")
-            addQueryParameter("limit", "50")
+            addQueryParameter("limit", "28")
             addQueryParameter("page", page.toString())
 
             if (preferences.hideNsfw()) {
                 NSFW_GENRE_IDS.forEach {
-                    addQueryParameter("genres[]", "-$it")
+                    addQueryParameter("genres_ex[]", it)
                 }
             }
         }.build()
@@ -80,7 +81,7 @@ class Comix :
 
     override fun latestUpdatesParse(response: Response) = searchMangaParse(response)
 
-    // ========================= Search =========================
+    // ============================== Search ===============================
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         if (query.isNotBlank()) {
             val queryUrl = query.trim().toHttpUrlOrNull()
@@ -99,20 +100,20 @@ class Comix :
             filters.filterIsInstance<Filters.UriFilter>()
                 .forEach { it.addToUri(this) }
 
-            // Make searches accurate
             if (query.isNotBlank()) {
                 addQueryParameter("keyword", query)
-                removeAllQueryParameters("order[views_30d]")
-                setQueryParameter("order[relevance]", "desc")
+                removeAllQueryParameters("order[score]")
+                removeAllQueryParameters("order[chapter_updated_at]")
+                addQueryParameter("order[relevance]", "desc")
             }
 
             if (preferences.hideNsfw()) {
                 NSFW_GENRE_IDS.forEach {
-                    addQueryParameter("genres[]", "-$it")
+                    addQueryParameter("genres_ex[]", it)
                 }
             }
 
-            addQueryParameter("limit", "50")
+            addQueryParameter("limit", "28")
             addQueryParameter("page", page.toString())
         }.build()
 
@@ -132,18 +133,19 @@ class Comix :
         } else {
             val res: SearchResponse = response.parseAs()
             val manga = res.result.items.map { it.toBasicSManga(posterQuality) }
-            return MangasPage(manga, res.result.pagination.page < res.result.pagination.lastPage)
+            return MangasPage(manga, res.result.hasNextPage())
         }
     }
 
-    // ========================= Filters =========================
+    // ============================== Filters ==============================
     override fun getFilterList() = Filters().getFilterList()
 
-    // ========================= Details =========================
+    // ============================== Details ==============================
     override fun mangaDetailsRequest(manga: SManga): Request {
+        val hid = manga.url.removePrefix("/").substringBefore("-")
         val url = apiUrl.toHttpUrl().newBuilder()
             .addPathSegment("manga")
-            .addPathSegment(manga.url)
+            .addPathSegment(hid)
             .addQueryParameter("includes[]", "demographic")
             .addQueryParameter("includes[]", "genre")
             .addQueryParameter("includes[]", "theme")
@@ -165,15 +167,19 @@ class Comix :
         )
     }
 
-    // ========================= Chapters =========================
+    override fun getMangaUrl(manga: SManga): String = "$baseUrl/title${manga.url}"
+
+    // ============================= Chapters ==============================
     override fun getChapterUrl(chapter: SChapter) = "$baseUrl/${chapter.url}"
 
-    override fun chapterListRequest(manga: SManga): Request = chapterListRequest(manga.url.removePrefix("/"), 1)
+    override fun chapterListRequest(manga: SManga): Request {
+        val hid = manga.url.removePrefix("/").substringBefore("-")
+        return chapterListRequest(hid, 1)
+    }
 
     private fun chapterListRequest(mangaHash: String, page: Int): Request {
         val path = "/manga/$mangaHash/chapters"
-        val time = 1L
-        val hashToken = generateHash(path, 0, time)
+        val hashToken = generateHash(path)
         val url = apiUrl.toHttpUrl().newBuilder()
             .addPathSegment("manga")
             .addPathSegment(mangaHash)
@@ -181,7 +187,6 @@ class Comix :
             .addQueryParameter("order[number]", "desc")
             .addQueryParameter("limit", "100")
             .addQueryParameter("page", page.toString())
-            .addQueryParameter("time", time.toString())
             .addQueryParameter("_", hashToken)
             .build()
 
@@ -193,9 +198,7 @@ class Comix :
         val mangaHash = response.request.url.pathSegments[3]
         var resp: ChapterDetailsResponse = response.parseAs()
 
-        // When deduplication is enabled store only the best chapter per number.
         var chapterMap: LinkedHashMap<Number, Chapter>? = null
-        // When disabled just accumulate all.
         var chapterList: ArrayList<Chapter>? = null
 
         if (deduplicate) {
@@ -206,23 +209,23 @@ class Comix :
         }
 
         var page = 2
-        var hasNext: Boolean
+        var hasNext = resp.result.hasNextPage()
 
-        do {
+        while (hasNext) {
             resp = client
                 .newCall(chapterListRequest(mangaHash, page++))
                 .execute()
                 .parseAs()
 
             val items = resp.result.items
-            hasNext = resp.result.pagination.lastPage > resp.result.pagination.page
 
             if (deduplicate) {
                 deduplicateChapters(chapterMap!!, items)
             } else {
                 chapterList!!.addAll(items)
             }
-        } while (hasNext)
+            hasNext = resp.result.hasNextPage()
+        }
 
         val finalChapters: List<Chapter> =
             if (deduplicate) {
@@ -234,8 +237,6 @@ class Comix :
         return finalChapters.map { it.toSChapter(mangaHash) }
     }
 
-    override fun getMangaUrl(manga: SManga): String = "$baseUrl/title${manga.url}"
-
     private fun deduplicateChapters(
         chapterMap: LinkedHashMap<Number, Chapter>,
         items: List<Chapter>,
@@ -246,26 +247,20 @@ class Comix :
             if (current == null) {
                 chapterMap[key] = ch
             } else {
-                // Prefer official flag first, then "Official?" group, then votes/updatedAt
-                val newIsOfficial = ch.isOfficial == 1
-                val currentIsOfficial = current.isOfficial == 1
-                val newIsGroup10702 = ch.scanlationGroupId == 10702
-                val currentIsGroup10702 = current.scanlationGroupId == 10702
+                val newIsOfficial = ch.isOfficial
+                val currentIsOfficial = current.isOfficial
+                val newIsGroup10702 = ch.group?.id == 10702
+                val currentIsGroup10702 = current.group?.id == 10702
 
                 val better = when {
-                    // Prefer official-marked chapters
                     newIsOfficial && !currentIsOfficial -> true
                     !newIsOfficial && currentIsOfficial -> false
-
-                    // If neither official, prefer group "Official?"
                     newIsGroup10702 && !currentIsGroup10702 -> true
                     !newIsGroup10702 && currentIsGroup10702 -> false
-
-                    // compare votes then updatedAt
                     else -> when {
                         ch.votes > current.votes -> true
                         ch.votes < current.votes -> false
-                        else -> ch.updatedAt > current.updatedAt
+                        else -> ch.id > current.id
                     }
                 }
                 if (better) chapterMap[key] = ch
@@ -273,12 +268,15 @@ class Comix :
         }
     }
 
-    // ========================= Pages =========================
+    // =============================== Pages ===============================
     override fun pageListRequest(chapter: SChapter): Request {
-        val chapterId = chapter.url.substringAfterLast("/")
+        val chapterId = chapter.url.substringAfterLast("/").substringBefore("-")
+        val path = "/chapters/$chapterId"
+        val hashToken = generateHash(path)
         val url = apiUrl.toHttpUrl().newBuilder()
             .addPathSegment("chapters")
             .addPathSegment(chapterId)
+            .addQueryParameter("_", hashToken)
             .build()
         return GET(url, headers)
     }
@@ -287,16 +285,16 @@ class Comix :
         val res: ChapterResponse = response.parseAs()
         val result = res.result ?: throw Exception("Chapter not found")
 
-        if (result.images.isEmpty()) {
-            throw Exception("No images found for chapter ${result.chapterId}")
+        if (result.pages.isEmpty()) {
+            throw Exception("No images found for chapter ${result.id}")
         }
 
-        return result.images.mapIndexed { index, img ->
+        return result.pages.mapIndexed { index, img ->
             Page(index, imageUrl = img.url)
         }
     }
 
-    // ========================= Settings =========================
+    // ============================= Settings =============================
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         ListPreference(screen.context).apply {
             key = PREF_POSTER_QUALITY
@@ -320,14 +318,12 @@ class Comix :
             summary = "Remove duplicate chapters from the chapter list.\n" +
                 "Official chapters (Comix-marked) are preferred, followed by the highest-voted or most recent.\n" +
                 "Warning: It can be slow on large lists."
-
             setDefaultValue(false)
         }.let(screen::addPreference)
 
         SwitchPreferenceCompat(screen.context).apply {
             key = ALTERNATIVE_NAMES_IN_DESCRIPTION
             title = "Show Alternative Names in Description"
-
             setDefaultValue(false)
         }.let(screen::addPreference)
 

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Dto.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Dto.kt
@@ -2,62 +2,49 @@ package eu.kanade.tachiyomi.extension.en.comix
 
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.descriptors.PrimitiveKind
-import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.json.JsonDecoder
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.booleanOrNull
-import kotlinx.serialization.json.intOrNull
 import java.math.BigDecimal
 import java.math.RoundingMode
+import java.util.Calendar
 
 @Serializable
 class Term(
-    @SerialName("term_id")
-    private val termId: Int,
-    private val type: String,
+    @SerialName("term_id") private val termId: Int? = null,
+    private val type: String? = null,
     val title: String,
-    private val slug: String,
-    private val count: Int?,
+    private val slug: String? = null,
+    private val count: Int? = null,
 )
 
 @Serializable
 class Manga(
-    @SerialName("hash_id")
-    private val hashId: String,
+    val hid: String,
     private val title: String,
-    @SerialName("alt_titles")
-    private val altTitles: List<String>,
-    private val synopsis: String?,
-    private val type: String,
-    private val poster: Poster,
-    private val status: String,
-    @SerialName("is_nsfw")
-    private val isNsfw: Boolean,
-    private val author: List<Term>?,
-    private val artist: List<Term>?,
-    private val genre: List<Term>?,
-    private val theme: List<Term>?,
-    private val demographic: List<Term>?,
-    @SerialName("rated_avg")
+    @SerialName("alt_titles") private val altTitles: List<String> = emptyList(),
+    private val synopsis: String? = null,
+    private val type: String = "",
+    private val poster: Poster? = null,
+    private val status: String = "",
+    private val contentRating: String = "safe",
+    private val author: List<Term>? = null,
+    private val artist: List<Term>? = null,
+    private val genre: List<Term>? = null,
+    private val theme: List<Term>? = null,
+    private val demographic: List<Term>? = null,
     private val ratedAvg: Double = 0.0,
+    private val url: String? = null,
 ) {
     @Serializable
     class Poster(
-        private val small: String,
-        private val medium: String,
-        private val large: String,
+        private val small: String? = null,
+        private val medium: String? = null,
+        private val large: String? = null,
     ) {
         fun from(quality: String?) = when (quality) {
-            "large" -> large
-            "small" -> small
-            else -> medium
+            "large" -> large ?: medium ?: small ?: ""
+            "small" -> small ?: medium ?: large ?: ""
+            else -> medium ?: large ?: small ?: ""
         }
     }
 
@@ -87,10 +74,10 @@ class Manga(
         altTitlesInDesc: Boolean = false,
         scorePosition: String,
     ) = SManga.create().apply {
-        url = "/$hashId"
+        url = this@Manga.url?.substringAfter("/title") ?: "/$hid"
         title = this@Manga.title
-        author = this@Manga.author.takeUnless { it.isNullOrEmpty() }?.joinToString { it.title }
-        artist = this@Manga.artist.takeUnless { it.isNullOrEmpty() }?.joinToString { it.title }
+        author = this@Manga.author?.joinToString { it.title }
+        artist = this@Manga.artist?.joinToString { it.title }
         description = buildString {
             if (scorePosition == "top") {
                 fancyScore.takeIf { it.isNotEmpty() }?.let {
@@ -99,14 +86,13 @@ class Manga(
                 }
             }
 
-            synopsis.takeUnless { it.isNullOrEmpty() }
-                ?.let { append(it) }
-            altTitles.takeIf { altTitlesInDesc && it.isNotEmpty() }
-                ?.let { altName ->
-                    append("\n\n")
-                    append("Alternative Names:\n")
-                    append(altName.joinToString("\n"))
-                }
+            synopsis?.takeUnless { it.isEmpty() }?.let { append(it) }
+
+            if (altTitlesInDesc && altTitles.isNotEmpty()) {
+                append("\n\n")
+                append("Alternative Names:\n")
+                append(altTitles.joinToString("\n"))
+            }
 
             if (scorePosition == "bottom") {
                 fancyScore.takeIf { it.isNotEmpty() }?.let {
@@ -123,30 +109,27 @@ class Manga(
             "discontinued" -> SManga.CANCELLED
             else -> SManga.UNKNOWN
         }
-        thumbnail_url = this@Manga.poster.from(posterQuality)
+        thumbnail_url = this@Manga.poster?.from(posterQuality)
         genre = getGenres()
     }
 
     fun toBasicSManga(posterQuality: String?) = SManga.create().apply {
-        url = "/$hashId"
+        url = this@Manga.url?.substringAfter("/title") ?: "/$hid"
         title = this@Manga.title
-        thumbnail_url = this@Manga.poster.from(posterQuality)
+        thumbnail_url = this@Manga.poster?.from(posterQuality)
     }
 
-    fun getGenres() = buildList {
+    private fun getGenres() = buildList {
         when (type) {
             "manhwa" -> add("Manhwa")
             "manhua" -> add("Manhua")
             "manga" -> add("Manga")
             else -> add("Other")
         }
-        genre.takeUnless { it.isNullOrEmpty() }?.map { it.title }
-            .let { addAll(it ?: emptyList()) }
-        theme.takeUnless { it.isNullOrEmpty() }?.map { it.title }
-            .let { addAll(it ?: emptyList()) }
-        demographic.takeUnless { it.isNullOrEmpty() }?.map { it.title }
-            .let { addAll(it ?: emptyList()) }
-        if (isNsfw) add("NSFW")
+        genre?.map { it.title }?.let { addAll(it) }
+        theme?.map { it.title }?.let { addAll(it) }
+        demographic?.map { it.title }?.let { addAll(it) }
+        if (contentRating == "erotica" || contentRating == "pornographic") add("NSFW")
     }.distinct().joinToString()
 }
 
@@ -156,9 +139,16 @@ class SingleMangaResponse(
 )
 
 @Serializable
+class Meta(
+    val page: Int = 1,
+    val lastPage: Int = 1,
+    val hasNext: Boolean = false,
+)
+
+@Serializable
 class Pagination(
-    @SerialName("current_page") val page: Int,
-    @SerialName("last_page") val lastPage: Int,
+    val page: Int = 1,
+    @SerialName("last_page") val lastPage: Int = 1,
 )
 
 @Serializable
@@ -167,9 +157,16 @@ class SearchResponse(
 ) {
     @Serializable
     class Items(
-        val items: List<Manga>,
-        val pagination: Pagination,
-    )
+        val items: List<Manga> = emptyList(),
+        val meta: Meta? = null,
+        val pagination: Pagination? = null,
+    ) {
+        fun hasNextPage(): Boolean = when {
+            meta != null -> meta.page < meta.lastPage
+            pagination != null -> pagination.page < pagination.lastPage
+            else -> false
+        }
+    }
 }
 
 @Serializable
@@ -178,104 +175,87 @@ class ChapterDetailsResponse(
 ) {
     @Serializable
     class Items(
-        val items: List<Chapter>,
-        val pagination: Pagination,
-    )
+        val items: List<Chapter> = emptyList(),
+        val meta: Meta? = null,
+        val pagination: Pagination? = null,
+    ) {
+        fun hasNextPage(): Boolean = when {
+            meta != null -> meta.page < meta.lastPage
+            pagination != null -> pagination.page < pagination.lastPage
+            else -> false
+        }
+    }
 }
 
 @Serializable
 class Chapter(
-    @SerialName("chapter_id")
-    private val chapterId: Int,
-    @SerialName("scanlation_group_id") val scanlationGroupId: Int,
+    val id: Int,
     val number: Double,
-    private val name: String,
-    val votes: Int,
-    @SerialName("updated_at")
-    val updatedAt: Long,
-    @SerialName("scanlation_group")
-    private val scanlationGroup: ScanlationGroup?,
-    @SerialName("is_official")
-    @Serializable(with = SafeIntBooleanDeserializer::class)
-    val isOfficial: Int,
+    private val name: String = "",
+    val votes: Int = 0,
+    private val createdAtFormatted: String = "",
+    val group: ScanlationGroup? = null,
+    val isOfficial: Boolean = false,
 ) {
     @Serializable
     class ScanlationGroup(
+        val id: Int? = null,
         val name: String,
     )
 
     fun toSChapter(mangaId: String) = SChapter.create().apply {
-        url = "title/$mangaId/$chapterId"
+        url = "title/$mangaId/$id"
         name = buildString {
             append("Chapter ")
             append(this@Chapter.number.toString().removeSuffix(".0"))
             this@Chapter.name.takeUnless { it.isEmpty() }?.let { append(": $it") }
         }
-        date_upload = this@Chapter.updatedAt * 1000
+        date_upload = parseRelativeDate(this@Chapter.createdAtFormatted)
         chapter_number = this@Chapter.number.toFloat()
-        scanlator = if (this@Chapter.scanlationGroup != null) {
-            this@Chapter.scanlationGroup.name
-        } else if (this@Chapter.isOfficial == 1) {
+        scanlator = if (this@Chapter.group != null) {
+            this@Chapter.group.name
+        } else if (this@Chapter.isOfficial) {
             "Official"
         } else {
             "Unknown"
         }
     }
-}
 
-object SafeIntBooleanDeserializer : KSerializer<Int> {
-    override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("SafeIntBoolean", PrimitiveKind.INT)
+    private fun parseRelativeDate(dateStr: String): Long {
+        if (dateStr.isEmpty()) return 0L
+        val trimmed = dateStr.trim().lowercase().removeSuffix(" ago")
+        val match = Regex("""^(\d+)\s*(s|m|h|d|w|mo|mos|y|yr|yrs|min|mins|sec|secs|hr|hrs|day|days|week|weeks|month|months|year|years)$""").find(trimmed)
+            ?: return 0L
 
-    override fun serialize(encoder: Encoder, value: Int) {
-        encoder.encodeInt(value)
-    }
+        val amount = match.groupValues[1].toIntOrNull() ?: return 0L
+        val unit = match.groupValues[2]
 
-    override fun deserialize(decoder: Decoder): Int {
-        val jsonDecoder = decoder as? JsonDecoder ?: return try {
-            decoder.decodeInt()
-        } catch (_: Exception) {
-            try {
-                if (decoder.decodeBoolean()) 1 else 0
-            } catch (_: Exception) {
-                0
-            }
+        val calendar = Calendar.getInstance()
+        when (unit) {
+            "s", "sec", "secs" -> calendar.add(Calendar.SECOND, -amount)
+            "m", "min", "mins" -> calendar.add(Calendar.MINUTE, -amount)
+            "h", "hr", "hrs" -> calendar.add(Calendar.HOUR_OF_DAY, -amount)
+            "d", "day", "days" -> calendar.add(Calendar.DAY_OF_YEAR, -amount)
+            "w", "week", "weeks" -> calendar.add(Calendar.WEEK_OF_YEAR, -amount)
+            "mo", "mos", "month", "months" -> calendar.add(Calendar.MONTH, -amount)
+            "y", "yr", "yrs", "year", "years" -> calendar.add(Calendar.YEAR, -amount)
         }
-
-        return try {
-            val element = jsonDecoder.decodeJsonElement()
-            when (element) {
-                is JsonPrimitive -> when {
-                    element.booleanOrNull != null ->
-                        if (element.booleanOrNull == true) 1 else 0
-
-                    element.intOrNull != null -> element.intOrNull ?: 0
-
-                    else -> element.content.toIntOrNull()
-                        ?: if (element.content.equals("true", ignoreCase = true)) 1 else 0
-                }
-
-                else -> 0
-            }
-        } catch (_: Exception) {
-            0
-        }
+        return calendar.timeInMillis
     }
 }
 
 @Serializable
 class ChapterResponse(
-    val result: Items?,
+    val result: ChapterResult? = null,
 ) {
     @Serializable
-    class Items(
-        @SerialName("chapter_id")
-        val chapterId: Int,
-        val images: List<Images>,
+    class ChapterResult(
+        val id: Int,
+        val pages: List<PageDto> = emptyList(),
     )
 
     @Serializable
-    class Images(
+    class PageDto(
         val url: String,
     )
 }

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Dto.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Dto.kt
@@ -203,8 +203,8 @@ class Chapter(
         val name: String,
     )
 
-    fun toSChapter(mangaId: String) = SChapter.create().apply {
-        url = "title/$mangaId/$id"
+    fun toSChapter(mangaSlug: String) = SChapter.create().apply {
+        url = "title/$mangaSlug/$id-chapter-${number.toString().removeSuffix(".0")}"
         name = buildString {
             append("Chapter ")
             append(this@Chapter.number.toString().removeSuffix(".0"))

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Filters.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Filters.kt
@@ -136,7 +136,7 @@ class Filters {
     private open class UriMultiSelectFilter(
         name: String,
         private val param: String,
-        private val vals: Array<Pair<String, String>>,
+        vals: Array<Pair<String, String>>,
     ) : Filter.Group<UriMultiSelectOption>(
         name,
         vals.map { UriMultiSelectOption(it.first, it.second) },
@@ -155,7 +155,7 @@ class Filters {
     private open class UriTriSelectFilter(
         name: String,
         private val param: String,
-        private val vals: Array<Pair<String, String>>,
+        vals: Array<Pair<String, String>>,
     ) : Filter.Group<UriTriSelectOption>(
         name,
         vals.map { UriTriSelectOption(it.first, it.second) },
@@ -171,7 +171,7 @@ class Filters {
         }
     }
 
-    private class DemographicFilter(val demographics: Array<Pair<String, String>>) :
+    private class DemographicFilter(demographics: Array<Pair<String, String>>) :
         UriTriSelectFilter(
             "Demographic",
             "demographics[]",
@@ -191,11 +191,19 @@ class Filters {
         )
 
     private class GenreFilter(genres: Array<Pair<String, String>>) :
-        UriTriSelectFilter(
-            "Genres",
-            "genres[]",
-            genres,
-        )
+        Filter.Group<UriTriSelectOption>("Genres", genres.map { UriTriSelectOption(it.first, it.second) }),
+        UriFilter {
+        override fun addToUri(builder: HttpUrl.Builder) {
+            val included = state.filter { it.state == TriState.STATE_INCLUDE }
+            val excluded = state.filter { it.state == TriState.STATE_EXCLUDE }
+
+            if (included.isNotEmpty() || excluded.isNotEmpty()) {
+                builder.addQueryParameter("genres_mode", "and")
+            }
+            included.forEach { builder.addQueryParameter("genres_in[]", it.value) }
+            excluded.forEach { builder.addQueryParameter("genres_ex[]", it.value) }
+        }
+    }
 
     private class StatusFilter :
         UriMultiSelectFilter(
@@ -245,13 +253,16 @@ class Filters {
 
     private fun getSortables() = arrayOf(
         Sortable("Best Match", "relevance"),
-        Sortable("Popular", "views_30d"),
-        Sortable("Updated Date", "chapter_updated_at"),
-        Sortable("Created Date", "created_at"),
+        Sortable("Latest update", "chapter_updated_at"),
+        Sortable("Recently added", "created_at"),
         Sortable("Title", "title"),
         Sortable("Year", "year"),
-        Sortable("Total Views", "views_total"),
-        Sortable("Most Follows", "follows_total"),
+        Sortable("Highest rated", "score"),
+        Sortable("Most viewed · 7 days", "views_7d"),
+        Sortable("Most viewed · 30 days", "views_30d"),
+        Sortable("Most viewed · 90 days", "views_90d"),
+        Sortable("Most viewed · all time", "views_total"),
+        Sortable("Most followed", "follows_total"),
     )
 
     private class SortFilter(private val sortables: Array<Sortable>) :

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Hash.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Hash.kt
@@ -190,15 +190,8 @@ object Hash {
         return out.toIntArray()
     }
 
-    /**
-     * @param path     API path, e.g. "/manga/some-hash/chapters"
-     * @param bodySize `encodeURIComponent(body).length` for POST, or 0 for GET
-     * @param time     1 for GET manga requests, `System.currentTimeMillis()` for POST
-     */
-    fun generateHash(path: String, bodySize: Int = 0, time: Long = 1): String {
-        val baseString = "$path:$bodySize:$time"
-
-        val encoded = URLEncoder.encode(baseString, "UTF-8")
+    fun generateHash(path: String): String {
+        val encoded = URLEncoder.encode(path, "UTF-8")
             .replace("+", "%20")
             .replace("*", "%2A")
             .replace("%7E", "~")


### PR DESCRIPTION
Closes #15610

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

<details>
<summary>Changes Done</summary>

# Comix: Update to API v1 + fixes and improvements

## Summary
Used Claude to summarize changes

Rewrites the extension to target the new API v1 endpoint and fixes several bugs
present in the previous version. Existing library entries (manga and chapter URLs)
are fully backward compatible — no migration needed.

---

## Comix.kt

- **Migrate to API v1** — `apiUrl` changed from `api/v2` to `api/v1`
- **Fix preferences initialisation** — changed eager `getPreferences()` to lazy
  `by getPreferencesLazy()` as recommended by the contribution guidelines
- **Fix `mangaDetailsRequest` URL bug** — previous code passed `manga.url`
  (including leading `/`) directly to `addPathSegment`, which caused OkHttp to
  URL-encode the slash as `%2F`; now strips prefix and slug with
  `removePrefix("/").substringBefore("-")`
- **Fix `chapterListRequest` slug handling** — same `substringBefore("-")` strip
  applied when extracting the manga hash from the stored URL
- **Fix chapter pagination** — replaced `do-while` loop (which always fired an
  unnecessary extra request even for single-page lists) with a `while` loop
  initialised from the first response's `hasNextPage()`
- **Fix `searchMangaParse` pagination** — replaced broken `res.meta?.let { ... }`
  expression (meta was always null at the top level) with `res.result.hasNextPage()`
- **Fix NSFW genre exclusion query param** — changed `genres[]: -$id` (incorrect
  negation syntax) to the proper `genres_ex[]: $id` parameter
- **Fix search query sort reset** — now also removes `order[chapter_updated_at]`
  before applying `order[relevance]` on keyword searches (previously only
  `order[score]` was removed, leaving a conflicting sort parameter)
- **Change popular sort** — from `order[views_30d]` to `order[score]`
- **Change page limit** — from 50 to 28 for popular, latest, and search requests
- **Fix deduplication tiebreaker** — last resort comparison changed from
  `ch.updatedAt > current.updatedAt` (epoch timestamp) to `ch.id > current.id`
  (higher ID = more recent upload), matching the new API's available fields
- **Fix `pageListParse`** — updated field reference from `result.images` to
  `result.pages` to match the v1 API response shape
- **Add `getMangaUrl`** — exposes the correct browser URL (`/title${manga.url}`)

---

## Dto.kt

- **Remove `SafeIntBooleanDeserializer`** — the v1 API returns `is_official` as a
  proper boolean; the custom `KSerializer` workaround for the v2 int/bool ambiguity
  is no longer needed; removed 40+ lines of boilerplate
- **Remove 8 unused imports** — all serialization reflection imports that only
  existed to support the custom deserializer
- **Update `Manga` identifier field** — from `@SerialName("hash_id") hashId` to
  `hid` (camelCase field name already matches the v1 JSON key, no `@SerialName`
  needed)
- **Add `Manga.url` field** — v1 returns a full URL string (e.g.
  `/title/abc123-some-slug`); `toSManga`/`toBasicSManga` now prefer
  `url.substringAfter("/title")` and fall back to `/$hid`
- **Replace `is_nsfw: Boolean` with `contentRating: String`** — NSFW tag in genres
  now added only when `contentRating` is `"erotica"` or `"pornographic"` (matches
  v1 schema; removes false positives from the old boolean flag)
- **Make all `Manga` fields nullable with defaults** — prevents deserialization
  crashes when the API omits optional fields
- **Make all `Poster` fields nullable with fallback chain** — `from()` now returns
  the best available quality instead of crashing on a missing field
- **Replace `Pagination` + implicit meta with explicit `Meta` class** — new `Meta`
  has `page`, `lastPage`, and `hasNext`; old `Pagination` used
  `@SerialName("current_page")` / `@SerialName("last_page")` matching v2 snake_case
  keys that no longer exist in v1
- **Move pagination into `Items` and add `hasNextPage()`** — both
  `SearchResponse.Items` and `ChapterDetailsResponse.Items` now carry their own
  `meta`/`pagination` and expose `hasNextPage()`, fixing the bug where the top-level
  `meta` field was always null
- **Update `Chapter` fields for v1 schema:**
  - `chapter_id: Int` → `id: Int`
  - `scanlation_group_id: Int` + `scanlation_group: ScanlationGroup?` →
    `group: ScanlationGroup?` (id now lives inside the group object)
  - `updated_at: Long` (epoch seconds) → `createdAtFormatted: String` (relative
    string e.g. `"3h"`, `"1d"`)
  - `is_official: Int` (custom deserializer) → `isOfficial: Boolean` (native)
- **Replace epoch date math with relative date parser** — new `parseRelativeDate()`
  handles strings like `"3h"`, `"1d"`, `"2w"`, `"3mos"`, `"1y"` using
  `Calendar.add()`; removed the old `updatedAt * 1000` conversion
- **Update `ChapterResponse` inner classes** — `Items` renamed to `ChapterResult`;
  `images: List<Images>` renamed to `pages: List<PageDto>`;
  `chapterId` renamed to `id`
- **Make all `Term` fields nullable with defaults** — prevents crashes on partial
  term objects

---

## Hash.kt

- **Simplify `generateHash` signature** — removed `bodySize: Int` and `time: Long`
  parameters; v1 only uses the path for hash generation so the base string is now
  just the encoded path, not `"$path:$bodySize:$time"`
- **Add missing URL encoding rules** — added `.replace("*", "%2A")` and
  `.replace("%7E", "~")` to match the full RFC 3986 encoding the API expects
- **Remove `time` query parameter** from chapter list requests (no longer needed
  by v1)

---

## Filters.kt

- **Fix `GenreFilter` query parameters** — replaced the single `genres[]` param
  with `-` prefix for exclusion with the correct split params: `genres_in[]` for
  included, `genres_ex[]` for excluded, and `genres_mode: and` when either is set
- **Expand sort options** — added `Highest rated (score)`, `Most viewed · 7 days
  (views_7d)`, and `Most viewed · 90 days (views_90d)`; renamed `Popular` →
  `Most viewed · 30 days` for clarity
- **Remove `Popular` sort alias** — `views_30d` is now properly labelled; the old
  `Popular` label was ambiguous
</details>