### PR TITLE
Barmanga (ES): fix images

### DIFF
--- a/src/es/barmanga/build.gradle
+++ b/src/es/barmanga/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.BarManga'
     themePkg = 'madara'
     baseUrl = 'https://archiviumbar.com'
-    overrideVersionCode = 10
+    overrideVersionCode = 11
     isNsfw = true
 }
 

--- a/src/es/barmanga/src/eu/kanade/tachiyomi/extension/es/barmanga/BarManga.kt
+++ b/src/es/barmanga/src/eu/kanade/tachiyomi/extension/es/barmanga/BarManga.kt
@@ -55,6 +55,10 @@ class BarManga :
 
         val imageHeaders = headers.newBuilder()
             .set("Accept", "*/*")
+            .set("Origin", baseUrl)
+            .set("Sec-Fetch-Dest", "empty")
+            .set("Sec-Fetch-Mode", "cors")
+            .set("Sec-Fetch-Site", "same-origin")
             .set("X-Requested-With", "XMLHttpRequest")
             .set("Referer", page.url)
             .build()


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop


Fix wrong images being served by adding required Sec-Fetch-* headers to image requests.
The site's anti-scraping plugin validates Sec-Fetch-Dest, Sec-Fetch-Mode, and Sec-Fetch-Site headers on the admin-ajax.php image endpoint. Without them, the server returns a decoy image instead of the real chapter page.