### PR TITLE
utils: update util functions

### DIFF
--- a/core/src/main/kotlin/keiyoushi/utils/Date.kt
+++ b/core/src/main/kotlin/keiyoushi/utils/Date.kt
@@ -1,15 +1,10 @@
 package keiyoushi.utils
 
-import java.text.ParseException
+import java.text.ParsePosition
 import java.text.SimpleDateFormat
 
-@Suppress("NOTHING_TO_INLINE")
-inline fun SimpleDateFormat.tryParse(date: String?): Long {
+fun SimpleDateFormat.tryParse(date: String?): Long {
     date ?: return 0L
 
-    return try {
-        parse(date)?.time ?: 0L
-    } catch (_: ParseException) {
-        0L
-    }
+    return parse(date, ParsePosition(0))?.time ?: 0L
 }

--- a/core/src/main/kotlin/keiyoushi/utils/Json.kt
+++ b/core/src/main/kotlin/keiyoushi/utils/Json.kt
@@ -1,24 +1,27 @@
 package keiyoushi.utils
 
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.decodeFromJsonElement
-import kotlinx.serialization.json.decodeFromStream
+import kotlinx.serialization.json.okio.decodeFromBufferedSource
+import kotlinx.serialization.serializer
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import okio.buffer
+import okio.source
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.io.InputStream
 
 val jsonInstance: Json = Injekt.get()
 
+val JSON_MEDIA_TYPE = "application/json".toMediaType()
+
 /**
  * Parses JSON string into an object of type [T].
  */
-inline fun <reified T> String.parseAs(json: Json = jsonInstance): T = json.decodeFromString(this)
+inline fun <reified T> String.parseAs(json: Json = jsonInstance): T = json.decodeFromString(serializer(), this)
 
 /**
  * Parses JSON string into an object of type [T], applying a [transform] function to the string before parsing.
@@ -31,7 +34,9 @@ inline fun <reified T> String.parseAs(json: Json = jsonInstance, transform: (Str
 /**
  * Parses the response body into an object of type [T].
  */
-inline fun <reified T> Response.parseAs(json: Json = jsonInstance): T = use { json.decodeFromStream(it.body.byteStream()) }
+inline fun <reified T> Response.parseAs(json: Json = jsonInstance): T = use {
+    json.decodeFromBufferedSource(serializer(), it.body.source())
+}
 
 /**
  * Parses the response body into an object of type [T], applying a transformation to the raw JSON string before parsing.
@@ -39,28 +44,32 @@ inline fun <reified T> Response.parseAs(json: Json = jsonInstance): T = use { js
  * @param json The [Json] instance to use for parsing. Defaults to the injected instance.
  * @param transform A function to transform the JSON string before it's decoded.
  */
-inline fun <reified T> Response.parseAs(json: Json = jsonInstance, transform: (String) -> String): T = use { it.body.string().parseAs(json, transform) }
+inline fun <reified T> Response.parseAs(json: Json = jsonInstance, transform: (String) -> String): T = use {
+    it.body.string().parseAs(json, transform)
+}
 
 /**
  * Parses a [JsonElement] into an object of type [T].
  *
  * @param json The [Json] instance to use for parsing. Defaults to the injected instance.
  */
-inline fun <reified T> JsonElement.parseAs(json: Json = jsonInstance): T = json.decodeFromJsonElement(this)
+inline fun <reified T> JsonElement.parseAs(json: Json = jsonInstance): T = json.decodeFromJsonElement(serializer(), this)
 
 /**
  * Parses a [InputStream] into an object of type [T]
  *
  * @param json The [Json] instance to use for parsing. Defaults to the injected instance.
  */
-inline fun <reified T> InputStream.parseAs(json: Json = jsonInstance): T = use { json.decodeFromStream(it) }
+inline fun <reified T> InputStream.parseAs(json: Json = jsonInstance): T = use {
+    json.decodeFromBufferedSource(serializer(), it.source().buffer())
+}
 
 /**
  * Serializes the object to a JSON string.
  */
-inline fun <reified T> T.toJsonString(json: Json = jsonInstance): String = json.encodeToString(this)
+inline fun <reified T> T.toJsonString(json: Json = jsonInstance): String = json.encodeToString(serializer(), this)
 
 /**
  * Encodes the object to a Response Body.
  */
-inline fun <reified T> T.toJsonRequestBody(json: Json = jsonInstance): RequestBody = toJsonString(json).toRequestBody("application/json".toMediaType())
+inline fun <reified T> T.toJsonRequestBody(json: Json = jsonInstance): RequestBody = toJsonString(json).toRequestBody(JSON_MEDIA_TYPE)

--- a/core/src/main/kotlin/keiyoushi/utils/Preferences.kt
+++ b/core/src/main/kotlin/keiyoushi/utils/Preferences.kt
@@ -23,5 +23,4 @@ inline fun HttpSource.getPreferencesLazy(
 /**
  * Returns the [SharedPreferences] associated with passed source id
  */
-@Suppress("NOTHING_TO_INLINE")
-inline fun getPreferences(sourceId: Long): SharedPreferences = Injekt.get<Application>().getSharedPreferences("source_$sourceId", 0x0000)
+fun getPreferences(sourceId: Long): SharedPreferences = Injekt.get<Application>().getSharedPreferences("source_$sourceId", 0x0000)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ injekt-core = { module = "com.github.null2264.injekt:injekt-core", version = "41
 jsoup = { module = "org.jsoup:jsoup", version = "1.22.1" }
 kotlin-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 kotlin-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf", version.ref = "serialization" }
+kotlin-json-okio = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json-okio", version.ref = "serialization" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin-gradle" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version = "5.3.2" }
 quickjs = { module = "app.cash.quickjs:quickjs-android", version = "0.9.2" }
@@ -43,4 +44,4 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 
 [bundles]
-common = ["kotlin-stdlib", "coroutines-core", "coroutines-android", "injekt-core", "rxjava", "kotlin-protobuf", "kotlin-json", "jsoup", "okhttp", "tachiyomi-lib", "quickjs"]
+common = ["kotlin-stdlib", "coroutines-core", "coroutines-android", "injekt-core", "rxjava", "kotlin-protobuf", "kotlin-json", "kotlin-json-okio", "jsoup", "okhttp", "tachiyomi-lib", "quickjs"]


### PR DESCRIPTION
- remove `inline` where not needed
- use `decodeFromBufferedSource` for okio based streaming
  - from `kotlinx-serialization-json-okio`
  - it is already included in all major supported forks including suwayomi
- based on https://github.com/keiyoushi/extensions-source/pull/10039
