### PR TITLE
ReadComicOnline: add deeplink & misc improvements

### DIFF
--- a/src/en/readcomiconline/AndroidManifest.xml
+++ b/src/en/readcomiconline/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity
+            android:name=".en.readcomiconline.UrlActivity"
+            android:excludeFromRecents="true"
+            android:exported="true"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="readcomiconline.li"
+                    android:pathPattern="/Comic/..*"
+                    android:scheme="https" />
+                <data
+                    android:host="rcostation.xyz"
+                    android:pathPattern="/Comic/..*"
+                    android:scheme="https" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/src/en/readcomiconline/build.gradle
+++ b/src/en/readcomiconline/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ReadComicOnline'
     extClass = '.Readcomiconline'
-    extVersionCode = 42
+    extVersionCode = 43
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
@@ -192,9 +192,11 @@ class Readcomiconline :
 
     override fun searchMangaParse(response: Response): MangasPage = popularMangaParse(response)
 
+    private val viewsRegex = Regex("Views:\\s*([\\d,]+)")
+
     override fun mangaDetailsParse(response: Response): SManga {
         val document = response.asJsoup()
-        val infoElement = document.select("div.barContent").first()!!
+        val infoElement = document.selectFirst("div.barContent")!!
 
         val manga = SManga.create()
         manga.title = infoElement.selectFirst("a.bigChar")!!.text()
@@ -205,12 +207,12 @@ class Readcomiconline :
             infoElement.select("p:has(span:contains(Summary:)) ~ p").text().takeIf { it.isNotEmpty() },
             infoElement.select("p:has(span:contains(Publisher:))").text().takeIf { it.isNotEmpty() }?.let { "\n$it" },
             infoElement.select("p:has(span:contains(Publication date:))").text().takeIf { it.isNotEmpty() },
-            Regex("Views:\\s*([\\d,]+)").find(infoElement.select("p:has(span:contains(Views:))").text())
+            viewsRegex.find(infoElement.select("p:has(span:contains(Views:))").text())
                 ?.let { "Views: ${it.groupValues[1]}" },
         ).joinToString("\n")
         manga.status = infoElement.select("p:has(span:contains(Status:))").first()?.text().orEmpty()
             .let { parseStatus(it) }
-        manga.thumbnail_url = document.select(".rightBox:eq(0) img").first()?.absUrl("src")
+        manga.thumbnail_url = document.selectFirst(".rightBox:eq(0) img")?.absUrl("src")
         return manga
     }
 
@@ -299,7 +301,7 @@ class Readcomiconline :
         }
     }
 
-    override fun imageUrlParse(response: Response) = ""
+    override fun imageUrlParse(response: Response) = throw UnsupportedOperationException()
 
     private class Status :
         SelectFilter(
@@ -430,13 +432,6 @@ class Readcomiconline :
             entries = arrayOf("High Quality", "Low Quality")
             entryValues = arrayOf("hq", "lq")
             summary = "%s"
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val selected = newValue as String
-                val index = this.findIndexOfValue(selected)
-                val entry = entryValues[index] as String
-                preferences.edit().putString(QUALITY_PREF, entry).commit()
-            }
         }
 
         val serverPref = ListPreference(screen.context).apply {
@@ -445,13 +440,6 @@ class Readcomiconline :
             entries = arrayOf("Server 1", "Server 2")
             entryValues = arrayOf("", "s2")
             summary = "%s"
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val selected = newValue as String
-                val index = this.findIndexOfValue(selected)
-                val entry = entryValues[index] as String
-                preferences.edit().putString(SERVER_PREF, entry).commit()
-            }
         }
 
         screen.addPreference(mirrorPref)

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
@@ -29,6 +29,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Element
+import org.jsoup.nodes.TextNode
 import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Calendar
@@ -200,20 +201,32 @@ class Readcomiconline :
 
         val manga = SManga.create()
         manga.title = infoElement.selectFirst("a.bigChar")!!.text()
