### PR TITLE
fix(keyoapp): use same selector for paid chapters for both chapter name and filter

### DIFF
--- a/lib-multisrc/keyoapp/build.gradle.kts
+++ b/lib-multisrc/keyoapp/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(kei.plugins.multisrc)
 }
 
-baseVersionCode = 18
+baseVersionCode = 19
 
 dependencies {
     api(project(":lib:i18n"))

--- a/lib-multisrc/keyoapp/src/eu/kanade/tachiyomi/multisrc/keyoapp/Keyoapp.kt
+++ b/lib-multisrc/keyoapp/src/eu/kanade/tachiyomi/multisrc/keyoapp/Keyoapp.kt
@@ -247,10 +247,11 @@ abstract class Keyoapp(
     }
 
     // Chapter list
+    protected open val paidChapterSelector: String = "img[alt~=Coin]"
 
     override fun chapterListSelector(): String {
         if (!preferences.showPaidChapters) {
-            return "#chapters > a:not(:has(.text-sm span:matches(Upcoming))):not(:has(img[alt~=Coin]))"
+            return "#chapters > a:not(:has(.text-sm span:matches(Upcoming))):not(:has($paidChapterSelector))"
         }
         return "#chapters > a:not(:has(.text-sm span:matches(Upcoming)))"
     }
@@ -261,7 +262,7 @@ abstract class Keyoapp(
         element.selectFirst(dateSelector)?.run {
             date_upload = text().trim().parseDate()
         }
-        if (element.select("img[src*=Coin.svg]").isNotEmpty()) {
+        if (element.select(paidChapterSelector).isNotEmpty()) {
             name = "🔒 $name"
         }
     }


### PR DESCRIPTION
Followup to #8627 

Tested on Rithar only so far but should be fine for the others.
The overridable selector doesn't help with ArtLapsa due to its slightly different DOM so not making any changes to that with this PR.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

<img width="83" height="182" alt="Screenshot 2026-05-16 at 10 43 58 PM" src="https://github.com/user-attachments/assets/424c8cf4-0f36-434d-904c-ebef44c79df9" />
