### PR TITLE
Pepper & Carrot: fix mini fantasy theather chapter page parsing

### DIFF
--- a/src/all/peppercarrot/build.gradle
+++ b/src/all/peppercarrot/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Pepper&Carrot'
     extClass = '.PepperCarrot'
-    extVersionCode = 4
+    extVersionCode = 5
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/peppercarrot/src/eu/kanade/tachiyomi/extension/all/peppercarrot/PepperCarrot.kt
+++ b/src/all/peppercarrot/src/eu/kanade/tachiyomi/extension/all/peppercarrot/PepperCarrot.kt
@@ -225,7 +225,9 @@ class PepperCarrot :
 
     override fun pageListParse(response: Response): List<Page> {
         val document = response.asJsoup()
-        val urls = document.select(".webcomic-page img").map { it.attr("src") }
+        val urls =
+            document.select(".webcomic-page img").map { it.attr("src") } +
+                document.select(".mft-cv-image").map { it.attr("src") }
         val thumbnail =
             if (urls[0].contains("miniFantasyTheater", true)) {
                 emptyList()


### PR DESCRIPTION
This fixes the page parsing for the Mini Fantasy Theater chapters.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
