### PR TITLE
Core: Add user configurable base URL helpers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -538,6 +538,24 @@ private val preferences = getPreferences()
 private val preferences by getPreferencesLazy()
 ```
 
+**User-configurable domain - `addDomainPreference` / `getDomain`**
+
+For sources whose domain changes often (e.g. mirrors), let users override the base URL with a one-line preference instead of writing the full `EditTextPreference` boilerplate.
+
+```kotlin
+import keiyoushi.utils.addDomainPreference
+import keiyoushi.utils.getDomain
+
+override val baseUrl: String
+    get() = preferences.getDomain(DEFAULT_BASE_URL)
+
+override fun setupPreferenceScreen(screen: PreferenceScreen) {
+    screen.addDomainPreference(preferences, DEFAULT_BASE_URL)
+}
+```
+
+Both helpers accept an optional `key` parameter when an extension needs more than one custom-domain pref or has to migrate from a legacy key. `addDomainPreference` also accepts `title` and `restartMessage` overrides for localization. The user is shown a toast reminding them to restart the app for the new domain to take effect.
+
 ##### Next.js data extraction - `extractNextJs` / `extractNextJsRsc`
 
 If the site is built with Next.js, use `keiyoushi.utils.extractNextJs` on a `Document` or `Response`,

--- a/core/src/main/kotlin/keiyoushi/utils/Domain.kt
+++ b/core/src/main/kotlin/keiyoushi/utils/Domain.kt
@@ -1,0 +1,55 @@
+package keiyoushi.utils
+
+import android.content.SharedPreferences
+import android.widget.Toast
+import androidx.preference.EditTextPreference
+import androidx.preference.PreferenceScreen
+
+private const val DEFAULT_DOMAIN_PREF_KEY = "custom_domain"
+
+/**
+ * Returns the user-configured custom domain, or [default] if none has been set.
+ *
+ * Use this in the extension's `baseUrl` getter when paired with [addDomainPreference].
+ *
+ * @param default the value returned when no override has been stored
+ * @param key the SharedPreferences key. Must match the one passed to [addDomainPreference]
+ */
+fun SharedPreferences.getDomain(
+    default: String,
+    key: String = DEFAULT_DOMAIN_PREF_KEY,
+): String = getString(key, null)?.takeIf { it.isNotBlank() } ?: default
+
+/**
+ * Adds an [EditTextPreference] to the screen that lets the user override the source domain.
+ *
+ * The value is stored in [prefs] under [key] and can be read back with [getDomain].
+ *
+ * @param prefs the source's [SharedPreferences]
+ * @param default the default domain shown as a hint when no override is set
+ * @param key the SharedPreferences key. Override when an extension needs more than one
+ *   custom-domain pref, or to migrate from a legacy key
+ * @param title the preference title (defaults to "Custom domain")
+ * @param restartMessage toast message displayed after the user changes the domain
+ */
+fun PreferenceScreen.addDomainPreference(
+    prefs: SharedPreferences,
+    default: String,
+    key: String = DEFAULT_DOMAIN_PREF_KEY,
+    title: String = "Custom domain",
+    restartMessage: String = "Restart the app to apply the new domain.",
+) {
+    EditTextPreference(context).apply {
+        this.key = key
+        this.title = title
+        dialogTitle = title
+        summary = prefs.getDomain(default, key)
+        setDefaultValue(default)
+        setOnPreferenceChangeListener { pref, newValue ->
+            val newDomain = (newValue as? String)?.trim().orEmpty()
+            pref.summary = newDomain.ifBlank { default }
+            Toast.makeText(context, restartMessage, Toast.LENGTH_LONG).show()
+            true
+        }
+    }.let(::addPreference)
+}


### PR DESCRIPTION
Lets sources expose a user-configurable base URL with one line in setupPreferenceScreen instead of the full EditTextPreference boilerplate.

A reviewer can verify the need/validity of this because I'm not sure.

In it's simple form, it can be used as follows:
```kt
override fun setupPreferenceScreen(screen: androidx.preference.PreferenceScreen) {
  // whatever code in setupPreferenceScreen  
  screen.addDomainPreference(preferences, DEFAULT_BASE_URL)
}
```
Then add to the companion object:
```kt
private const val DEFAULT_BASE_URL = "https://www.example.net"
```

With more options:
```kt
override fun setupPreferenceScreen(screen: androidx.preference.PreferenceScreen) {
  screen.addDomainPreference(
    prefs = preferences,
    default = DOMAIN_DEFAULT,
    key = DOMAIN_TITLE,
    title = DOMAIN_TITLE,
    restartMessage = "Restart the app to apply the new domain.",
  )
}
```

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