-        manga.artist = infoElement.select("p:has(span:contains(Artist:)) > a").first()?.text()
-        manga.author = infoElement.select("p:has(span:contains(Writer:)) > a").eachText().joinToString()
-        manga.genre = infoElement.select("p:has(span:contains(Genres:)) > *:gt(0)").text()
+        manga.artist = infoElement.select("p:has(span:contains(Artist:)) > a").eachText().summarize()
+        manga.author = infoElement.select("p:has(span:contains(Writer:)) > a").eachText().summarize()
+        manga.genre = infoElement.select("p:has(span:contains(Genres:)) > a").eachText().joinToString()
         manga.description = listOfNotNull(
-            infoElement.select("p:has(span:contains(Summary:)) ~ p").text().takeIf { it.isNotEmpty() },
+            infoElement.select("p:has(span:contains(Summary:)) ~ p")
+                .joinToString("\n\n") { it.textPreserveLineBreaks() }
+                .trim()
+                .takeIf { it.isNotEmpty() },
             infoElement.select("p:has(span:contains(Publisher:))").text().takeIf { it.isNotEmpty() }?.let { "\n$it" },
             infoElement.select("p:has(span:contains(Publication date:))").text().takeIf { it.isNotEmpty() },
             viewsRegex.find(infoElement.select("p:has(span:contains(Views:))").text())
                 ?.let { "Views: ${it.groupValues[1]}" },
         ).joinToString("\n")
-        manga.status = infoElement.select("p:has(span:contains(Status:))").first()?.text().orEmpty()
+        manga.status = infoElement.selectFirst("p:has(span:contains(Status:))")?.text().orEmpty()
             .let { parseStatus(it) }
         manga.thumbnail_url = document.selectFirst(".rightBox:eq(0) img")?.absUrl("src")
         return manga
+    }
+
+    private fun List<String>.summarize(): String = if (size > 2) "${first()} & others" else joinToString()
+
+    private fun Element.textPreserveLineBreaks(): String {
+        // Replace <br> with newline text nodes so wholeText() preserves them as line breaks.
+        // .text() would collapse them into spaces.
+        select("br").forEach { it.replaceWith(TextNode("\n")) }
+        return wholeText()
     }
 
     override fun getMangaUrl(manga: SManga): String {

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
@@ -24,12 +24,14 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Element
 import org.jsoup.nodes.TextNode
+import rx.Observable
 import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Calendar
@@ -98,6 +100,25 @@ class Readcomiconline :
     }
 
     override fun latestUpdatesParse(response: Response): MangasPage = popularMangaParse(response)
+
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        if (query.startsWith("http")) {
+            val url = query.toHttpUrlOrNull()
+            val mirrorHosts = MIRROR_URLS.map { it.toHttpUrl().host }
+            if (url != null && url.host in mirrorHosts &&
+                url.pathSegments.size >= 2 && url.pathSegments[0] == "Comic"
+            ) {
+                val manga = SManga.create().apply {
+                    this.url = "/Comic/${url.pathSegments[1]}"
+                }
+                return fetchMangaDetails(manga).map { details ->
+                    details.url = manga.url
+                    MangasPage(listOf(details), false)
+                }
+            }
+        }
+        return super.fetchSearchManga(page, query, filters)
+    }
 
     override fun searchMangaRequest(
         page: Int,

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
@@ -62,7 +62,7 @@ class Readcomiconline :
             filterInclude = listOf("chrome"),
         )
 
-    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
+    override val client: OkHttpClient = network.client.newBuilder()
         .addNetworkInterceptor(::captchaInterceptor).build()
 
     private fun captchaInterceptor(chain: Interceptor.Chain): Response {

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
@@ -138,7 +138,6 @@ class Readcomiconline :
                 addPathSegment(genreName)
                 if (sortOption != null) addPathSegment(sortOption)
                 addQueryParameter("page", page.toString())
-                if (yearOption != null) addQueryParameter("pubDate", yearOption)
             }.build()
             GET(url, headers)
         } else if (query.isEmpty() && genreList.included.isEmpty() && genreList.excluded.isEmpty() && yearOption == null) {
@@ -183,7 +182,6 @@ class Readcomiconline :
                     addPathSegment(sortOption)
                 }
                 addQueryParameter("page", page.toString())
-                if (yearOption != null) addQueryParameter("pubDate", yearOption)
             }.build()
             GET(url, headers)
         } else {

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
@@ -113,6 +113,7 @@ class Readcomiconline :
                 }
                 return fetchMangaDetails(manga).map { details ->
                     details.url = manga.url
+                    details.initialized = true
                     MangasPage(listOf(details), false)
                 }
             }

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
@@ -1,7 +1,6 @@
 package eu.kanade.tachiyomi.extension.en.readcomiconline
 
 import android.content.SharedPreferences
-import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
 import app.cash.quickjs.QuickJs
