### PR TITLE
MangaBuddy (EN): fix duplicate chapters

### DIFF
--- a/src/en/mangabuddy/build.gradle
+++ b/src/en/mangabuddy/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaBuddy'
     themePkg = 'madtheme'
     baseUrl = 'https://mangabuddy.com'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
     isNsfw = true
 }
 

--- a/src/en/mangabuddy/src/eu/kanade/tachiyomi/extension/en/mangabuddy/MangaBuddy.kt
+++ b/src/en/mangabuddy/src/eu/kanade/tachiyomi/extension/en/mangabuddy/MangaBuddy.kt
@@ -1,5 +1,11 @@
 package eu.kanade.tachiyomi.extension.en.mangabuddy
 
 import eu.kanade.tachiyomi.multisrc.madtheme.MadTheme
+import eu.kanade.tachiyomi.source.model.SChapter
+import org.jsoup.nodes.Element
 
-class MangaBuddy : MadTheme("MangaBuddy", "https://mangabuddy.com", "en")
+class MangaBuddy : MadTheme("MangaBuddy", "https://mangabuddy.com", "en") {
+    override fun chapterFromElement(element: Element): SChapter = super.chapterFromElement(element).apply {
+        url = url.replace(Regex("(?<=[^:/])//+"), "/")
+    }
+}

--- a/src/en/mangabuddy/src/eu/kanade/tachiyomi/extension/en/mangabuddy/MangaBuddy.kt
+++ b/src/en/mangabuddy/src/eu/kanade/tachiyomi/extension/en/mangabuddy/MangaBuddy.kt
@@ -6,6 +6,10 @@ import org.jsoup.nodes.Element
 
 class MangaBuddy : MadTheme("MangaBuddy", "https://mangabuddy.com", "en") {
     override fun chapterFromElement(element: Element): SChapter = super.chapterFromElement(element).apply {
-        url = url.replace(Regex("(?<=[^:/])//+"), "/")
+        url = url.replace(URL_CLEAN_REGEX, "/")
+    }
+
+    companion object {
+        private val URL_CLEAN_REGEX = Regex("(?<=[^:/])//+")
     }
 }


### PR DESCRIPTION
Closes #15871
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
