### PR TITLE
Refactor domain handling in ProChan class

### DIFF
--- a/src/ar/mangapro/src/eu/kanade/tachiyomi/extension/ar/mangapro/ProChan.kt
+++ b/src/ar/mangapro/src/eu/kanade/tachiyomi/extension/ar/mangapro/ProChan.kt
@@ -53,11 +53,27 @@ import kotlin.io.encoding.Base64
 class ProChan : HttpSource() {
     override val name = "ProChan"
     override val lang = "ar"
-    private val domain = "prochan.net"
-    override val baseUrl = "https://$domain"
+    import uy.kohesive.injekt.Injekt
+import android.app.Application
+import android.content.SharedPreferences
+
+private val prefs: SharedPreferences by lazy {
+    Injekt.get<Application>()
+        .getSharedPreferences("procomic_prefs", 0)
+}
+    private val defaultDomain = "procomic.net"
+
+private var domain: String
+    get() = prefs.getString("domain", defaultDomain) ?: defaultDomain
+    set(value) = prefs.edit().putString("domain", value).apply()
+
+override val baseUrl: String
+    get() = "https://$domain"
     override val supportsLatest = true
     override val versionId = 5
-
+fun setCustomDomain(newDomain: String) {
+    domain = newDomain
+}
     override val client = network.cloudflareClient.newBuilder()
         .addInterceptor(::scrambledImageInterceptor)
         .addNetworkInterceptor(


### PR DESCRIPTION
Refactor ProChan class to use SharedPreferences for domain management and allow setting a custom domain.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
