### PR TITLE
MangaCloud (EN): update headers and chapter endpoint

### DIFF
--- a/src/en/mangacloud/build.gradle
+++ b/src/en/mangacloud/build.gradle
@@ -1,7 +1,7 @@
 ext {
 	extName = 'MangaCloud'
 	extClass = '.MangaCloud'
-	extVersionCode = 3
+	extVersionCode = 4
 	isNsfw = false
 }
 

--- a/src/en/mangacloud/src/eu/kanade/tachiyomi/extension/en/mangacloud/MangaCloud.kt
+++ b/src/en/mangacloud/src/eu/kanade/tachiyomi/extension/en/mangacloud/MangaCloud.kt
@@ -47,7 +47,6 @@ class MangaCloud : HttpSource() {
 
     override fun headersBuilder() = super.headersBuilder()
         .set("Referer", "$baseUrl/")
-        .set("Key", generateKey())
 
     override fun popularMangaRequest(page: Int): Request {
         return if (page > 3) {
@@ -59,7 +58,7 @@ class MangaCloud : HttpSource() {
                 else -> "month"
             }
 
-            return GET("$API_URL/comic-popular-view/$time", headersBuilder().build())
+            return GET("$API_URL/comic-popular-view/$time", headers)
         }
     }
 
@@ -79,7 +78,7 @@ class MangaCloud : HttpSource() {
             .toJsonString()
             .toRequestBody(jsonMediaType)
 
-        return POST(url, headersBuilder().build(), payload)
+        return POST(url, headers, payload)
     }
 
     override fun latestUpdatesParse(response: Response): MangasPage {
@@ -120,7 +119,7 @@ class MangaCloud : HttpSource() {
     private fun fetchOnlineTags(tagsFile: File) {
         if (!fetchingOnlineTags.compareAndSet(false, true)) return
 
-        val request = GET("$API_URL/tag/list", headersBuilder().build())
+        val request = GET("$API_URL/tag/list", headers)
 
         client.newCall(request).enqueue(
             object : Callback {
@@ -206,7 +205,7 @@ class MangaCloud : HttpSource() {
             .toJsonString()
             .toRequestBody(jsonMediaType)
 
-        return POST(url, headersBuilder().build(), payload)
+        return POST(url, headers, payload)
     }
 
     override fun searchMangaParse(response: Response): MangasPage {
@@ -240,7 +239,7 @@ class MangaCloud : HttpSource() {
 
     override fun mangaDetailsRequest(manga: SManga) = mangaDetailsRequest(manga.url)
 
-    private fun mangaDetailsRequest(comicId: String) = GET("$API_URL/comic/$comicId", headersBuilder().build())
+    private fun mangaDetailsRequest(comicId: String) = GET("$API_URL/comic/$comicId", headers)
 
     override fun getMangaUrl(manga: SManga): String = "$baseUrl/comic/${manga.url}"
 
@@ -271,7 +270,7 @@ class MangaCloud : HttpSource() {
     override fun pageListRequest(chapter: SChapter): Request {
         val chapterId = chapter.url.parseAs<ChapterUrl>().chapterId
 
-        return GET("$API_URL/chapter/$chapterId", headersBuilder().build())
+        return GET("$API_URL/chapters/$chapterId", headers)
     }
 
     override fun getChapterUrl(chapter: SChapter): String {


### PR DESCRIPTION
Closes #15645

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
