### PR TITLE
refactor UrlActivities

### DIFF
--- a/lib-multisrc/comicaso/build.gradle.kts
+++ b/lib-multisrc/comicaso/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 5
+baseVersionCode = 6

--- a/lib-multisrc/comicaso/src/eu/kanade/tachiyomi/multisrc/comicaso/Comicaso.kt
+++ b/lib-multisrc/comicaso/src/eu/kanade/tachiyomi/multisrc/comicaso/Comicaso.kt
@@ -79,6 +79,8 @@ abstract class Comicaso(
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
         if (query.isNotEmpty()) {
             val url = when {
+                query.startsWith("https://") ->
+                    query.trim()
                 query.startsWith(URL_SEARCH_PREFIX) ->
                     query.removePrefix(URL_SEARCH_PREFIX).trim()
                 query.contains("://") ->
@@ -87,6 +89,10 @@ abstract class Comicaso(
             }
 
             if (url != null) {
+                val httpUrl = url.toHttpUrl()
+                if (httpUrl.host != baseUrl.toHttpUrl().host) {
+                    throw Exception("Unsupported url")
+                }
                 val mangaSlug = url.substringAfter("/komik/").substringBefore("/")
                 return fetchMangaDetails(SManga.create().apply { this.url = mangaSlug })
                     .map { MangasPage(listOf(it), false) }

--- a/lib-multisrc/comicaso/src/eu/kanade/tachiyomi/multisrc/comicaso/UrlActivity.kt
+++ b/lib-multisrc/comicaso/src/eu/kanade/tachiyomi/multisrc/comicaso/UrlActivity.kt
@@ -13,21 +13,16 @@ class UrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val data = intent?.data
-        if (data != null) {
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${Comicaso.URL_SEARCH_PREFIX}$data")
-                putExtra("filter", packageName)
-            }
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "Could not parse URI from intent $intent")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/lib-multisrc/galleryadults/build.gradle.kts
+++ b/lib-multisrc/galleryadults/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 8
+baseVersionCode = 9

--- a/lib-multisrc/galleryadults/src/eu/kanade/tachiyomi/multisrc/galleryadults/GalleryAdults.kt
+++ b/lib-multisrc/galleryadults/src/eu/kanade/tachiyomi/multisrc/galleryadults/GalleryAdults.kt
@@ -161,6 +161,16 @@ abstract class GalleryAdults(
 
     /* Search */
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return fetchSearchManga(page, "$PREFIX_ID_SEARCH$id", filters)
+        }
+
         val randomEntryFilter = filters.firstInstanceOrNull<RandomEntryFilter>()
 
         return when {

--- a/lib-multisrc/galleryadults/src/eu/kanade/tachiyomi/multisrc/galleryadults/GalleryAdultsUrlActivity.kt
+++ b/lib-multisrc/galleryadults/src/eu/kanade/tachiyomi/multisrc/galleryadults/GalleryAdultsUrlActivity.kt
@@ -13,22 +13,16 @@ import kotlin.system.exitProcess
 class GalleryAdultsUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val id = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${GalleryAdults.PREFIX_ID_SEARCH}$id")
-                putExtra("filter", packageName)
-            }
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("GalleryAdultsUrl", e.toString())
-            }
-        } else {
-            Log.e("GalleryAdultsUrl", "could not parse uri from intent $intent")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("GalleryAdultsUrl", "Unable to launch activity", e)
         }
 
         finish()

--- a/lib-multisrc/grouple/build.gradle.kts
+++ b/lib-multisrc/grouple/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 36
+baseVersionCode = 37

--- a/lib-multisrc/grouple/src/eu/kanade/tachiyomi/multisrc/grouple/GroupLe.kt
+++ b/lib-multisrc/grouple/src/eu/kanade/tachiyomi/multisrc/grouple/GroupLe.kt
@@ -584,21 +584,30 @@ abstract class GroupLe(
         page: Int,
         query: String,
         filters: FilterList,
-    ): Observable<MangasPage> = if (query.startsWith(PREFIX_SLUG_SEARCH)) {
-        val realQuery = query.removePrefix(PREFIX_SLUG_SEARCH)
-        client.newCall(searchMangaByIdRequest(realQuery))
-            .asObservableSuccess()
-            .map { response ->
-                val details = mangaDetailsParse(response)
-                details.url = "/$realQuery"
-                MangasPage(listOf(details), false)
-            }
-    } else {
-        client.newCall(searchMangaRequest(page, query, filters))
-            .asObservableSuccess()
-            .map { response ->
-                searchMangaParse(response)
-            }
+    ): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            val titleId = url.pathSegments.firstOrNull()?.takeIf { it.isNotEmpty() }
+                ?: throw Exception("Unsupported url")
+            return fetchSearchManga(page, "$PREFIX_SLUG_SEARCH$titleId", filters)
+        }
+
+        return if (query.startsWith(PREFIX_SLUG_SEARCH)) {
+            val realQuery = query.removePrefix(PREFIX_SLUG_SEARCH)
+            client.newCall(searchMangaByIdRequest(realQuery))
+                .asObservableSuccess()
+                .map { response ->
+                    val details = mangaDetailsParse(response)
+                    details.url = "/$realQuery"
+                    MangasPage(listOf(details), false)
+                }
+        } else {
+            client.newCall(searchMangaRequest(page, query, filters))
+                .asObservableSuccess()
+                .map { response ->
+                    searchMangaParse(response)
+                }
+        }
     }
 
     override fun setupPreferenceScreen(screen: androidx.preference.PreferenceScreen) {

--- a/lib-multisrc/grouple/src/eu/kanade/tachiyomi/multisrc/grouple/GroupLeUrlActivity.kt
+++ b/lib-multisrc/grouple/src/eu/kanade/tachiyomi/multisrc/grouple/GroupLeUrlActivity.kt
@@ -16,22 +16,16 @@ class GroupLeUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 0) {
-            val titleid = pathSegments[0]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${GroupLe.PREFIX_SLUG_SEARCH}$titleid")
-                putExtra("filter", packageName)
-            }
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("GroupLeUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("GroupLeUrlActivity", "could not parse uri from intent $intent")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("GroupLeUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/lib-multisrc/guya/build.gradle.kts
+++ b/lib-multisrc/guya/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 6
+baseVersionCode = 7

--- a/lib-multisrc/guya/src/eu/kanade/tachiyomi/multisrc/guya/Guya.kt
+++ b/lib-multisrc/guya/src/eu/kanade/tachiyomi/multisrc/guya/Guya.kt
@@ -17,6 +17,7 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.utils.getPreferencesLazy
 import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.json.JSONArray
@@ -135,22 +136,34 @@ abstract class Guya(
         return parsePageFromJson(pages, metadata)
     }
 
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = when {
-        query.startsWith(SLUG_PREFIX) -> {
-            val slug = query.removePrefix(SLUG_PREFIX)
-            client.newCall(searchMangaRequest(page, query, filters))
-                .asObservableSuccess()
-                .map { response ->
-                    searchMangaParseWithSlug(response, slug)
-                }
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val slug = url.pathSegments.getOrNull(2)
+                ?: throw Exception("Unsupported url")
+            return fetchSearchManga(page, "$SLUG_PREFIX$slug", filters)
         }
 
-        else -> {
-            client.newCall(searchMangaRequest(page, query, filters))
-                .asObservableSuccess()
-                .map { response ->
-                    searchMangaParse(response, query)
-                }
+        return when {
+            query.startsWith(SLUG_PREFIX) -> {
+                val slug = query.removePrefix(SLUG_PREFIX)
+                client.newCall(searchMangaRequest(page, query, filters))
+                    .asObservableSuccess()
+                    .map { response ->
+                        searchMangaParseWithSlug(response, slug)
+                    }
+            }
+
+            else -> {
+                client.newCall(searchMangaRequest(page, query, filters))
+                    .asObservableSuccess()
+                    .map { response ->
+                        searchMangaParse(response, query)
+                    }
+            }
         }
     }
 

--- a/lib-multisrc/guya/src/eu/kanade/tachiyomi/multisrc/guya/GuyaUrlActivity.kt
+++ b/lib-multisrc/guya/src/eu/kanade/tachiyomi/multisrc/guya/GuyaUrlActivity.kt
@@ -17,39 +17,19 @@ class GuyaUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val host = intent?.data?.host
-        val pathSegments = intent?.data?.pathSegments
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-        if (host != null && pathSegments != null) {
-            val query = fromGuya(pathSegments)
-
-            if (query == null) {
-                Log.e("GuyaUrlActivity", "Unable to parse URI from intent $intent")
-                finish()
-                exitProcess(1)
-            }
-
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", query)
-                putExtra("filter", packageName)
-            }
-
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("GuyaUrlActivity", e.toString())
-            }
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("GuyaUrlActivity", "Unable to launch activity", e)
         }
 
         finish()
         exitProcess(0)
-    }
-
-    private fun fromGuya(pathSegments: MutableList<String>): String? = if (pathSegments.size >= 3) {
-        val slug = pathSegments[2]
-        "${Guya.SLUG_PREFIX}$slug"
-    } else {
-        null
     }
 }

--- a/lib-multisrc/heancms/build.gradle.kts
+++ b/lib-multisrc/heancms/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 29
+baseVersionCode = 30
 
 dependencies {
     api(project(":lib:i18n"))

--- a/lib-multisrc/heancms/src/eu/kanade/tachiyomi/multisrc/heancms/HeanCms.kt
+++ b/lib-multisrc/heancms/src/eu/kanade/tachiyomi/multisrc/heancms/HeanCms.kt
@@ -152,6 +152,16 @@ abstract class HeanCms(
     override fun latestUpdatesParse(response: Response): MangasPage = popularMangaParse(response)
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val slug = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return fetchSearchManga(page, "$SEARCH_PREFIX$slug", filters)
+        }
+
         if (!query.startsWith(SEARCH_PREFIX)) {
             return super.fetchSearchManga(page, query, filters)
         }

--- a/lib-multisrc/heancms/src/eu/kanade/tachiyomi/multisrc/heancms/HeanCmsUrlActivity.kt
+++ b/lib-multisrc/heancms/src/eu/kanade/tachiyomi/multisrc/heancms/HeanCmsUrlActivity.kt
@@ -10,31 +10,19 @@ import kotlin.system.exitProcess
 class HeanCmsUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-        if (pathSegments != null && pathSegments.size >= 2) {
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", createQuery(pathSegments))
-                putExtra("filter", packageName)
-            }
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("HeanCmsUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("HeanCmsUrlActivity", "could not parse uri from intent $intent")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("HeanCmsUrlActivity", "Unable to launch activity", e)
         }
 
         finish()
         exitProcess(0)
-    }
-
-    private fun createQuery(pathSegments: MutableList<String>): String? = if (pathSegments.size >= 2) {
-        val slug = pathSegments[1]
-        "${HeanCms.SEARCH_PREFIX}$slug"
-    } else {
-        null
     }
 }

--- a/lib-multisrc/libgroup/build.gradle.kts
+++ b/lib-multisrc/libgroup/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 40
+baseVersionCode = 41

--- a/lib-multisrc/libgroup/src/eu/kanade/tachiyomi/multisrc/libgroup/LibGroup.kt
+++ b/lib-multisrc/libgroup/src/eu/kanade/tachiyomi/multisrc/libgroup/LibGroup.kt
@@ -418,20 +418,29 @@ abstract class LibGroup(
 
     override fun imageRequest(page: Page): Request = GET(page.imageUrl!!, imageHeader())
 
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (query.startsWith(PREFIX_SLUG_SEARCH)) {
-        val realQuery = query.removePrefix(PREFIX_SLUG_SEARCH).substringBefore("/").substringBefore("?")
-        client.newCall(GET("$apiDomain/api/manga/$realQuery", headers))
-            .asObservableSuccess()
-            .map { response ->
-                val details = response.parseAs<Data<MangaShort>>().data.toSManga(isEng())
-                MangasPage(listOf(details), false)
-            }
-    } else {
-        client.newCall(searchMangaRequest(page, query, filters))
-            .asObservableSuccess()
-            .map { response ->
-                searchMangaParse(response)
-            }
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            val titleId = url.pathSegments.getOrNull(2)?.takeIf { it.isNotEmpty() }
+                ?: throw Exception("Unsupported url")
+            return fetchSearchManga(page, "$PREFIX_SLUG_SEARCH$titleId", filters)
+        }
+
+        return if (query.startsWith(PREFIX_SLUG_SEARCH)) {
+            val realQuery = query.removePrefix(PREFIX_SLUG_SEARCH).substringBefore("/").substringBefore("?")
+            client.newCall(GET("$apiDomain/api/manga/$realQuery", headers))
+                .asObservableSuccess()
+                .map { response ->
+                    val details = response.parseAs<Data<MangaShort>>().data.toSManga(isEng())
+                    MangasPage(listOf(details), false)
+                }
+        } else {
+            client.newCall(searchMangaRequest(page, query, filters))
+                .asObservableSuccess()
+                .map { response ->
+                    searchMangaParse(response)
+                }
+        }
     }
 
     // Search

