### PR TITLE
Iken: fix deeplinking 

### DIFF
--- a/lib-multisrc/iken/build.gradle.kts
+++ b/lib-multisrc/iken/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(kei.plugins.multisrc)
 }
 
-baseVersionCode = 20
+baseVersionCode = 21
 
 dependencies {
     api(project(":lib:i18n"))

--- a/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Dto.kt
+++ b/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Dto.kt
@@ -18,9 +18,9 @@ class SearchResponse(
 @Serializable
 class Manga(
     private val id: Int,
-    val slug: String,
+    private val slug: String,
     private val postTitle: String,
-    val postContent: String? = null,
+    private val postContent: String? = null,
     val isNovel: Boolean = false,
     private val featuredImage: String? = null,
     private val alternativeTitles: String? = null,
@@ -28,7 +28,7 @@ class Manga(
     private val artist: String? = null,
     private val seriesType: String? = null,
     private val seriesStatus: String? = null,
-    val genres: List<Genre> = emptyList(),
+    private val genres: List<Genre> = emptyList(),
 ) {
     fun toSManga() = SManga.create().apply {
         url = "$slug#$id"
@@ -94,6 +94,7 @@ class RelatedMangaDto(
 class ChapterListResponse(
     val isNovel: Boolean = false,
     val slug: String? = null,
+    val id: Int? = null,
     val chapters: List<Chapter>,
 )
 

--- a/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Dto.kt
+++ b/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Dto.kt
@@ -17,8 +17,8 @@ class SearchResponse(
 
 @Serializable
 class Manga(
-    private val id: Int,
-    private val slug: String,
+    val id: Int,
+    val slug: String,
     private val postTitle: String,
     private val postContent: String? = null,
     val isNovel: Boolean = false,

--- a/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Iken.kt
+++ b/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Iken.kt
@@ -110,26 +110,21 @@ abstract class Iken(
     // search
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
-        if (!query.startsWith("http")) {
-            return super.fetchSearchManga(page, query, filters)
+        if (query.startsWith("https://")) {
+            val mangaUrl = query.toHttpUrl()
+            if (mangaUrl.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            if (mangaUrl.pathSegments.size < 2) {
+                throw Exception("Unsupported url")
+            }
+            val slug = mangaUrl.pathSegments[1]
+            val manga = SManga.create().apply { url = slug }
+            return fetchMangaDetails(manga)
+                .map { MangasPage(listOf(it), false) }
         }
 
-        val url = query.toHttpUrl()
-        val baseHost = baseUrl.toHttpUrl().host
-
-        if (url.host != baseHost) throw Exception("Unsupported URL")
-
-        val pathSegments = url.pathSegments
-        val slug = pathSegments.getOrNull(1)
-            ?.takeIf { it.isNotBlank() }
-            ?: throw Exception("Invalid URL format")
-
-        val manga = SManga.create().apply {
-            this@apply.url = slug
-        }
-
-        return fetchMangaDetails(manga)
-            .map { MangasPage(listOf(it), false) }
+        return super.fetchSearchManga(page, query, filters)
     }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {

--- a/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Iken.kt
+++ b/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Iken.kt
@@ -327,8 +327,8 @@ abstract class Iken(
     override fun getMangaUrl(manga: SManga): String = "$baseUrl/series/${manga.url.substringBeforeLast("#")}"
 
     override fun mangaDetailsRequest(manga: SManga): Request {
-        val id = manga.url.substringAfterLast("#")
-        return GET("$apiUrl/api/post?postId=$id", headers)
+        val slug = manga.url.substringBeforeLast("#")
+        return GET("$apiUrl/api/post?postSlug=$slug", headers)
     }
 
     override fun mangaDetailsParse(response: Response): SManga = response.parseAs<Post<Manga>>().post.toSManga()
@@ -344,11 +344,9 @@ abstract class Iken(
     override fun chapterListRequest(manga: SManga): Request = mangaDetailsRequest(manga)
 
     override fun chapterListParse(response: Response): List<SChapter> {
-        val id = response.request.url.queryParameter("postId")
-
         val data = response.parseAs<Post<ChapterListResponse>>()
 
-        launchIO { updateViews(id?.toInt()) }
+        launchIO { updateViews(data.post.id) }
 
         assert(!data.post.isNovel) { "Novels are unsupported" }
 


### PR DESCRIPTION
Deeplinking generates `apiUrl/api/post?postId={mangaPath}`, causing a `404`, This pr fixes it by switching to `?postSlug` instead

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
