### PR TITLE
Com-X: add missing headers

### DIFF
--- a/src/ru/comx/build.gradle
+++ b/src/ru/comx/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Com-X'
     extClass = '.ComX'
-    extVersionCode = 36
+    extVersionCode = 37
     isNsfw = false
 }
 

--- a/src/ru/comx/src/eu/kanade/tachiyomi/extension/ru/comx/ComX.kt
+++ b/src/ru/comx/src/eu/kanade/tachiyomi/extension/ru/comx/ComX.kt
@@ -311,6 +311,8 @@ class ComX :
             .post(verifyBody)
             .header("X-Requested-With", "XMLHttpRequest")
             .header("Referer", challenge.request.url.toString())
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .headers(headers)
             .build()
         chain.proceed(verifyReq).close()
 

--- a/src/ru/comx/src/eu/kanade/tachiyomi/extension/ru/comx/ComX.kt
+++ b/src/ru/comx/src/eu/kanade/tachiyomi/extension/ru/comx/ComX.kt
@@ -309,10 +309,10 @@ class ComX :
         val verifyReq = Request.Builder()
             .url("$baseUrl/_v")
             .post(verifyBody)
+            .headers(headers)
             .header("X-Requested-With", "XMLHttpRequest")
             .header("Referer", challenge.request.url.toString())
             .header("Content-Type", "application/x-www-form-urlencoded")
-            .headers(headers)
             .build()
         chain.proceed(verifyReq).close()
 


### PR DESCRIPTION
Checklist:

Addition to #15756
Added headers that bypass_guard requires (lines from JavaScript that forms __gurad_token on the site):
```
var x = new XMLHttpRequest();
        x.open("POST", "/_v", true);
        x.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
```

Also, because standard `headers` weren’t sent with Post request
```
        val verifyReq = Request.Builder()
            .url("$baseUrl/_v")
            .post(verifyBody)
```
site didn't receive __guard_token and request to `/_v` returned "502 Bad Gateway". I've just added them.


- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
