### PR TITLE
TheBlank (EN): Fix prefix size

### DIFF
--- a/src/en/theblank/build.gradle
+++ b/src/en/theblank/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'The Blank'
     extClass = '.TheBlank'
-    extVersionCode = 54
+    extVersionCode = 55
     isNsfw = true
 }
 

--- a/src/en/theblank/src/eu/kanade/tachiyomi/extension/en/theblank/TheBlank.kt
+++ b/src/en/theblank/src/eu/kanade/tachiyomi/extension/en/theblank/TheBlank.kt
@@ -548,5 +548,5 @@ class TheBlank :
 private const val THUMBNAIL_FRAGMENT = "thumbnail"
 private const val HIDE_PREMIUM_PREF = "pref_hide_premium_chapters"
 private const val CHUNK_SIZE = 65536 + 17 // libsodium secretstream chunk + ABYTES
-private const val PREFIX_LENGTH = 128
+private const val PREFIX_LENGTH = 192
 private const val STREAM_HEADER_LENGTH = 24


### PR DESCRIPTION
Closes #15985

vue-BOOzTbSE.js:
```js
const n = await aee(e, t),
        r = await n.blob(),
        i = n.headers.get("X-Page-Name") || "",
        s = n.headers.get("X-Key-Hint") || "",
        o = 192;
             ^
```

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop 

