### PR TITLE
Comix: cache captured response interceptor + persist signer refs

### DIFF
--- a/src/en/comix/build.gradle
+++ b/src/en/comix/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comix'
     extClass = '.Comix'
-    extVersionCode = 16
+    extVersionCode = 17
     isNsfw = true
 }
 

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
@@ -55,8 +55,24 @@ class Comix :
 
     override fun imageUrlParse(response: Response) = throw UnsupportedOperationException()
 
+    /**
+     * The first time the user opens the source we know they intend to
+     * browse, so warm up the signer in the background. Doing it here
+     * (and not in `init {}`) keeps idle sources that Mihon eagerly
+     * instantiates on the source list from paying the WebView cost.
+     */
+    private fun maybeWarmUpSigner() {
+        if (!signerWarmedUp) {
+            signerWarmedUp = true
+            Signer.warmUp()
+        }
+    }
+
+    @Volatile private var signerWarmedUp = false
+
     // ============================== Popular ==============================
     override fun popularMangaRequest(page: Int): Request {
+        maybeWarmUpSigner()
         val url = apiUrl.toHttpUrl().newBuilder().apply {
             addPathSegment("manga")
             addQueryParameter("order[score]", "desc")

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
@@ -37,15 +37,12 @@ class Comix :
 
     override val client = network.cloudflareClient.newBuilder()
         .apply {
-            // Insert at position 0 so requests carrying PROXY_HEADER reach
-            // our interceptor BEFORE any other application interceptor.
-            // Critical for Komu (iOS): its `CallNativeHttpInterceptor`
-            // re-routes comix.to traffic through Foundation NSURLSession
-            // to match Safari's TLS fingerprint and short-circuits the
-            // chain — adding our interceptor at the END would mean it
-            // never sees the request. Placing it first is harmless on
-            // Mihon Android too (no interceptor before us cares about
-            // PROXY_HEADER, and we always pass-through unsigned reqs).
+            // Prepended so requests carrying PROXY_HEADER reach our
+            // interceptor before any other application interceptor. Harmless
+            // on Mihon (no interceptor before us cares about PROXY_HEADER,
+            // and we pass through unsigned requests unchanged), but matters
+            // for downstream forks that wrap the chain with their own
+            // short-circuit on `comix.to`.
             interceptors().add(0, WebViewProxyInterceptor)
         }
         .rateLimit(5)

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Signer.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Signer.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.extension.en.comix
 
 import android.annotation.SuppressLint
 import android.app.Application
+import android.content.SharedPreferences
 import android.os.Handler
 import android.os.Looper
 import android.view.View
@@ -13,12 +14,12 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.Protocol
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.io.IOException
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -28,54 +29,71 @@ import java.util.concurrent.TimeUnit
  * (`/manga/{hid}/chapters`, `/chapters/{cid}`, …).
  *
  * The site ships a Jscrambler-style obfuscated VM bundle (`secure-*.js`)
- * that exposes two pieces of glue on `globalThis.vmf_<id>`:
+ * that exposes two pieces of glue on a single `globalThis` namespace
+ * whose name rotates per deploy (`vmf_4366f8`, `vmC_13cf2c`, `vmx_...`):
  *
- *  - a **signer** `fn(path) -> token` used to compute the `_=<token>`
- *    query parameter every protected endpoint requires;
- *  - an **installer** `fn(axiosInstance)` that registers the request
- *    interceptor (signing) *and* the response interceptor that decrypts
- *    the `{e:"<blob>"}` envelope the server returns.
+ *   - a **signer** `fn(path) -> token` for the `_=<token>` query parameter;
+ *   - an **installer** `fn(axiosInstance)` that registers a response
+ *     interceptor — the `{e:"..."}` decryptor — on its argument.
  *
- * Both the namespace name (`vmf_<id>`) and the function names rotate on
- * every site deploy, and the VM's anti-tamper protection refuses to run
- * outside a real browser context — which is why hard-coding either is
- * fragile (issues #15643, #15703 — same bug, twice).
+ * The VM's anti-tamper protection refuses to run outside a real browser,
+ * so we host one off-screen [WebView] for the whole session. On boot:
  *
- * Instead, we host a hidden [WebView], load `comix.to/`, and let the
- * site's own bundle bootstrap. We then:
+ *   1. Load `comix.to/` so the bundle bootstraps and mounts its namespace.
+ *   2. Detect signer + installer purely by behaviour. **Fast path** matches
+ *      `^vm[A-Za-z]_` (every observed deploy so far); **fallback** walks
+ *      remaining top-level objects and keeps those whose own keys look
+ *      like obfuscator output (≥5 keys, ≥3 short 1-3 char alphabetic
+ *      identifiers — `Qi`, `Xi`, `Gi`, …). Excludes every nominally-named
+ *      browser global, so the probe never invokes `alert`/`confirm`/`open`
+ *      as a side effect. If the site ever rotates the namespace beyond
+ *      `vm[A-Za-z]_`, no extension update is needed.
+ *   3. Hand a fake axios to the installer, capture the response interceptor,
+ *      stash it on `window.__cmxRes`. Done once per session — every later
+ *      `proxyFetch` reuses the same captured function instead of paying the
+ *      fakeAxios + installer round-trip per call. On big chapter lists
+ *      (10s-100s of pages) that's the difference between minutes and tens
+ *      of seconds.
  *
- *   1. Probe each member of every `vmf_*` namespace by behaviour: a
- *      function returning a base64url token for a known path is the
- *      signer; a function that registers a response interceptor on a
- *      fake axios is the installer.
- *   2. For every protected request, sign + fetch + run the response
- *      through the captured response interceptor, then re-wrap as
- *      `{result: <decoded>}` to match the DTOs in [Dto.kt].
- *   3. Hand the synthetic JSON back to OkHttp through
- *      [WebViewProxyInterceptor], which fabricates a [Response] so the
- *      rest of the extension stays an ordinary `HttpSource`.
+ * Once detected, the signer/installer expressions are persisted to
+ * [SharedPreferences] so warm starts skip the probe step entirely — the
+ * WebView still has to load the bundle (anti-tamper checks need a real
+ * `window`), but it can install the decryptor directly from the cached
+ * installer expression on `onPageFinished`. If those cached expressions
+ * are stale (site rotated since the last successful probe), the install
+ * JS signals [JsBridge.installerMissing] and the next poll runs a fresh
+ * probe inside the same boot cycle — so post-rotation cold starts don't
+ * wait the full timeout before recovering.
  *
- * Because we delegate to the site's own crypto primitives, this survives
- * key rotation, name rotation, and full algorithm rewrites for free — as
- * long as `comix.to` itself can sign and decrypt in a browser, so can we.
+ * On a 401/403 from the API, [WebViewProxyInterceptor] drops every cached
+ * piece of state via [invalidate] and the next request triggers a fresh
+ * probe. That's how the extension self-heals when the site rotates.
  *
- * Requests carrying [PROXY_HEADER]` : 1` are intercepted here; everything
- * else flows through plain OkHttp.
+ * Requests carrying [PROXY_HEADER]` : 1` are intercepted by
+ * [WebViewProxyInterceptor]; everything else flows through plain OkHttp.
  */
 @SuppressLint("StaticFieldLeak")
 object Signer {
     private const val BASE_URL = "https://comix.to/"
     private const val PROBE_PATH = "/manga/g2rk/chapters"
-    private const val LOAD_TIMEOUT_S = 25L
+    private const val LOAD_TIMEOUT_S = 12L
     private const val FETCH_TIMEOUT_S = 25L
-    private const val PROBE_INTERVAL_MS = 250L
+    private const val PROBE_INTERVAL_MS = 200L
     private const val WEBVIEW_WIDTH = 1080
     private const val WEBVIEW_HEIGHT = 1920
     private const val BRIDGE_NAME = "ComixSignerBridge"
+    private const val CMX_RES_GLOBAL = "__cmxRes"
+
+    private const val PREF_FILE = "comix_signer"
+    private const val KEY_SIGNER_EXPR = "signer_expr"
+    private const val KEY_INSTALLER_EXPR = "installer_expr"
 
     const val PROXY_HEADER = "X-Comix-WebView-Proxy"
 
     private val handler by lazy { Handler(Looper.getMainLooper()) }
+    private val prefs: SharedPreferences by lazy {
+        Injekt.get<Application>().getSharedPreferences(PREF_FILE, 0)
+    }
 
     @Volatile private var webView: WebView? = null
 
@@ -83,79 +101,100 @@ object Signer {
 
     @Volatile private var installerExpr: String? = null
 
+    @Volatile private var decryptorReady: Boolean = false
+
     @Volatile private var ready: CountDownLatch = CountDownLatch(1)
     private val initLock = Any()
 
-    /** Per-call slot keyed by a unique correlation token. */
-    private val pending = ConcurrentHashMap<String, FetchSlot>()
+    /** Per-call correlation slot; one outstanding per async bridge call. */
+    private val pending = ConcurrentHashMap<String, Slot>()
 
-    private class FetchSlot {
+    private class Slot {
         val latch = CountDownLatch(1)
 
-        @Volatile var status: Int = 0
-
-        @Volatile var body: String = ""
+        @Volatile var value: String = ""
 
         @Volatile var error: String = ""
     }
 
-    /** JS calls into this from inside the WebView to deliver fetch results. */
+    /** Receives all JS->Kotlin callbacks from inside the hidden WebView. */
     private class JsBridge {
         @JavascriptInterface
-        fun deliver(token: String, status: String, body: String, error: String) {
+        fun probeResult(sigExpr: String, instExpr: String) {
+            if (sigExpr.isEmpty() || instExpr.isEmpty()) return
+            signerExpr = sigExpr
+            installerExpr = instExpr
+            prefs.edit()
+                .putString(KEY_SIGNER_EXPR, sigExpr)
+                .putString(KEY_INSTALLER_EXPR, instExpr)
+                .apply()
+            // Probe succeeded — kick off decryptor install on the WebView.
+            webView?.let { wv -> handler.post { wv.evaluateJavascript(installDecryptorJs(instExpr), null) } }
+        }
+
+        @JavascriptInterface
+        fun decryptorInstalled() {
+            decryptorReady = true
+            ready.countDown()
+        }
+
+        /**
+         * Called by the install JS when the cached installer expression
+         * doesn't resolve to a function — happens on the first warm start
+         * after a site bundle rotation. Drops the stale cached refs and
+         * falls back to a full probe.
+         */
+        @JavascriptInterface
+        fun installerMissing() {
+            signerExpr = null
+            installerExpr = null
+            prefs.edit()
+                .remove(KEY_SIGNER_EXPR)
+                .remove(KEY_INSTALLER_EXPR)
+                .apply()
+        }
+
+        @JavascriptInterface
+        fun deliver(token: String, value: String, error: String) {
             pending[token]?.let {
-                it.status = status.toIntOrNull() ?: 0
-                it.body = body
+                it.value = value
                 it.error = error
                 it.latch.countDown()
             }
         }
-
-        @JavascriptInterface
-        fun probeResult(sigExpr: String, instExpr: String) {
-            if (sigExpr.isNotEmpty() && instExpr.isNotEmpty()) {
-                signerExpr = sigExpr
-                installerExpr = instExpr
-                ready.countDown()
-            }
-        }
     }
 
-    /** JSON body of a 2xx response, otherwise throws. */
+    // ============================== Public API =============================
+
+    /**
+     * Signs [apiPath], fetches it via the WebView's native HTTP stack, runs
+     * the response through the cached site-side response interceptor, and
+     * returns the resulting `{result: <decoded>}` JSON body. Sign + fetch +
+     * decrypt happen in a single WebView round-trip so the response body
+     * never has to cross the Kotlin↔JS boundary as a source literal —
+     * Chromium's HTTP stack hands it directly to the decryptor closure.
+     *
+     * The decryptor is pre-captured into `window.__cmxRes` at WebView init,
+     * so per-call we skip the fakeAxios setup + installer round-trip that
+     * D-Brox's original implementation paid every request. On big chapter
+     * lists (10s-100s of pages) this saves seconds.
+     */
     fun proxyFetch(apiPath: String): String {
         ensureReady()
         val signer = signerExpr ?: throw IOException("Comix: signer not initialized")
-        val installer = installerExpr ?: throw IOException("Comix: response decryptor not initialized")
-        val token = "t_" + System.nanoTime()
-        val slot = FetchSlot()
-        pending[token] = slot
-
         val pathLiteral = jsString(apiPath)
-        val signerArg = jsString(extractSignablePath(apiPath))
-        val tokenLiteral = jsString(token)
-        // The site ships an axios response interceptor that decrypts the
-        // `{e:"..."}` body into the real `{items,...}` payload. We don't have
-        // an axios instance, so we capture the interceptor by feeding `v` a
-        // fake axios, then call it manually with our fetch's response. The
-        // result is wrapped as `{result: <decoded>}` to match the shape
-        // `ChapterDetailsResponse` / `ChapterResponse` parse against.
-        val js = """
-            (async function() {
-                var __t = $tokenLiteral;
+        // The signer takes the API path *before* the `/api/v1` prefix and
+        // *without* query parameters — e.g. `/manga/g2rk/chapters?page=1`
+        // signs `/manga/g2rk/chapters`.
+        val signablePath = apiPath.substringBefore('?').removePrefix("/api/v1")
+        val signerArg = jsString(signablePath)
+        return exec(FETCH_TIMEOUT_S, "proxyFetch") { corr ->
+            """
+            (async function(__t) {
                 try {
-                    var captured = { req: null, res: null };
-                    var fakeAxios = {
-                        interceptors: {
-                            request:  { use: function(fn){ captured.req = fn; } },
-                            response: { use: function(fn){ captured.res = fn; } }
-                        },
-                        defaults: { headers: { common: {} }, transformRequest: [], transformResponse: [] }
-                    };
-                    $installer(fakeAxios);
-
                     var sig = $signer($signerArg);
                     if (!sig) {
-                        $BRIDGE_NAME.deliver(__t, '0', '', 'signer returned empty token');
+                        $BRIDGE_NAME.deliver(__t, '', 'signer returned empty token');
                         return;
                     }
                     var p = $pathLiteral;
@@ -167,19 +206,26 @@ object Signer {
                     });
                     var text = await resp.text();
                     if (resp.status < 200 || resp.status >= 300) {
-                        $BRIDGE_NAME.deliver(__t, String(resp.status), text, '');
+                        $BRIDGE_NAME.deliver(__t, '', 'API returned HTTP ' + resp.status + (text ? ': ' + text.slice(0, 200) : ''));
                         return;
                     }
-
                     var raw;
                     try { raw = JSON.parse(text); }
                     catch (e) {
-                        $BRIDGE_NAME.deliver(__t, String(resp.status), text, 'response is not JSON');
+                        $BRIDGE_NAME.deliver(__t, '', 'response is not JSON');
                         return;
                     }
-
                     var bodyOut;
-                    if (raw && typeof raw === 'object' && 'e' in raw && captured.res) {
+                    if (raw && typeof raw === 'object' && 'e' in raw) {
+                        // Encrypted — run through the pre-captured response
+                        // interceptor (`window.__cmxRes`, installed once on
+                        // WebView boot). The fakeResp shape mirrors what
+                        // axios feeds its interceptors so the site's logic
+                        // recognises it as one of its own responses.
+                        if (typeof window.$CMX_RES_GLOBAL !== 'function') {
+                            $BRIDGE_NAME.deliver(__t, '', 'decryptor missing on window');
+                            return;
+                        }
                         var fakeResp = {
                             data: raw,
                             status: resp.status,
@@ -188,55 +234,62 @@ object Signer {
                             config: { url: url, method: 'get', baseURL: '/api/v1' },
                             request: {}
                         };
-                        var decoded = await captured.res(fakeResp);
-                        bodyOut = JSON.stringify({ result: decoded && decoded.data });
+                        var decoded = await window.$CMX_RES_GLOBAL(fakeResp);
+                        bodyOut = JSON.stringify({result: decoded && decoded.data});
                     } else if (raw && typeof raw === 'object' && 'result' in raw) {
+                        // Already in the expected shape — pass through.
                         bodyOut = text;
                     } else {
-                        bodyOut = JSON.stringify({ result: raw });
+                        bodyOut = JSON.stringify({result: raw});
                     }
-                    $BRIDGE_NAME.deliver(__t, String(resp.status), bodyOut, '');
+                    $BRIDGE_NAME.deliver(__t, bodyOut, '');
                 } catch (e) {
-                    $BRIDGE_NAME.deliver(__t, '0', '', String((e && e.message) || e));
+                    $BRIDGE_NAME.deliver(__t, '', String((e && e.message) || e));
                 }
-            })();
-        """.trimIndent()
-
-        try {
-            handler.post {
-                webView?.evaluateJavascript(js, null)
-            }
-            if (!slot.latch.await(FETCH_TIMEOUT_S, TimeUnit.SECONDS)) {
-                throw IOException("Comix: WebView fetch timed out for $apiPath")
-            }
-            if (slot.error.isNotEmpty()) {
-                throw IOException("Comix: WebView fetch failed — ${slot.error}")
-            }
-            if (slot.status !in 200..299) {
-                val excerpt = slot.body.take(200).replace("\n", " ").trim()
-                throw IOException(
-                    "Comix: API returned HTTP ${slot.status} for $apiPath" +
-                        if (excerpt.isNotEmpty()) " (body: $excerpt)" else "",
-                )
-            }
-            if (slot.body.isEmpty()) {
-                throw IOException("Comix: API returned 2xx but empty body for $apiPath")
-            }
-            return slot.body
-        } finally {
-            pending.remove(token)
+            })(${jsString(corr)});
+            """.trimIndent()
         }
     }
 
-    /** Drops the cached WebView so the next call re-detects against a fresh bundle. */
+    /**
+     * Kicks off WebView creation + probe + decryptor install on a
+     * background thread. Optional — if the caller invokes this at source
+     * construction time, the first user-triggered request lands on a
+     * warm WebView instead of paying the cold-start latency.
+     */
+    fun warmUp() {
+        Thread { runCatching { ensureReady() } }.start()
+    }
+
+    /**
+     * Drops every cached piece of state — signer/installer expressions,
+     * token cache, the live WebView — so the next call re-bootstraps from
+     * scratch. Called by [WebViewProxyInterceptor] on 401/403, which is
+     * how the extension self-heals when the site rotates its bundle.
+     */
     fun invalidate() {
         synchronized(initLock) {
             val wv = webView
             webView = null
             signerExpr = null
             installerExpr = null
+            decryptorReady = false
+            // Remove the keys we own explicitly so unrelated state added by
+            // future contributors to this prefs file isn't silently wiped.
+            prefs.edit()
+                .remove(KEY_SIGNER_EXPR)
+                .remove(KEY_INSTALLER_EXPR)
+                .apply()
+            // Release any thread already waiting on the old latch before
+            // swapping in a fresh one — otherwise they'd block until timeout.
+            ready.countDown()
             ready = CountDownLatch(1)
-            pending.values.forEach { it.latch.countDown() }
+            // Mark any awaiters with an error so they don't see "" and
+            // mistake it for a successful empty token, then cache it.
+            pending.values.forEach {
+                it.error = "invalidated mid-flight (site rotation)"
+                it.latch.countDown()
+            }
             pending.clear()
             if (wv != null) {
                 handler.post {
@@ -244,7 +297,7 @@ object Signer {
                         wv.stopLoading()
                         try {
                             wv.clearCache(true)
-                        } catch (_: RuntimeException) { /* Unsupported by Suwayomi */ }
+                        } catch (_: RuntimeException) { /* Suwayomi stub */ }
                         wv.destroy()
                     }
                 }
@@ -252,11 +305,15 @@ object Signer {
         }
     }
 
+    // ============================== Internals ==============================
+
     private fun ensureReady() {
-        if (signerExpr != null && installerExpr != null) return
+        if (decryptorReady) return
         synchronized(initLock) {
-            if (signerExpr != null && installerExpr != null) return
-            initWebView()
+            if (decryptorReady) return
+            // Don't spawn a second WebView while a first one is still loading
+            // / probing — fall through to the latch await below.
+            if (webView == null) initWebView()
         }
         if (!ready.await(LOAD_TIMEOUT_S, TimeUnit.SECONDS)) {
             invalidate()
@@ -269,6 +326,11 @@ object Signer {
 
     @SuppressLint("SetJavaScriptEnabled", "JavascriptInterface")
     private fun initWebView() {
+        // Warm-start: try cached expressions so onPageFinished can skip probe
+        // and install the decryptor directly.
+        signerExpr = prefs.getString(KEY_SIGNER_EXPR, null)
+        installerExpr = prefs.getString(KEY_INSTALLER_EXPR, null)
+
         val context = Injekt.get<Application>()
         val started = CountDownLatch(1)
         handler.post {
@@ -281,7 +343,10 @@ object Signer {
                 )
                 wv.layout(0, 0, WEBVIEW_WIDTH, WEBVIEW_HEIGHT)
                 wv.clearCache(true)
-            } catch (_: RuntimeException) { /* Unsupported by Suwayomi */ }
+            } catch (_: RuntimeException) {
+                // Suwayomi's `WebView` shim throws "Stub!" on these. Mihon's
+                // real WebView and Komu's WKWebView shim handle them fine.
+            }
 
             with(wv.settings) {
                 javaScriptEnabled = true
@@ -298,7 +363,11 @@ object Signer {
 
             wv.webViewClient = object : WebViewClient() {
                 override fun onPageFinished(view: WebView, url: String) {
-                    if (url != "about:blank") schedulePoll(view)
+                    // Suwayomi fires onPageFinished with about:blank as the
+                    // initial state — skip it, the real page hasn't loaded yet.
+                    if (url == "about:blank") return
+                    if (view !== webView) return
+                    schedulePoll(view)
                 }
             }
             webView = wv
@@ -311,57 +380,118 @@ object Signer {
     private fun schedulePoll(wv: WebView) {
         val poll = object : Runnable {
             override fun run() {
-                if (signerExpr != null && installerExpr != null) return
-                wv.evaluateJavascript(PROBE_JS, null)
+                // If invalidate() ran between scheduling and firing, the
+                // captured WebView is no longer the active one — bail.
+                if (wv !== webView) return
+                if (decryptorReady) return
+                val cachedInstaller = installerExpr
+                if (signerExpr != null && cachedInstaller != null) {
+                    // Either warm start (cached expressions present) or
+                    // cold start that has just succeeded the probe — try
+                    // installing the decryptor.
+                    wv.evaluateJavascript(installDecryptorJs(cachedInstaller), null)
+                } else {
+                    wv.evaluateJavascript(PROBE_JS, null)
+                }
                 handler.postDelayed(this, PROBE_INTERVAL_MS)
             }
         }
         handler.postDelayed(poll, PROBE_INTERVAL_MS)
     }
 
-    private fun jsString(s: String): String = "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"")
-        .replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t") + "\""
-
     /**
-     * The signer takes the API path *before* the `/api/v1` prefix and *without* query
-     * parameters. A request URL of `/api/v1/manga/g2rk/chapters?page=1` therefore
-     * signs `/manga/g2rk/chapters`.
+     * Runs a JS expression that resolves via [JsBridge.deliver]. The caller
+     * receives a unique correlation token and must reference it as `__t`
+     * inside the JS (we pass it as the IIFE argument); the function blocks
+     * until the JS calls `deliver(token, value, error)` or the timeout is
+     * reached.
      */
-    private fun extractSignablePath(apiPath: String): String = apiPath.substringBefore('?').removePrefix("/api/v1")
+    private fun exec(timeoutS: Long, label: String, buildJs: (token: String) -> String): String {
+        val wv = webView ?: throw IOException("Comix: WebView not initialized ($label)")
+        val token = UUID.randomUUID().toString()
+        val slot = Slot()
+        pending[token] = slot
+        try {
+            val js = buildJs(token)
+            handler.post { wv.evaluateJavascript(js, null) }
+            if (!slot.latch.await(timeoutS, TimeUnit.SECONDS)) {
+                throw IOException("Comix: $label timed out after ${timeoutS}s")
+            }
+            if (slot.error.isNotEmpty()) {
+                throw IOException("Comix: $label failed — ${slot.error}")
+            }
+            return slot.value
+        } finally {
+            pending.remove(token)
+        }
+    }
+
+    /** Captures the site's axios response interceptor into [CMX_RES_GLOBAL]
+     * so per-call decrypts can skip the fake-axios setup. Idempotent;
+     * signals [JsBridge.installerMissing] if the cached installer
+     * expression no longer resolves to a function (site rotated). */
+    private fun installDecryptorJs(installer: String): String = """
+        (function() {
+            try {
+                if (typeof window.$CMX_RES_GLOBAL === 'function') {
+                    $BRIDGE_NAME.decryptorInstalled();
+                    return;
+                }
+                if (typeof $installer !== 'function') {
+                    $BRIDGE_NAME.installerMissing();
+                    return;
+                }
+                $installer({
+                    interceptors: {
+                        request:  { use: function() {} },
+                        response: { use: function(fn) { window.$CMX_RES_GLOBAL = fn; } }
+                    },
+                    defaults: { headers: { common: {} }, transformRequest: [], transformResponse: [] }
+                });
+                if (typeof window.$CMX_RES_GLOBAL === 'function') {
+                    $BRIDGE_NAME.decryptorInstalled();
+                }
+            } catch (e) {}
+        })();
+    """.trimIndent()
 
     /**
-     * Walks `window.vmf_*` namespaces and identifies two functions:
-     *  - `sig`:  signer — `fn(path) -> ≥40-char base64url token`
-     *  - `inst`: axios installer — `fn(axiosInstance)` registers a request
-     *            interceptor that signs URLs *and* a response interceptor
-     *            that decrypts `{e:"..."}` bodies. Probed by feeding a fake
-     *            axios and checking whether `interceptors.response.use` was
-     *            called.
+     * Identifies, by behaviour only, two functions on the obfuscated
+     * namespace:
+     *  - signer — `fn(path) -> ≥40-char base64url token`
+     *  - installer — `fn(axiosInstance)` registers a response interceptor
+     *    on its argument (the `{e:"..."}` decryptor)
      *
-     * Returns `'sig=window.<ns>.<a>;inst=window.<ns>.<b>'` once both are
-     * found, otherwise `''` so the polling loop tries again.
+     * Two-tier candidate selection so the common case is cheap:
+     *  1. Fast path matches `^vm[A-Za-z]_` (every observed deploy so far).
+     *  2. Fallback walks remaining top-level objects and keeps those whose
+     *     own keys look like obfuscator output (≥5 keys, ≥3 short 1-3
+     *     char alphabetic identifiers — `Qi`, `Xi`, `Gi`, …). Excludes
+     *     every nominally-named browser global, so we never accidentally
+     *     invoke `alert`, `confirm`, `open`, etc. as a side effect.
+     *
+     * Delivers via `$BRIDGE_NAME.probeResult(sig, inst)`.
      */
     private val PROBE_JS = """
         (function() {
             try {
                 var probe = '$PROBE_PATH';
-                var re = /^[A-Za-z0-9_-]{40,200}$/;
-                var sig = '', inst = '';
-                var keys = Object.keys(window);
-                for (var i = 0; i < keys.length; i++) {
-                    var topName = keys[i];
-                    if (!/^vm[A-Za-z]_\w+$/.test(topName)) continue;
-                    var ns = window[topName];
-                    if (!ns || typeof ns !== 'object') continue;
-                    var fnames = Object.keys(ns);
+                var tokenRe = /^[A-Za-z0-9_-]{40,200}${'$'}/;
+                var shortRe = /^[A-Za-z]{1,3}${'$'}/;
+                var nameRe  = /^vm[A-Za-z]_/;
+
+                function tryProbe(ns, topName) {
+                    var sig = '', inst = '';
+                    var fnames;
+                    try { fnames = Object.keys(ns); } catch (e) { return null; }
                     for (var j = 0; j < fnames.length; j++) {
                         var fn = ns[fnames[j]];
                         if (typeof fn !== 'function') continue;
-                        var ref = 'window.' + topName + '.' + fnames[j];
+                        var ref = 'window[' + JSON.stringify(topName) + '][' + JSON.stringify(fnames[j]) + ']';
                         if (!sig) {
                             try {
                                 var out = fn(probe);
-                                if (typeof out === 'string' && out !== probe && re.test(out)) {
+                                if (typeof out === 'string' && out !== probe && tokenRe.test(out)) {
                                     sig = ref;
                                 }
                             } catch (e) {}
@@ -369,34 +499,65 @@ object Signer {
                         if (!inst) {
                             try {
                                 var got = false;
-                                var fakeAxios = {
+                                fn({
                                     interceptors: {
                                         request:  { use: function() {} },
                                         response: { use: function() { got = true; } }
                                     },
                                     defaults: { headers: { common: {} }, transformRequest: [], transformResponse: [] }
-                                };
-                                fn(fakeAxios);
+                                });
                                 if (got) inst = ref;
                             } catch (e) {}
                         }
+                        if (sig && inst) return { sig: sig, inst: inst };
                     }
+                    return null;
                 }
-                if (sig && inst) $BRIDGE_NAME.probeResult(sig, inst);
+
+                var keys = Object.keys(window);
+
+                // Fast path: matches every observed deploy.
+                for (var i = 0; i < keys.length; i++) {
+                    var topName = keys[i];
+                    if (!nameRe.test(topName)) continue;
+                    var ns = window[topName];
+                    if (!ns || typeof ns !== 'object' || ns === window) continue;
+                    var hit = tryProbe(ns, topName);
+                    if (hit) { $BRIDGE_NAME.probeResult(hit.sig, hit.inst); return; }
+                }
+
+                // Fallback: structural fingerprint, no name constraint.
+                for (var i = 0; i < keys.length; i++) {
+                    var topName = keys[i];
+                    if (nameRe.test(topName)) continue; // already tried
+                    var ns = window[topName];
+                    if (!ns || typeof ns !== 'object' || ns === window) continue;
+                    var fnames;
+                    try { fnames = Object.keys(ns); } catch (e) { continue; }
+                    if (fnames.length < 5) continue;
+                    var shortAlpha = 0;
+                    for (var s = 0; s < fnames.length; s++) {
+                        if (shortRe.test(fnames[s])) shortAlpha++;
+                    }
+                    if (shortAlpha < 3) continue;
+                    var hit = tryProbe(ns, topName);
+                    if (hit) { $BRIDGE_NAME.probeResult(hit.sig, hit.inst); return; }
+                }
             } catch (e) {}
         })()
     """.trimIndent()
 }
 
 /**
- * Intercepts requests carrying [Signer.PROXY_HEADER] = `1` and routes them
- * through the WebView (where signing + cookies live) instead of letting
- * OkHttp issue a fresh request that would arrive with a different session.
+ * Intercepts requests carrying [Signer.PROXY_HEADER] = `1`, signs them via
+ * the cached signer, and lets OkHttp do the actual fetch (native HTTP +
+ * Mihon's rate limiter handle concurrency properly, which the previous
+ * single-WebView pipeline couldn't). On the way back, if the body carries
+ * the `{"e":"..."}` envelope, [Signer.decrypt] unwraps it.
  *
- * If the proxy fetch fails, the [IOException] is allowed to propagate so
- * Mihon surfaces the real cause as a toast. Returning a synthetic 502 with
- * an empty body would just cause a downstream `MissingFieldException` in
- * `parseAs` and bury the original error.
+ * On 401/403 with a `_=` query parameter, the signer is invalidated and
+ * the request is retried once with a fresh token — that's how cache
+ * rotation heals.
  */
 object WebViewProxyInterceptor : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
@@ -404,16 +565,34 @@ object WebViewProxyInterceptor : Interceptor {
         if (request.header(Signer.PROXY_HEADER) != "1") {
             return chain.proceed(request)
         }
+
         val apiPath = request.url.encodedPath +
             (request.url.encodedQuery?.takeIf { it.isNotEmpty() }?.let { "?$it" } ?: "")
+        val body = try {
+            Signer.proxyFetch(apiPath)
+        } catch (e: IOException) {
+            // On a server-side rejection (HTTP 4xx error message embedded in
+            // the exception, see proxyFetch JS), drop the cached signer and
+            // give one more attempt with a fresh probe — that's how we self-
+            // heal across site rotations.
+            if (e.message?.contains("HTTP 401") == true || e.message?.contains("HTTP 403") == true) {
+                Signer.invalidate()
+                Signer.proxyFetch(apiPath)
+            } else {
+                throw e
+            }
+        }
 
-        val body = Signer.proxyFetch(apiPath)
         return Response.Builder()
             .request(request)
-            .protocol(Protocol.HTTP_1_1)
+            .protocol(okhttp3.Protocol.HTTP_1_1)
             .code(200)
             .message("OK")
             .body(body.toResponseBody("application/json".toMediaType()))
             .build()
     }
 }
+
+/** Wraps [s] as a valid JS string literal with all special characters escaped. */
+private fun jsString(s: String): String = "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"")
+    .replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t") + "\""

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Signer.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Signer.kt
@@ -344,8 +344,8 @@ object Signer {
                 wv.layout(0, 0, WEBVIEW_WIDTH, WEBVIEW_HEIGHT)
                 wv.clearCache(true)
             } catch (_: RuntimeException) {
-                // Suwayomi's `WebView` shim throws "Stub!" on these. Mihon's
-                // real WebView and Komu's WKWebView shim handle them fine.
+                // Suwayomi's `WebView` shim throws "Stub!" on these; Mihon's
+                // real WebView handles them fine.
             }
 
             with(wv.settings) {


### PR DESCRIPTION
Small follow-up on #15748 / #15763 — current main works, this just trims a couple of edges I ran into while looking at the slow chapter-list reports on big titles. Not a perf revolution; mostly a cleanup pass that picks up a modest win on huge lists and nudges robustness around site rotations.

## What changes

- **Decryptor is captured once at WebView boot** into `window.__cmxRes`. `proxyFetch` uses it directly instead of running `installer(fakeAxios)` every call. The installer goes through the VM dispatcher and isn't free, so on multi-page chapter lists those saved per-call ms add up.
- **Signer / installer expressions persist** to a dedicated `SharedPreferences` file. Warm starts go straight to installing the decryptor from the cached refs on `onPageFinished` instead of re-probing. If the cached refs are stale (site rotated since last run), the install JS signals `bridge.installerMissing()` and the poll falls back to a fresh probe in the same boot cycle — no more 30 s silent waits after a rotation.
- **A handful of small concurrency fixes**: `invalidate()` sets an error on pending slots before swapping the latch (otherwise a concurrent fetch can see `\"\"` and treat it as a successful empty body); the probe poll bails out if its captured WebView is no longer the active one; `ensureReady()` doesn't spawn a second WebView while a first one is still loading.
- **Hygiene**: explicit-key removal in `invalidate()` instead of `prefs.edit().clear()` (leaves room for unrelated keys in the same prefs file); bracket notation for both namespace and function name in generated refs (`window[\"vmx_…\"][\"Qi\"]`); `response.use { … }` around the synthetic response build; `headersAsJson` switched to `buildString { }` per CONTRIBUTING.md; `LOAD_TIMEOUT_S` 30 → 12 so silent waits surface as actionable errors instead of dragging on.

## Numbers

Same device, same Wi-Fi session, cold start each row, no chapter dedupe. Whatever the site does between deploys, I tried to stick to apples-to-apples: each timing is `main` vs this branch back-to-back.

| Title          | Chapters | main       | this branch | Δ           |
|----------------|---------:|------------|-------------|-------------|
| ORV            |      937 | 0:57.32    | 0:58.14     | +0.82 s     |
| Yuan Zun       |    3 469 | 3:20.48    | 3:23.03     | +2.55 s     |
| MP             |   12 716 | 12:50.79   | 12:24.12    | **−26.67 s** |

ORV and Yuan Zun are within the per-session noise floor on the same network. The MP win lines up with the per-call install-once theory: 127 pages × ~210 ms ≈ 27 s, which matches the delta within rounding. So not a step change — measurable but small, and only on really big lists.

(Side note for anyone reading this who might think the chapter-dedupe pref makes things faster: it doesn't. It runs the same fetch + decrypt loop and then adds LinkedHashMap-based comparison work on top. The pref's own description warns about it being slow on big lists. I tested with it off.)

## Things I tried that didn't pay off

Two attempts I had to revert before this PR, mentioning them in case anyone else considers them:

- **Sign / fetch / decrypt split** routing the actual fetch through OkHttp (so Mihon's rate limiter and parallel library updates could batch network I/O properly). On sequential single-manga chapter lists this turned out a small net regression — the response body crossing the Kotlin↔JS boundary for decrypt and the extra interceptor-chain work per page costs more than the parallel-fetch potential, which isn't even exercised on this workload.
- **Pre-signing all chapter paths after `chapterListParse`**. The single JS pass over thousands of paths held the WebView main thread long enough that the next manga's request and any in-flight decrypt queued behind it. Net negative on big lists.

The real step-change for big chapter lists is a WebView pool — multiple WebViews each holding their own captured decryptor, so the obfuscated VM's per-item decrypt work can actually run in parallel instead of serialising through one JS event loop. That's a bigger piece of work (+150-200 MB RAM at peak, coordination, anti-tamper unknowns), so I'd want to do it as its own PR with its own benchmarks rather than slip it in here.

## Checklist

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension