### PR TITLE
feat(YellowNote): Add video page support with mp4 external playback

### DIFF
--- a/src/all/yellownote/src/eu/kanade/tachiyomi/extension/all/yellownote/YellowNote.kt
+++ b/src/all/yellownote/src/eu/kanade/tachiyomi/extension/all/yellownote/YellowNote.kt
@@ -22,6 +22,7 @@ import keiyoushi.utils.tryParse
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
+import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
@@ -56,18 +57,19 @@ class YellowNote :
 
     private val dateFormat = SimpleDateFormat("yyyy.MM.dd", Locale.US)
 
-    // yyyy.MM.dd
     private val dateRegex = """\d{4}\.\d{2}\.\d{2}""".toRegex()
 
-    // <div role="img" class="img" style="background-image:url('https://img.xchina.io/photos/641aea8f589cb/0068_600x0.webp');"></div>
     private val styleUrlRegex = """background-image\s*:\s*url\('([^']+)'\)""".toRegex()
 
-    // 100P + 2V
     private val mediaCountRegex = """\d+P( \+ \d+V)?""".toRegex()
 
     private val mangaSelector = "div.list.photo-list > div.item.photo, div.list.amateur-list > div.item.amateur"
     private val nextPageSelector = "div.pager:first-of-type > a.pager-next"
     private val imageSelector = "div.list.photo-items > div.item.photo-image, div.list.amateur-items > div.item.amateur-image"
+
+    private val videosRegex = """var videos = (\[.*?\]);""".toRegex(RegexOption.DOT_MATCHES_ALL)
+    private val videoUrlRegex = """"url":"([^"]+)"""".toRegex()
+    private val domainRegex = """var domain = "([^"]+)";""".toRegex()
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         Preferences.buildPreferences(screen.context, intl)
@@ -189,12 +191,39 @@ class YellowNote :
     }
 
     override fun pageListParse(response: Response): List<Page> {
-        val document = response.asJsoup()
-        return document.select(imageSelector)
+        val html = response.body.string()
+        val document = Jsoup.parse(html)
+
+        val videoDomain = domainRegex.find(html)?.groupValues?.get(1)
+            ?: "https://img.xchina.io"
+
+        val firstImageUrl = document.selectFirst(imageSelector)
+            ?.let { parseUrlFormStyle(it.selectFirst("div.img")) }
+
+        val videoPages = videosRegex.find(html)?.let { match ->
+            val jsonStr = match.groupValues[1]
+            videoUrlRegex.findAll(jsonStr).map { it.groupValues[1] }.toList()
+                .mapIndexed { i, path ->
+                    Page(
+                        index = i,
+                        url = "$videoDomain$path",
+                        imageUrl = firstImageUrl,
+                    )
+                }
+        } ?: emptyList()
+
+        val offset = videoPages.size
+        val imagePages = document.select(imageSelector)
             .mapIndexed { i, imageElement ->
                 val url = parseUrlFormStyle(imageElement.selectFirst("div.img"))!!
-                Page(i, imageUrl = url)
+                Page(
+                    index = offset + i,
+                    url = null,
+                    imageUrl = url,
+                )
             }
+
+        return videoPages + imagePages
     }
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()

--- a/src/all/yellownote/src/eu/kanade/tachiyomi/extension/all/yellownote/YellowNote.kt
+++ b/src/all/yellownote/src/eu/kanade/tachiyomi/extension/all/yellownote/YellowNote.kt
@@ -22,7 +22,6 @@ import keiyoushi.utils.tryParse
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
@@ -69,12 +68,6 @@ class YellowNote :
     private val mangaSelector = "div.list.photo-list > div.item.photo, div.list.amateur-list > div.item.amateur"
     private val nextPageSelector = "div.pager:first-of-type > a.pager-next"
     private val imageSelector = "div.list.photo-items > div.item.photo-image, div.list.amateur-items > div.item.amateur-image"
-
-    // var videos = [{"url":"/photos/.../00001.mp4","filename":"00001.mp4","filesize":"1M"},...];
-    private val videosRegex = """var videos = (\[.*?\]);""".toRegex(RegexOption.DOT_MATCHES_ALL)
-    private val videoUrlRegex = """"url":"([^"]+)"""".toRegex()
-    // var domain = "https://img.xchina.io";
-    private val domainRegex = """var domain = "([^"]+)";""".toRegex()
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         Preferences.buildPreferences(screen.context, intl)
@@ -196,43 +189,12 @@ class YellowNote :
     }
 
     override fun pageListParse(response: Response): List<Page> {
-        val html = response.body.string()
-        val document = Jsoup.parse(html)
-
-        // Resolve video CDN domain (default: img.xchina.io)
-        val videoDomain = domainRegex.find(html)?.groupValues?.get(1)
-            ?: "https://img.xchina.io"
-
-        // Use the first image as cover for video pages
-        val firstImageUrl = document.selectFirst(imageSelector)
-            ?.let { parseUrlFormStyle(it.selectFirst("div.img")) }
-
-        // Parse embedded video array from JS
-        val videoPages = videosRegex.find(html)?.let { match ->
-            val jsonStr = match.groupValues[1]
-            videoUrlRegex.findAll(jsonStr).map { it.groupValues[1] }.toList()
-                .mapIndexed { i, path ->
-                    Page(
-                        index = i,
-                        url = "$videoDomain$path",
-                        imageUrl = firstImageUrl,
-                    )
-                }
-        } ?: emptyList()
-
-        // Parse image pages (offset by video count)
-        val offset = videoPages.size
-        val imagePages = document.select(imageSelector)
+        val document = response.asJsoup()
+        return document.select(imageSelector)
             .mapIndexed { i, imageElement ->
                 val url = parseUrlFormStyle(imageElement.selectFirst("div.img"))!!
-                Page(
-                    index = offset + i,
-                    url = null,
-                    imageUrl = url,
-                )
+                Page(i, imageUrl = url)
             }
-
-        return videoPages + imagePages
     }
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()

