### PR TITLE
Comix: Fix timed out waiting for token when load a chapter.

### DIFF
--- a/src/en/comix/build.gradle
+++ b/src/en/comix/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comix'
     extClass = '.Comix'
-    extVersionCode = 19
+    extVersionCode = 20
     isNsfw = true
 }
 

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
@@ -378,7 +378,7 @@ class Comix :
     // =============================== Pages ===============================
     override fun fetchPageList(chapter: SChapter): Observable<List<Page>> = runBlocking {
         // Legacy URL example: title/qnj9/5241183-chapter-0
-        if (chapter.url.substringBeforeLast("/").indexOf("-") == -1) throw Exception("Outdated chapter URL. Please refresh the chapter list")
+        if (chapter.url.substringAfter("/").substringBeforeLast("/").indexOf("-") == -1) throw Exception("Outdated chapter URL. Please refresh the chapter list")
 
         val chapterId = chapter.url.substringAfterLast("/").substringBefore("-")
 

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
@@ -377,6 +377,9 @@ class Comix :
 
     // =============================== Pages ===============================
     override fun fetchPageList(chapter: SChapter): Observable<List<Page>> = runBlocking {
+        // Legacy URL example: title/qnj9/5241183-chapter-0
+        if (chapter.url.substringBeforeLast("/").indexOf("-") == -1) throw Exception("Outdated chapter URL. Please refresh the chapter list")
+
         val chapterId = chapter.url.substringAfterLast("/").substringBefore("-")
 
         val token = captureToken(

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Dto.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Dto.kt
@@ -244,6 +244,7 @@ class ChapterDetailsResponse(
 @Serializable
 class Chapter(
     val id: Int,
+    val url: String = "",
     val number: Double,
     private val name: String = "",
     val votes: Int = 0,
@@ -262,7 +263,13 @@ class Chapter(
     }
 
     fun toSChapter(mangaSlug: String) = SChapter.create().apply {
-        url = "title/$mangaSlug/$id-chapter-${number.toString().removeSuffix(".0")}"
+        url = this@Chapter.url.indexOf("/title/").let { index ->
+            if (index != -1) {
+                this@Chapter.url.substring(index + 1)
+            } else {
+                "title/$mangaSlug/$id-chapter-${number.toString().removeSuffix(".0")}"
+            }
+        }
         name = buildString {
             append("Chapter ")
             append(this@Chapter.number.toString().removeSuffix(".0"))


### PR DESCRIPTION
Legacy titles from Comix used to save only the manga slug up to the first dash "-" to the database.

For example: https://comix.to/title/qnj9
- legacy: /qnj9
- now: /qnj9-kanojo-ni-shitai-joshi-ichii-no-tonari-de-mitsuketa-amari-chan

This doesn't affect loading the manga detail or the chapter list, since the API only uses /qnj9 to load them.

The issue happens when loading chapter details:
With legacy url(Example: https://comix.to/title/qnj9/7293580-chapter-7.5), Comix returns a 404, and the app ends up timing out waiting for a token:

This fix attempts to save the full slug and use it when loading chapter details.
No migration needed anymore — chapter URLs are updated automatically.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
