### PR TITLE
Luvyaa (ID): update subdomain to v4 and add locked chapter handling

### DIFF
--- a/src/id/Luvyaa/build.gradle
+++ b/src/id/Luvyaa/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Luvyaa'
     extClass = '.Luvyaa'
     themePkg = 'mangathemesia'
-    baseUrl = 'https://v1.luvyaa.co'
-    overrideVersionCode = 3
+    baseUrl = 'https://v4.luvyaa.co'
+    overrideVersionCode = 4
     isNsfw = true
 }
 

--- a/src/id/Luvyaa/src/eu/kanade/tachiyomi/extension/id/Luvyaa/Luvyaa.kt
+++ b/src/id/Luvyaa/src/eu/kanade/tachiyomi/extension/id/Luvyaa/Luvyaa.kt
@@ -4,12 +4,13 @@ package eu.kanade.tachiyomi.extension.id.Luvyaa
 
 import android.content.SharedPreferences
 import androidx.preference.PreferenceScreen
+import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
-import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesiaPaidChapterHelper
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.SChapter
-import keiyoushi.utils.getPreferences
-import org.jsoup.nodes.Element
+import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.getPreferencesLazy
+import okhttp3.Response
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -22,24 +23,46 @@ class Luvyaa :
     ),
     ConfigurableSource {
 
-    private val preferences: SharedPreferences = getPreferences()
+    private val preferences: SharedPreferences by getPreferencesLazy()
 
-    private val paidChapterHelper = MangaThemesiaPaidChapterHelper(
-        lockedChapterSelector = "img[alt='🔒']",
-    )
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val document = response.asJsoup()
 
-    override fun chapterListSelector() = paidChapterHelper.getChapterListSelectorBasedOnHidePaidChaptersPref(
-        super.chapterListSelector(),
-        preferences,
-    )
+        val lockedUrls = LOCKED_URLS_REGEX.find(document.toString())?.groupValues?.get(1)
+            ?.split(",")
+            ?.map { it.trim().removeSurrounding("'").removeSurrounding("\"").replace("\\/", "/") }
+            .orEmpty()
 
-    override fun chapterFromElement(element: Element): SChapter = super.chapterFromElement(element).apply {
-        if (element.selectFirst("img[alt='🔒']") != null) {
-            name = "🔒 $name"
+        val hideLocked = preferences.getBoolean(PREF_HIDE_LOCKED, false)
+
+        countViews(document)
+
+        return document.select(super.chapterListSelector()).mapNotNull { element ->
+            val chapter = super.chapterFromElement(element)
+            val isLocked = lockedUrls.any { it.endsWith(chapter.url) }
+
+            if (hideLocked && isLocked) return@mapNotNull null
+
+            chapter.apply {
+                if (isLocked) {
+                    name = "🔒 $name"
+                }
+            }
         }
     }
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        paidChapterHelper.addHidePaidChaptersPreferenceToScreen(screen, intl)
+        SwitchPreferenceCompat(screen.context).apply {
+            key = PREF_HIDE_LOCKED
+            title = "Sembunyikan chapter terkunci"
+            summary = "Sembunyikan chapter yang memerlukan membership (VIP)"
+            setDefaultValue(false)
+        }.also(screen::addPreference)
+    }
+
+    companion object {
+        private const val PREF_HIDE_LOCKED = "pref_hide_locked_chapters"
+
+        private val LOCKED_URLS_REGEX = """lockedUrls\s*=\s*\[(.*?)]""".toRegex()
     }
 }

--- a/src/id/Luvyaa/src/eu/kanade/tachiyomi/extension/id/Luvyaa/Luvyaa.kt
+++ b/src/id/Luvyaa/src/eu/kanade/tachiyomi/extension/id/Luvyaa/Luvyaa.kt
@@ -2,14 +2,44 @@
 
 package eu.kanade.tachiyomi.extension.id.Luvyaa
 
+import android.content.SharedPreferences
+import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesiaPaidChapterHelper
+import eu.kanade.tachiyomi.source.ConfigurableSource
+import eu.kanade.tachiyomi.source.model.SChapter
+import keiyoushi.utils.getPreferences
+import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
 
 class Luvyaa :
     MangaThemesia(
         "Luvyaa",
-        "https://v1.luvyaa.co",
+        "https://v4.luvyaa.co",
         "id",
-        dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale.US),
+        dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.US),
+    ),
+    ConfigurableSource {
+
+    private val preferences: SharedPreferences = getPreferences()
+
+    private val lockedChapterSelector = "img[alt='🔒']"
+
+    private val paidChapterHelper = MangaThemesiaPaidChapterHelper(lockedChapterSelector = lockedChapterSelector)
+
+    override fun chapterListSelector(): String = paidChapterHelper.getChapterListSelectorBasedOnHidePaidChaptersPref(
+        super.chapterListSelector(),
+        preferences,
     )
+
+    override fun chapterFromElement(element: Element): SChapter = super.chapterFromElement(element).apply {
+        if (element.selectFirst(lockedChapterSelector) != null) {
+            name = "🔒 ${name.removePrefix(" ").trim()}"
+        }
+    }
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        paidChapterHelper.addHidePaidChaptersPreferenceToScreen(screen, intl)
+    }
+}

--- a/src/id/Luvyaa/src/eu/kanade/tachiyomi/extension/id/Luvyaa/Luvyaa.kt
+++ b/src/id/Luvyaa/src/eu/kanade/tachiyomi/extension/id/Luvyaa/Luvyaa.kt
@@ -24,18 +24,18 @@ class Luvyaa :
 
     private val preferences: SharedPreferences = getPreferences()
 
-    private val lockedChapterSelector = "img[alt='🔒']"
+    private val paidChapterHelper = MangaThemesiaPaidChapterHelper(
+        lockedChapterSelector = "img[alt='🔒']",
+    )
 
-    private val paidChapterHelper = MangaThemesiaPaidChapterHelper(lockedChapterSelector = lockedChapterSelector)
-
-    override fun chapterListSelector(): String = paidChapterHelper.getChapterListSelectorBasedOnHidePaidChaptersPref(
+    override fun chapterListSelector() = paidChapterHelper.getChapterListSelectorBasedOnHidePaidChaptersPref(
         super.chapterListSelector(),
         preferences,
     )
 
     override fun chapterFromElement(element: Element): SChapter = super.chapterFromElement(element).apply {
-        if (element.selectFirst(lockedChapterSelector) != null) {
-            name = "🔒 ${name.removePrefix(" ").trim()}"
+        if (element.selectFirst("img[alt='🔒']") != null) {
+            name = "🔒 $name"
         }
     }
 


### PR DESCRIPTION
- Update baseUrl to https://v4.luvyaa.co
- Implement locked chapter detection and prepending lock icon (🔒)
- Add preference to hide paid/locked chapters using MangaThemesiaPaidChapterHelper
- Update dateFormat to dd/MM/yyyy to match the new site version
- Increment version code to 4
- Use local constant for locked chapter selector to avoid modifying multi-src

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
