### PR TITLE
LunarManga (ALL): fix incomplete manga details loading

### DIFF
--- a/src/all/lunaranime/build.gradle
+++ b/src/all/lunaranime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Lunar Manga'
     extClass = '.LunarAnimeFactory'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = true
 }
 

--- a/src/all/lunaranime/src/eu/kanade/tachiyomi/extension/all/lunaranime/LunarAnime.kt
+++ b/src/all/lunaranime/src/eu/kanade/tachiyomi/extension/all/lunaranime/LunarAnime.kt
@@ -140,7 +140,7 @@ class LunarAnime(override val lang: String, private val internalLang: String = l
 
     override fun mangaDetailsParse(response: Response): SManga {
         val result = response.parseAs<LunarMangaResponse>()
-        return result.manga.toSManga()
+        return result.manga.toSManga().apply { initialized = true }
     }
 
     // ============================== Chapters ==============================

--- a/src/all/lunaranime/src/eu/kanade/tachiyomi/extension/all/lunaranime/LunarAnimeDto.kt
+++ b/src/all/lunaranime/src/eu/kanade/tachiyomi/extension/all/lunaranime/LunarAnimeDto.kt
@@ -32,6 +32,9 @@ class LunarMangaDto(
     @SerialName("publication_status") val publicationStatus: String? = null,
     val author: String? = null,
     val artist: String? = null,
+    @SerialName("alternative_titles") val alternativeTitles: String? = null,
+    val demographic: String? = null,
+    val themes: String? = null,
 ) {
     fun toSManga(): SManga = SManga.create().apply {
         title = this@LunarMangaDto.title
@@ -39,7 +42,22 @@ class LunarMangaDto(
         url = "/manga/$slug"
         author = this@LunarMangaDto.author?.trim()
         artist = this@LunarMangaDto.artist?.trim()
-        description = this@LunarMangaDto.description
+
+        description = buildString {
+            this@LunarMangaDto.description?.let { append(it) }
+
+            alternativeTitles?.let { alt ->
+                try {
+                    val titles = alt.parseAs<List<String>>()
+                    if (titles.isNotEmpty()) {
+                        if (isNotEmpty()) append("\n\n")
+                        append("Alternative Titles: ")
+                        append(titles.joinToString())
+                    }
+                } catch (_: Exception) {}
+            }
+        }
+
         status = when (publicationStatus?.lowercase(Locale.ROOT)) {
             "ongoing" -> SManga.ONGOING
             "completed" -> SManga.COMPLETED
@@ -48,14 +66,26 @@ class LunarMangaDto(
             "cancelled" -> SManga.CANCELLED
             else -> SManga.UNKNOWN
         }
-        genre = genres?.let { g ->
-            try {
-                g.parseAs<List<String>>().joinToString()
-            } catch (e: Exception) {
-                g
+
+        genre = buildList {
+            demographic?.takeIf { it.isNotBlank() }?.let { d ->
+                add(d.replaceFirstChar { it.titlecase(Locale.ROOT) })
             }
-        }
-        initialized = true
+
+            genres?.let { g ->
+                try {
+                    addAll(g.parseAs<List<String>>())
+                } catch (e: Exception) {
+                    add(g)
+                }
+            }
+
+            themes?.let { t ->
+                try {
+                    addAll(t.parseAs<List<String>>())
+                } catch (_: Exception) {}
+            }
+        }.filter { it.isNotBlank() }.distinct().joinToString()
     }
 }
 


### PR DESCRIPTION
- Capture 'alternative_titles', 'demographic', and 'themes' from the API.
- Update 'toSManga' to include the new metadata in description and genres.
- Remove 'initialized = true' from listing parsers to ensure the app fetches full details automatically.
- Bump version code.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
