### PR TITLE
Comix: source-level Content preferences + tags-in-genre-chips toggle

### DIFF
--- a/src/en/comix/build.gradle
+++ b/src/en/comix/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comix'
     extClass = '.Comix'
-    extVersionCode = 15
+    extVersionCode = 16
     isNsfw = true
 }
 

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.extension.en.comix
 
 import android.content.SharedPreferences
 import androidx.preference.ListPreference
+import androidx.preference.MultiSelectListPreference
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.network.GET
@@ -35,7 +36,18 @@ class Comix :
     private val preferences: SharedPreferences by getPreferencesLazy()
 
     override val client = network.cloudflareClient.newBuilder()
-        .addInterceptor(WebViewProxyInterceptor)
+        .apply {
+            // Insert at position 0 so requests carrying PROXY_HEADER reach
+            // our interceptor BEFORE any other application interceptor.
+            // Critical for Komu (iOS): its `CallNativeHttpInterceptor`
+            // re-routes comix.to traffic through Foundation NSURLSession
+            // to match Safari's TLS fingerprint and short-circuits the
+            // chain — adding our interceptor at the END would mean it
+            // never sees the request. Placing it first is harmless on
+            // Mihon Android too (no interceptor before us cares about
+            // PROXY_HEADER, and we always pass-through unsigned reqs).
+            interceptors().add(0, WebViewProxyInterceptor)
+        }
         .rateLimit(5)
         .build()
 
@@ -50,7 +62,7 @@ class Comix :
             addQueryParameter("order[score]", "desc")
             addQueryParameter("limit", "28")
             addQueryParameter("page", page.toString())
-            applyContentRatingPreference()
+            applyContentPreferences()
         }.build()
 
         return GET(url, headers)
@@ -65,7 +77,7 @@ class Comix :
             addQueryParameter("order[chapter_updated_at]", "desc")
             addQueryParameter("limit", "28")
             addQueryParameter("page", page.toString())
-            applyContentRatingPreference()
+            applyContentPreferences()
         }.build()
 
         return GET(url, headers)
@@ -108,17 +120,28 @@ class Comix :
             .build()
 
         val url = withFilters.newBuilder().apply {
-            // Manual content rating filter wins over the preference; otherwise
-            // fall back to the user's source-level setting.
+            // Manual filters in the search sheet override the corresponding
+            // source-level preference; otherwise fall back to the preference.
             if (withFilters.queryParameter("content_rating") == null) {
                 applyContentRatingPreference()
             }
+            if (withFilters.queryParameterValues("types[]").isEmpty()) {
+                applyTypesPreference()
+            }
+            if (withFilters.queryParameterValues("demographics[]").isEmpty()) {
+                applyDemographicsPreference()
+            }
+            // Blocked genres are ALWAYS applied (even alongside manual genre
+            // include/exclude) — the helper itself skips any genre the user
+            // explicitly INCLUDED in the search filter, so a one-off lookup
+            // for a normally-blocked genre still works.
+            applyBlockedGenresPreference()
 
-            // The Match filter contributes `genres_mode`. If the user never
-            // touched it but selected Genres/Formats/Tags, drop the parameter
-            // so the site can pick its own default.
-            val hasTermSelection = withFilters.queryParameterValues("genres_in[]").isNotEmpty() ||
-                withFilters.queryParameterValues("genres_ex[]").isNotEmpty()
+            // The Match filter contributes `genres_mode`. If neither the
+            // search filter nor the blocked-genres preference put any term
+            // on the URL, drop the param so the site picks its own default.
+            val hasTermSelection = build().queryParameterValues("genres_in[]").isNotEmpty() ||
+                build().queryParameterValues("genres_ex[]").isNotEmpty()
             if (!hasTermSelection) {
                 removeAllQueryParameters("genres_mode")
             }
@@ -137,10 +160,63 @@ class Comix :
         return GET(url, headers)
     }
 
