### PR TITLE
CatharsisWorld Update Domain

### DIFF
--- a/src/es/catharsisworld/build.gradle
+++ b/src/es/catharsisworld/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Catharsis World'
     extClass = '.CatharsisWorld'
     themePkg = 'madara'
-    baseUrl = 'https://catharsisworld.lat'
-    overrideVersionCode = 11
+    baseUrl = 'https://catharsisworld.online'
+    overrideVersionCode = 12
     isNsfw = true
 }
 

--- a/src/es/catharsisworld/src/eu/kanade/tachiyomi/extension/es/catharsisworld/CatharsisWorld.kt
+++ b/src/es/catharsisworld/src/eu/kanade/tachiyomi/extension/es/catharsisworld/CatharsisWorld.kt
@@ -18,7 +18,7 @@ import java.util.Locale
 class CatharsisWorld :
     Madara(
         "Catharsis World",
-        "https://catharsisworld.lat",
+        "https://catharsisworld.online",
         "es",
         SimpleDateFormat("MMMM dd, yyyy", Locale("es")),
     ),


### PR DESCRIPTION
Closes #15595
Covers load normally

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
