### PR TITLE
Fix ComicsKingdom Default Value

### DIFF
--- a/src/all/comicskingdom/build.gradle
+++ b/src/all/comicskingdom/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ComicsKingdom'
     extClass = '.ComicsKingdomFactory'
-    extVersionCode = 2
+    extVersionCode = 3
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/all/comicskingdom/src/eu/kanade/tachiyomi/extension/all/comicskingdom/ComicsKingdom.kt
+++ b/src/all/comicskingdom/src/eu/kanade/tachiyomi/extension/all/comicskingdom/ComicsKingdom.kt
@@ -292,7 +292,7 @@ class ComicsKingdom(override val lang: String) :
             title = "Compact chapters"
             summary =
                 "Unchecking this will make each daily/weekly upload into a chapter which can be very slow because some comics have 8000+ uploads"
-            isChecked = true
+            setDefaultValue(true)
         }
 
         screen.addPreference(compactpref)


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop


---

Was found by https://github.com/Suwayomi/Suwayomi-Server/issues/2030