--- a/src/all/yellownote/src/eu/kanade/tachiyomi/extension/all/yellownote/YellowNote.kt
+++ b/src/all/yellownote/src/eu/kanade/tachiyomi/extension/all/yellownote/YellowNote.kt
@@ -22,6 +22,7 @@ import keiyoushi.utils.tryParse
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
+import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
@@ -68,6 +69,12 @@ class YellowNote :
     private val mangaSelector = "div.list.photo-list > div.item.photo, div.list.amateur-list > div.item.amateur"
     private val nextPageSelector = "div.pager:first-of-type > a.pager-next"
     private val imageSelector = "div.list.photo-items > div.item.photo-image, div.list.amateur-items > div.item.amateur-image"
+
+    // var videos = [{"url":"/photos/.../00001.mp4","filename":"00001.mp4","filesize":"1M"},...];
+    private val videosRegex = """var videos = (\[.*?\]);""".toRegex(RegexOption.DOT_MATCHES_ALL)
+    private val videoUrlRegex = """"url":"([^"]+)"""".toRegex()
+    // var domain = "https://img.xchina.io";
+    private val domainRegex = """var domain = "([^"]+)";""".toRegex()
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         Preferences.buildPreferences(screen.context, intl)
@@ -189,12 +196,43 @@ class YellowNote :
     }
 
     override fun pageListParse(response: Response): List<Page> {
-        val document = response.asJsoup()
-        return document.select(imageSelector)
+        val html = response.body.string()
+        val document = Jsoup.parse(html)
+
+        // Resolve video CDN domain (default: img.xchina.io)
+        val videoDomain = domainRegex.find(html)?.groupValues?.get(1)
+            ?: "https://img.xchina.io"
+
+        // Use the first image as cover for video pages
+        val firstImageUrl = document.selectFirst(imageSelector)
+            ?.let { parseUrlFormStyle(it.selectFirst("div.img")) }
+
+        // Parse embedded video array from JS
+        val videoPages = videosRegex.find(html)?.let { match ->
+            val jsonStr = match.groupValues[1]
+            videoUrlRegex.findAll(jsonStr).map { it.groupValues[1] }.toList()
+                .mapIndexed { i, path ->
+                    Page(
+                        index = i,
+                        url = "$videoDomain$path",
+                        imageUrl = firstImageUrl,
+                    )
+                }
+        } ?: emptyList()
+
+        // Parse image pages (offset by video count)
+        val offset = videoPages.size
+        val imagePages = document.select(imageSelector)
             .mapIndexed { i, imageElement ->
                 val url = parseUrlFormStyle(imageElement.selectFirst("div.img"))!!
-                Page(i, imageUrl = url)
+                Page(
+                    index = offset + i,
+                    url = null,
+                    imageUrl = url,
+                )
             }
+
+        return videoPages + imagePages
     }
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()


### PR DESCRIPTION
## Summary

Add video support to YellowNote (XChina source) extension. Works with the reader's built-in "Open externally" menu for one-tap video playback.

## How It Works

1. Parses the embedded `var videos = [...]` JS array from photo detail pages
2. Extracts video CDN domain (`img.xchina.io`)
3. Creates `Page` entries with:
   - `url` → full mp4 address (for external playback)
   - `imageUrl` → first image as cover thumbnail
4. Video pages appear before image pages in the reader

**User flow**: Swipe to a video page → see cover → tap menu "Open externally" → system player opens mp4

## Changes

### YellowNote.kt
- Added `videosRegex`, `videoUrlRegex`, `domainRegex` to extract video data from embedded JS
- Rewrote `pageListParse()`:
  - Now reads raw HTML body for JS extraction
  - Parses video array and creates `Page` entries with mp4 URLs
  - Image pages are offset by video count for correct indexing
- Added `import org.jsoup.Jsoup` for parsing HTML from string

## Testing

- Verified HTML structure on live XChina pages with video content (e.g., 371P+9V works)
- Video URL extraction tested against real page source
- Non-video pages (no `videos` array) fall back to original image-only behavior

## Notes

- This does NOT embed a video player in the reader — it uses the existing "Open externally" menu
- Requires Mihon reader (Tachiyomi forks) with external-open support
- Clean separation: video and image pages don't interfere with each other