### PR TITLE
GocTruyenTranhVui: Update domain, configurable domain

### DIFF
--- a/src/vi/goctruyentranhvui/build.gradle
+++ b/src/vi/goctruyentranhvui/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Goc Truyen Tranh Vui'
     extClass = '.GocTruyenTranhVui'
-    extVersionCode = 12
+    extVersionCode = 13
     isNsfw = false
 }
 

--- a/src/vi/goctruyentranhvui/src/eu/kanade/tachiyomi/extension/vi/goctruyentranhvui/GocTruyenTranhVui.kt
+++ b/src/vi/goctruyentranhvui/src/eu/kanade/tachiyomi/extension/vi/goctruyentranhvui/GocTruyenTranhVui.kt
@@ -41,15 +41,26 @@ class GocTruyenTranhVui :
     ConfigurableSource {
     override val lang = "vi"
 
-    override val baseUrl = "https://goctruyentranhvui23.com"
+    private val defaultBaseUrl = "https://goctruyentranhvuiiiiiiiiii.site"
+
+    override val baseUrl get() = getPrefBaseUrl()
 
     override val name = "Goc Truyen Tranh Vui"
 
-    private val apiUrl = "$baseUrl/api/v2"
+    private val apiUrl get() = "$baseUrl/api/v2"
 
     override val supportsLatest: Boolean = true
 
-    private val preferences: SharedPreferences = getPreferences()
+    private val preferences: SharedPreferences = getPreferences {
+        getString(DEFAULT_BASE_URL_PREF, null).let { prefDefaultBaseUrl ->
+            if (prefDefaultBaseUrl != defaultBaseUrl) {
+                edit()
+                    .putString(BASE_URL_PREF, defaultBaseUrl)
+                    .putString(DEFAULT_BASE_URL_PREF, defaultBaseUrl)
+                    .apply()
+            }
+        }
+    }
 
     override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .rateLimit(3)
@@ -282,6 +293,15 @@ class GocTruyenTranhVui :
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         EditTextPreference(screen.context).apply {
+            key = BASE_URL_PREF
+            title = BASE_URL_PREF_TITLE
+            summary = BASE_URL_PREF_SUMMARY
+            setDefaultValue(defaultBaseUrl)
+            dialogTitle = BASE_URL_PREF_TITLE
+            dialogMessage = "Default: $defaultBaseUrl"
+        }.let(screen::addPreference)
+
+        EditTextPreference(screen.context).apply {
             key = CUSTOM_TOKEN
             title = "Authorization Token"
             summary = "Enter token manually"
@@ -294,9 +314,15 @@ class GocTruyenTranhVui :
         }.also(screen::addPreference)
     }
 
+    private fun getPrefBaseUrl(): String = preferences.getString(BASE_URL_PREF, defaultBaseUrl)!!
+
     companion object {
         private const val CUSTOM_TOKEN = "custom_token"
         private const val RESTART_APP = "Khởi chạy lại ứng dụng để áp dụng token mới nhập."
         private val WEBVIEW_TOKEN_REGEX = Regex(""";\s*wv\)""")
+        private const val DEFAULT_BASE_URL_PREF = "defaultBaseUrl"
+        private const val BASE_URL_PREF = "overrideBaseUrl"
+        private const val BASE_URL_PREF_TITLE = "Ghi đè URL cơ sở"
+        private const val BASE_URL_PREF_SUMMARY = "Dành cho sử dụng tạm thời, cập nhật tiện ích sẽ xóa cài đặt."
     }
 }


### PR DESCRIPTION
They changed their domain but didn't set up a redirect. There is an official announcement in their Discord.

<img width="1803" height="754" alt="image" src="https://github.com/user-attachments/assets/edf3e428-26d0-46c6-9a2d-a8793b06f739" />


Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
