### PR TITLE
Shinigami (ID): Update subdomain, status mapping, and genres

### DIFF
--- a/src/id/shinigami/build.gradle
+++ b/src/id/shinigami/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Shinigami'
     extClass = '.Shinigami'
-    extVersionCode = 77
+    extVersionCode = 78
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/shinigami/src/eu/kanade/tachiyomi/extension/id/shinigami/Shinigami.kt
+++ b/src/id/shinigami/src/eu/kanade/tachiyomi/extension/id/shinigami/Shinigami.kt
@@ -23,7 +23,7 @@ class Shinigami : HttpSource() {
 
     override val name = "Shinigami"
 
-    override val baseUrl = "https://c.shinigami.asia"
+    override val baseUrl = "https://g.shinigami.asia"
 
     private val apiUrl = "https://api.shngm.io"
 
@@ -135,6 +135,7 @@ class Shinigami : HttpSource() {
         Pair("Crime", "crime"),
         Pair("Demon", "demon"),
         Pair("Demons", "demons"),
+        Pair("Dra", "dra-genre"),
         Pair("Drama", "drama"),
         Pair("Ecchi", "ecchi"),
         Pair("Fantasy", "fantasy"),
@@ -145,6 +146,9 @@ class Shinigami : HttpSource() {
         Pair("Historical", "historical"),
         Pair("Horror", "horror"),
         Pair("Isekai", "isekai"),
+        Pair("Josei", "josei-genre"),
+        Pair("Latest", "latest"),
+        Pair("Love", "love"),
         Pair("Magic", "magic"),
         Pair("Martial Arts", "martial-arts"),
         Pair("Mature", "mature"),
@@ -166,8 +170,11 @@ class Shinigami : HttpSource() {
         Pair("Smut", "smut"),
         Pair("Sports", "sports"),
         Pair("Supernatural", "supernatural"),
+        Pair("Supranatural", "supranatural"),
         Pair("Thriller", "thriller"),
         Pair("Tragedy", "tragedy"),
+        Pair("Violence", "violence"),
+        Pair("Wuxia", "wuxia"),
     )
 
     override fun getMangaUrl(manga: SManga): String = "$baseUrl/series/${manga.url}"
@@ -200,6 +207,7 @@ class Shinigami : HttpSource() {
     private fun Int.toStatus(): Int = when (this) {
         1 -> SManga.ONGOING
         2 -> SManga.COMPLETED
+        3 -> SManga.ON_HIATUS
         else -> SManga.UNKNOWN
     }
 


### PR DESCRIPTION
- Update baseUrl to https://g.shinigami.asia
- Add hiatus status mapping (3 -> SManga.ON_HIATUS)
- Update genre list with latest data from API
- Bump extVersionCode to 78

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
