### PR TITLE
Mangahub: add preferences to change domain

### DIFF
--- a/src/ru/mangahub/build.gradle
+++ b/src/ru/mangahub/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Mangahub'
     extClass = '.Mangahub'
-    extVersionCode = 21
+    extVersionCode = 22
     isNsfw = true
 }
 

--- a/src/ru/mangahub/src/eu/kanade/tachiyomi/extension/ru/mangahub/Mangahub.kt
+++ b/src/ru/mangahub/src/eu/kanade/tachiyomi/extension/ru/mangahub/Mangahub.kt
@@ -35,7 +35,16 @@ class Mangahub :
 
     override val supportsLatest = true
 
-    private val preferences by getPreferencesLazy()
+    private val preferences by getPreferencesLazy {
+        getString(DOMAIN_OVERRIDE, null).let { prefDefaultBaseUrl ->
+            if (prefDefaultBaseUrl != DOMAIN_DEFAULT) {
+                edit()
+                    .putString(DOMAIN_PREF, DOMAIN_DEFAULT)
+                    .putString(DOMAIN_OVERRIDE, DOMAIN_DEFAULT)
+                    .apply()
+            }
+        }
+    }
 
     override val baseUrl = preferences.getString(DOMAIN_PREF, DOMAIN_DEFAULT)!!
 
@@ -205,7 +214,8 @@ class Mangahub :
             SimpleDateFormat("dd.MM.yyyy", Locale.US)
         }
         private const val DOMAIN_DEFAULT = "https://mangahub.ru"
-        private const val DOMAIN_PREF = "DOMAIN_PREF"
+        private const val DOMAIN_PREF = "defaultBaseUrl"
+        private const val DOMAIN_OVERRIDE = "overrideBaseUrl"
         private const val DOMAIN_RESTART_MESSAGE = "Для смены домена необходимо перезапустить приложение с полной остановкой."
         private const val DOMAIN_MISMATCH_1 = "Домен должен начинаться с https:// или http://."
         private const val DOMAIN_MISMATCH_2 = "Домен не должен заканчиваться символом /."

--- a/src/ru/mangahub/src/eu/kanade/tachiyomi/extension/ru/mangahub/Mangahub.kt
+++ b/src/ru/mangahub/src/eu/kanade/tachiyomi/extension/ru/mangahub/Mangahub.kt
@@ -35,12 +35,7 @@ class Mangahub :
 
     override val supportsLatest = true
 
-    private val preferences by getPreferencesLazy {
-        val domain = this.getString(DOMAIN_PREF, DOMAIN_DEFAULT)
-        if (domain == null || !domain.matches(URL_REGEX) || domain.endsWith("/")) {
-            this.edit().putString(DOMAIN_PREF, DOMAIN_DEFAULT).apply()
-        }
-    }
+    private val preferences by getPreferencesLazy()
 
     override val baseUrl = preferences.getString(DOMAIN_PREF, DOMAIN_DEFAULT)!!
 

--- a/src/ru/mangahub/src/eu/kanade/tachiyomi/extension/ru/mangahub/Mangahub.kt
+++ b/src/ru/mangahub/src/eu/kanade/tachiyomi/extension/ru/mangahub/Mangahub.kt
@@ -1,7 +1,11 @@
 package eu.kanade.tachiyomi.extension.ru.mangahub
 
