### PR TITLE
Remove gradle worker limit and disable lint on build

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -58,6 +58,10 @@ android {
         }
     }
 
+    lintOptions {
+        checkReleaseBuilds false
+    }
+
     signingConfigs {
         release {
             storeFile = rootProject.file("signingkey.jks")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,24 +1,6 @@
-# Project-wide Gradle settings.
-
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-
-# For more details on how to configure your build environment visit
-# http://www.gradle.org/docs/current/userguide/build_environment.html
-
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx6144m
-
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-org.gradle.parallel=true
-org.gradle.workers.max=5
-org.gradle.configureondemand=true
-
+kotlin.stdlib.default.dependency=false
 org.gradle.caching=true
 org.gradle.configuration-cache=true
-
-kotlin.stdlib.default.dependency=false
+org.gradle.configureondemand=true
+org.gradle.jvmargs=-Xmx6144m
+org.gradle.parallel=true


### PR DESCRIPTION
`ubuntu-latest` only has 4 CPU core so worker limit isn't really relevant to CI. And I don't think we care about android's lint. Both combined will make mass building extensions faster on capable hardware.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
