### PR TITLE
Poseidon Scans: handle $undefined boolean in RSC payload

### DIFF
--- a/src/fr/poseidonscans/build.gradle
+++ b/src/fr/poseidonscans/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Poseidon Scans'
     extClass = '.PoseidonScans'
-    extVersionCode = 50
+    extVersionCode = 51
     isNsfw = false
 }
 

--- a/src/fr/poseidonscans/src/eu/kanade/tachiyomi/extension/fr/poseidonscans/PoseidonScansDto.kt
+++ b/src/fr/poseidonscans/src/eu/kanade/tachiyomi/extension/fr/poseidonscans/PoseidonScansDto.kt
@@ -1,6 +1,15 @@
 package eu.kanade.tachiyomi.extension.fr.poseidonscans
 
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
 
 @Serializable
 class LatestApiManga(
@@ -22,7 +31,8 @@ class PopularMangaData(
 
 @Serializable
 class MangaPageDetailsData(
-    val isPremiumUser: Boolean,
+    @Serializable(with = LenientBooleanSerializer::class)
+    val isPremiumUser: Boolean = false,
     val manga: MangaDetailsData,
 )
 
@@ -30,10 +40,10 @@ class MangaPageDetailsData(
 class MangaDetailsData(
     val title: String,
     val slug: String,
-    val description: String,
-    val status: String,
-    val artist: String?,
-    val author: String?,
+    val description: String = "",
+    val status: String? = null,
+    val artist: String? = null,
+    val author: String? = null,
     val categories: List<CategoryData> = emptyList(),
     val chapters: List<ChapterData> = emptyList(),
 )
@@ -55,8 +65,9 @@ class ChapterData(
 class PageData(
     val currentChapter: CurrentChapterData,
     val initialData: InitialData,
-    var isPremiumUser: Boolean,
-    var sessionStatus: String,
+    @Serializable(with = LenientBooleanSerializer::class)
+    var isPremiumUser: Boolean = false,
+    var sessionStatus: String = "",
 )
 
 @Serializable
@@ -74,3 +85,17 @@ class ImageData(
     val originalUrl: String,
     val order: Int,
 )
+
+// Next.js RSC payloads may emit the literal string "$undefined" for an
+// unresolved boolean; treat anything that isn't a real boolean as false.
+object LenientBooleanSerializer : KSerializer<Boolean> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("LenientBoolean", PrimitiveKind.BOOLEAN)
+
+    override fun deserialize(decoder: Decoder): Boolean {
+        val jsonDecoder = decoder as? JsonDecoder ?: return decoder.decodeBoolean()
+        return (jsonDecoder.decodeJsonElement() as? JsonPrimitive)?.booleanOrNull ?: false
+    }
+
+    override fun serialize(encoder: Encoder, value: Boolean) = encoder.encodeBoolean(value)
+}


### PR DESCRIPTION
Fixes a `JsonDecodingException` raised when the Next.js RSC payload returns the literal string `"$undefined"` for `isPremiumUser` instead of a real boolean, which prevented the chapter list from loading.

Adds a lenient `KSerializer<Boolean>` that falls back to `false` for any non-boolean primitive, applied to `MangaPageDetailsData.isPremiumUser` and `PageData.isPremiumUser`.

Closes #15855

### Checklist

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