+    /**
+     * Apply every content-related source-level preference (rating, types,
+     * demographics, blocked genres) in one go. Used by popular/latest
+     * where there's no search filter sheet to override anything.
+     * `searchMangaRequest` calls each helper individually so the search
+     * filter can short-circuit per-field.
+     */
+    private fun HttpUrl.Builder.applyContentPreferences() {
+        applyContentRatingPreference()
+        applyTypesPreference()
+        applyDemographicsPreference()
+        applyBlockedGenresPreference()
+    }
+
     private fun HttpUrl.Builder.applyContentRatingPreference() {
         preferences.contentRating().takeIf { it.isNotEmpty() }?.let {
             addQueryParameter("content_rating", it)
         }
+    }
+
+    /**
+     * Apply the source-level Default Types preference. The site treats no
+     * `types[]` param as "show all", so we omit the filter when the user
+     * has every type selected (the only state that would be a no-op
+     * otherwise). An empty selection — meaning the user explicitly
+     * unchecked everything — would hide every result; treat that as
+     * "no preference" and skip too, since the alternative is a confusing
+     * empty browse.
+     */
+    private fun HttpUrl.Builder.applyTypesPreference() {
+        val selected = preferences.defaultTypes()
+        val all = Filters.getTypes().map { it.second }.toSet()
+        if (selected.isEmpty() || selected == all) return
+        selected.forEach { addQueryParameter("types[]", it) }
+    }
+
+    /** Same shape as [applyTypesPreference] for Demographics. */
+    private fun HttpUrl.Builder.applyDemographicsPreference() {
+        val selected = preferences.defaultDemographics()
+        val all = Filters.getDemographics().map { it.second }.toSet()
+        if (selected.isEmpty() || selected == all) return
+        selected.forEach { addQueryParameter("demographics[]", it) }
+    }
+
+    /**
+     * Add a `genres_ex[]` for every genre the user listed in their Blocked
+     * Genres preference, except those the search filter explicitly
+     * INCLUDED (so a manual search for a normally-blocked genre still
+     * works as a one-off escape hatch).
+     */
+    private fun HttpUrl.Builder.applyBlockedGenresPreference() {
+        val blocked = preferences.blockedGenres()
+        if (blocked.isEmpty()) return
+        val explicitlyIncluded = build().queryParameterValues("genres_in[]").toSet()
+        blocked.asSequence()
+            .filter { it !in explicitlyIncluded }
+            .forEach { addQueryParameter("genres_ex[]", it) }
     }
 
     /**
@@ -209,6 +285,7 @@ class Comix :
             preferences.alternativeNamesInDescription(),
             preferences.scorePosition(),
             preferences.showExtraInfo(),
+            preferences.showTagsInGenres(),
         )
     }
 
@@ -370,6 +447,47 @@ class Comix :
             setDefaultValue(DEFAULT_CONTENT_RATING)
         }.let(screen::addPreference)
 
+        // Content preferences (mirrors comix.to's "Content preferences" modal):
+        //   - Default Types       — checkbox per type, all checked by default
+        //   - Default Demographics — same, all checked by default
+        //   - Blocked Genres      — opt-in list of genres to always exclude
+        //
+        // The first two omit the corresponding query param when ALL are checked
+        // (= "no filter"). Any narrower selection sends `types[]` /
+        // `demographics[]`. The Blocked Genres set adds `genres_ex[]` for each
+        // entry. All three are overridable per-search via the existing filter
+        // sheet, except blocked genres which always apply unless the search
+        // filter explicitly INCLUDED the same genre.
+        MultiSelectListPreference(screen.context).apply {
+            key = PREF_DEFAULT_TYPES
+            title = "Default types"
+            summary = "Types to include in popular, latest, and search results. " +
+                "The Type filter in search overrides this."
+            entries = Filters.getTypes().map { it.first }.toTypedArray()
+            entryValues = Filters.getTypes().map { it.second }.toTypedArray()
+            setDefaultValue(Filters.getTypes().map { it.second }.toSet())
+        }.let(screen::addPreference)
+
+        MultiSelectListPreference(screen.context).apply {
+            key = PREF_DEFAULT_DEMOGRAPHICS
+            title = "Default demographics"
+            summary = "Demographics to include in popular, latest, and search " +
+                "results. The Demographic filter in search overrides this."
+            entries = Filters.getDemographics().map { it.first }.toTypedArray()
+            entryValues = Filters.getDemographics().map { it.second }.toTypedArray()
+            setDefaultValue(Filters.getDemographics().map { it.second }.toSet())
+        }.let(screen::addPreference)
+
+        MultiSelectListPreference(screen.context).apply {
+            key = PREF_BLOCKED_GENRES
+            title = "Blocked genres"
+            summary = "Genres always excluded from results. The search filter " +
+                "can still include a blocked genre as a one-off override."
+            entries = Filters.getGenres().map { it.first }.toTypedArray()
+            entryValues = Filters.getGenres().map { it.second }.toTypedArray()
+            setDefaultValue(emptySet<String>())
+        }.let(screen::addPreference)
+
         SwitchPreferenceCompat(screen.context).apply {
             key = DEDUPLICATE_CHAPTERS
             title = "Deduplicate Chapters"
@@ -393,6 +511,16 @@ class Comix :
             setDefaultValue(true)
         }.let(screen::addPreference)
 
+        SwitchPreferenceCompat(screen.context).apply {
+            key = PREF_SHOW_TAGS_IN_GENRES
+            title = "Show tags in genre chips"
+            summary = "Include the site's narrative tag list (e.g. Demons, " +
+                "Vampires, Time Travel) alongside the curated genres in the " +
+                "manga details. Off by default — the curated set matches what " +
+                "comix.to itself shows on the page."
+            setDefaultValue(false)
+        }.let(screen::addPreference)
+
         ListPreference(screen.context).apply {
             key = PREF_SCORE_POSITION
             title = "Score display position"
@@ -413,6 +541,20 @@ class Comix :
 
     private fun SharedPreferences.showExtraInfo() = getBoolean(PREF_SHOW_EXTRA_INFO, true)
 
+    private fun SharedPreferences.showTagsInGenres() = getBoolean(PREF_SHOW_TAGS_IN_GENRES, false)
+
+    private fun SharedPreferences.defaultTypes(): Set<String> {
+        val all = Filters.getTypes().map { it.second }.toSet()
+        return getStringSet(PREF_DEFAULT_TYPES, all) ?: all
+    }
+
+    private fun SharedPreferences.defaultDemographics(): Set<String> {
+        val all = Filters.getDemographics().map { it.second }.toSet()
+        return getStringSet(PREF_DEFAULT_DEMOGRAPHICS, all) ?: all
+    }
+
+    private fun SharedPreferences.blockedGenres(): Set<String> = getStringSet(PREF_BLOCKED_GENRES, emptySet()) ?: emptySet()
+
     // The legacy "Hide NSFW" boolean still exists in some users' preferences;
     // map it to a sensible default until they pick a value explicitly.
     private fun SharedPreferences.contentRating(): String {
@@ -428,10 +570,14 @@ class Comix :
     companion object {
         private const val PREF_POSTER_QUALITY = "pref_poster_quality"
         private const val PREF_CONTENT_RATING = "pref_content_rating"
+        private const val PREF_DEFAULT_TYPES = "pref_default_types"
+        private const val PREF_DEFAULT_DEMOGRAPHICS = "pref_default_demographics"
+        private const val PREF_BLOCKED_GENRES = "pref_blocked_genres"
         private const val LEGACY_HIDE_NSFW_PREF = "nsfw_pref"
         private const val DEDUPLICATE_CHAPTERS = "pref_deduplicate_chapters"
         private const val ALTERNATIVE_NAMES_IN_DESCRIPTION = "pref_alt_names_in_description"
         private const val PREF_SHOW_EXTRA_INFO = "pref_show_extra_info"
+        private const val PREF_SHOW_TAGS_IN_GENRES = "pref_show_tags_in_genres"
         private const val PREF_SCORE_POSITION = "pref_score_position"
 
         private const val DEFAULT_CONTENT_RATING = "suggestive"

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Dto.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Dto.kt
@@ -90,6 +90,7 @@ class Manga(
         altTitlesInDesc: Boolean = false,
         scorePosition: String,
         showExtraInfo: Boolean = true,
+        showTags: Boolean = false,
     ) = SManga.create().apply {
         url = this@Manga.url?.substringAfter("/title") ?: "/$hid"
         title = this@Manga.title
@@ -140,7 +141,7 @@ class Manga(
             else -> SManga.UNKNOWN
         }
         thumbnail_url = this@Manga.poster?.from(posterQuality)
-        genre = getGenres()
+        genre = getGenres(showTags)
     }
 
     fun toBasicSManga(posterQuality: String?) = SManga.create().apply {
@@ -162,9 +163,11 @@ class Manga(
 
     // The site has separate `genres`, `tags`, `formats`, and `demographics`
     // groupings but only the curated `genres` (plus the type and demographics)
-    // belong in Mihon's "genre" chips. Including the long `tags` list flooded
-    // the UI with dozens of narrative tags that aren't shown on the site.
-    private fun getGenres() = buildList {
+    // belong in Mihon's "genre" chips by default — the `tags` list is dozens
+    // of narrative descriptors and the site doesn't surface them in its own
+    // detail layout. Users who want them back can flip the
+    // "Show tags in genre chips" preference.
+    private fun getGenres(showTags: Boolean) = buildList {
         when (type) {
             "manhwa" -> add("Manhwa")
             "manhua" -> add("Manhua")
@@ -173,6 +176,7 @@ class Manga(
         }
         (genres ?: genreOld)?.map { it.title }?.let { addAll(it) }
         (demographics ?: demographicOld)?.map { it.title }?.let { addAll(it) }
+        if (showTags) tags?.map { it.title }?.let { addAll(it) }
         if (contentRating == "erotica" || contentRating == "pornographic") add("NSFW")
     }.distinct().joinToString()
 }

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Filters.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Filters.kt
@@ -34,37 +34,41 @@ class Filters {
         // browse panel exactly). Narrative tags like "Aliens" or "School Life"
         // used to live here too, but they belong under Tags and are searched
         // by name rather than enumerated.
+        // Order mirrors the site's "Content preferences" modal (popularity-
+        // ranked, not alphabetical). Used by both the GenreFilter in the
+        // search sheet and the Blocked Genres source-level preference, so
+        // both surfaces are consistent with the website.
         fun getGenres() = arrayOf(
-            "Action" to "6",
-            "Adult" to "87264",
-            "Adventure" to "7",
-            "Boys Love" to "8",
-            "Comedy" to "9",
-            "Crime" to "10",
-            "Drama" to "11",
-            "Ecchi" to "87265",
-            "Fantasy" to "12",
-            "Girls Love" to "13",
-            "Hentai" to "87266",
-            "Historical" to "14",
-            "Horror" to "15",
-            "Isekai" to "16",
-            "Magical Girls" to "17",
-            "Mature" to "87267",
-            "Mecha" to "18",
-            "Medical" to "19",
-            "Mystery" to "20",
-            "Philosophical" to "21",
-            "Psychological" to "22",
             "Romance" to "23",
-            "Sci-Fi" to "24",
+            "Drama" to "11",
+            "Comedy" to "9",
+            "Fantasy" to "12",
             "Slice of Life" to "25",
+            "Action" to "6",
+            "Boys Love" to "8",
+            "Adventure" to "7",
+            "Adult" to "87264",
             "Smut" to "87268",
-            "Sports" to "26",
-            "Superhero" to "27",
-            "Thriller" to "28",
+            "Psychological" to "22",
+            "Mystery" to "20",
+            "Historical" to "14",
+            "Mature" to "87267",
             "Tragedy" to "29",
+            "Sci-Fi" to "24",
+            "Ecchi" to "87265",
+            "Horror" to "15",
+            "Girls Love" to "13",
+            "Isekai" to "16",
+            "Hentai" to "87266",
+            "Thriller" to "28",
+            "Sports" to "26",
+            "Crime" to "10",
+            "Philosophical" to "21",
+            "Mecha" to "18",
             "Wuxia" to "30",
+            "Medical" to "19",
+            "Superhero" to "27",
+            "Magical Girls" to "17",
         )
 
         // The 9 site formats (matches the Formats section in the browse panel).
@@ -80,11 +84,23 @@ class Filters {
             "Web Comic" to "93171",
         )
 
+        // Order mirrors the site's "Content preferences" modal:
+        // Shounen, Shoujo, Seinen, Josei. IDs are API-tied and unchanged.
         fun getDemographics() = arrayOf(
-            Pair("Shoujo", "1"),
             Pair("Shounen", "2"),
-            Pair("Josei", "3"),
+            Pair("Shoujo", "1"),
             Pair("Seinen", "4"),
+            Pair("Josei", "3"),
+        )
+
+        // Same set TypeFilter exposes in the search filter sheet — duplicated
+        // here as a public getter so source-level preferences (in Comix.kt)
+        // can present the identical pick list.
+        fun getTypes() = arrayOf(
+            Pair("Manga", "manga"),
+            Pair("Manhwa", "manhwa"),
+            Pair("Manhua", "manhua"),
+            Pair("Other", "other"),
         )
     }
 
@@ -184,12 +200,7 @@ class Filters {
         UriMultiSelectFilter(
             "Type",
             "types[]",
-            arrayOf(
-                Pair("Manga", "manga"),
-                Pair("Manhwa", "manhwa"),
-                Pair("Manhua", "manhua"),
-                Pair("Other", "other"),
-            ),
+            getTypes(),
         )
 
     // Genres, Formats, and Tags all share the same `genres_in[]` /


### PR DESCRIPTION
Closes #15722.
Closes #14450.

Two additions in Source Settings, mirroring comix.to's own "Content preferences" modal (Site → ⚙ Settings → Content preferences):

## Content preferences (site-modal parity)

Three new `MultiSelectListPreference` entries:

- **Default types** — Manga / Manhwa / Manhua / Other
- **Default demographics** — Shounen / Shoujo / Seinen / Josei
- **Blocked genres** — opt-in list of genres to always exclude

Applied to popular, latest, and search via the same per-field override pattern as the existing Content rating preference: a manual selection in the search filter sheet wins; otherwise the preference fills in. Blocked genres always apply (additive `genres_ex[]`), with a one-off escape hatch — any genre the user explicitly INCLUDED in the search filter is skipped, so a manual lookup for a normally-blocked genre still works.

## Tags in genre chips

A `Show tags in genre chips` switch (off by default) brings back the site's narrative tag list (Demons, Vampires, Time Travel, etc.) in Manga Details. The previous PR (#15696) trimmed those out to match what `comix.to` itself shows on its page; this preference makes that behaviour opt-in for users who wanted them back.

## Filters.kt rework

- `getDemographics()` reordered to **Shounen / Shoujo / Seinen / Josei** (site order; IDs unchanged).
- `getGenres()` reordered to the site's **"Content preferences" popularity ranking** (Romance first, Magical Girls last) so both the search filter sheet and the Blocked Genres preference render in the same order as the website.
- `getTypes()` extracted to a public companion getter so both `TypeFilter` and the new preference draw from a single source of truth.

## Checklist

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension