### PR TITLE
[RU]Com-X bypass __guard antibot

### DIFF
--- a/src/ru/comx/build.gradle
+++ b/src/ru/comx/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Com-X'
     extClass = '.ComX'
-    extVersionCode = 35
+    extVersionCode = 36
     isNsfw = false
 }
 

--- a/src/ru/comx/src/eu/kanade/tachiyomi/extension/ru/comx/ComX.kt
+++ b/src/ru/comx/src/eu/kanade/tachiyomi/extension/ru/comx/ComX.kt
@@ -27,11 +27,13 @@ import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.FormBody
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.Jsoup
 import rx.Observable
 import java.io.IOException
+import java.security.MessageDigest
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.concurrent.TimeUnit
@@ -94,10 +96,8 @@ class ComX :
             }
 
             var response = chain.proceed(finalRequest)
-            val bodyString = response.peekBody(2048).string()
-            if (response.code == 404 && bodyString.contains("Protected by Batman")) {
-                response.close()
-                throw IOException("Antibot, попробуйте пройти капчу в WebView")
+            if (response.code == 404 && response.request.url.encodedPath == "/_c") {
+                response = solveGuardChallenge(chain, response, finalRequest)
             }
 
             val imgPreloadHost = baseUrl.replace(Regex("^https?://"), "img.")
@@ -281,6 +281,40 @@ class ComX :
         element.contains("Продолжается") || element.contains(" из ") || element.contains("Онгоинг") -> SManga.ONGOING
         element.contains("Заверш") || element.contains("Лимитка") || element.contains("Ван шот") || element.contains("Графический роман") -> SManga.COMPLETED
         else -> SManga.UNKNOWN
+    }
+
+    private fun solveGuardChallenge(chain: Interceptor.Chain, challenge: Response, original: Request): Response {
+        val token = TOKEN_REGEX.find(challenge.peekBody(4096).string())?.groupValues?.get(1)
+            ?: throw IOException("Antibot challenge failed: token not found")
+        challenge.close()
+
+        var nonce = 0L
+        val md = MessageDigest.getInstance("SHA-256")
+        val start = System.currentTimeMillis()
+        while (md.digest("$token:$nonce".toByteArray())[0] != 0.toByte()) {
+            nonce++
+            if (nonce > 1_000_000L) throw IOException("Antibot challenge failed: PoW exhausted")
+        }
+        val workTime = (System.currentTimeMillis() - start).coerceAtLeast(120)
+
+        val verifyBody = FormBody.Builder()
+            .add("token", token).add("mode", "modern")
+            .add("workTime", workTime.toString()).add("iterations", (nonce + 1).toString())
+            .add("webdriver", "0").add("touch", "1")
+            .add("screen_w", "390").add("screen_h", "844").add("screen_cd", "24")
+            .add("wgv", "Apple Inc.").add("wgr", "Apple GPU")
+            .add("tz", "-180").add("dpr", "3").add("cdp", "0").add("cdpf", "")
+            .build()
+
+        val verifyReq = Request.Builder()
+            .url("$baseUrl/_v")
+            .post(verifyBody)
+            .header("X-Requested-With", "XMLHttpRequest")
+            .header("Referer", challenge.request.url.toString())
+            .build()
+        chain.proceed(verifyReq).close()
+
+        return chain.proceed(original)
     }
 
     // Chapters
@@ -499,5 +533,6 @@ class ComX :
 
         private val URL_REGEX = Regex("^https?://.+")
         private val IMG_DOMAIN_REGEX = "\"host\":\"(.+?)\"".toRegex()
+        private val TOKEN_REGEX = """token:\s*"([^"]+)"""".toRegex()
     }
 }


### PR DESCRIPTION
The site replaced the old `Protected by Batman` antibot with a SHA-256 PoW challenge served as HTTP 404 from `/_c`. The previous detection (`bodyString.contains("Protected by Batman")`) no longer matches anything, so every manga details / chapter list / search request now fails with a generic `HTTP 404` and the source is effectively unusable.

### What the new antibot does

1. `GET <page>` → `302` to `/_c?t=<token>&u=<encoded-target>` + `Set-Cookie: __guard_token=...`
2. `GET /_c?...` → **HTTP 404** (intentional) with an HTML+JS body
3. JS computes SHA-256 of `<token>:<nonce>` until the hash starts with `00`, gathers a small fingerprint (touch / screen / WebGL renderer / timezone / DPR / CDP-detector flags) and `POST`s it form-encoded to `/_v`
4. `/_v` returns `200 OK` + `Set-Cookie: __guard_trust=...`
5. The original URL now returns the real page

### What this PR does

Replaces the dead `"Protected by Batman"` detection with detection by URL path (`response.request.url.encodedPath == "/_c"`) and adds `solveGuardChallenge` which performs the same flow in Kotlin: parse the token from the body, run the SHA-256 PoW (`MessageDigest`), `POST /_v` with a static fingerprint, then retry the original request. The `__guard_trust` cookie lands in the okhttp `cookieJar` automatically and subsequent requests skip the challenge.

The fingerprint values were verified against the live server with multiple `User-Agent`s (iPhone CriOS / desktop Chrome / Android Chrome) — the chosen Apple-GPU fingerprint passes regardless of UA, which keeps the patch UA-agnostic.

### Checklist

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop