### PR TITLE
Fix Comix "open in browser" URLs

### DIFF
--- a/src/en/comix/build.gradle
+++ b/src/en/comix/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comix'
     extClass = '.Comix'
-    extVersionCode = 14
+    extVersionCode = 15
     isNsfw = true
 }
 

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
@@ -32,6 +32,7 @@ class Comix :
     override val supportsLatest = true
 
     private val preferences: SharedPreferences by getPreferencesLazy()
+    private val mangaSlugCache = mutableMapOf<String, String>()
 
     override val client = network.cloudflareClient.newBuilder()
         .rateLimit(5)
@@ -161,10 +162,13 @@ class Comix :
         )
     }
 
-    override fun getMangaUrl(manga: SManga): String = "$baseUrl/title${manga.url}"
+    override fun getMangaUrl(manga: SManga): String {
+        val mangaSlug = manga.url.removePrefix("/").toFullMangaSlug()
+        return "$baseUrl/title/$mangaSlug"
+    }
 
     // ============================= Chapters ==============================
-    override fun getChapterUrl(chapter: SChapter) = "$baseUrl/${chapter.url}"
+    override fun getChapterUrl(chapter: SChapter): String = "$baseUrl/${chapter.toFullChapterUrl()}"
 
     override fun chapterListRequest(manga: SManga): Request {
         val hid = manga.url.removePrefix("/").substringBefore("-")
@@ -288,6 +292,43 @@ class Comix :
 
         return result.pages.mapIndexed { index, img ->
             Page(index, imageUrl = img.url)
+        }
+    }
+
+    private fun SChapter.toFullChapterUrl(): String {
+        val chapterUrl = url.removePrefix("/")
+        val segments = chapterUrl.split("/")
+        if (segments.size != 3 || segments[0] != "title" || "-" in segments[1]) return chapterUrl
+
+        val mangaSlug = segments[1].toFullMangaSlug()
+        val chapterSlug = segments[2].toFullChapterSlug(chapter_number)
+        return "title/$mangaSlug/$chapterSlug"
+    }
+
+    private fun String.toFullChapterSlug(chapterNumber: Float): String {
+        if ("-" in this) return this
+
+        val number = when {
+            chapterNumber % 1 == 0f -> chapterNumber.toInt().toString()
+            else -> chapterNumber.toString()
+        }
+        return "$this-chapter-$number"
+    }
+
+    private fun String.toFullMangaSlug(): String {
+        if ("-" in this) return this
+
+        return mangaSlugCache.getOrPut(this) {
+            val url = apiUrl.toHttpUrl().newBuilder()
+                .addPathSegment("manga")
+                .addPathSegment(this)
+                .build()
+
+            client.newCall(GET(url, headers))
+                .execute()
+                .parseAs<SingleMangaResponse>()
+                .result
+                .slug
         }
     }
 

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Dto.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Dto.kt
@@ -38,6 +38,12 @@ class Manga(
     private val ratedAvg: Double = 0.0,
     private val url: String? = null,
 ) {
+    val slug: String
+        get() = url
+            ?.substringAfter("/title/", missingDelimiterValue = "")
+            ?.takeIf(String::isNotBlank)
+            ?: hid
+
     @Serializable
     class Poster(
         private val small: String? = null,


### PR DESCRIPTION
Fixes Comix “Open in browser” for manga/chapter entries saved with the old hash-only URL format.

Older library entries can store URLs like /ylrd1, so opening a chapter could produce an invalid browser URL such as:
`https://comix.to/title/ylrd1/8177513-chapter-9`

This resolves the full manga slug from the API first, producing the correct browser URL:
`https://comix.to/title/ylrd1-how-can-i-escape-from-this-knights-crazy-love/8177513-chapter-9`

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [X] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
