### PR TITLE
Manga/in/ua fix displaying deleted chapters

### DIFF
--- a/src/uk/mangainua/build.gradle
+++ b/src/uk/mangainua/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaInUa'
     extClass = '.Mangainua'
-    extVersionCode = 8
+    extVersionCode = 9
     isNsfw = true
 }
 

--- a/src/uk/mangainua/src/eu/kanade/tachiyomi/extension/uk/mangainua/Mangainua.kt
+++ b/src/uk/mangainua/src/eu/kanade/tachiyomi/extension/uk/mangainua/Mangainua.kt
@@ -184,8 +184,7 @@ class Mangainua :
             val chapterNumber = element.attr("manga-chappter")
             val volumeNumber = element.attr("manga-tom")
 
-            // Skip creating SChapter if both chapterNumber and volumeNumber are empty. 
-            //That's indication of deleted chapter, that site still (for some reason) shows. Like deleted mangas in search, look mangaFromElement
+            // Skip creating SChapter if both chapterNumber and volumeNumber are empty
             if (chapterNumber.isEmpty() && volumeNumber.isEmpty()) {
                 return@mapNotNull null
             }

--- a/src/uk/mangainua/src/eu/kanade/tachiyomi/extension/uk/mangainua/Mangainua.kt
+++ b/src/uk/mangainua/src/eu/kanade/tachiyomi/extension/uk/mangainua/Mangainua.kt
@@ -178,17 +178,23 @@ class Mangainua :
 
     override fun chapterListParse(response: Response): List<SChapter> {
         val newResponse = getAjaxChapters(response)
-        return newResponse.asJsoup().select("div.ltcitems").asReversed().map { element ->
-            SChapter.create().apply {
-                val urlElement = element.selectFirst("a")!!
-                val chapterName = urlElement.ownText().trim()
-                val chapterNumber = element.attr("manga-chappter")
-                val volumeNumber = element.attr("manga-tom")
+        return newResponse.asJsoup().select("div.ltcitems").asReversed().mapNotNull { element ->
+            val urlElement = element.selectFirst("a") ?: return@mapNotNull null // Skip if no URL element
+            val chapterName = urlElement.ownText().trim()
+            val chapterNumber = element.attr("manga-chappter")
+            val volumeNumber = element.attr("manga-tom")
 
+            // Skip creating SChapter if both chapterNumber and volumeNumber are empty. 
+            //That's indication of deleted chapter, that site still (for some reason) shows. Like deleted mangas in search, look mangaFromElement
+            if (chapterNumber.isEmpty() && volumeNumber.isEmpty()) {
+                return@mapNotNull null
+            }
+
+            SChapter.create().apply {
                 setUrlWithoutDomain(urlElement.attr("abs:href"))
                 scanlator = element.attr("translate").takeUnless(String::isBlank) ?: urlElement.text().substringAfter("від:").trim()
                 date_upload = parseDate(element.child(0).ownText())
-                chapter_number = chapterNumber.toFloat()
+                chapter_number = chapterNumber.toFloatOrNull() ?: 0f
                 name = when {
                     chapterName.contains("Альтернативний") -> "Том $volumeNumber. Розділ $chapterNumber"
                     else -> chapterName


### PR DESCRIPTION
Checklist:

Site, for some reason, show chapters that are (most likely) deleted.
Added code to ignore such chapters (they don't have data about Volume and Chapter number, but url still exist and leads to a chapter with no images, so check based on those variables).
Also added code to ignore chapter if link to it doesn't exist (in case site won't show that for some reason).

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
