### PR TITLE
ManhwaZ (EN): fix Popular tab

### DIFF
--- a/src/en/manhwaz/build.gradle
+++ b/src/en/manhwaz/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ManhwaZCom'
     themePkg = 'manhwaz'
     baseUrl = 'https://manhwaz.com'
-    overrideVersionCode = 35
+    overrideVersionCode = 36
     isNsfw = true
 }
 

--- a/src/en/manhwaz/src/eu/kanade/tachiyomi/extension/en/manhwaz/ManhwaZCom.kt
+++ b/src/en/manhwaz/src/eu/kanade/tachiyomi/extension/en/manhwaz/ManhwaZCom.kt
@@ -1,8 +1,12 @@
 package eu.kanade.tachiyomi.extension.en.manhwaz
 
 import eu.kanade.tachiyomi.multisrc.manhwaz.ManhwaZ
+import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.jsoup.nodes.Element
 
 class ManhwaZCom :
     ManhwaZ(
@@ -13,4 +17,20 @@ class ManhwaZCom :
     override val client: OkHttpClient = super.client.newBuilder()
         .rateLimit(2)
         .build()
+
+    // The original homepage popular slider (#slide-top) was removed by
+    // the site, so the inherited selector returns nothing. Site is named
+    // "ManhwaZ" and its dominant catalog is manhwa (57 pages vs 23 manga,
+    // 43 manhua), so reuse the manhwa genre listing sorted by views.
+    override fun popularMangaRequest(page: Int): Request {
+        val url = "$baseUrl/genre/manhwa".toHttpUrl().newBuilder()
+            .addQueryParameter("m_orderby", "views")
+            .addQueryParameter("page", page.toString())
+            .build()
+        return GET(url, headers)
+    }
+
+    override fun popularMangaSelector() = latestUpdatesSelector()
+
+    override fun popularMangaFromElement(element: Element) = latestUpdatesFromElement(element)
 }


### PR DESCRIPTION
Site removed the homepage popular slider — `#slide-top` is now an empty div, so the inherited selector returns nothing and the Popular tab shows "No results found".

There's no aggregated "all manga" endpoint on the site, only three category pages: `/genre/manhwa`, `/genre/manga`, `/genre/manhua`, each accepting `?m_orderby=views`. Pointed Popular at `/genre/manhwa?m_orderby=views` since manhwa is the dominant catalog (57 pages vs 23 manga / 43 manhua) and the site brand. Latest and Search untouched.

Closes #15759

Checklist:

- [ ] Updated \`extVersionCode\` value in \`build.gradle\` for individual extensions
- [x] Updated \`overrideVersionCode\` or \`baseVersionCode\` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. \"Closes #xyz\")
- [ ] Added the \`isNsfw = true\` flag in \`build.gradle\` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the \`id\` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed \`web_hi_res_512.png\` when adding a new extension