### PR TITLE
MangaDotNet: Fix chapter list parsing due to website switching databases

### DIFF
--- a/src/en/mangadotnet/build.gradle
+++ b/src/en/mangadotnet/build.gradle
@@ -1,5 +1,5 @@
 ext {
-	extName = 'MangadotnetTEST'
+	extName = 'Mangadotnet'
 	extClass = '.Mangadotnet'
 	extVersionCode = 5
 	isNsfw = true

--- a/src/en/mangadotnet/build.gradle
+++ b/src/en/mangadotnet/build.gradle
@@ -1,7 +1,7 @@
 ext {
-	extName = 'Mangadotnet'
+	extName = 'MangadotnetTEST'
 	extClass = '.Mangadotnet'
-	extVersionCode = 4
+	extVersionCode = 5
 	isNsfw = true
 }
 

--- a/src/en/mangadotnet/src/eu/kanade/tachiyomi/extension/en/mangadotnet/Dto.kt
+++ b/src/en/mangadotnet/src/eu/kanade/tachiyomi/extension/en/mangadotnet/Dto.kt
@@ -189,10 +189,10 @@ class Manga(
 
 @Serializable
 class Chapter(
-    val id: String,
+    val id: Long,
     val source: String,
     @SerialName("chapter_number")
-    val number: String? = null,
+    val number: Float? = null,
     @SerialName("chapter_title")
     val name: String? = null,
     @SerialName("group_name")

--- a/src/en/mangadotnet/src/eu/kanade/tachiyomi/extension/en/mangadotnet/Mangadotnet.kt
+++ b/src/en/mangadotnet/src/eu/kanade/tachiyomi/extension/en/mangadotnet/Mangadotnet.kt
@@ -254,14 +254,15 @@ class Mangadotnet :
                 response.parseAs<List<Chapter>>()
                     .map { chapter ->
                         SChapter.create().apply {
-                            url = ChapterUrl(chapter.id, chapter.source, false).toJsonString()
+                            url = ChapterUrl(chapter.id.toString(), chapter.source, false).toJsonString()
                             name = buildString {
-                                val number = (chapter.number ?: "0").toFloat().toString().substringBefore(".0")
+                                val number = (chapter.number ?: "0f").toString().substringBefore(".0")
                                 val name = chapter.name ?: ""
                                 if (!name.contains(number)) append("Chapter ", number, ": ")
                                 append(name.trim())
                             }
-                            chapter_number = (chapter.number ?: "0").toFloat()
+                            val num: Float = chapter.number ?: 0f
+                            chapter_number = num
                             scanlator = (chapter.group ?: chapter.scanlator)?.takeIf { it.isNotBlank() }
                             date_upload = dateFormat.tryParse(chapter.date)
                         }


### PR DESCRIPTION
Fixes chapter list parsing due to website switching databases to Postgre SQL. 

chapter id -> Long
chapter number -> Float nullable

Closes #15907 

Checklist:

- [ x ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ x ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ x ] Have not changed source names
- [ x ] Have explicitly kept the `id` if a source's name or language were changed
- [ x ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
