### PR TITLE
fix(comix): Suwayomi looper deadlock

### DIFF
--- a/src/en/comix/build.gradle
+++ b/src/en/comix/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comix'
     extClass = '.Comix'
-    extVersionCode = 18
+    extVersionCode = 19
     isNsfw = true
 }
 

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
@@ -411,9 +411,9 @@ class Comix :
         val handler = Handler(Looper.getMainLooper())
         val latch = CountDownLatch(1)
         val tokenRef = AtomicReference<String>()
-
         var webView: WebView? = null
-        handler.post {
+
+        val createAndLoad = {
             val view = WebView(Injekt.get<Application>())
             webView = view
 
@@ -442,6 +442,12 @@ class Comix :
             }
 
             view.loadUrl(pageUrl)
+        }
+
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            createAndLoad()
+        } else {
+            handler.post(createAndLoad)
         }
 
         val completed = latch.await(30, TimeUnit.SECONDS)


### PR DESCRIPTION
For some reason, on Suwayomi's LooperThread, `handler.post { ... }` + `latch.await()` deadlocks.

The LooperThread posts work to itself then blocks, so the work never runs. The guard runs the WebView creation inline when already on the LooperThread, avoiding the deadlock. On Android this branch is never taken (background thread calls `captureToken` instead), so it's harmless.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