--- a/lib-multisrc/libgroup/src/eu/kanade/tachiyomi/multisrc/libgroup/LibUrlActivity.kt
+++ b/lib-multisrc/libgroup/src/eu/kanade/tachiyomi/multisrc/libgroup/LibUrlActivity.kt
@@ -17,22 +17,16 @@ class LibUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 0) {
-            val titleid = pathSegments[2]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${LibGroup.PREFIX_SLUG_SEARCH}$titleid")
-                putExtra("filter", packageName)
-            }
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("LibUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("LibUrlActivity", "could not parse uri from intent $intent")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("LibUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/lib-multisrc/madara/build.gradle.kts
+++ b/lib-multisrc/madara/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 48
+baseVersionCode = 49
 
 dependencies {
     api(project(":lib:cryptoaes"))

--- a/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
+++ b/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
@@ -260,6 +260,17 @@ abstract class Madara(
     // Search Manga
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            if (url.pathSegments.size < 2) {
+                throw Exception("Unsupported url")
+            }
+            val slug = url.pathSegments[1]
+            return fetchSearchManga(page, "$URL_SEARCH_PREFIX$slug", filters)
+        }
         if (query.startsWith(URL_SEARCH_PREFIX)) {
             val mangaUrl = baseUrl.toHttpUrl().newBuilder().apply {
                 addPathSegment(mangaSubString)

--- a/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/MadaraUrlActivity.kt
+++ b/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/MadaraUrlActivity.kt
@@ -10,31 +10,20 @@ import kotlin.system.exitProcess
 class MadaraUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
 
-        if (pathSegments != null && pathSegments.size >= 2) {
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${getSLUG(pathSegments)}")
-                putExtra("filter", packageName)
-            }
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("MadaraUrl", e.toString())
-            }
-        } else {
-            Log.e("MadaraUrl", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("MadaraUrl", "Unable to launch activity", e)
         }
 
         finish()
         exitProcess(0)
-    }
-
-    private fun getSLUG(pathSegments: MutableList<String>): String? = if (pathSegments.size >= 2) {
-        val slug = pathSegments[1]
-        "${Madara.URL_SEARCH_PREFIX}$slug"
-    } else {
-        null
     }
 }

--- a/lib-multisrc/mangadventure/build.gradle.kts
+++ b/lib-multisrc/mangadventure/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 14
+baseVersionCode = 15

--- a/lib-multisrc/mangadventure/src/eu/kanade/tachiyomi/multisrc/mangadventure/MangAdventure.kt
+++ b/lib-multisrc/mangadventure/src/eu/kanade/tachiyomi/multisrc/mangadventure/MangAdventure.kt
@@ -13,6 +13,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromJsonElement
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Response
+import rx.Observable
 import uy.kohesive.injekt.injectLazy
 
 /** MangAdventure base source. */
@@ -54,6 +55,20 @@ abstract class MangAdventure(
     override fun latestUpdatesRequest(page: Int) = GET("$apiUrl/series?page=$page&sort=-latest_upload", headers)
 
     override fun popularMangaRequest(page: Int) = GET("$apiUrl/series?page=$page&sort=-views", headers)
+
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            if (url.pathSegments.size < 2) {
+                throw Exception("Unsupported url")
+            }
+            return fetchSearchManga(page, SLUG_QUERY + url.pathSegments[1], filters)
+        }
+        return super.fetchSearchManga(page, query, filters)
+    }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList) = apiUrl.toHttpUrl().newBuilder().addEncodedPathSegment("series").run {
         if (query.startsWith(SLUG_QUERY)) {

--- a/lib-multisrc/mangadventure/src/eu/kanade/tachiyomi/multisrc/mangadventure/MangAdventureActivity.kt
+++ b/lib-multisrc/mangadventure/src/eu/kanade/tachiyomi/multisrc/mangadventure/MangAdventureActivity.kt
@@ -14,20 +14,15 @@ import kotlin.system.exitProcess
 class MangAdventureActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val segments = intent?.data?.pathSegments
-        if (segments != null && segments.size > 1) {
-            val activity = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", MangAdventure.SLUG_QUERY + segments[1])
-                putExtra("filter", packageName)
-            }
-            try {
-                startActivity(activity)
-            } catch (ex: ActivityNotFoundException) {
-                Log.e("MangAdventureActivity", ex.message, ex)
-            }
-        } else {
-            Log.e("MangAdventureActivity", "Failed to parse URI from intent: $intent")
+        val activity = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+        try {
+            startActivity(activity)
+        } catch (ex: ActivityNotFoundException) {
+            Log.e("MangAdventureActivity", ex.message, ex)
         }
         finish()
         exitProcess(0)

--- a/lib-multisrc/mangathemesia/build.gradle.kts
+++ b/lib-multisrc/mangathemesia/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 31
+baseVersionCode = 32
 
 dependencies {
     api(project(":lib:i18n"))

--- a/lib-multisrc/mangathemesia/src/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesia.kt
+++ b/lib-multisrc/mangathemesia/src/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesia.kt
@@ -68,6 +68,9 @@ abstract class MangaThemesia(
 
     // Search
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            return fetchSearchManga(page, "$URL_SEARCH_PREFIX$query", filters)
+        }
         if (query.startsWith(URL_SEARCH_PREFIX).not()) return super.fetchSearchManga(page, query, filters)
 
         val mangaPath = try {

--- a/lib-multisrc/mangathemesia/src/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaUrlActivity.kt
+++ b/lib-multisrc/mangathemesia/src/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaUrlActivity.kt
@@ -11,21 +11,17 @@ class MangaThemesiaUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
 
-        if (pathSegments != null && pathSegments.size >= 1) {
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${MangaThemesia.URL_SEARCH_PREFIX}${intent?.data?.toString()}")
-                putExtra("filter", packageName)
-            }
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("MangaThemesiaUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("MangaThemesiaUrlActivity", "Could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("MangaThemesiaUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/lib-multisrc/monochrome/build.gradle.kts
+++ b/lib-multisrc/monochrome/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 4
+baseVersionCode = 5

--- a/lib-multisrc/monochrome/src/eu/kanade/tachiyomi/multisrc/monochrome/MonochromeActivity.kt
+++ b/lib-multisrc/monochrome/src/eu/kanade/tachiyomi/multisrc/monochrome/MonochromeActivity.kt
@@ -14,20 +14,15 @@ import kotlin.system.exitProcess
 class MonochromeActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val segments = intent?.data?.pathSegments
-        if (segments != null && segments.size > 1) {
-            val activity = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", UUID_QUERY + segments[1])
-                putExtra("filter", packageName)
-            }
-            try {
-                startActivity(activity)
-            } catch (ex: ActivityNotFoundException) {
-                Log.e("MonochromeActivity", ex.message, ex)
-            }
-        } else {
-            Log.e("MonochromeActivity", "Failed to parse URI from intent: $intent")
+        val activity = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+        try {
+            startActivity(activity)
+        } catch (ex: ActivityNotFoundException) {
+            Log.e("MonochromeActivity", ex.message, ex)
         }
         finish()
         exitProcess(0)

--- a/lib-multisrc/monochrome/src/eu/kanade/tachiyomi/multisrc/monochrome/MonochromeCMS.kt
+++ b/lib-multisrc/monochrome/src/eu/kanade/tachiyomi/multisrc/monochrome/MonochromeCMS.kt
@@ -11,6 +11,7 @@ import eu.kanade.tachiyomi.source.online.HttpSource
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Response
 import rx.Observable
 import uy.kohesive.injekt.injectLazy
@@ -43,6 +44,16 @@ open class MonochromeCMS(
         query: String,
         filters: FilterList,
     ): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            if (url.pathSegments.size < 2) {
+                throw Exception("Unsupported url")
+            }
+            return fetchSearchManga(page, UUID_QUERY + url.pathSegments[1], filters)
+        }
         if (!query.startsWith(UUID_QUERY)) {
             return super.fetchSearchManga(page, query, filters)
         }

--- a/lib-multisrc/peachscan/build.gradle.kts
+++ b/lib-multisrc/peachscan/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 9
+baseVersionCode = 10
 
 dependencies {
     api(project(":lib:zipinterceptor"))

--- a/lib-multisrc/peachscan/src/eu/kanade/tachiyomi/multisrc/peachscan/PeachScan.kt
+++ b/lib-multisrc/peachscan/src/eu/kanade/tachiyomi/multisrc/peachscan/PeachScan.kt
@@ -73,6 +73,14 @@ abstract class PeachScan(
     override fun latestUpdatesNextPageSelector() = null
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val path = url.encodedPath
+            return fetchSearchManga(page, "$URL_SEARCH_PREFIX$path", filters)
+        }
         if (query.startsWith(URL_SEARCH_PREFIX)) {
             val manga = SManga.create().apply { url = query.substringAfter(URL_SEARCH_PREFIX) }
             return client.newCall(mangaDetailsRequest(manga))

--- a/lib-multisrc/peachscan/src/eu/kanade/tachiyomi/multisrc/peachscan/PeachScanUrlActivity.kt
+++ b/lib-multisrc/peachscan/src/eu/kanade/tachiyomi/multisrc/peachscan/PeachScanUrlActivity.kt
@@ -10,20 +10,17 @@ import kotlin.system.exitProcess
 class PeachScanUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val path = intent?.data?.path
-        if (path != null) {
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${PeachScan.URL_SEARCH_PREFIX}$path")
-                putExtra("filter", packageName)
-            }
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("PeachScanUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("PeachScanUrlActivity", "could not parse uri from intent $intent")
+
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("PeachScanUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/lib-multisrc/yuyu/build.gradle.kts
+++ b/lib-multisrc/yuyu/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 1
+baseVersionCode = 2

--- a/lib-multisrc/yuyu/src/eu/kanade/tachiyomi/multisrc/yuyu/YuYu.kt
+++ b/lib-multisrc/yuyu/src/eu/kanade/tachiyomi/multisrc/yuyu/YuYu.kt
@@ -93,6 +93,16 @@ abstract class YuYu(
     }
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            if (url.pathSegments.size < 2) {
+                throw Exception("Unsupported url")
+            }
+            return fetchSearchManga(page, "$PREFIX_SEARCH${url.pathSegments[1]}", filters)
+        }
         if (query.startsWith(PREFIX_SEARCH)) {
             val slug = query.substringAfter(PREFIX_SEARCH)
             return client.newCall(GET("$baseUrl/manga/$slug", headers))

--- a/lib-multisrc/yuyu/src/eu/kanade/tachiyomi/multisrc/yuyu/YuYuUrlActivity.kt
+++ b/lib-multisrc/yuyu/src/eu/kanade/tachiyomi/multisrc/yuyu/YuYuUrlActivity.kt
@@ -13,21 +13,17 @@ class YuYuUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegment = intent?.data?.pathSegments
-        if (pathSegment != null && pathSegment.size > 1) {
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${YuYu.PREFIX_SEARCH}${pathSegment[1]}")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/all/akuma/build.gradle
+++ b/src/all/akuma/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Akuma'
     extClass = '.AkumaFactory'
-    extVersionCode = 8
+    extVersionCode = 9
     isNsfw = true
 }
 

--- a/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
+++ b/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/Akuma.kt
@@ -18,6 +18,7 @@ import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.tryParse
 import okhttp3.FormBody
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
@@ -174,7 +175,14 @@ class Akuma(
         page: Int,
         query: String,
         filters: FilterList,
-    ): Observable<MangasPage> = if (query.startsWith(PREFIX_ID)) {
+    ): Observable<MangasPage> = if (query.startsWith("https://")) {
+        val url = query.toHttpUrl()
+        if (url.host != baseUrl.toHttpUrl().host) {
+            throw Exception("Unsupported url")
+        }
+        val id = url.pathSegments[1]
+        fetchSearchManga(page, "$PREFIX_ID$id", filters)
+    } else if (query.startsWith(PREFIX_ID)) {
         val url = "/g/${query.substringAfter(PREFIX_ID)}"
         val manga = SManga.create().apply { this.url = url }
         fetchMangaDetails(manga).map {

--- a/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/UrlActivity.kt
+++ b/src/all/akuma/src/eu/kanade/tachiyomi/extension/all/akuma/UrlActivity.kt
@@ -10,22 +10,17 @@ import kotlin.system.exitProcess
 class UrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val id = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${Akuma.PREFIX_ID}$id")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("UrlActivity", e.toString())
-            }
-        } else {
-            Log.e("UrlActivity", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("UrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/all/comikey/build.gradle
+++ b/src/all/comikey/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = "Comikey"
     extClass = ".ComikeyFactory"
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = false
 }
 

--- a/src/all/comikey/src/eu/kanade/tachiyomi/extension/all/comikey/Comikey.kt
+++ b/src/all/comikey/src/eu/kanade/tachiyomi/extension/all/comikey/Comikey.kt
@@ -91,7 +91,14 @@ open class Comikey(
         page: Int,
         query: String,
         filters: FilterList,
-    ): Observable<MangasPage> = if (query.startsWith(PREFIX_SLUG_SEARCH)) {
+    ): Observable<MangasPage> = if (query.startsWith("https://")) {
+        val url = query.toHttpUrl()
+        if (url.host != baseUrl.toHttpUrl().host) {
+            throw Exception("Unsupported url")
+        }
+        val slug = "${url.pathSegments[1]}/${url.pathSegments[2]}"
+        fetchSearchManga(page, "$PREFIX_SLUG_SEARCH$slug", filters)
+    } else if (query.startsWith(PREFIX_SLUG_SEARCH)) {
         val slug = query.removePrefix(PREFIX_SLUG_SEARCH)
         val url = "/comics/$slug/"
 

--- a/src/all/comikey/src/eu/kanade/tachiyomi/extension/all/comikey/UrlActivity.kt
+++ b/src/all/comikey/src/eu/kanade/tachiyomi/extension/all/comikey/UrlActivity.kt
@@ -11,22 +11,16 @@ class UrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val pathSegments = intent?.data?.pathSegments
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-        if (pathSegments != null && pathSegments.size > 2) {
-            val intent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${Comikey.PREFIX_SLUG_SEARCH}${pathSegments[1]}/${pathSegments[2]}")
-                putExtra("filter", packageName)
-            }
-
-            try {
-                startActivity(intent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("UrlActivity", "Could not start activity", e)
-            }
-        } else {
-            Log.e("UrlActivity", "Could not parse URI from intent $intent")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("UrlActivity", "Could not start activity", e)
         }
 
         finish()

--- a/src/all/deviantart/build.gradle
+++ b/src/all/deviantart/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'DeviantArt'
     extClass = '.DeviantArt'
-    extVersionCode = 9
+    extVersionCode = 10
     isNsfw = true
 }
 

--- a/src/all/deviantart/src/eu/kanade/tachiyomi/extension/all/deviantart/DeviantArt.kt
+++ b/src/all/deviantart/src/eu/kanade/tachiyomi/extension/all/deviantart/DeviantArt.kt
@@ -21,6 +21,7 @@ import okhttp3.Response
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.parser.Parser
+import rx.Observable
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -48,6 +49,19 @@ class DeviantArt :
     override fun popularMangaRequest(page: Int): Request = throw UnsupportedOperationException(SEARCH_FORMAT_MSG)
 
     override fun popularMangaParse(response: Response): MangasPage = throw UnsupportedOperationException(SEARCH_FORMAT_MSG)
+
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val username = url.pathSegments[0]
+            val folderId = url.pathSegments[2]
+            return super.fetchSearchManga(page, "gallery:$username/$folderId", filters)
+        }
+        return super.fetchSearchManga(page, query, filters)
+    }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         val matchGroups = requireNotNull(

--- a/src/all/deviantart/src/eu/kanade/tachiyomi/extension/all/deviantart/DeviantArtUrlActivity.kt
+++ b/src/all/deviantart/src/eu/kanade/tachiyomi/extension/all/deviantart/DeviantArtUrlActivity.kt
@@ -10,25 +10,17 @@ import kotlin.system.exitProcess
 class DeviantArtUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
 
-        if (pathSegments != null && pathSegments.size >= 3) {
-            val username = pathSegments[0]
-            val folderId = pathSegments[2]
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "gallery:$username/$folderId")
-                putExtra("filter", packageName)
-            }
-
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("DeviantArtUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("DeviantArtUrlActivity", "Could not parse URI from intent $intent")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("DeviantArtUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/all/globalcomix/build.gradle
+++ b/src/all/globalcomix/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'GlobalComix'
     extClass = '.GlobalComixFactory'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/all/globalcomix/src/eu/kanade/tachiyomi/extension/all/globalcomix/GlobalComix.kt
+++ b/src/all/globalcomix/src/eu/kanade/tachiyomi/extension/all/globalcomix/GlobalComix.kt
@@ -30,6 +30,7 @@ import kotlinx.serialization.modules.polymorphic
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
+import rx.Observable
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
@@ -115,6 +116,18 @@ abstract class GlobalComix(final override val lang: String, private val extLang:
                 false,
             )
         }
+    }
+
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val titleId = url.pathSegments[1]
+            return super.fetchSearchManga(page, "$PREFIX_ID_SEARCH$titleId", filters)
+        }
+        return super.fetchSearchManga(page, query, filters)
     }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {

--- a/src/all/globalcomix/src/eu/kanade/tachiyomi/extension/all/globalcomix/GlobalComixUrlActivity.kt
+++ b/src/all/globalcomix/src/eu/kanade/tachiyomi/extension/all/globalcomix/GlobalComixUrlActivity.kt
@@ -5,7 +5,6 @@ import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
-import android.widget.Toast
 import kotlin.system.exitProcess
 
 /**
@@ -18,25 +17,16 @@ class GlobalComixUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val pathSegments = intent?.data?.pathSegments
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-        // Supported path: /c/title-slug
-        if (pathSegments != null && pathSegments.size > 1) {
-            val titleId = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", PREFIX_ID_SEARCH + titleId)
-                putExtra("filter", packageName)
-            }
-
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("GlobalComixUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("GlobalComixUrlActivity", "Received data URL is unsupported: ${intent?.data}")
-            Toast.makeText(this, "This URL cannot be handled by the GlobalComix extension.", Toast.LENGTH_SHORT).show()
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("GlobalComixUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/all/kiutaku/build.gradle
+++ b/src/all/kiutaku/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Kiutaku'
     extClass = '.Kiutaku'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/all/kiutaku/src/eu/kanade/tachiyomi/extension/all/kiutaku/Kiutaku.kt
+++ b/src/all/kiutaku/src/eu/kanade/tachiyomi/extension/all/kiutaku/Kiutaku.kt
@@ -59,7 +59,14 @@ class Kiutaku : HttpSource() {
     override fun latestUpdatesParse(response: Response) = popularMangaParse(response)
 
     // =============================== Search ===============================
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (query.startsWith(PREFIX_SEARCH)) {
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (query.startsWith("https://")) {
+        val url = query.toHttpUrl()
+        if (url.host != baseUrl.toHttpUrl().host) {
+            throw Exception("Unsupported url")
+        }
+        val id = url.pathSegments.first()
+        fetchSearchManga(page, "$PREFIX_SEARCH$id", filters)
+    } else if (query.startsWith(PREFIX_SEARCH)) {
         val id = query.removePrefix(PREFIX_SEARCH)
         client.newCall(GET("$baseUrl/$id"))
             .asObservableSuccess()

--- a/src/all/kiutaku/src/eu/kanade/tachiyomi/extension/all/kiutaku/UrlActivity.kt
+++ b/src/all/kiutaku/src/eu/kanade/tachiyomi/extension/all/kiutaku/UrlActivity.kt
@@ -17,22 +17,17 @@ class UrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.isNotEmpty()) {
-            val id = pathSegments.first()
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${Kiutaku.PREFIX_SEARCH}$id")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/all/koharu/build.gradle
+++ b/src/all/koharu/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'SchaleNetwork'
     extClass = '.KoharuFactory'
-    extVersionCode = 18
+    extVersionCode = 19
     isNsfw = true
 }
 

--- a/src/all/koharu/src/eu/kanade/tachiyomi/extension/all/koharu/Koharu.kt
+++ b/src/all/koharu/src/eu/kanade/tachiyomi/extension/all/koharu/Koharu.kt
@@ -273,6 +273,12 @@ class Koharu(
     // Search
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = when {
+        query.startsWith("https://") -> {
+            val url = query.toHttpUrl()
+            val id = "${url.pathSegments[1]}/${url.pathSegments[2]}"
+            fetchSearchManga(page, "$PREFIX_ID_KEY_SEARCH$id", filters)
+        }
+
         query.startsWith(PREFIX_ID_KEY_SEARCH) -> {
             val ipk = query.removePrefix(PREFIX_ID_KEY_SEARCH)
             val response = client.newCall(GET("$apiBooksUrl/detail/$ipk", lazyHeaders)).execute()

--- a/src/all/koharu/src/eu/kanade/tachiyomi/extension/all/koharu/KoharuUrlActivity.kt
+++ b/src/all/koharu/src/eu/kanade/tachiyomi/extension/all/koharu/KoharuUrlActivity.kt
@@ -10,22 +10,17 @@ import kotlin.system.exitProcess
 class KoharuUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 2) {
-            val id = "${pathSegments[1]}/${pathSegments[2]}"
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${Koharu.PREFIX_ID_KEY_SEARCH}$id")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("KoharuUrlActivity", "Could not start activity", e)
-            }
-        } else {
-            Log.e("KoharuUrlActivity", "Could not parse URI from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("KoharuUrlActivity", "Could not start activity", e)
         }
 
         finish()

--- a/src/all/luscious/build.gradle
+++ b/src/all/luscious/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Luscious'
     extClass = '.LusciousFactory'
-    extVersionCode = 31
+    extVersionCode = 32
     isNsfw = true
 }
 

--- a/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/Luscious.kt
+++ b/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/Luscious.kt
@@ -468,7 +468,11 @@ abstract class Luscious(
         query,
     )
 
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (query.startsWith("ID:")) {
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (query.startsWith("https://")) {
+        val url = query.toHttpUrl()
+        val album = url.pathSegments[1]
+        fetchSearchManga(page, "ALBUM:$album", filters)
+    } else if (query.startsWith("ID:")) {
         val id = query.substringAfterLast("ID:")
         client.newCall(buildAlbumInfoRequest(id))
             .asObservableSuccess()

--- a/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/LusciousUrlActivity.kt
+++ b/src/all/luscious/src/eu/kanade/tachiyomi/extension/all/luscious/LusciousUrlActivity.kt
@@ -14,22 +14,17 @@ import kotlin.system.exitProcess
 class LusciousUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val album = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "ALBUM:$album")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("LusciousUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("LusciousUrlActivity", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("LusciousUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaDex'
     extClass = '.MangaDexFactory'
-    extVersionCode = 207
+    extVersionCode = 208
     isNsfw = true
 }
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangadexUrlActivity.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangadexUrlActivity.kt
@@ -21,44 +21,19 @@ class MangadexUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val data = intent?.data
-        if (data != null && data.pathSegments != null && data.pathSegments.size > 1) {
-            val path = data.pathSegments[0]
-            val id = data.pathSegments[1]
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
 
-            var query = "id:$id"
-            when (path) {
-                "chapter" -> {
-                    query = "ch:$id"
-                }
-                "group" -> {
-                    query = "grp:$id"
-                }
-                "user" -> {
-                    query = "usr:$id"
-                }
-                "author" -> {
-                    query = "author:$id"
-                }
-                "list" -> {
-                    query = "list:$id"
-                }
-            }
-
-            val mainIntent = Intent("eu.kanade.tachiyomi.SEARCH")
-            mainIntent.putExtra("query", query)
-            mainIntent.putExtra("filter", packageName)
-            mainIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("MangadexUrlActivity", "Activity not found: " + e.message)
-            } catch (e: Throwable) {
-                Log.e("MangadexUrlActivity", "Unexpected throwable: " + e.message)
-            }
-        } else {
-            Log.e("MangadexUrlActivity", "Unable to parse URI: $data")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("MangadexUrlActivity", "Activity not found: " + e.message)
+        } catch (e: Throwable) {
+            Log.e("MangadexUrlActivity", "Unexpected throwable: " + e.message)
         }
 
         finish()

--- a/src/all/mangaplus/build.gradle
+++ b/src/all/mangaplus/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MANGA Plus by SHUEISHA'
     extClass = '.MangaPlusFactory'
-    extVersionCode = 60
+    extVersionCode = 61
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlus.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlus.kt
@@ -146,12 +146,35 @@ class MangaPlus(
         page: Int,
         query: String,
         filters: FilterList,
-    ): Observable<MangasPage> = if (page == 1) {
-        client.newCall(searchMangaRequest(page, query, filters))
-            .asObservableSuccess()
-            .map { searchMangaParse(it, query) }
-    } else {
-        Observable.just(parseDirectory(page))
+    ): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host !in listOf(
+                    "mangaplus.shueisha.co.jp",
+                    "www.mangaplus.shueisha.co.jp",
+                    "jumpg-webapi.tokyo-cdn.com",
+                    "www.jumpg-webapi.tokyo-cdn.com",
+                )
+            ) {
+                throw Exception("Unsupported url")
+            }
+            val newQuery = when {
+                url.pathSegments.firstOrNull() == "viewer" ->
+                    PREFIX_CHAPTER_ID_SEARCH + url.pathSegments[1]
+                url.pathSegments.lastOrNull() == "sns_share" ->
+                    url.queryParameter("title_id")?.let { PREFIX_ID_SEARCH + it }
+                        ?: throw Exception("Unsupported url")
+                else -> PREFIX_ID_SEARCH + url.pathSegments[1]
+            }
+            return fetchSearchManga(page, newQuery, filters)
+        }
+        return if (page == 1) {
+            client.newCall(searchMangaRequest(page, query, filters))
+                .asObservableSuccess()
+                .map { searchMangaParse(it, query) }
+        } else {
+            Observable.just(parseDirectory(page))
+        }
     }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusUrlActivity.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusUrlActivity.kt
@@ -12,39 +12,16 @@ class MangaPlusUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            // Using Java's equals to not cause crashes in the activity.
-            val query = when {
-                pathSegments[0].equals("viewer") -> {
-                    MangaPlus.PREFIX_CHAPTER_ID_SEARCH + pathSegments[1]
-                }
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-                pathSegments[0].equals("sns_share") -> {
-                    intent?.data?.getQueryParameter("title_id")
-                        ?.let { MangaPlus.PREFIX_ID_SEARCH + it }
-                }
-
-                else -> MangaPlus.PREFIX_ID_SEARCH + pathSegments[1]
-            }
-
-            if (query != null) {
-                val mainIntent = Intent().apply {
-                    action = "eu.kanade.tachiyomi.SEARCH"
-                    putExtra("query", query)
-                    putExtra("filter", packageName)
-                }
-
-                try {
-                    startActivity(mainIntent)
-                } catch (e: ActivityNotFoundException) {
-                    Log.e("MangaPlusUrlActivity", e.toString())
-                }
-            } else {
-                Log.e("MangaPlusUrlActivity", "Missing the title or chapter ID from the URL")
-            }
-        } else {
-            Log.e("MangaPlusUrlActivity", "Could not parse URI from intent $intent")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("MangaPlusUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/all/mangapluscreators/build.gradle
+++ b/src/all/mangapluscreators/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MANGA Plus Creators by SHUEISHA'
     extClass = '.MangaPlusCreatorsFactory'
-    extVersionCode = 2
+    extVersionCode = 3
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MPCUrlActivity.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MPCUrlActivity.kt
@@ -12,52 +12,16 @@ class MPCUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            // {medibang.com/mpc,mangaplus-creators.jp}/{episodes,titles,authors}
-            // TODO: val pathIndex = if (intent?.data?.host?.startsWith("medibang") == true) 1 else 0
-            val host = intent?.data?.host ?: ""
-            val pathIndex = with(host) {
-                when {
-                    equals("medibang.com") -> 1
-                    else -> 0
-                }
-            }
-            val idIndex = pathIndex + 1
-            val query = when {
-                pathSegments[pathIndex].equals("episodes") -> {
-                    MangaPlusCreators.PREFIX_EPISODE_ID_SEARCH + pathSegments[idIndex]
-                }
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-                pathSegments[pathIndex].equals("authors") -> {
-                    MangaPlusCreators.PREFIX_AUTHOR_ID_SEARCH + pathSegments[idIndex]
-                }
-
-                pathSegments[pathIndex].equals("titles") -> {
-                    MangaPlusCreators.PREFIX_TITLE_ID_SEARCH + pathSegments[idIndex]
-                }
-
-                else -> null // TODO: is this required?
-            }
-
-            if (query != null) {
-                // TODO: val mainIntent = Intent().setAction("eu.kanade.tachiyomi.SEARCH").apply {
-                val mainIntent = Intent().apply {
-                    setAction("eu.kanade.tachiyomi.SEARCH")
-                    putExtra("query", query)
-                    putExtra("filter", packageName)
-                }
-
-                try {
-                    startActivity(mainIntent)
-                } catch (e: ActivityNotFoundException) {
-                    Log.e("MPCUrlActivity", e.toString())
-                }
-            } else {
-                Log.e("MPCUrlActivity", "Missing alphanumeric ID from the URL")
-            }
-        } else {
-            Log.e("MPCUrlActivity", "Could not parse URI from intent $intent")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("MPCUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
+++ b/src/all/mangapluscreators/src/eu/kanade/tachiyomi/extension/all/mangapluscreators/MangaPlusCreators.kt
@@ -99,6 +99,24 @@ class MangaPlusCreators(override val lang: String) : HttpSource() {
 
     // SEARCH Section
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host !in listOf("mangaplus-creators.jp", "medibang.com")) {
+                throw Exception("Unsupported url")
+            }
+            val pathIndex = if (url.host == "medibang.com") 1 else 0
+            val idIndex = pathIndex + 1
+            if (url.pathSegments.size <= idIndex) {
+                throw Exception("Unsupported url")
+            }
+            val newQuery = when (url.pathSegments[pathIndex]) {
+                "episodes" -> PREFIX_EPISODE_ID_SEARCH + url.pathSegments[idIndex]
+                "authors" -> PREFIX_AUTHOR_ID_SEARCH + url.pathSegments[idIndex]
+                "titles" -> PREFIX_TITLE_ID_SEARCH + url.pathSegments[idIndex]
+                else -> throw Exception("Unsupported url")
+            }
+            return fetchSearchManga(page, newQuery, filters)
+        }
         // TODO: HTTPSource::fetchSearchManga is deprecated? super.getSearchManga
         if (query.startsWith(PREFIX_TITLE_ID_SEARCH)) {
             val titleContentId = query.removePrefix(PREFIX_TITLE_ID_SEARCH)

--- a/src/all/mangaup/build.gradle
+++ b/src/all/mangaup/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Manga UP!'
     extClass = '.MangaUpFactory'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = false
 }
 

--- a/src/all/mangaup/src/eu/kanade/tachiyomi/extension/all/mangaup/MangaUp.kt
+++ b/src/all/mangaup/src/eu/kanade/tachiyomi/extension/all/mangaup/MangaUp.kt
@@ -26,6 +26,7 @@ import kotlinx.serialization.protobuf.ProtoBuf
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
+import rx.Observable
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.io.IOException
@@ -205,6 +206,18 @@ class MangaUp(override val lang: String) :
         }
         val mangas = list?.map { it.toSManga(imgUrl) } ?: emptyList()
         return MangasPage(mangas, false)
+    }
+
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host && url.host != "www.${baseUrl.toHttpUrl().host}") {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments[1]
+            return fetchSearchManga(page, "$PREFIX_ID_SEARCH$id", filters)
+        }
+        return super.fetchSearchManga(page, query, filters)
     }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {

--- a/src/all/mangaup/src/eu/kanade/tachiyomi/extension/all/mangaup/MangaUpUrlActivity.kt
+++ b/src/all/mangaup/src/eu/kanade/tachiyomi/extension/all/mangaup/MangaUpUrlActivity.kt
@@ -12,27 +12,16 @@ class MangaUpUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val query = pathSegments[1]
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-            if (query != null) {
-                val mainIntent = Intent().apply {
-                    action = "eu.kanade.tachiyomi.SEARCH"
-                    putExtra("query", MangaUp.PREFIX_ID_SEARCH + query)
-                    putExtra("filter", packageName)
-                }
-
-                try {
-                    startActivity(mainIntent)
-                } catch (e: ActivityNotFoundException) {
-                    Log.e("MangaPlusUrlActivity", e.toString())
-                }
-            } else {
-                Log.e("MangaUpUrlActivity", "Missing the title ID from the URL")
-            }
-        } else {
-            Log.e("MangaUpUrlActivity", "Could not parse URI from intent $intent")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("MangaUpUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/all/namicomi/build.gradle
+++ b/src/all/namicomi/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'NamiComi'
     extClass = '.NamiComiFactory'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = false
 }
 

--- a/src/all/namicomi/src/eu/kanade/tachiyomi/extension/all/namicomi/NamiComi.kt
+++ b/src/all/namicomi/src/eu/kanade/tachiyomi/extension/all/namicomi/NamiComi.kt
@@ -30,6 +30,7 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import okio.IOException
+import rx.Observable
 
 abstract class NamiComi(final override val lang: String, private val extLang: String = lang) :
     HttpSource(),
@@ -104,6 +105,18 @@ abstract class NamiComi(final override val lang: String, private val extLang: St
     }
 
     // Search manga section
+
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments[2]
+            return fetchSearchManga(page, "${NamiComiConstants.PREFIX_ID_SEARCH}$id", filters)
+        }
+        return super.fetchSearchManga(page, query, filters)
+    }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         if (query.startsWith(NamiComiConstants.PREFIX_ID_SEARCH)) {

--- a/src/all/namicomi/src/eu/kanade/tachiyomi/extension/all/namicomi/NamiComiUrlActivity.kt
+++ b/src/all/namicomi/src/eu/kanade/tachiyomi/extension/all/namicomi/NamiComiUrlActivity.kt
@@ -5,7 +5,6 @@ import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
-import android.widget.Toast
 import kotlin.system.exitProcess
 
 /**
@@ -18,25 +17,16 @@ class NamiComiUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val pathSegments = intent?.data?.pathSegments
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-        // Supported path: /en/title/12345
-        if (pathSegments != null && pathSegments.size > 2) {
-            val titleId = pathSegments[2]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", NamiComiConstants.PREFIX_ID_SEARCH + titleId)
-                putExtra("filter", packageName)
-            }
-
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("NamiComiUrlActivity", e.toString())
-            }
-        } else {
-            Toast.makeText(this, "This URL cannot be handled by the Namicomi extension.", Toast.LENGTH_SHORT).show()
-            Log.e("NamiComiUrlActivity", "Could not parse URI from intent $intent")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("NamiComiUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/all/pandachaika/build.gradle
+++ b/src/all/pandachaika/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'PandaChaika'
     extClass = '.PandaChaikaFactory'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/all/pandachaika/src/eu/kanade/tachiyomi/extension/all/pandachaika/PandaChaika.kt
+++ b/src/all/pandachaika/src/eu/kanade/tachiyomi/extension/all/pandachaika/PandaChaika.kt
@@ -76,57 +76,70 @@ class PandaChaika(
         }
     }
 
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = when {
-        query.startsWith(PREFIX_ID_SEARCH) -> {
-            val id = query.removePrefix(PREFIX_ID_SEARCH).toInt()
-            client.newCall(GET("$baseUrl/api?archive=$id", headers))
-                .asObservable()
-                .map { response ->
-                    searchMangaByIdParse(response, id)
-                }
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            if (url.pathSegments.size <= 2) {
+                throw Exception("Unsupported url")
+            }
+            val id = "${url.pathSegments[1]}/${url.pathSegments[2]}"
+            return fetchSearchManga(page, "$PREFIX_ID_SEARCH$id", filters)
         }
+        return when {
+            query.startsWith(PREFIX_ID_SEARCH) -> {
+                val id = query.removePrefix(PREFIX_ID_SEARCH).toInt()
+                client.newCall(GET("$baseUrl/api?archive=$id", headers))
+                    .asObservable()
+                    .map { response ->
+                        searchMangaByIdParse(response, id)
+                    }
+            }
 
-        query.startsWith(PREFIX_EHEN_ID_SEARCH) -> {
-            val id = query.removePrefix(PREFIX_EHEN_ID_SEARCH).replace(ehentaiRegex, "")
-            val baseLink = "https://e-hentai.org/g/"
-            val fullLink = baseSearchUrl.toHttpUrl().newBuilder().apply {
-                addQueryParameter("qsearch", baseLink + id)
-                addQueryParameter("json", "")
-            }.build()
-            client.newCall(GET(fullLink, headers))
-                .asObservableSuccess()
-                .map {
-                    val archive = it.parseAs<ArchiveResponse>().archives.getOrNull(0)?.toSManga() ?: throw Exception("Not Found")
-                    MangasPage(listOf(archive), false)
-                }
+            query.startsWith(PREFIX_EHEN_ID_SEARCH) -> {
+                val id = query.removePrefix(PREFIX_EHEN_ID_SEARCH).replace(ehentaiRegex, "")
+                val baseLink = "https://e-hentai.org/g/"
+                val fullLink = baseSearchUrl.toHttpUrl().newBuilder().apply {
+                    addQueryParameter("qsearch", baseLink + id)
+                    addQueryParameter("json", "")
+                }.build()
+                client.newCall(GET(fullLink, headers))
+                    .asObservableSuccess()
+                    .map {
+                        val archive = it.parseAs<ArchiveResponse>().archives.getOrNull(0)?.toSManga() ?: throw Exception("Not Found")
+                        MangasPage(listOf(archive), false)
+                    }
+            }
+
+            query.startsWith(PREFIX_FAK_ID_SEARCH) -> {
+                val slug = query.removePrefix(PREFIX_FAK_ID_SEARCH).replace(fakkuRegex, "")
+                val baseLink = "https://www.fakku.net/hentai/"
+                val fullLink = baseSearchUrl.toHttpUrl().newBuilder().apply {
+                    addQueryParameter("qsearch", baseLink + slug)
+                    addQueryParameter("json", "")
+                }.build()
+                client.newCall(GET(fullLink, headers))
+                    .asObservableSuccess()
+                    .map {
+                        val archive = it.parseAs<ArchiveResponse>().archives.getOrNull(0)?.toSManga() ?: throw Exception("Not Found")
+                        MangasPage(listOf(archive), false)
+                    }
+            }
+
+            query.startsWith(PREFIX_SOURCE_SEARCH) -> {
+                val url = query.removePrefix(PREFIX_SOURCE_SEARCH)
+                client.newCall(GET("$baseSearchUrl/?qsearch=$url&json=", headers))
+                    .asObservableSuccess()
+                    .map {
+                        val archive = it.parseAs<ArchiveResponse>().archives.getOrNull(0)?.toSManga() ?: throw Exception("Not Found")
+                        MangasPage(listOf(archive), false)
+                    }
+            }
+
+            else -> super.fetchSearchManga(page, query, filters)
         }
-
-        query.startsWith(PREFIX_FAK_ID_SEARCH) -> {
-            val slug = query.removePrefix(PREFIX_FAK_ID_SEARCH).replace(fakkuRegex, "")
-            val baseLink = "https://www.fakku.net/hentai/"
-            val fullLink = baseSearchUrl.toHttpUrl().newBuilder().apply {
-                addQueryParameter("qsearch", baseLink + slug)
-                addQueryParameter("json", "")
-            }.build()
-            client.newCall(GET(fullLink, headers))
-                .asObservableSuccess()
-                .map {
-                    val archive = it.parseAs<ArchiveResponse>().archives.getOrNull(0)?.toSManga() ?: throw Exception("Not Found")
-                    MangasPage(listOf(archive), false)
-                }
-        }
-
-        query.startsWith(PREFIX_SOURCE_SEARCH) -> {
-            val url = query.removePrefix(PREFIX_SOURCE_SEARCH)
-            client.newCall(GET("$baseSearchUrl/?qsearch=$url&json=", headers))
-                .asObservableSuccess()
-                .map {
-                    val archive = it.parseAs<ArchiveResponse>().archives.getOrNull(0)?.toSManga() ?: throw Exception("Not Found")
-                    MangasPage(listOf(archive), false)
-                }
-        }
-
-        else -> super.fetchSearchManga(page, query, filters)
     }
 
     private fun searchMangaByIdParse(response: Response, id: Int = 0): MangasPage {

--- a/src/all/pandachaika/src/eu/kanade/tachiyomi/extension/all/pandachaika/PandaChaikaUrlActivity.kt
+++ b/src/all/pandachaika/src/eu/kanade/tachiyomi/extension/all/pandachaika/PandaChaikaUrlActivity.kt
@@ -10,22 +10,17 @@ import kotlin.system.exitProcess
 class PandaChaikaUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 2) {
-            val id = "${pathSegments[1]}/${pathSegments[2]}"
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${PandaChaika.PREFIX_ID_SEARCH}$id")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("KoharuUrlActivity", "Could not start activity", e)
-            }
-        } else {
-            Log.e("KoharuUrlActivity", "Could not parse URI from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("PandaChaikaUrlActivity", "Could not start activity", e)
         }
 
         finish()

--- a/src/all/projectsuki/build.gradle
+++ b/src/all/projectsuki/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Project Suki'
     extClass = '.ProjectSuki'
-    extVersionCode = 6
+    extVersionCode = 7
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/projectsuki/src/eu/kanade/tachiyomi/extension/all/projectsuki/ProjectSuki.kt
+++ b/src/all/projectsuki/src/eu/kanade/tachiyomi/extension/all/projectsuki/ProjectSuki.kt
@@ -369,6 +369,7 @@ class ProjectSuki :
         val queryAsURL: HttpUrl? by unexpectedErrorCatchingLazy { query.toHttpUrlOrNull() ?: """${homepageUri}$query""".toHttpUrlOrNull() }
         val bookUrlMatch by unexpectedErrorCatchingLazy { queryAsURL?.matchAgainst(bookUrlPattern) }
         val readUrlMatch by unexpectedErrorCatchingLazy { queryAsURL?.matchAgainst(chapterUrlPattern) }
+        val isSearchUrl = queryAsURL?.host == homepageUrl.host && queryAsURL?.pathSegments?.firstOrNull() == "search"
 
         return when {
             // sent by the url activity, might also be because the user entered a query via $ps-search:
@@ -413,6 +414,19 @@ class ProjectSuki :
                 if (bookid.isBlank()) error("Empty bookid!")
 
                 bookid.toMangasPageObservable()
+            }
+
+            // raw search url e.g. https://projectsuki.com/search?q=...
+            isSearchUrl -> {
+                val urlQuery = queryAsURL!!.query ?: error("Empty search query!")
+                if (urlQuery.isBlank()) error("Empty search query!")
+
+                val rawUrl = """${homepageUri.toASCIIString()}/search?$urlQuery"""
+                val url = rawUrl.toHttpUrlOrNull() ?: reportErrorToUser { "Invalid search url: $rawUrl" }
+
+                client.newCall(GET(url, headers))
+                    .asObservableSuccess()
+                    .map { response -> searchMangaParse(response, overrideHasNextPage = false) }
             }
 
             // use result from https://projectsuki.com/api/book/search

--- a/src/all/projectsuki/src/eu/kanade/tachiyomi/extension/all/projectsuki/activities/ProjectSukiBookUrlActivity.kt
+++ b/src/all/projectsuki/src/eu/kanade/tachiyomi/extension/all/projectsuki/activities/ProjectSukiBookUrlActivity.kt
@@ -43,32 +43,19 @@ class ProjectSukiBookUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        if ((intent?.data?.pathSegments?.size ?: 0) >= 2) {
-            // Project Suki Url Activity Book
-            Log.e("PSUABook", "could not handle URI ${intent?.data} from intent $intent")
-        }
-
-        val intent = Intent().apply {
-            // tell tachiyomi we want to search for something
+        val mainIntent = Intent().apply {
             action = "eu.kanade.tachiyomi.SEARCH"
-            // "filter" for our own extension instead of doing a global search
             putExtra("filter", packageName)
-            // value that will be passed onto the "query" parameter in fetchSearchManga
-            putExtra("query", "$INTENT_BOOK_QUERY_PREFIX${intent?.data?.pathSegments?.get(1)}")
+            putExtra("query", intent.data.toString())
         }
 
         try {
-            // actually do the thing
-            startActivity(intent)
+            startActivity(mainIntent)
         } catch (e: ActivityNotFoundException) {
-            // tachiyomi isn't installed (?)
-            // Project Suki Url Activity Book
             Log.e("PSUABook", e.toString())
         }
 
-        // we're done
         finish()
-        // just for safety
         exitProcess(0)
     }
 }

--- a/src/all/projectsuki/src/eu/kanade/tachiyomi/extension/all/projectsuki/activities/ProjectSukiReadUrlActivity.kt
+++ b/src/all/projectsuki/src/eu/kanade/tachiyomi/extension/all/projectsuki/activities/ProjectSukiReadUrlActivity.kt
@@ -43,32 +43,19 @@ class ProjectSukiReadUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        if ((intent?.data?.pathSegments?.size ?: 0) >= 2) {
-            // Project Suki Url Activity Read
-            Log.e("PSUARead", "could not handle URI ${intent?.data} from intent $intent")
-        }
-
-        val intent = Intent().apply {
-            // tell tachiyomi we want to search for something
+        val mainIntent = Intent().apply {
             action = "eu.kanade.tachiyomi.SEARCH"
-            // "filter" for our own extension instead of doing a global search
             putExtra("filter", packageName)
-            // value that will be passed onto the "query" parameter in fetchSearchManga
-            putExtra("query", "$INTENT_READ_QUERY_PREFIX${intent?.data?.pathSegments?.get(1)}")
+            putExtra("query", intent.data.toString())
         }
 
         try {
-            // actually do the thing
-            startActivity(intent)
+            startActivity(mainIntent)
         } catch (e: ActivityNotFoundException) {
-            // tachiyomi isn't installed (?)
-            // Project Suki Url Activity Read
             Log.e("PSUARead", e.toString())
         }
 
-        // we're done
         finish()
-        // just for safety
         exitProcess(0)
     }
 }

--- a/src/all/projectsuki/src/eu/kanade/tachiyomi/extension/all/projectsuki/activities/ProjectSukiSearchUrlActivity.kt
+++ b/src/all/projectsuki/src/eu/kanade/tachiyomi/extension/all/projectsuki/activities/ProjectSukiSearchUrlActivity.kt
@@ -43,32 +43,19 @@ class ProjectSukiSearchUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        if (intent?.data?.pathSegments?.size != 1) {
-            // Project Suki Url Activity Search
-            Log.e("PSUASearch", "could not handle URI ${intent?.data} from intent $intent")
-        }
-
-        val intent = Intent().apply {
-            // tell tachiyomi we want to search for something
+        val mainIntent = Intent().apply {
             action = "eu.kanade.tachiyomi.SEARCH"
-            // "filter" for our own extension instead of doing a global search
             putExtra("filter", packageName)
-            // value that will be passed onto the "query" parameter in fetchSearchManga
-            putExtra("query", "$INTENT_SEARCH_QUERY_PREFIX${intent?.data?.query}")
+            putExtra("query", intent.data.toString())
         }
 
         try {
-            // actually do the thing
-            startActivity(intent)
+            startActivity(mainIntent)
         } catch (e: ActivityNotFoundException) {
-            // tachiyomi isn't installed (?)
-            // Project Suki Url Activity Search
             Log.e("PSUASearch", e.toString())
         }
 
-        // we're done
         finish()
-        // just for safety
         exitProcess(0)
     }
 }

--- a/src/all/simplycosplay/build.gradle
+++ b/src/all/simplycosplay/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Simply Cosplay'
     extClass = '.SimplyCosplay'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/all/simplycosplay/src/eu/kanade/tachiyomi/extension/all/simplycosplay/SimplyCosplay.kt
+++ b/src/all/simplycosplay/src/eu/kanade/tachiyomi/extension/all/simplycosplay/SimplyCosplay.kt
@@ -139,14 +139,27 @@ class SimplyCosplay :
 
     override fun latestUpdatesParse(response: Response) = popularMangaParse(response)
 
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (query.startsWith(SEARCH_PREFIX)) {
-        val url = query.substringAfter(SEARCH_PREFIX)
-        val manga = SManga.create().apply { this.url = url }
-        fetchMangaDetails(manga).map {
-            MangasPage(listOf(it), false)
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host !in listOf("simply-cosplay.com", "www.simply-cosplay.com")) {
+                throw Exception("Unsupported url")
+            }
+            if (url.pathSegments.size < 3) {
+                throw Exception("Unsupported url")
+            }
+            val newQuery = "$SEARCH_PREFIX/${url.pathSegments[0]}/new/${url.pathSegments[2]}"
+            return fetchSearchManga(page, newQuery, filters)
         }
-    } else {
-        super.fetchSearchManga(page, query, filters)
+        return if (query.startsWith(SEARCH_PREFIX)) {
+            val url = query.substringAfter(SEARCH_PREFIX)
+            val manga = SManga.create().apply { this.url = url }
+            fetchMangaDetails(manga).map {
+                MangasPage(listOf(it), false)
+            }
+        } else {
+            super.fetchSearchManga(page, query, filters)
+        }
     }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {

--- a/src/all/simplycosplay/src/eu/kanade/tachiyomi/extension/all/simplycosplay/SimplyCosplayUrlActivity.kt
+++ b/src/all/simplycosplay/src/eu/kanade/tachiyomi/extension/all/simplycosplay/SimplyCosplayUrlActivity.kt
@@ -10,21 +10,17 @@ import kotlin.system.exitProcess
 class SimplyCosplayUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size >= 3) {
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${SimplyCosplay.SEARCH_PREFIX}/${pathSegments[0]}/new/${pathSegments[2]}")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("SimplyCosplayUrlActivit", e.toString())
-            }
-        } else {
-            Log.e("SimplyCosplayUrlActivit", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("SimplyCosplayUrlActivit", e.toString())
         }
 
         finish()

--- a/src/all/taddyink/build.gradle
+++ b/src/all/taddyink/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Taddy INK (Webtoons)'
     extClass = '.TaddyInkFactory'
-    extVersionCode = 1
+    extVersionCode = 2
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/taddyink/src/eu/kanade/tachiyomi/extension/all/taddyink/TaddyInk.kt
+++ b/src/all/taddyink/src/eu/kanade/tachiyomi/extension/all/taddyink/TaddyInk.kt
@@ -18,6 +18,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
+import rx.Observable
 import uy.kohesive.injekt.injectLazy
 
 open class TaddyInk(
@@ -63,6 +64,24 @@ open class TaddyInk(
     }
 
     override fun popularMangaParse(response: Response) = parseManga(response)
+
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            // pathSegments[1] is the slug used to identify the comic
+            url.pathSegments.getOrNull(1) ?: throw Exception("Unsupported url")
+
+            val manga = SManga.create().apply { this.url = query }
+            return fetchMangaDetails(manga).map {
+                MangasPage(listOf(it.apply { this.url = query }), false)
+            }
+        }
+
+        return super.fetchSearchManga(page, query, filters)
+    }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         val filterList = if (filters.isEmpty()) getFilterList() else filters

--- a/src/all/taddyink/src/eu/kanade/tachiyomi/extension/all/taddyink/TaddyInkUrlActivity.kt
+++ b/src/all/taddyink/src/eu/kanade/tachiyomi/extension/all/taddyink/TaddyInkUrlActivity.kt
@@ -14,22 +14,17 @@ import kotlin.system.exitProcess
 class TaddyInkUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val id = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "id")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("TaddyInkUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("TaddyInkUrlActivity", "Could not parse URI from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("TaddyInkUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/all/webtoons/build.gradle
+++ b/src/all/webtoons/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Webtoons.com'
     extClass = '.WebtoonsFactory'
-    extVersionCode = 52
+    extVersionCode = 53
     isNsfw = false
 }
 

--- a/src/all/webtoons/src/eu/kanade/tachiyomi/extension/all/webtoons/Webtoons.kt
+++ b/src/all/webtoons/src/eu/kanade/tachiyomi/extension/all/webtoons/Webtoons.kt
@@ -124,6 +124,22 @@ open class Webtoons(
     }
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val titleNo = url.queryParameter("title_no")
+                ?: throw Exception("Unsupported url")
+            val path = url.pathSegments
+            if (path.size < 3) {
+                throw Exception("Unsupported url")
+            }
+            val urlLang = path[0]
+            val type = path[1]
+            return fetchSearchManga(page, "$ID_SEARCH_PREFIX$type:$urlLang:$titleNo", filters)
+        }
+
         if (query.startsWith(ID_SEARCH_PREFIX)) {
             val (_, type, lang, titleNo) = query.split(":", limit = 4)
             val tmpManga = SManga.create().apply {

--- a/src/all/webtoons/src/eu/kanade/tachiyomi/extension/all/webtoons/WebtoonsUrlActivity.kt
+++ b/src/all/webtoons/src/eu/kanade/tachiyomi/extension/all/webtoons/WebtoonsUrlActivity.kt
@@ -18,28 +18,21 @@ import kotlin.system.exitProcess
  */
 class WebtoonsUrlActivity : Activity() {
 
-    private val name = javaClass.simpleName
+    private val tag = javaClass.simpleName
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val titleNo = intent?.data?.getQueryParameter("title_no")
-        val path = intent?.data?.pathSegments
-        if (titleNo != null && path != null && path.size >= 3) {
-            val lang = path[0]
-            val type = path[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "$ID_SEARCH_PREFIX$type:$lang:$titleNo")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(name, e.toString())
-            }
-        } else {
-            Log.e(name, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/all/xinmeitulu/build.gradle
+++ b/src/all/xinmeitulu/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Xinmeitulu'
     extClass = '.Xinmeitulu'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = true
 }
 

--- a/src/all/xinmeitulu/src/eu/kanade/tachiyomi/extension/all/xinmeitulu/UrlActivity.kt
+++ b/src/all/xinmeitulu/src/eu/kanade/tachiyomi/extension/all/xinmeitulu/UrlActivity.kt
@@ -11,39 +11,20 @@ class UrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val host = intent?.data?.host
-        val pathSegments = intent?.data?.pathSegments
 
-        if (host != null && pathSegments != null) {
-            val query = fromUrl(pathSegments)
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-            if (query == null) {
-                Log.e("UrlActivity", "Unable to parse URI from intent $intent")
-                finish()
-                exitProcess(1)
-            }
-
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", query)
-                putExtra("filter", packageName)
-            }
-
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("UrlActivity", e.toString())
-            }
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("UrlActivity", "Unable to launch activity", e)
         }
 
         finish()
         exitProcess(0)
-    }
-
-    private fun fromUrl(pathSegments: MutableList<String>): String? = if (pathSegments.size >= 2) {
-        val slug = pathSegments[1]
-        "SLUG:$slug"
-    } else {
-        null
     }
 }

--- a/src/all/xinmeitulu/src/eu/kanade/tachiyomi/extension/all/xinmeitulu/Xinmeitulu.kt
+++ b/src/all/xinmeitulu/src/eu/kanade/tachiyomi/extension/all/xinmeitulu/Xinmeitulu.kt
@@ -9,6 +9,7 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Response
@@ -52,12 +53,24 @@ class Xinmeitulu : HttpSource() {
 
     override fun searchMangaParse(response: Response) = popularMangaParse(response)
 
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (query.startsWith("SLUG:")) {
-        val slug = query.removePrefix("SLUG:")
-        client.newCall(GET("$baseUrl/photo/$slug", headers)).asObservableSuccess()
-            .map { response -> MangasPage(listOf(mangaDetailsParse(response)), false) }
-    } else {
-        super.fetchSearchManga(page, query, filters)
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val slug = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return fetchSearchManga(page, "SLUG:$slug", filters)
+        }
+
+        return if (query.startsWith("SLUG:")) {
+            val slug = query.removePrefix("SLUG:")
+            client.newCall(GET("$baseUrl/photo/$slug", headers)).asObservableSuccess()
+                .map { response -> MangasPage(listOf(mangaDetailsParse(response)), false) }
+        } else {
+            super.fetchSearchManga(page, query, filters)
+        }
     }
 
     // Details

--- a/src/en/allanime/build.gradle
+++ b/src/en/allanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AllManga'
     extClass = '.AllManga'
-    extVersionCode = 15
+    extVersionCode = 16
     isNsfw = true
 }
 

--- a/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/AllManga.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/AllManga.kt
@@ -86,6 +86,16 @@ class AllManga :
 
     /* Search */
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val httpUrl = query.toHttpUrl()
+            if (httpUrl.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = httpUrl.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return fetchSearchManga(page, "$SEARCH_PREFIX$id", filters)
+        }
+
         if (!query.startsWith(SEARCH_PREFIX)) {
             return super.fetchSearchManga(page, query, filters)
         }

--- a/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/AllMangaUrlActivity.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/AllMangaUrlActivity.kt
@@ -10,22 +10,17 @@ import kotlin.system.exitProcess
 class AllMangaUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val id = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${AllManga.SEARCH_PREFIX}$id")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("AllMangaUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("AllMangaUrlActivity", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("AllMangaUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/en/cutiecomics/build.gradle
+++ b/src/en/cutiecomics/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Cutie Comics'
     extClass = '.CutieComics'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/en/cutiecomics/src/eu/kanade/tachiyomi/extension/en/cutiecomics/CutieComics.kt
+++ b/src/en/cutiecomics/src/eu/kanade/tachiyomi/extension/en/cutiecomics/CutieComics.kt
@@ -59,13 +59,25 @@ class CutieComics : HttpSource() {
     override fun latestUpdatesParse(response: Response): MangasPage = throw UnsupportedOperationException()
 
     // =============================== Search ===============================
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/$id"))
-            .asObservableSuccess()
-            .map(::searchMangaByIdParse)
-    } else {
-        super.fetchSearchManga(page, query, filters)
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(0)?.takeIf { it.isNotEmpty() }
+                ?: throw Exception("Unsupported url")
+            return fetchSearchManga(page, "$PREFIX_SEARCH$id", filters)
+        }
+
+        return if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
+            val id = query.removePrefix(PREFIX_SEARCH)
+            client.newCall(GET("$baseUrl/$id"))
+                .asObservableSuccess()
+                .map(::searchMangaByIdParse)
+        } else {
+            super.fetchSearchManga(page, query, filters)
+        }
     }
 
     private fun searchMangaByIdParse(response: Response): MangasPage {

--- a/src/en/cutiecomics/src/eu/kanade/tachiyomi/extension/en/cutiecomics/UrlActivity.kt
+++ b/src/en/cutiecomics/src/eu/kanade/tachiyomi/extension/en/cutiecomics/UrlActivity.kt
@@ -17,22 +17,17 @@ class UrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.isNotEmpty()) {
-            val item = pathSegments[0]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${CutieComics.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/en/hentaihere/build.gradle
+++ b/src/en/hentaihere/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'HentaiHere'
     extClass = '.HentaiHere'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = true
 }
 

--- a/src/en/hentaihere/src/eu/kanade/tachiyomi/extension/en/hentaihere/HentaiHere.kt
+++ b/src/en/hentaihere/src/eu/kanade/tachiyomi/extension/en/hentaihere/HentaiHere.kt
@@ -37,13 +37,25 @@ class HentaiHere : HttpSource() {
         page: Int,
         query: String,
         filters: FilterList,
-    ): Observable<MangasPage> = if (query.startsWith(PREFIX_ID_SEARCH)) {
-        val id = query.removePrefix(PREFIX_ID_SEARCH)
-        client.newCall(searchMangaByIdRequest(id))
-            .asObservableSuccess()
-            .map { response -> searchMangaByIdParse(response, id) }
-    } else {
-        super.fetchSearchManga(page, query, filters)
+    ): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return fetchSearchManga(page, "$PREFIX_ID_SEARCH$id", filters)
+        }
+
+        return if (query.startsWith(PREFIX_ID_SEARCH)) {
+            val id = query.removePrefix(PREFIX_ID_SEARCH)
+            client.newCall(searchMangaByIdRequest(id))
+                .asObservableSuccess()
+                .map { response -> searchMangaByIdParse(response, id) }
+        } else {
+            super.fetchSearchManga(page, query, filters)
+        }
     }
 
     private fun searchMangaByIdRequest(id: String) = GET("$baseUrl/m/$id")

--- a/src/en/hentaihere/src/eu/kanade/tachiyomi/extension/en/hentaihere/UrlActivity.kt
+++ b/src/en/hentaihere/src/eu/kanade/tachiyomi/extension/en/hentaihere/UrlActivity.kt
@@ -14,22 +14,17 @@ import kotlin.system.exitProcess
 class UrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val id = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${HentaiHere.PREFIX_ID_SEARCH}$id")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("UrlActivity", e.toString())
-            }
-        } else {
-            Log.e("UrlActivity", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("UrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/en/hentainexus/build.gradle
+++ b/src/en/hentainexus/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = "HentaiNexus"
     extClass = ".HentaiNexus"
-    extVersionCode = 14
+    extVersionCode = 15
     isNsfw = true
 }
 

--- a/src/en/hentainexus/src/eu/kanade/tachiyomi/extension/en/hentainexus/HentaiNexus.kt
+++ b/src/en/hentainexus/src/eu/kanade/tachiyomi/extension/en/hentainexus/HentaiNexus.kt
@@ -68,12 +68,24 @@ class HentaiNexus : HttpSource() {
 
     override fun latestUpdatesParse(response: Response): MangasPage = throw UnsupportedOperationException()
 
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (query.startsWith(PREFIX_ID_SEARCH)) {
-        val id = query.removePrefix(PREFIX_ID_SEARCH)
-        client.newCall(GET("$baseUrl/view/$id", headers)).asObservableSuccess()
-            .map { MangasPage(listOf(mangaDetailsParse(it).apply { url = "/view/$id" }), false) }
-    } else {
-        super.fetchSearchManga(page, query, filters)
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return fetchSearchManga(page, "$PREFIX_ID_SEARCH$id", filters)
+        }
+
+        return if (query.startsWith(PREFIX_ID_SEARCH)) {
+            val id = query.removePrefix(PREFIX_ID_SEARCH)
+            client.newCall(GET("$baseUrl/view/$id", headers)).asObservableSuccess()
+                .map { MangasPage(listOf(mangaDetailsParse(it).apply { url = "/view/$id" }), false) }
+        } else {
+            super.fetchSearchManga(page, query, filters)
+        }
     }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {

--- a/src/en/hentainexus/src/eu/kanade/tachiyomi/extension/en/hentainexus/UrlActivity.kt
+++ b/src/en/hentainexus/src/eu/kanade/tachiyomi/extension/en/hentainexus/UrlActivity.kt
@@ -14,22 +14,17 @@ import kotlin.system.exitProcess
 class UrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val id = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${HentaiNexus.PREFIX_ID_SEARCH}$id")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("UrlActivity", e.toString())
-            }
-        } else {
-            Log.e("UrlActivity", "Could not parse URI from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("UrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/en/kmanga/build.gradle
+++ b/src/en/kmanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'K Manga'
     extClass = '.KManga'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = false
 }
 

--- a/src/en/kmanga/src/eu/kanade/tachiyomi/extension/en/kmanga/KManga.kt
+++ b/src/en/kmanga/src/eu/kanade/tachiyomi/extension/en/kmanga/KManga.kt
@@ -143,6 +143,14 @@ class KManga :
 
     // Search
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val titleId = url.pathSegments[1]
+            return fetchSearchManga(page, "$PREFIX_SEARCH$titleId", filters)
+        }
         if (query.startsWith(PREFIX_SEARCH)) {
             val titleId = query.removePrefix(PREFIX_SEARCH)
             fetchMangaDetails(

--- a/src/en/kmanga/src/eu/kanade/tachiyomi/extension/en/kmanga/KMangaUrlActivity.kt
+++ b/src/en/kmanga/src/eu/kanade/tachiyomi/extension/en/kmanga/KMangaUrlActivity.kt
@@ -10,22 +10,17 @@ import kotlin.system.exitProcess
 class KMangaUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val titleId = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${KManga.PREFIX_SEARCH}$titleId")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("KMangaUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("KMangaUrlActivity", "Could not parse URI from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("KMangaUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/en/likemanga/build.gradle
+++ b/src/en/likemanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'LikeManga'
     extClass = '.LikeManga'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = false
 }
 

--- a/src/en/likemanga/src/eu/kanade/tachiyomi/extension/en/likemanga/LikeManga.kt
+++ b/src/en/likemanga/src/eu/kanade/tachiyomi/extension/en/likemanga/LikeManga.kt
@@ -55,6 +55,14 @@ class LikeManga : HttpSource() {
     override fun latestUpdatesParse(response: Response): MangasPage = searchMangaParse(response)
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments[0]
+            return fetchSearchManga(page, "$URL_SEARCH_PREFIX$id", filters)
+        }
         if (query.startsWith(URL_SEARCH_PREFIX)) {
             val url = "$baseUrl/${query.substringAfter(URL_SEARCH_PREFIX)}"
             return client.newCall(GET(url, headers)).asObservableSuccess().map { response ->

--- a/src/en/likemanga/src/eu/kanade/tachiyomi/extension/en/likemanga/UrlActivity.kt
+++ b/src/en/likemanga/src/eu/kanade/tachiyomi/extension/en/likemanga/UrlActivity.kt
@@ -12,21 +12,17 @@ class UrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 0) {
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${LikeManga.URL_SEARCH_PREFIX}${pathSegments[0]}")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/en/myhentaigallery/build.gradle
+++ b/src/en/myhentaigallery/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MyHentaiGallery'
     extClass = '.MyHentaiGallery'
-    extVersionCode = 8
+    extVersionCode = 9
     isNsfw = true
 }
 

--- a/src/en/myhentaigallery/src/eu/kanade/tachiyomi/extension/en/myhentaigallery/MyHentaiGallery.kt
+++ b/src/en/myhentaigallery/src/eu/kanade/tachiyomi/extension/en/myhentaigallery/MyHentaiGallery.kt
@@ -41,16 +41,26 @@ class MyHentaiGallery : HttpSource() {
 
     // =============================== Search =================================
 
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (query.startsWith(PREFIX_ID_SEARCH)) {
-        val id = query.removePrefix(PREFIX_ID_SEARCH)
-        client.newCall(GET("$baseUrl/g/$id", headers))
-            .asObservableSuccess()
-            .map { response ->
-                val details = mangaDetailsParse(response).apply { url = "/g/$id" }
-                MangasPage(listOf(details), false)
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
             }
-    } else {
-        super.fetchSearchManga(page, query, filters)
+            val id = url.pathSegments[2]
+            return fetchSearchManga(page, "$PREFIX_ID_SEARCH$id", filters)
+        }
+        return if (query.startsWith(PREFIX_ID_SEARCH)) {
+            val id = query.removePrefix(PREFIX_ID_SEARCH)
+            client.newCall(GET("$baseUrl/g/$id", headers))
+                .asObservableSuccess()
+                .map { response ->
+                    val details = mangaDetailsParse(response).apply { url = "/g/$id" }
+                    MangasPage(listOf(details), false)
+                }
+        } else {
+            super.fetchSearchManga(page, query, filters)
+        }
     }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {

--- a/src/en/myhentaigallery/src/eu/kanade/tachiyomi/extension/en/myhentaigallery/UrlActivity.kt
+++ b/src/en/myhentaigallery/src/eu/kanade/tachiyomi/extension/en/myhentaigallery/UrlActivity.kt
@@ -14,22 +14,17 @@ import kotlin.system.exitProcess
 class UrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 2) {
-            val id = pathSegments[2]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${MyHentaiGallery.PREFIX_ID_SEARCH}$id")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("MyHentaiGalUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("MyHentaiGalUrlActivity", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("MyHentaiGalUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/en/ninehentai/build.gradle
+++ b/src/en/ninehentai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'NineHentai'
     extClass = '.NineHentai'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/en/ninehentai/src/eu/kanade/tachiyomi/extension/en/ninehentai/NineHentai.kt
+++ b/src/en/ninehentai/src/eu/kanade/tachiyomi/extension/en/ninehentai/NineHentai.kt
@@ -19,6 +19,7 @@ import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -106,6 +107,14 @@ class NineHentai : HttpSource() {
 
     // Search
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments[1]
+            return fetchSearchManga(page, "id:$id", filters)
+        }
         if (query.startsWith("id:")) {
             val id = query.substringAfter("id:").toInt()
             return client.newCall(buildDetailRequest(id))

--- a/src/en/ninehentai/src/eu/kanade/tachiyomi/extension/en/ninehentai/NineHentaiUrlActivity.kt
+++ b/src/en/ninehentai/src/eu/kanade/tachiyomi/extension/en/ninehentai/NineHentaiUrlActivity.kt
@@ -14,22 +14,17 @@ import kotlin.system.exitProcess
 class NineHentaiUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val id = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "id:$id")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("NineHentaiUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("NineHentaiUrlActivity", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("NineHentaiUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/en/oppaistream/build.gradle
+++ b/src/en/oppaistream/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Oppai Stream'
     extClass = '.OppaiStream'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/en/oppaistream/src/eu/kanade/tachiyomi/extension/en/oppaistream/OppaiStream.kt
+++ b/src/en/oppaistream/src/eu/kanade/tachiyomi/extension/en/oppaistream/OppaiStream.kt
@@ -46,6 +46,15 @@ class OppaiStream : HttpSource() {
 
     // search
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val slug = url.queryParameter("m")
+                ?: throw Exception("Unsupported url")
+            return fetchSearchManga(page, "$SLUG_SEARCH_PREFIX$slug", filters)
+        }
         if (!query.startsWith(SLUG_SEARCH_PREFIX)) {
             return super.fetchSearchManga(page, query, filters)
         }

--- a/src/en/oppaistream/src/eu/kanade/tachiyomi/extension/en/oppaistream/OppaiStreamUrlActivity.kt
+++ b/src/en/oppaistream/src/eu/kanade/tachiyomi/extension/en/oppaistream/OppaiStreamUrlActivity.kt
@@ -10,22 +10,17 @@ import kotlin.system.exitProcess
 class OppaiStreamUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val uri = intent?.data
-        val slug = uri?.getQueryParameter("m")
-        if (slug != null) {
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${OppaiStream.SLUG_SEARCH_PREFIX}$slug")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("OppaiStreamUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("OppaiStreamUrlActivity", "slug not found in uri $uri")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("OppaiStreamUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/en/vizshonenjump/build.gradle
+++ b/src/en/vizshonenjump/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'VIZ'
     extClass = '.VizFactory'
-    extVersionCode = 23
+    extVersionCode = 24
     isNsfw = false
 }
 

--- a/src/en/vizshonenjump/src/eu/kanade/tachiyomi/extension/en/vizshonenjump/Viz.kt
+++ b/src/en/vizshonenjump/src/eu/kanade/tachiyomi/extension/en/vizshonenjump/Viz.kt
@@ -88,6 +88,22 @@ open class Viz(
     override fun latestUpdatesParse(response: Response): MangasPage = popularMangaParse(response)
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val pathSegments = url.pathSegments
+            if (pathSegments.size < 3) {
+                throw Exception("Unsupported url")
+            }
+            val seriesSlug = if (pathSegments[2] == "chapter" && pathSegments[1].contains("-chapter-")) {
+                pathSegments[1].substringBeforeLast("-chapter-")
+            } else {
+                pathSegments[2]
+            }
+            return fetchSearchManga(page, "$PREFIX_URL_SEARCH/${pathSegments[0]}/chapters/$seriesSlug", filters)
+        }
         if (query.startsWith(PREFIX_URL_SEARCH)) {
             val url = query.substringAfter(PREFIX_URL_SEARCH)
             val service = url.split("/")[1]

--- a/src/en/vizshonenjump/src/eu/kanade/tachiyomi/extension/en/vizshonenjump/VizUrlActivity.kt
+++ b/src/en/vizshonenjump/src/eu/kanade/tachiyomi/extension/en/vizshonenjump/VizUrlActivity.kt
@@ -10,66 +10,20 @@ import kotlin.system.exitProcess
 class VizUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments: List<String>? = intent?.data?.pathSegments
-        if (!pathSegments.isNullOrEmpty() && pathSegments.size >= 3) {
-            // Have to use .equals, otherwise get an error 'Didn't find class "kotlin.jvm.internal.Intrinsics"'
-            val seriesSlug = if (pathSegments[2].equals("chapter") && contains(pathSegments[1], "-chapter-")) {
-                substringBeforeLast(pathSegments[1], "-chapter-")
-            } else {
-                pathSegments[2]
-            }
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra(
-                    "query",
-                    "${Viz.PREFIX_URL_SEARCH}/${pathSegments[0]}/chapters/$seriesSlug",
-                )
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("VizUrlActivity", "failed to start activity with error: $e")
-            }
-        } else {
-            Log.e("VizUrlActivity", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("VizUrlActivity", "Unable to launch activity", e)
         }
 
         finish()
         exitProcess(0)
-    }
-
-    private fun containsAt(haystack: String, startIndex: Int, needle: String): Boolean {
-        for (i in 0 until needle.length) {
-            if (needle[i] != haystack[startIndex + i]) {
-                return false
-            }
-        }
-        return true
-    }
-
-    private fun contains(haystack: String, needle: String): Boolean {
-        if (needle.length > haystack.length) {
-            return false
-        }
-        for (startIndex in 0..haystack.length - needle.length) {
-            if (containsAt(haystack, startIndex, needle)) {
-                return true
-            }
-        }
-        return false
-    }
-
-    private fun substringBeforeLast(haystack: String, needle: String): String {
-        if (needle.length > haystack.length) {
-            return haystack
-        }
-        for (startIndex in (haystack.length - needle.length) downTo 0) {
-            if (containsAt(haystack, startIndex, needle)) {
-                return haystack.subSequence(0, startIndex).toString()
-            }
-        }
-        return haystack
     }
 }

--- a/src/en/weebcentral/build.gradle
+++ b/src/en/weebcentral/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Weeb Central'
     extClass = '.WeebCentral'
-    extVersionCode = 19
+    extVersionCode = 20
     isNsfw = true
 }
 

--- a/src/en/weebcentral/src/eu/kanade/tachiyomi/extension/en/weebcentral/WeebCentral.kt
+++ b/src/en/weebcentral/src/eu/kanade/tachiyomi/extension/en/weebcentral/WeebCentral.kt
@@ -65,6 +65,17 @@ class WeebCentral : HttpSource() {
     // =============================== Search ===============================
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val pathSegments = url.pathSegments
+            if (pathSegments.size < 3) {
+                throw Exception("Unsupported url")
+            }
+            return fetchSearchManga(page, "$URL_SEARCH_PREFIX${pathSegments[1]}/${pathSegments[2]}", filters)
+        }
         val pathSegment = query.takeIf { it.startsWith(URL_SEARCH_PREFIX) }
             ?.removePrefix(URL_SEARCH_PREFIX)
             ?: return super.fetchSearchManga(page, query, filters)

--- a/src/en/weebcentral/src/eu/kanade/tachiyomi/extension/en/weebcentral/WeebCentralUrlActivity.kt
+++ b/src/en/weebcentral/src/eu/kanade/tachiyomi/extension/en/weebcentral/WeebCentralUrlActivity.kt
@@ -13,30 +13,20 @@ class WeebCentralUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
 
-        if (pathSegments != null && pathSegments.size >= 3) {
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", getEntry(pathSegments))
-                putExtra("filter", packageName)
-            }
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()
         exitProcess(0)
-    }
-
-    private fun getEntry(pathSegments: MutableList<String>): String? {
-        val id = pathSegments[1]
-        val slug = pathSegments[2]
-        return "${WeebCentral.URL_SEARCH_PREFIX}$id/$slug"
     }
 }

--- a/src/es/hentaimode/build.gradle
+++ b/src/es/hentaimode/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'HentaiMode'
     extClass = '.HentaiMode'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = true
 }
 

--- a/src/es/hentaimode/src/eu/kanade/tachiyomi/extension/es/hentaimode/HentaiMode.kt
+++ b/src/es/hentaimode/src/eu/kanade/tachiyomi/extension/es/hentaimode/HentaiMode.kt
@@ -56,13 +56,23 @@ class HentaiMode : HttpSource() {
     override fun latestUpdatesParse(response: Response): MangasPage = throw UnsupportedOperationException()
 
     // =============================== Search ===============================
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/g/$id", headers))
-            .asObservableSuccess()
-            .map(::searchMangaByIdParse)
-    } else {
-        super.fetchSearchManga(page, query, filters)
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val item = url.pathSegments[1]
+            return fetchSearchManga(page, "$PREFIX_SEARCH$item", filters)
+        }
+        return if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
+            val id = query.removePrefix(PREFIX_SEARCH)
+            client.newCall(GET("$baseUrl/g/$id", headers))
+                .asObservableSuccess()
+                .map(::searchMangaByIdParse)
+        } else {
+            super.fetchSearchManga(page, query, filters)
+        }
     }
 
     private fun searchMangaByIdParse(response: Response): MangasPage {

--- a/src/es/hentaimode/src/eu/kanade/tachiyomi/extension/es/hentaimode/UrlActivity.kt
+++ b/src/es/hentaimode/src/eu/kanade/tachiyomi/extension/es/hentaimode/UrlActivity.kt
@@ -12,27 +12,19 @@ import kotlin.system.exitProcess
  * and redirects them to the main Tachiyomi process.
  */
 class UrlActivity : Activity() {
-
-    private val tag = javaClass.simpleName
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${HentaiMode.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("HentaiMode", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/fr/bigsolo/build.gradle
+++ b/src/fr/bigsolo/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'BigSolo'
     extClass = '.BigSolo'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = false
 }
 

--- a/src/fr/bigsolo/src/eu/kanade/tachiyomi/extension/fr/bigsolo/BigSolo.kt
+++ b/src/fr/bigsolo/src/eu/kanade/tachiyomi/extension/fr/bigsolo/BigSolo.kt
@@ -8,8 +8,10 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.utils.parseAs
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
+import rx.Observable
 import java.net.URI
 
 class BigSolo : HttpSource() {
@@ -40,6 +42,18 @@ class BigSolo : HttpSource() {
     override fun latestUpdatesParse(response: Response): MangasPage = searchMangaParse(response)
 
     // Search
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val slug = url.pathSegments[0]
+            return fetchSearchManga(page, "SLUG:$slug", filters)
+        }
+        return super.fetchSearchManga(page, query, filters)
+    }
+
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         val url = if (query.isNotBlank()) {
             "$baseUrl/data/series#$query"

--- a/src/fr/bigsolo/src/eu/kanade/tachiyomi/extension/fr/bigsolo/BigSoloUrlActivity.kt
+++ b/src/fr/bigsolo/src/eu/kanade/tachiyomi/extension/fr/bigsolo/BigSoloUrlActivity.kt
@@ -14,22 +14,17 @@ import kotlin.system.exitProcess
 class BigSoloUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size >= 1) {
-            val slug = pathSegments[0]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "SLUG:$slug")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("BigSoloUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("BigSoloUrlActivity", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("BigSoloUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/fr/manganova/build.gradle
+++ b/src/fr/manganova/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaNova'
     extClass = '.MangaNova'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = false
 }
 

--- a/src/fr/manganova/src/eu/kanade/tachiyomi/extension/fr/manganova/MangaNova.kt
+++ b/src/fr/manganova/src/eu/kanade/tachiyomi/extension/fr/manganova/MangaNova.kt
@@ -11,6 +11,7 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.utils.parseAs
 import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import rx.Observable
@@ -61,6 +62,18 @@ class MangaNova : HttpSource() {
     }
 
     // Search
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val slug = url.pathSegments[1]
+            return fetchSearchManga(page, "SLUG:$slug", filters)
+        }
+        return super.fetchSearchManga(page, query, filters)
+    }
+
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         val url = if (query.isNotBlank()) {
             "$api/catalogue/#$query"

--- a/src/fr/manganova/src/eu/kanade/tachiyomi/extension/fr/manganova/MangaNovaUrlActivity.kt
+++ b/src/fr/manganova/src/eu/kanade/tachiyomi/extension/fr/manganova/MangaNovaUrlActivity.kt
@@ -15,22 +15,17 @@ import kotlin.system.exitProcess
 class MangaNovaUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size >= 2) {
-            val slug = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "SLUG:$slug")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("MangaNovaUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("MangaNovaUrlActivity", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("MangaNovaUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/fr/scanr/build.gradle
+++ b/src/fr/scanr/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ScanR'
     extClass = '.ScanR'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/fr/scanr/src/eu/kanade/tachiyomi/extension/fr/scanr/ScanR.kt
+++ b/src/fr/scanr/src/eu/kanade/tachiyomi/extension/fr/scanr/ScanR.kt
@@ -36,6 +36,18 @@ class ScanR : HttpSource() {
     override fun popularMangaParse(response: Response): MangasPage = searchMangaParse(response)
 
     // Search
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val slug = url.pathSegments[0]
+            return fetchSearchManga(page, "SLUG:$slug", filters)
+        }
+        return super.fetchSearchManga(page, query, filters)
+    }
+
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         val url = "$cdnUrl/index.json".toHttpUrl().newBuilder()
         if (query.isNotBlank()) {

--- a/src/fr/scanr/src/eu/kanade/tachiyomi/extension/fr/scanr/ScanRUrlActivity.kt
+++ b/src/fr/scanr/src/eu/kanade/tachiyomi/extension/fr/scanr/ScanRUrlActivity.kt
@@ -14,22 +14,17 @@ import kotlin.system.exitProcess
 class ScanRUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size >= 1) {
-            val slug = pathSegments[0]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "SLUG:$slug")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("ScanRUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("ScanRUrlActivity", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("ScanRUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/id/dreamteamsscans/build.gradle
+++ b/src/id/dreamteamsscans/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'DreamTeams Scans'
     extClass = '.DreamTeamsScans'
-    extVersionCode = 31
+    extVersionCode = 32
     baseUrl = 'https://dreamteams.space'
     isNsfw = true
 }

--- a/src/id/dreamteamsscans/src/eu/kanade/tachiyomi/extension/id/dreamteamsscans/DreamTeamsScans.kt
+++ b/src/id/dreamteamsscans/src/eu/kanade/tachiyomi/extension/id/dreamteamsscans/DreamTeamsScans.kt
@@ -75,13 +75,17 @@ class DreamTeamsScans : HttpSource() {
     // =============================== Search ===============================
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
-        val slug = when {
-            query.startsWith(PREFIX_ID_SEARCH) -> query.removePrefix(PREFIX_ID_SEARCH)
-            query.startsWith("$baseUrl/comic/") -> query.substringAfter("/comic/").substringBefore("/")
-            else -> null
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments[1]
+            return fetchSearchManga(page, "$PREFIX_ID_SEARCH$id", filters)
         }
 
-        return if (slug != null) {
+        return if (query.startsWith(PREFIX_ID_SEARCH)) {
+            val slug = query.removePrefix(PREFIX_ID_SEARCH)
             client.newCall(GET("$apiBaseUrl/series/comic/$slug", headers))
                 .asObservableSuccess()
                 .map { response ->

--- a/src/id/dreamteamsscans/src/eu/kanade/tachiyomi/extension/id/dreamteamsscans/DreamTeamsScansUrlActivity.kt
+++ b/src/id/dreamteamsscans/src/eu/kanade/tachiyomi/extension/id/dreamteamsscans/DreamTeamsScansUrlActivity.kt
@@ -11,22 +11,16 @@ class DreamTeamsScansUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val id = pathSegments[1]
-            try {
-                startActivity(
-                    Intent().apply {
-                        action = "eu.kanade.tachiyomi.SEARCH"
-                        putExtra("query", "${DreamTeamsScans.PREFIX_ID_SEARCH}$id")
-                        putExtra("filter", packageName)
-                    },
-                )
-            } catch (e: ActivityNotFoundException) {
-                Log.e("DreamTeamsScansUrl", e.toString())
-            }
-        } else {
-            Log.e("DreamTeamsScansUrl", "Could not parse URI from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("DreamTeamsScansUrl", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/ja/hachiraw/build.gradle
+++ b/src/ja/hachiraw/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = "Hachiraw"
     extClass = ".Hachiraw"
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/ja/hachiraw/src/eu/kanade/tachiyomi/extension/ja/hachiraw/Hachiraw.kt
+++ b/src/ja/hachiraw/src/eu/kanade/tachiyomi/extension/ja/hachiraw/Hachiraw.kt
@@ -55,17 +55,28 @@ class Hachiraw : HttpSource() {
         page: Int,
         query: String,
         filters: FilterList,
-    ): Observable<MangasPage> = if (query.startsWith(PREFIX_SLUG_SEARCH)) {
-        val slug = query.removePrefix(PREFIX_SLUG_SEARCH)
-        val manga = SManga.create().apply { url = "/manga/$slug" }
-
-        fetchMangaDetails(manga)
-            .map {
-                it.url = "/manga/$slug"
-                MangasPage(listOf(it), false)
+    ): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
             }
-    } else {
-        super.fetchSearchManga(page, query, filters)
+            val slug = url.pathSegments[1]
+            return fetchSearchManga(page, "$PREFIX_SLUG_SEARCH$slug", filters)
+        }
+
+        return if (query.startsWith(PREFIX_SLUG_SEARCH)) {
+            val slug = query.removePrefix(PREFIX_SLUG_SEARCH)
+            val manga = SManga.create().apply { url = "/manga/$slug" }
+
+            fetchMangaDetails(manga)
+                .map {
+                    it.url = "/manga/$slug"
+                    MangasPage(listOf(it), false)
+                }
+        } else {
+            super.fetchSearchManga(page, query, filters)
+        }
     }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {

--- a/src/ja/hachiraw/src/eu/kanade/tachiyomi/extension/ja/hachiraw/UrlActivity.kt
+++ b/src/ja/hachiraw/src/eu/kanade/tachiyomi/extension/ja/hachiraw/UrlActivity.kt
@@ -11,22 +11,16 @@ class UrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val pathSegments = intent?.data?.pathSegments
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-        if (pathSegments != null && pathSegments.size > 1) {
-            val intent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${Hachiraw.PREFIX_SLUG_SEARCH}${pathSegments[1]}")
-                putExtra("filter", packageName)
-            }
-
-            try {
-                startActivity(intent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("UrlActivity", "Could not start activity", e)
-            }
-        } else {
-            Log.e("UrlActivity", "Could not parse URI from intent $intent")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("UrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/ja/twi4/build.gradle
+++ b/src/ja/twi4/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Twi4'
     extClass = '.Twi4'
-    extVersionCode = 5
+    extVersionCode = 6
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ja/twi4/src/eu/kanade/tachiyomi/extension/ja/twi4/Twi4.kt
+++ b/src/ja/twi4/src/eu/kanade/tachiyomi/extension/ja/twi4/Twi4.kt
@@ -15,6 +15,7 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import rx.Observable
@@ -228,6 +229,15 @@ class Twi4 : HttpSource() {
         query: String,
         filters: FilterList,
     ): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val slug = url.pathSegments[2]
+            return fetchSearchManga(page, "$SEARCH_PREFIX_SLUG$slug", filters)
+        }
+
         if (query.startsWith(SEARCH_PREFIX_SLUG)) {
             val slug = query.drop(SEARCH_PREFIX_SLUG.length)
             // Explicitly ignore anything that ends with .html or starts with zadankai

--- a/src/ja/twi4/src/eu/kanade/tachiyomi/extension/ja/twi4/Twi4Activity.kt
+++ b/src/ja/twi4/src/eu/kanade/tachiyomi/extension/ja/twi4/Twi4Activity.kt
@@ -1,23 +1,26 @@
 package eu.kanade.tachiyomi.extension.ja.twi4
 
 import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import kotlin.system.exitProcess
 
 class Twi4Activity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 2) {
-            val slug = pathSegments[2]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${Twi4.SEARCH_PREFIX_SLUG}$slug")
-                putExtra("filter", packageName)
-            }
 
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
             startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("Twi4Activity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/pt/brasilhentai/build.gradle
+++ b/src/pt/brasilhentai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Brasil Hentai'
     extClass = '.BrasilHentai'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/pt/brasilhentai/src/eu/kanade/tachiyomi/extension/pt/brasilhentai/BrasilHentai.kt
+++ b/src/pt/brasilhentai/src/eu/kanade/tachiyomi/extension/pt/brasilhentai/BrasilHentai.kt
@@ -76,6 +76,14 @@ class BrasilHentai : HttpSource() {
     override fun searchMangaParse(response: Response): MangasPage = popularMangaParse(response)
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val item = url.pathSegments.last { it.isNotBlank() }
+            return fetchSearchManga(page, "$SEARCH_PREFIX$item", filters)
+        }
         if (query.startsWith(SEARCH_PREFIX)) {
             val url = "$baseUrl/${query.substringAfter(SEARCH_PREFIX)}/"
             return client.newCall(GET(url, headers))

--- a/src/pt/brasilhentai/src/eu/kanade/tachiyomi/extension/pt/brasilhentai/UrlActivity.kt
+++ b/src/pt/brasilhentai/src/eu/kanade/tachiyomi/extension/pt/brasilhentai/UrlActivity.kt
@@ -8,25 +8,19 @@ import android.util.Log
 import kotlin.system.exitProcess
 
 class UrlActivity : Activity() {
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size >= 1) {
-            val item = pathSegments[pathSegments.size - 1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${BrasilHentai.SEARCH_PREFIX}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("UrlActivity", e.toString())
-            }
-        } else {
-            Log.e("UrlActivity", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("UrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/pt/exhentainetbr/build.gradle
+++ b/src/pt/exhentainetbr/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ExHentai.net.br'
     extClass = '.ExHentaiNetBR'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/pt/exhentainetbr/src/eu/kanade/tachiyomi/extension/pt/exhentainetbr/ExHentaiNetBR.kt
+++ b/src/pt/exhentainetbr/src/eu/kanade/tachiyomi/extension/pt/exhentainetbr/ExHentaiNetBR.kt
@@ -70,6 +70,14 @@ class ExHentaiNetBR : HttpSource() {
     }
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val item = url.pathSegments[1]
+            return fetchSearchManga(page, "$PREFIX_SEARCH$item", filters)
+        }
         if (!query.startsWith(PREFIX_SEARCH)) {
             return super.fetchSearchManga(page, query, filters)
         }

--- a/src/pt/exhentainetbr/src/eu/kanade/tachiyomi/extension/pt/exhentainetbr/UrlActivity.kt
+++ b/src/pt/exhentainetbr/src/eu/kanade/tachiyomi/extension/pt/exhentainetbr/UrlActivity.kt
@@ -13,22 +13,17 @@ class UrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${ExHentaiNetBR.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/pt/taiyo/build.gradle
+++ b/src/pt/taiyo/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Taiyō'
     extClass = '.Taiyo'
-    extVersionCode = 9
+    extVersionCode = 10
     isNsfw = true
 }
 

--- a/src/pt/taiyo/src/eu/kanade/tachiyomi/extension/pt/taiyo/Taiyo.kt
+++ b/src/pt/taiyo/src/eu/kanade/tachiyomi/extension/pt/taiyo/Taiyo.kt
@@ -75,13 +75,23 @@ class Taiyo : HttpSource() {
 
     // =============================== Search ===============================
 
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (query.startsWith(PREFIX_SEARCH)) {
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/media/$id"))
-            .asObservableSuccess()
-            .map(::searchMangaByIdParse)
-    } else {
-        super.fetchSearchManga(page, query, filters)
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val item = url.pathSegments[1]
+            return fetchSearchManga(page, "$PREFIX_SEARCH$item", filters)
+        }
+        return if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            client.newCall(GET("$baseUrl/media/$id"))
+                .asObservableSuccess()
+                .map(::searchMangaByIdParse)
+        } else {
+            super.fetchSearchManga(page, query, filters)
+        }
     }
 
     private fun searchMangaByIdParse(response: Response): MangasPage {

--- a/src/pt/taiyo/src/eu/kanade/tachiyomi/extension/pt/taiyo/UrlActivity.kt
+++ b/src/pt/taiyo/src/eu/kanade/tachiyomi/extension/pt/taiyo/UrlActivity.kt
@@ -17,22 +17,17 @@ class UrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${Taiyo.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/pt/taosect/build.gradle
+++ b/src/pt/taosect/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Tao Sect'
     extClass = '.TaoSect'
-    extVersionCode = 20
+    extVersionCode = 21
     isNsfw = true
 }
 

--- a/src/pt/taosect/src/eu/kanade/tachiyomi/extension/pt/taosect/TaoSect.kt
+++ b/src/pt/taosect/src/eu/kanade/tachiyomi/extension/pt/taosect/TaoSect.kt
@@ -137,6 +137,18 @@ class TaoSect : HttpSource() {
         return MangasPage(projectList, hasNextPage)
     }
 
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val projectSlug = url.pathSegments[1]
+            return fetchSearchManga(page, "$SLUG_PREFIX_SEARCH$projectSlug", filters)
+        }
+        return super.fetchSearchManga(page, query, filters)
+    }
+
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         if (query.startsWith(SLUG_PREFIX_SEARCH) && query.removePrefix(SLUG_PREFIX_SEARCH).isNotBlank()) {
             return mangaDetailsRequest(query.removePrefix(SLUG_PREFIX_SEARCH))

--- a/src/pt/taosect/src/eu/kanade/tachiyomi/extension/pt/taosect/TaoSectUrlActivity.kt
+++ b/src/pt/taosect/src/eu/kanade/tachiyomi/extension/pt/taosect/TaoSectUrlActivity.kt
@@ -11,22 +11,17 @@ class TaoSectUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val projectSlug = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", TaoSect.SLUG_PREFIX_SEARCH + projectSlug)
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("TaoSectUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("TaoSectUrlActivity", "Could not parse URI from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("TaoSectUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/pt/zettahq/build.gradle
+++ b/src/pt/zettahq/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ZettaHQ'
     extClass = '.ZettaHQ'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/pt/zettahq/src/eu/kanade/tachiyomi/extension/pt/zettahq/UrlActivity.kt
+++ b/src/pt/zettahq/src/eu/kanade/tachiyomi/extension/pt/zettahq/UrlActivity.kt
@@ -11,22 +11,17 @@ class UrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size >= 1) {
-            val item = pathSegments[pathSegments.size - 1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${ZettaHQ.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("UrlActivity", e.toString())
-            }
-        } else {
-            Log.e("UrlActivity", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("UrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/pt/zettahq/src/eu/kanade/tachiyomi/extension/pt/zettahq/ZettaHQ.kt
+++ b/src/pt/zettahq/src/eu/kanade/tachiyomi/extension/pt/zettahq/ZettaHQ.kt
@@ -126,6 +126,14 @@ class ZettaHQ : HttpSource() {
     }
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val item = url.pathSegments.last { it.isNotBlank() }
+            return fetchSearchManga(page, "$PREFIX_SEARCH$item", filters)
+        }
         if (query.startsWith(PREFIX_SEARCH)) {
             val slug = query.substringAfter(PREFIX_SEARCH)
             return fetchMangaDetails(SManga.create().apply { url = "/$slug" })

--- a/src/ru/desu/build.gradle
+++ b/src/ru/desu/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Desu'
     extClass = '.Desu'
-    extVersionCode = 31
+    extVersionCode = 32
     isNsfw = true
 }
 

--- a/src/ru/desu/src/eu/kanade/tachiyomi/extension/ru/desu/Desu.kt
+++ b/src/ru/desu/src/eu/kanade/tachiyomi/extension/ru/desu/Desu.kt
@@ -262,21 +262,31 @@ class Desu :
 
     private fun searchMangaByIdRequest(id: String): Request = GET("$baseUrl$API_URL/$id", headers)
 
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (query.startsWith(PREFIX_SLUG_SEARCH)) {
-        val realQuery = query.removePrefix(PREFIX_SLUG_SEARCH)
-        client.newCall(searchMangaByIdRequest(realQuery))
-            .asObservableSuccess()
-            .map { response ->
-                val details = mangaDetailsParse(response)
-                details.url = "/$realQuery"
-                MangasPage(listOf(details), false)
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
             }
-    } else {
-        client.newCall(searchMangaRequest(page, query, filters))
-            .asObservableSuccess()
-            .map { response ->
-                searchMangaParse(response)
-            }
+            val titleid = url.pathSegments[1]
+            return fetchSearchManga(page, "$PREFIX_SLUG_SEARCH$titleid", filters)
+        }
+        return if (query.startsWith(PREFIX_SLUG_SEARCH)) {
+            val realQuery = query.removePrefix(PREFIX_SLUG_SEARCH)
+            client.newCall(searchMangaByIdRequest(realQuery))
+                .asObservableSuccess()
+                .map { response ->
+                    val details = mangaDetailsParse(response)
+                    details.url = "/$realQuery"
+                    MangasPage(listOf(details), false)
+                }
+        } else {
+            client.newCall(searchMangaRequest(page, query, filters))
+                .asObservableSuccess()
+                .map { response ->
+                    searchMangaParse(response)
+                }
+        }
     }
 
     private class OrderBy :

--- a/src/ru/desu/src/eu/kanade/tachiyomi/extension/ru/desu/DesuActivity.kt
+++ b/src/ru/desu/src/eu/kanade/tachiyomi/extension/ru/desu/DesuActivity.kt
@@ -16,22 +16,17 @@ class DesuActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val titleid = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${Desu.PREFIX_SLUG_SEARCH}$titleid")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("DesuActivity", e.toString())
-            }
-        } else {
-            Log.e("DesuActivity", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("DesuActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/ru/mangabuff/build.gradle
+++ b/src/ru/mangabuff/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaBuff'
     extClass = '.MangaBuff'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/MangaBuff.kt
+++ b/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/MangaBuff.kt
@@ -102,6 +102,14 @@ class MangaBuff : HttpSource() {
         query: String,
         filters: FilterList,
     ): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val slug = url.pathSegments[1]
+            return fetchSearchManga(page, "$SEARCH_PREFIX$slug", filters)
+        }
         if (!query.startsWith(SEARCH_PREFIX)) {
             return super.fetchSearchManga(page, query, filters)
         }

--- a/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/UrlActivity.kt
+++ b/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/UrlActivity.kt
@@ -10,24 +10,17 @@ import kotlin.system.exitProcess
 class UrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
 
-        if (pathSegments != null && pathSegments.size > 1) {
-            val slug = pathSegments[1]
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${MangaBuff.SEARCH_PREFIX}$slug")
-                putExtra("filter", packageName)
-            }
-
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("UrlActivity", e.toString())
-            }
-        } else {
-            Log.e("UrlActivity", "could not parse uri from intent $intent")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("UrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/ru/unicomics/build.gradle
+++ b/src/ru/unicomics/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'UniComics'
     extClass = '.UniComics'
-    extVersionCode = 8
+    extVersionCode = 9
     isNsfw = false
 }
 

--- a/src/ru/unicomics/src/eu/kanade/tachiyomi/extension/ru/unicomics/UniComics.kt
+++ b/src/ru/unicomics/src/eu/kanade/tachiyomi/extension/ru/unicomics/UniComics.kt
@@ -12,6 +12,7 @@ import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
 import okhttp3.Headers
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -160,6 +161,14 @@ class UniComics : HttpSource() {
     }
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val titleid = url.pathSegments[2]
+            return fetchSearchManga(page, "$PREFIX_SLUG_SEARCH$titleid", filters)
+        }
         if (query.startsWith(PREFIX_SLUG_SEARCH)) {
             val realQuery = query.removePrefix(PREFIX_SLUG_SEARCH)
             return client.newCall(GET("$baseUrl$PATH_URL$realQuery", headers))

--- a/src/ru/unicomics/src/eu/kanade/tachiyomi/extension/ru/unicomics/UrlActivity.kt
+++ b/src/ru/unicomics/src/eu/kanade/tachiyomi/extension/ru/unicomics/UrlActivity.kt
@@ -10,22 +10,17 @@ class UrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 2) {
-            val titleid = pathSegments[2]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${UniComics.PREFIX_SLUG_SEARCH}$titleid")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: Throwable) {
-                Log.e("UrlActivity", e.toString())
-            }
-        } else {
-            Log.e("UrlActivity", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: Throwable) {
+            Log.e("UrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/tr/hattorimanga/build.gradle
+++ b/src/tr/hattorimanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hattori Manga'
     extClass = '.HattoriManga'
-    extVersionCode = 42
+    extVersionCode = 43
     isNsfw = true
 }
 

--- a/src/tr/hattorimanga/src/eu/kanade/tachiyomi/extension/tr/hattorimanga/HattoriManga.kt
+++ b/src/tr/hattorimanga/src/eu/kanade/tachiyomi/extension/tr/hattorimanga/HattoriManga.kt
@@ -210,6 +210,15 @@ class HattoriManga : HttpSource() {
     }
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val item = url.pathSegments[1]
+            return fetchSearchManga(page, "$SEARCH_PREFIX$item", filters)
+        }
+
         if (query.startsWith(SEARCH_PREFIX)) {
             val slug = query.removePrefix(SEARCH_PREFIX)
             return client.newCall(GET("$baseUrl/manga/$slug", headers))

--- a/src/tr/hattorimanga/src/eu/kanade/tachiyomi/extension/tr/hattorimanga/HattoriMangaUrlActivity.kt
+++ b/src/tr/hattorimanga/src/eu/kanade/tachiyomi/extension/tr/hattorimanga/HattoriMangaUrlActivity.kt
@@ -8,27 +8,19 @@ import android.util.Log
 import kotlin.system.exitProcess
 
 class HattoriMangaUrlActivity : Activity() {
-
-    private val tag = javaClass.simpleName
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${HattoriManga.SEARCH_PREFIX}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("HattoriMangaUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/vi/lxhentai/build.gradle
+++ b/src/vi/lxhentai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'LXManga'
     extClass = '.LxHentai'
-    extVersionCode = 28
+    extVersionCode = 29
     isNsfw = true
 }
 

--- a/src/vi/lxhentai/src/eu/kanade/tachiyomi/extension/vi/lxhentai/LxHentai.kt
+++ b/src/vi/lxhentai/src/eu/kanade/tachiyomi/extension/vi/lxhentai/LxHentai.kt
@@ -75,18 +75,29 @@ class LxHentai :
 
     // ============================== Search ================================
 
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = when {
-        query.startsWith(PREFIX_ID_SEARCH) -> {
-            val slug = query.substringAfter(PREFIX_ID_SEARCH)
-            val mangaUrl = "/truyen/$slug"
-            fetchMangaDetails(SManga.create().apply { url = mangaUrl })
-                .map {
-                    it.url = mangaUrl
-                    it.initialized = true
-                    MangasPage(listOf(it), false)
-                }
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments[1]
+            return fetchSearchManga(page, "$PREFIX_ID_SEARCH$id", filters)
         }
-        else -> super.fetchSearchManga(page, query, filters)
+
+        return when {
+            query.startsWith(PREFIX_ID_SEARCH) -> {
+                val slug = query.substringAfter(PREFIX_ID_SEARCH)
+                val mangaUrl = "/truyen/$slug"
+                fetchMangaDetails(SManga.create().apply { url = mangaUrl })
+                    .map {
+                        it.url = mangaUrl
+                        it.initialized = true
+                        MangasPage(listOf(it), false)
+                    }
+            }
+            else -> super.fetchSearchManga(page, query, filters)
+        }
     }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {

--- a/src/vi/lxhentai/src/eu/kanade/tachiyomi/extension/vi/lxhentai/LxHentaiUrlActivity.kt
+++ b/src/vi/lxhentai/src/eu/kanade/tachiyomi/extension/vi/lxhentai/LxHentaiUrlActivity.kt
@@ -11,23 +11,17 @@ class LxHentaiUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val data = intent?.data
-        if (data != null && data.pathSegments != null && data.pathSegments.size > 1) {
-            val id = data.pathSegments[1]
-            val mainIntent = Intent("eu.kanade.tachiyomi.SEARCH")
-            mainIntent.putExtra("query", LxHentai.PREFIX_ID_SEARCH + id)
-            mainIntent.putExtra("filter", packageName)
-            mainIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("LxHentaiUrlActivity", "Activity not found: " + e.message)
-            } catch (e: Throwable) {
-                Log.e("LxHentaiUrlActivity", "Error: " + e.message)
-            }
-        } else {
-            Log.e("LxHentaiUrlActivity", "Unable to parse URI: $data")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("LxHentaiUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/vi/mimi/build.gradle
+++ b/src/vi/mimi/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MiMi'
     extClass = '.MiMi'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/vi/mimi/src/eu/kanade/tachiyomi/extension/vi/mimi/MiMi.kt
+++ b/src/vi/mimi/src/eu/kanade/tachiyomi/extension/vi/mimi/MiMi.kt
@@ -91,6 +91,15 @@ class MiMi : HttpSource() {
     // ============================== Search ======================================
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments[1]
+            return fetchSearchManga(page, "$PREFIX_ID_SEARCH$id", filters)
+        }
+
         val isIdSearch = query.startsWith(PREFIX_ID_SEARCH) ||
             (query.length >= 4 && query.toIntOrNull() != null)
 

--- a/src/vi/mimi/src/eu/kanade/tachiyomi/extension/vi/mimi/MiMiUrlActivity.kt
+++ b/src/vi/mimi/src/eu/kanade/tachiyomi/extension/vi/mimi/MiMiUrlActivity.kt
@@ -11,23 +11,17 @@ class MiMiUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val data = intent.data
-        if (data != null && data.pathSegments.size > 1) {
-            val id = data.pathSegments[1]
-            val mainIntent = Intent("eu.kanade.tachiyomi.SEARCH")
-            mainIntent.putExtra("query", MiMi.PREFIX_ID_SEARCH + id)
-            mainIntent.putExtra("filter", packageName)
-            mainIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("MiMiUrlActivity", "Activity not found: " + e.message)
-            } catch (e: Throwable) {
-                Log.e("MiMiUrlActivity", "Unexpected throwable: " + e.message)
-            }
-        } else {
-            Log.e("MiMiUrlActivity", "Unable to parse URI: $data")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("MiMiUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/zh/baozimanhua/build.gradle
+++ b/src/zh/baozimanhua/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Baozi Manhua'
     extClass = '.Baozi'
-    extVersionCode = 26
+    extVersionCode = 27
     isNsfw = false
 }
 

--- a/src/zh/baozimanhua/src/eu/kanade/tachiyomi/extension/zh/baozimanhua/Baozi.kt
+++ b/src/zh/baozimanhua/src/eu/kanade/tachiyomi/extension/zh/baozimanhua/Baozi.kt
@@ -182,13 +182,27 @@ class Baozi :
 
     override fun imageUrlParse(response: Response) = throw UnsupportedOperationException()
 
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (query.startsWith(ID_SEARCH_PREFIX)) {
-        val id = query.removePrefix(ID_SEARCH_PREFIX)
-        client.newCall(searchMangaByIdRequest(id))
-            .asObservableSuccess()
-            .map { response -> searchMangaByIdParse(response, id) }
-    } else {
-        super.fetchSearchManga(page, query, filters)
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host !in MIRRORS) {
+                throw Exception("Unsupported url")
+            }
+            val id = if (url.pathSegments[1] == "chapter") {
+                url.pathSegments[2]
+            } else {
+                url.pathSegments[1]
+            }
+            return fetchSearchManga(page, "$ID_SEARCH_PREFIX$id", filters)
+        }
+        return if (query.startsWith(ID_SEARCH_PREFIX)) {
+            val id = query.removePrefix(ID_SEARCH_PREFIX)
+            client.newCall(searchMangaByIdRequest(id))
+                .asObservableSuccess()
+                .map { response -> searchMangaByIdParse(response, id) }
+        } else {
+            super.fetchSearchManga(page, query, filters)
+        }
     }
 
     private fun searchMangaByIdRequest(id: String) = GET("$baseUrl/comic/$id", headers)

--- a/src/zh/baozimanhua/src/eu/kanade/tachiyomi/extension/zh/baozimanhua/UrlActivity.kt
+++ b/src/zh/baozimanhua/src/eu/kanade/tachiyomi/extension/zh/baozimanhua/UrlActivity.kt
@@ -10,26 +10,17 @@ import kotlin.system.exitProcess
 class UrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val id = if (pathSegments[1].equals("chapter")) {
-                pathSegments[2]
-            } else {
-                pathSegments[1]
-            }
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${Baozi.ID_SEARCH_PREFIX}$id")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("UrlActivity", e.toString())
-            }
-        } else {
-            Log.e("UrlActivity", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("UrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/zh/jinmantiantang/build.gradle
+++ b/src/zh/jinmantiantang/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Jinman Tiantang'
     extClass = '.Jinmantiantang'
-    extVersionCode = 55
+    extVersionCode = 56
     isNsfw = true
 }
 

--- a/src/zh/jinmantiantang/src/eu/kanade/tachiyomi/extension/zh/jinmantiantang/Jinmantiantang.kt
+++ b/src/zh/jinmantiantang/src/eu/kanade/tachiyomi/extension/zh/jinmantiantang/Jinmantiantang.kt
@@ -110,13 +110,23 @@ class Jinmantiantang :
         return MangasPage(listOf(sManga), false)
     }
 
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (query.startsWith(PREFIX_ID_SEARCH_NO_COLON, true) || query.toIntOrNull() != null) {
-        val id = query.removePrefix(PREFIX_ID_SEARCH_NO_COLON).removePrefix(":")
-        client.newCall(searchMangaByIdRequest(id))
-            .asObservableSuccess()
-            .map { response -> searchMangaByIdParse(response, id) }
-    } else {
-        super.fetchSearchManga(page, query, filters)
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val titleid = url.pathSegments[1]
+            return fetchSearchManga(page, "$PREFIX_ID_SEARCH$titleid", filters)
+        }
+        return if (query.startsWith(PREFIX_ID_SEARCH_NO_COLON, true) || query.toIntOrNull() != null) {
+            val id = query.removePrefix(PREFIX_ID_SEARCH_NO_COLON).removePrefix(":")
+            client.newCall(searchMangaByIdRequest(id))
+                .asObservableSuccess()
+                .map { response -> searchMangaByIdParse(response, id) }
+        } else {
+            super.fetchSearchManga(page, query, filters)
+        }
     }
 
     // 查询信息

--- a/src/zh/jinmantiantang/src/eu/kanade/tachiyomi/extension/zh/jinmantiantang/UrlActivity.kt
+++ b/src/zh/jinmantiantang/src/eu/kanade/tachiyomi/extension/zh/jinmantiantang/UrlActivity.kt
@@ -17,22 +17,17 @@ class UrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val titleid = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${Jinmantiantang.PREFIX_ID_SEARCH}$titleid")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("JinmantiantangUrl", e.toString())
-            }
-        } else {
-            Log.e("JinmantiantangUrl", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("JinmantiantangUrl", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/zh/komiic/build.gradle
+++ b/src/zh/komiic/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Komiic'
     extClass = '.Komiic'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = true
 }
 

--- a/src/zh/komiic/src/eu/kanade/tachiyomi/extension/zh/komiic/Komiic.kt
+++ b/src/zh/komiic/src/eu/kanade/tachiyomi/extension/zh/komiic/Komiic.kt
@@ -5,16 +5,19 @@ import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.Response
+import rx.Observable
 import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -87,6 +90,18 @@ class Komiic :
     // Search Manga ================================================================================
 
     override fun getFilterList() = buildFilterList()
+
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments[1]
+            return fetchSearchManga(page, "$PREFIX_ID_SEARCH$id", filters)
+        }
+        return super.fetchSearchManga(page, query, filters)
+    }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request = if (query.startsWith(PREFIX_ID_SEARCH)) {
         idsQuery(query.removePrefix(PREFIX_ID_SEARCH)).request()

--- a/src/zh/komiic/src/eu/kanade/tachiyomi/extension/zh/komiic/UrlActivity.kt
+++ b/src/zh/komiic/src/eu/kanade/tachiyomi/extension/zh/komiic/UrlActivity.kt
@@ -12,22 +12,17 @@ const val PREFIX_ID_SEARCH = "id:"
 class UrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val id = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "$PREFIX_ID_SEARCH$id")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("KomiicUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("KomiicUrlActivity", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("KomiicUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/zh/kuaikanmanhua/build.gradle
+++ b/src/zh/kuaikanmanhua/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Kuaikanmanhua'
     extClass = '.Kuaikanmanhua'
-    extVersionCode = 11
+    extVersionCode = 12
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/zh/kuaikanmanhua/src/eu/kanade/tachiyomi/extension/zh/kuaikanmanhua/Kuaikanmanhua.kt
+++ b/src/zh/kuaikanmanhua/src/eu/kanade/tachiyomi/extension/zh/kuaikanmanhua/Kuaikanmanhua.kt
@@ -12,6 +12,7 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.parseAs
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -92,6 +93,15 @@ class Kuaikanmanhua : HttpSource() {
     // Search
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            val id = when (url.host) {
+                "m.kuaikanmanhua.com" -> url.pathSegments[1]
+                "www.kuaikanmanhua.com" -> url.pathSegments[2]
+                else -> throw Exception("Unsupported url")
+            }
+            return fetchSearchManga(page, "$TOPIC_ID_SEARCH_PREFIX$id", filters)
+        }
         if (query.startsWith(TOPIC_ID_SEARCH_PREFIX)) {
             val newQuery = query.removePrefix(TOPIC_ID_SEARCH_PREFIX)
             return client.newCall(GET("$apiUrl/v1/topics/$newQuery"))

--- a/src/zh/kuaikanmanhua/src/eu/kanade/tachiyomi/extension/zh/kuaikanmanhua/KuaikanmanhuaUrlActivity.kt
+++ b/src/zh/kuaikanmanhua/src/eu/kanade/tachiyomi/extension/zh/kuaikanmanhua/KuaikanmanhuaUrlActivity.kt
@@ -10,26 +10,17 @@ import kotlin.system.exitProcess
 class KuaikanmanhuaUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val host = intent?.data?.host
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val id = when (host) {
-                "m.kuaikanmanhua.com" -> pathSegments[1]
-                else -> pathSegments[2]
-            }
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${Kuaikanmanhua.TOPIC_ID_SEARCH_PREFIX}$id")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("KkmhUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("KkmhUrlActivity", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("KkmhUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/zh/mangabz/build.gradle
+++ b/src/zh/mangabz/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Mangabz'
     extClass = '.Mangabz'
-    extVersionCode = 12
+    extVersionCode = 13
     isNsfw = false
 }
 

--- a/src/zh/mangabz/src/eu/kanade/tachiyomi/extension/zh/mangabz/Mangabz.kt
+++ b/src/zh/mangabz/src/eu/kanade/tachiyomi/extension/zh/mangabz/Mangabz.kt
@@ -66,6 +66,14 @@ class Mangabz :
     }
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (MIRRORS.none { it.domain == url.host }) {
+                throw Exception("Unsupported url")
+            }
+            val titleId = url.pathSegments[0]
+            return fetchSearchManga(page, "$PREFIX_ID_SEARCH$titleId", filters)
+        }
         if (query.isEmpty()) {
             val ids = parseFilterList(filters)
             if (ids.isEmpty()) return fetchPopularManga(page)

--- a/src/zh/mangabz/src/eu/kanade/tachiyomi/extension/zh/mangabz/MangabzUrlActivity.kt
+++ b/src/zh/mangabz/src/eu/kanade/tachiyomi/extension/zh/mangabz/MangabzUrlActivity.kt
@@ -17,23 +17,17 @@ class MangabzUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 0) {
-            val titleId = pathSegments[0]
 
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${Mangabz.PREFIX_ID_SEARCH}$titleId")
-                putExtra("filter", packageName)
-            }
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("MangabzUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("MangabzUrlActivity", "could not parse uri from intent $intent")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("MangabzUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/zh/manhuagui/build.gradle
+++ b/src/zh/manhuagui/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ManHuaGui'
     extClass = '.Manhuagui'
-    extVersionCode = 26
+    extVersionCode = 27
     isNsfw = true
 }
 

--- a/src/zh/manhuagui/src/eu/kanade/tachiyomi/extension/zh/manhuagui/Manhuagui.kt
+++ b/src/zh/manhuagui/src/eu/kanade/tachiyomi/extension/zh/manhuagui/Manhuagui.kt
@@ -265,13 +265,23 @@ class Manhuagui(
         return MangasPage(listOf(sManga), false)
     }
 
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (query.startsWith(PREFIX_ID_SEARCH)) {
-        val id = query.removePrefix(PREFIX_ID_SEARCH)
-        client.newCall(searchMangaByIdRequest(id))
-            .asObservableSuccess()
-            .map { response -> searchMangaByIdParse(response, id) }
-    } else {
-        super.fetchSearchManga(page, query, filters)
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (!url.host.endsWith("manhuagui.com") && !url.host.endsWith("mhgui.com")) {
+                throw Exception("Unsupported url")
+            }
+            val titleid = url.pathSegments[1]
+            return fetchSearchManga(page, "$PREFIX_ID_SEARCH$titleid", filters)
+        }
+        return if (query.startsWith(PREFIX_ID_SEARCH)) {
+            val id = query.removePrefix(PREFIX_ID_SEARCH)
+            client.newCall(searchMangaByIdRequest(id))
+                .asObservableSuccess()
+                .map { response -> searchMangaByIdParse(response, id) }
+        } else {
+            super.fetchSearchManga(page, query, filters)
+        }
     }
 
     override fun chapterListParse(response: Response): List<SChapter> {

--- a/src/zh/manhuagui/src/eu/kanade/tachiyomi/extension/zh/manhuagui/UrlActivity.kt
+++ b/src/zh/manhuagui/src/eu/kanade/tachiyomi/extension/zh/manhuagui/UrlActivity.kt
@@ -17,22 +17,17 @@ class UrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val titleid = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${Manhuagui.PREFIX_ID_SEARCH}$titleid")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("UrlActivity", e.toString())
-            }
-        } else {
-            Log.e("UrlActivity", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("UrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/zh/tencentcomics/build.gradle
+++ b/src/zh/tencentcomics/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Tencent Comics (ac.qq.com)'
     extClass = '.TencentComics'
-    extVersionCode = 9
+    extVersionCode = 10
     isNsfw = true
 }
 

--- a/src/zh/tencentcomics/src/eu/kanade/tachiyomi/extension/zh/tencentcomics/TencentComics.kt
+++ b/src/zh/tencentcomics/src/eu/kanade/tachiyomi/extension/zh/tencentcomics/TencentComics.kt
@@ -13,6 +13,7 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.parseAs
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -121,13 +122,23 @@ class TencentComics : HttpSource() {
 
     override fun imageUrlParse(response: Response) = throw UnsupportedOperationException()
 
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = if (query.startsWith(ID_SEARCH_PREFIX)) {
-        val id = query.removePrefix(ID_SEARCH_PREFIX)
-        client.newCall(searchMangaByIdRequest(id))
-            .asObservableSuccess()
-            .map { response -> searchMangaByIdParse(response, id) }
-    } else {
-        super.fetchSearchManga(page, query, filters)
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments[3]
+            return fetchSearchManga(page, "$ID_SEARCH_PREFIX$id", filters)
+        }
+        return if (query.startsWith(ID_SEARCH_PREFIX)) {
+            val id = query.removePrefix(ID_SEARCH_PREFIX)
+            client.newCall(searchMangaByIdRequest(id))
+                .asObservableSuccess()
+                .map { response -> searchMangaByIdParse(response, id) }
+        } else {
+            super.fetchSearchManga(page, query, filters)
+        }
     }
 
     private fun searchMangaByIdRequest(id: String) = GET("$baseUrl/comic/index/id/$id", headers)

--- a/src/zh/tencentcomics/src/eu/kanade/tachiyomi/extension/zh/tencentcomics/UrlActivity.kt
+++ b/src/zh/tencentcomics/src/eu/kanade/tachiyomi/extension/zh/tencentcomics/UrlActivity.kt
@@ -10,22 +10,17 @@ import kotlin.system.exitProcess
 class UrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 3) {
-            val id = pathSegments[3]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${TencentComics.ID_SEARCH_PREFIX}$id")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("TencentUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("TencentUrlActivity", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.SEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("TencentUrlActivity", "Unable to launch activity", e)
         }
 
         finish()


### PR DESCRIPTION
- Moved url parsing / slug extraction logic to `fetchSearchMang`
- Removed all parsing from Activities
- bonus: allows users to paste manga url in browse
- Ai assisted

Doing this now to eventually have the urlactivity and manifest deeplinks be generated via gradle

Don't know if I should bump all of these sources together...

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