+import android.widget.Toast
+import androidx.preference.EditTextPreference
+import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
@@ -9,6 +13,7 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.tryParse
 import okhttp3.FormBody
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -20,15 +25,24 @@ import org.jsoup.Jsoup
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class Mangahub : HttpSource() {
+class Mangahub :
+    HttpSource(),
+    ConfigurableSource {
 
     override val name = "Mangahub"
-
-    override val baseUrl = "https://mangahub.ru"
 
     override val lang = "ru"
 
     override val supportsLatest = true
+
+    private val preferences by getPreferencesLazy {
+        val domain = this.getString(DOMAIN_PREF, DOMAIN_DEFAULT)
+        if (domain == null || !domain.matches(URL_REGEX) || domain.endsWith("/")) {
+            this.edit().putString(DOMAIN_PREF, DOMAIN_DEFAULT).apply()
+        }
+    }
+
+    override val baseUrl = preferences.getString(DOMAIN_PREF, DOMAIN_DEFAULT)!!
 
     override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .addInterceptor(::confirmAgeInterceptor)
@@ -163,10 +177,38 @@ class Mangahub : HttpSource() {
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException("Not used.")
 
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        EditTextPreference(screen.context).apply {
+            key = DOMAIN_PREF
+            title = "Домен"
+            summary = "$baseUrl\n\nПо умолчанию: $DOMAIN_DEFAULT"
+            setDefaultValue(DOMAIN_DEFAULT)
+            setOnPreferenceChangeListener { _, newValue ->
+                if (!newValue.toString().matches(URL_REGEX)) {
+                    Toast.makeText(screen.context, DOMAIN_MISMATCH_1, Toast.LENGTH_LONG).show()
+                    return@setOnPreferenceChangeListener false
+                }
+                if (newValue.toString().endsWith("/")) {
+                    Toast.makeText(screen.context, DOMAIN_MISMATCH_2, Toast.LENGTH_LONG).show()
+                    return@setOnPreferenceChangeListener false
+                }
+                Toast.makeText(screen.context, DOMAIN_RESTART_MESSAGE, Toast.LENGTH_LONG).show()
+                this.summary = "$newValue\n\nПо умолчанию: $DOMAIN_DEFAULT"
+                true
+            }
+        }.let(screen::addPreference)
+    }
+
     companion object {
         private val chapterRegex = Regex("""(Глава\s)((\d|\.)+)""")
         private val dateFormat by lazy {
             SimpleDateFormat("dd.MM.yyyy", Locale.US)
         }
+        private const val DOMAIN_DEFAULT = "https://mangahub.ru"
+        private const val DOMAIN_PREF = "DOMAIN_PREF"
+        private const val DOMAIN_RESTART_MESSAGE = "Для смены домена необходимо перезапустить приложение с полной остановкой."
+        private const val DOMAIN_MISMATCH_1 = "Домен должен начинаться с https:// или http://."
+        private const val DOMAIN_MISMATCH_2 = "Домен не должен заканчиваться символом /."
+        private val URL_REGEX = Regex("^https?://.+")
     }
 }

--- a/src/ru/mangahub/src/eu/kanade/tachiyomi/extension/ru/mangahub/Mangahub.kt
+++ b/src/ru/mangahub/src/eu/kanade/tachiyomi/extension/ru/mangahub/Mangahub.kt
@@ -184,12 +184,17 @@ class Mangahub :
             summary = "$baseUrl\n\nПо умолчанию: $DOMAIN_DEFAULT"
             setDefaultValue(DOMAIN_DEFAULT)
             setOnPreferenceChangeListener { _, newValue ->
-                if (!newValue.toString().matches(URL_REGEX)) {
+                val url = newValue.toString()
+                if (!url.matches(URL_REGEX)) {
                     Toast.makeText(screen.context, DOMAIN_MISMATCH_1, Toast.LENGTH_LONG).show()
                     return@setOnPreferenceChangeListener false
                 }
-                if (newValue.toString().endsWith("/")) {
+                if (url.endsWith("/")) {
                     Toast.makeText(screen.context, DOMAIN_MISMATCH_2, Toast.LENGTH_LONG).show()
+                    return@setOnPreferenceChangeListener false
+                }
+                if (url.length !in 12..255) {
+                    Toast.makeText(screen.context, DOMAIN_MISMATCH_3, Toast.LENGTH_LONG).show()
                     return@setOnPreferenceChangeListener false
                 }
                 Toast.makeText(screen.context, DOMAIN_RESTART_MESSAGE, Toast.LENGTH_LONG).show()
@@ -209,6 +214,7 @@ class Mangahub :
         private const val DOMAIN_RESTART_MESSAGE = "Для смены домена необходимо перезапустить приложение с полной остановкой."
         private const val DOMAIN_MISMATCH_1 = "Домен должен начинаться с https:// или http://."
         private const val DOMAIN_MISMATCH_2 = "Домен не должен заканчиваться символом /."
+        private const val DOMAIN_MISMATCH_3 = "Домен не может быть меньше 12 символов. И не больше 255."
         private val URL_REGEX = Regex("^https?://.+")
     }
 }


### PR DESCRIPTION
Checklist:

Closes #8954
In issue request were to add https://v2.mangahub.one/ as a mirror, but as i checked current mirror already https://v4.mangahub.one/ so option to set your own domain looked more appropriate

Also: Closes #11853 - issue was about version 1.4.19 while current are already 1.4.21 and works fine. Probably fixed long time ago but weren't mentioned

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