@@ -425,26 +424,6 @@ class Readcomiconline :
             summary = "%s"
         }
 
-        val remoteConfigPref = EditTextPreference(screen.context).apply {
-            key = IMAGE_REMOTE_CONFIG_PREF
-            title = IMAGE_REMOTE_CONFIG_TITLE
-            summary = IMAGE_REMOTE_CONFIG_SUMMARY
-            setDefaultValue(IMAGE_REMOTE_CONFIG_DEFAULT)
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val commitResult =
-                    preferences.edit().putString(IMAGE_REMOTE_CONFIG_PREF, newValue as String)
-                        .commit()
-
-                if (commitResult) {
-                    // Make it null so remoteConfigItem would request for a link again
-                    remoteConfigItem = null
-                }
-
-                commitResult
-            }
-        }
-
         val qualityPref = ListPreference(screen.context).apply {
             key = QUALITY_PREF
             title = QUALITY_PREF_TITLE
@@ -476,7 +455,6 @@ class Readcomiconline :
         }
 
         screen.addPreference(mirrorPref)
-        screen.addPreference(remoteConfigPref)
         screen.addPreference(qualityPref)
         screen.addPreference(serverPref)
     }
@@ -491,10 +469,7 @@ class Readcomiconline :
                 return field
             }
 
-            val configLink = preferences.getString(
-                IMAGE_REMOTE_CONFIG_PREF,
-                IMAGE_REMOTE_CONFIG_DEFAULT,
-            )?.ifBlank { IMAGE_REMOTE_CONFIG_DEFAULT }?.addBustQuery() ?: return null
+            val configLink = IMAGE_REMOTE_CONFIG_DEFAULT.addBustQuery()
 
             try {
                 val configResponse = client.newCall(GET(configLink)).execute()
@@ -525,9 +500,6 @@ class Readcomiconline :
         private const val MIRROR_PREF = "mirrorpref"
         private val MIRROR_NAMES = arrayOf("readcomiconline.li", "rcostation.xyz")
         private val MIRROR_URLS = arrayOf("https://readcomiconline.li", "https://rcostation.xyz")
-        private const val IMAGE_REMOTE_CONFIG_TITLE = "Remote Config"
-        private const val IMAGE_REMOTE_CONFIG_SUMMARY = "Remote Config Link"
-        private const val IMAGE_REMOTE_CONFIG_PREF = "imageuseremotelinkpref"
         private const val IMAGE_REMOTE_CONFIG_DEFAULT =
             "https://raw.githubusercontent.com/keiyoushi/extensions-source/refs/heads/main/src/en/readcomiconline/config.json"
     }

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
@@ -254,13 +254,7 @@ class Readcomiconline :
     private val dateFormat = SimpleDateFormat("MM/dd/yyyy", Locale.getDefault())
 
     override fun pageListRequest(chapter: SChapter): Request {
-        val qualitySuffix =
-            if ((qualityPref() != "lq" && serverPref() != "s2") || (qualityPref() == "lq" && serverPref() == "s2")) {
-                "&s=${serverPref()}&quality=${qualityPref()}&readType=1"
-            } else {
-                "&s=${serverPref()}&readType=1"
-            }
-
+        val qualitySuffix = "&s=${serverPref()}&quality=${qualityPref()}&readType=1"
         return GET(baseUrl + chapter.url + qualitySuffix, headers)
     }
 

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/UrlActivity.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/UrlActivity.kt
@@ -1,0 +1,31 @@
+package eu.kanade.tachiyomi.extension.en.readcomiconline
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import kotlin.system.exitProcess
+
+class UrlActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val intentData = intent?.data?.toString()
+        if (intentData != null) {
+            val mainIntent = Intent().apply {
+                action = "eu.kanade.tachiyomi.SEARCH"
+                putExtra("query", intentData)
+                putExtra("filter", packageName)
+            }
+            try {
+                startActivity(mainIntent)
+            } catch (e: Throwable) {
+                Log.e("ReadcomiconlineUrl", e.toString())
+            }
+        } else {
+            Log.e("ReadcomiconlineUrl", "could not parse uri from intent $intent")
+        }
+
+        finish()
+        exitProcess(0)
+    }
+}


### PR DESCRIPTION
- Add deep linking support
- Remove remote config URL preference 
  - It has been the same for half a year now. We still use the one in the repo, but users can't add a custom config link anymore.
- Simplify page list request URL
- Improve comic details
- Update code to standards in contributing guidelines

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
