### PR TITLE
Asmodeus Scans add Wayback Machine support

### DIFF
--- a/src/en/asmotoon/build.gradle
+++ b/src/en/asmotoon/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Asmotoon'
     themePkg = 'keyoapp'
     baseUrl = 'https://asmotoon.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = false
 }
 

--- a/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/Asmotoon.kt
+++ b/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/Asmotoon.kt
@@ -42,7 +42,7 @@ class Asmotoon :
     val waybackMachineClient: OkHttpClient = super
         .client
         .newBuilder()
-        .addInterceptor(WaybackMachineInterceptor())
+        .addInterceptor(WaybackMachineInterceptor("""\w+://asmotoon\.com/.*""".toRegex()))
         .followRedirects(false)
         .build()
 

--- a/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/Asmotoon.kt
+++ b/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/Asmotoon.kt
@@ -42,7 +42,7 @@ class Asmotoon :
     val waybackMachineClient: OkHttpClient = super
         .client
         .newBuilder()
-        .addInterceptor(WaybackMachineInterceptor("""\w+://asmotoon\.com/.*""".toRegex()))
+        .addInterceptor(WaybackMachineInterceptor("""^${Regex.escape(baseUrl)}/.*$""".toRegex()))
         .followRedirects(false)
         .build()
 

--- a/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/Asmotoon.kt
+++ b/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/Asmotoon.kt
@@ -1,7 +1,12 @@
 package eu.kanade.tachiyomi.extension.en.asmotoon
 
+import android.content.SharedPreferences
+import androidx.preference.PreferenceScreen
+import androidx.preference.SwitchPreferenceCompat
+import eu.kanade.tachiyomi.extension.en.asmotoon.waybackmachineinterceptor.WaybackMachineInterceptor
 import eu.kanade.tachiyomi.multisrc.keyoapp.Keyoapp
 import eu.kanade.tachiyomi.source.model.SManga
+import okhttp3.OkHttpClient
 import org.jsoup.nodes.Document
 import java.util.Locale
 
@@ -32,5 +37,38 @@ class Asmotoon :
             }.let(::add)
             document.select(genreSelector).forEach { add(it.text().removeSuffix(",")) }
         }.joinToString()
+    }
+
+    val waybackMachineClient: OkHttpClient = super
+        .client
+        .newBuilder()
+        .addInterceptor(WaybackMachineInterceptor())
+        .followRedirects(false)
+        .build()
+
+    override val client: OkHttpClient get() = if (preferences.getUseWaybackMachinePref()) {
+        waybackMachineClient
+    } else {
+        super.client
+    }
+
+    private fun SharedPreferences.getUseWaybackMachinePref(): Boolean = getBoolean(
+        PREF_USE_WAYBACK_MACHINE,
+        false,
+    )
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        super.setupPreferenceScreen(screen)
+        SwitchPreferenceCompat(screen.context).apply {
+            key = PREF_USE_WAYBACK_MACHINE
+            title = "Use WayBack Machine (web.archive.org)"
+            summaryOff = "Requests are not redirected to web.archive.org"
+            summaryOn = "Requests are redirected to web.archive.org"
+            setDefaultValue(false)
+        }.let(screen::addPreference)
+    }
+
+    companion object {
+        private const val PREF_USE_WAYBACK_MACHINE = "pref_use_wayback_machine"
     }
 }

--- a/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/waybackmachineinterceptor/WaybackMachineInterceptor.kt
+++ b/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/waybackmachineinterceptor/WaybackMachineInterceptor.kt
@@ -1,8 +1,11 @@
 package eu.kanade.tachiyomi.extension.en.asmotoon.waybackmachineinterceptor
 
 import android.util.Log
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.asResponseBody
 import okio.Buffer
@@ -10,42 +13,79 @@ import okio.EOFException
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
+import java.util.UUID
 
-class WaybackMachineInterceptor : Interceptor {
-    override fun intercept(chain: Interceptor.Chain): Response {
-        var request = chain.request()
-        val url = request.url
-        if (url.host != HOST) {
-            var dateStr = getDateStr(chain, "$WEB_PREFIX$url")
-            if (dateStr == null) {
-                dateStr = getDateStr(chain, "$SAVE_PREFIX$url") ?: throw Exception("Failed to archive page")
-            } else {
-                val date = DATE_FORMAT.parse(dateStr)!!
+class WaybackMachineInterceptor(
+    private val regex: Regex = ".*".toRegex(),
+) : Interceptor {
+    // LinkedHashMap with a capacity of 250. When exceeding the capacity the oldest entry is removed.
+    private val urlCache = object : LinkedHashMap<HttpUrl, HttpUrl>() {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<HttpUrl, HttpUrl>?): Boolean = size > 250
+    }
+
+    /**
+     * Gets the response from the Wayback Machine without following redirects
+     */
+    private fun getImmediateResponse(chain: Interceptor.Chain, request: Request): Response = urlCache[request.url]?.let {
+        // url is cached, use cached url
+        chain.proceed(request.newBuilder().url(it).build())
+    } ?: request.url.let { url ->
+        if (url.host == HOST) {
+            // url is a Wayback Machine URL, do nothing
+            chain.proceed(request)
+        } else {
+            val (dateStr, newUrl) = getDateStr(chain, "$WEB_PREFIX$url")?.let {
+                val date = DATE_FORMAT.parse(it)!!
                 if (System.currentTimeMillis() - date.time > 24 * 60 * 60 * 1000) {
-                    dateStr = getDateStr(chain, "$SAVE_PREFIX$url") ?: dateStr
+                    // archive is older than 24 hours, create a new archive
+                    archiveUrl(chain, url) ?: Pair(it, url)
+                } else {
+                    // archive is recent
+                    Pair(it, url)
                 }
             }
-            request = request
-                .newBuilder()
-                .url("$WEB_PREFIX${dateStr}id_/$url")
-                .build()
+
+                // archive doesn't exist, create a new archive
+                ?: archiveUrl(chain, url)
+
+                // archiving failed
+                ?: throw Exception("Failed to archive page")
+
+            // use the "id_" url, which points to the raw, unmodified content
+            val finalUrl = "$WEB_PREFIX${dateStr}id_/$newUrl".toHttpUrl()
+            chain.proceed(request.newBuilder().url(finalUrl).build())
+        }
+    }
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+
+        if (!regex.matches(request.url.toString())) {
+            // url does not match regex, do nothing
+            return chain.proceed(request)
         }
 
-        var response = chain.proceed(request)
+        var response = getImmediateResponse(chain, request)
 
+        // resolve all redirects
         while (response.isRedirect) {
             response = response.use {
-                chain.proceed(
-                    request
+                getImmediateResponse(
+                    chain,
+                    it
+                        .request
                         .newBuilder()
-                        .url(it.header("Location")!!)
+                        .url(response.request.header("Location")!!)
                         .build(),
                 )
             }
         }
 
-        // Sometimes, the response is truncated. This prevents an EOFException
-        if (response.request.url.host == HOST) {
+        // Cache the url
+        urlCache[request.url] = response.request.url
+
+        if (response.body.contentType()?.type == "text") {
+            // Sometimes, the response is truncated. This prevents an EOFException
             response = response.use { response ->
                 response.newBuilder().headers(
                     response.headers.newBuilder()
@@ -75,20 +115,38 @@ class WaybackMachineInterceptor : Interceptor {
         return response
     }
 
+    private fun archiveUrl(
+        chain: Interceptor.Chain,
+        url: HttpUrl,
+    ): Pair<String, HttpUrl>? = getDateStr(chain, "$SAVE_PREFIX$url")?.let {
+        Pair(it, url)
+    } ?: getRetryUrl(url).let { retryUrl ->
+        // Retry archive with a new URL
+        getDateStr(chain, "$SAVE_PREFIX$retryUrl")?.let {
+            Pair(it, retryUrl)
+        }
+    }
+
     companion object {
-        private fun getDateStr(chain: Interceptor.Chain, url: String): String? = chain.proceed(
+        private fun getDateStr(chain: Interceptor.Chain, archiveUrl: String): String? = chain.proceed(
             chain
                 .request()
                 .newBuilder()
-                .url(url)
+                .url(archiveUrl)
                 .build(),
         ).use {
             it.header("Location")?.substring(WEB_PREFIX.length, WEB_PREFIX.length + 14)
         }
 
+        private fun getRetryUrl(url: HttpUrl): HttpUrl = url
+            .newBuilder()
+            .setQueryParameter(RANDOM_QUERY_PARAM, UUID.randomUUID().toString())
+            .build()
+
         private const val HOST = "web.archive.org"
         private const val SAVE_PREFIX = "https://$HOST/save/"
         private const val WEB_PREFIX = "https://$HOST/web/"
+        private const val RANDOM_QUERY_PARAM = "__WaybackMachineInterceptor_RANDOM_QUERY_PARAM__"
         private val DATE_FORMAT = SimpleDateFormat("yyyyMMddHHmmss", Locale.ROOT).apply {
             timeZone = TimeZone.getTimeZone("UTC")
         }

--- a/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/waybackmachineinterceptor/WaybackMachineInterceptor.kt
+++ b/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/waybackmachineinterceptor/WaybackMachineInterceptor.kt
@@ -167,7 +167,7 @@ class WaybackMachineInterceptor(
         private const val RANDOM_QUERY_PARAM = "__WaybackMachineInterceptor_RANDOM_QUERY_PARAM__"
         private const val SNAPSHOT_MAX_AGE_MS = 24 * 60 * 60 * 1000
         private const val URL_CACHE_MAX_ENTRIES = 250
-        private val TIMESTAMP_REGEX = """(?<=://${Regex.escape(HOST)})/web/)\d{14}""".toRegex()
+        private val TIMESTAMP_REGEX = """(?<=://${Regex.escape(HOST)}/web/)\d{14}""".toRegex()
         private val DATE_FORMAT = SimpleDateFormat("yyyyMMddHHmmss", Locale.ROOT).apply {
             timeZone = TimeZone.getTimeZone("UTC")
         }

--- a/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/waybackmachineinterceptor/WaybackMachineInterceptor.kt
+++ b/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/waybackmachineinterceptor/WaybackMachineInterceptor.kt
@@ -1,0 +1,91 @@
+package eu.kanade.tachiyomi.extension.en.asmotoon.waybackmachineinterceptor
+
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.asResponseBody
+import okio.Buffer
+import okio.EOFException
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+
+class WaybackMachineInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        var request = chain.request()
+        val url = request.url
+        if (url.host != HOST) {
+            var dateStr = getDateStr(chain, "$WEB_PREFIX$url")
+            if (dateStr == null) {
+                dateStr = getDateStr(chain, "$SAVE_PREFIX$url") ?: throw Exception("Failed to archive page")
+            } else {
+                val date = DATE_FORMAT.parse(dateStr)!!
+                if (System.currentTimeMillis() - date.time > 24 * 60 * 60 * 1000) {
+                    dateStr = getDateStr(chain, "$SAVE_PREFIX$url") ?: dateStr
+                }
+            }
+            request = request
+                .newBuilder()
+                .url("$WEB_PREFIX${dateStr}id_/$url")
+                .build()
+        }
+
+        var response = chain.proceed(request)
+
+        while (response.isRedirect) {
+            response.close()
+            response = chain.proceed(
+                request
+                    .newBuilder()
+                    .url(response.header("Location")!!)
+                    .build(),
+            )
+        }
+
+        // Sometimes, the response is truncated. This prevents an EOFException
+        if (response.request.url.host == HOST) {
+            response = response.newBuilder().headers(
+                response.headers.newBuilder()
+                    .removeAll("Content-Encoding")
+                    .removeAll("Content-Length")
+                    .build(),
+            ).body(
+                Buffer().also {
+                    val out = it.outputStream()
+                    response.body.byteStream().use { stream ->
+                        val buf = ByteArray(8192)
+                        while (true) {
+                            try {
+                                val len = stream.read(buf)
+                                if (len <= 0) break
+                                out.write(buf, 0, len)
+                            } catch (_: EOFException) {
+                                break
+                            }
+                        }
+                        stream.close()
+                    }
+                }.asResponseBody(response.header("Content-Type")?.toMediaType()),
+            ).build()
+        }
+
+        return response
+    }
+
+    companion object {
+        private fun getDateStr(chain: Interceptor.Chain, url: String): String? = chain.proceed(
+            chain
+                .request()
+                .newBuilder()
+                .url(url)
+                .build(),
+        ).apply { close() }.header("Location")?.substring(WEB_PREFIX.length, WEB_PREFIX.length + 14)
+
+        private const val HOST = "web.archive.org"
+        private const val SAVE_PREFIX = "https://$HOST/save/"
+        private const val WEB_PREFIX = "https://$HOST/web/"
+        private val DATE_FORMAT = SimpleDateFormat("yyyyMMddHHmmss", Locale.ROOT).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
+    }
+}

--- a/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/waybackmachineinterceptor/WaybackMachineInterceptor.kt
+++ b/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/waybackmachineinterceptor/WaybackMachineInterceptor.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.extension.en.asmotoon.waybackmachineinterceptor
 
+import android.util.Log
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Response
@@ -33,26 +34,28 @@ class WaybackMachineInterceptor : Interceptor {
         var response = chain.proceed(request)
 
         while (response.isRedirect) {
-            response.close()
-            response = chain.proceed(
-                request
-                    .newBuilder()
-                    .url(response.header("Location")!!)
-                    .build(),
-            )
+            response = response.use {
+                chain.proceed(
+                    request
+                        .newBuilder()
+                        .url(it.header("Location")!!)
+                        .build(),
+                )
+            }
         }
 
         // Sometimes, the response is truncated. This prevents an EOFException
         if (response.request.url.host == HOST) {
-            response = response.newBuilder().headers(
-                response.headers.newBuilder()
-                    .removeAll("Content-Encoding")
-                    .removeAll("Content-Length")
-                    .build(),
-            ).body(
-                Buffer().also {
-                    val out = it.outputStream()
-                    response.body.byteStream().use { stream ->
+            response = response.use { response ->
+                response.newBuilder().headers(
+                    response.headers.newBuilder()
+                        .removeAll("Content-Encoding")
+                        .removeAll("Content-Length")
+                        .build(),
+                ).body(
+                    Buffer().also {
+                        val stream = response.body.byteStream()
+                        val out = it.outputStream()
                         val buf = ByteArray(8192)
                         while (true) {
                             try {
@@ -60,13 +63,13 @@ class WaybackMachineInterceptor : Interceptor {
                                 if (len <= 0) break
                                 out.write(buf, 0, len)
                             } catch (_: EOFException) {
+                                Log.e("WaybackMachine", "Response truncated")
                                 break
                             }
                         }
-                        stream.close()
-                    }
-                }.asResponseBody(response.header("Content-Type")?.toMediaType()),
-            ).build()
+                    }.asResponseBody(response.header("Content-Type")?.toMediaType()),
+                ).build()
+            }
         }
 
         return response
@@ -79,7 +82,9 @@ class WaybackMachineInterceptor : Interceptor {
                 .newBuilder()
                 .url(url)
                 .build(),
-        ).apply { close() }.header("Location")?.substring(WEB_PREFIX.length, WEB_PREFIX.length + 14)
+        ).use {
+            it.header("Location")?.substring(WEB_PREFIX.length, WEB_PREFIX.length + 14)
+        }
 
         private const val HOST = "web.archive.org"
         private const val SAVE_PREFIX = "https://$HOST/save/"

--- a/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/waybackmachineinterceptor/WaybackMachineInterceptor.kt
+++ b/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/waybackmachineinterceptor/WaybackMachineInterceptor.kt
@@ -26,7 +26,10 @@ class WaybackMachineInterceptor(
     /**
      * Gets the response from the Wayback Machine without following redirects
      */
-    private fun getImmediateResponse(chain: Interceptor.Chain, request: Request): Response = urlCache[request.url]?.let {
+    private fun getImmediateResponse(
+        chain: Interceptor.Chain,
+        request: Request,
+    ): Response = urlCache[request.url]?.let {
         // url is cached, use cached url
         chain.proceed(request.newBuilder().url(it).build())
     } ?: request.url.let { url ->
@@ -34,14 +37,14 @@ class WaybackMachineInterceptor(
             // url is a Wayback Machine URL, do nothing
             chain.proceed(request)
         } else {
-            val (dateStr, newUrl) = getDateStr(chain, "$WEB_PREFIX$url")?.let {
-                val date = DATE_FORMAT.parse(it)!!
+            val (dateStr, newUrl) = getDateStr(chain, "$WEB_PREFIX$url")?.let { dateStr ->
+                val date = DATE_FORMAT.parse(dateStr)!!
                 if (System.currentTimeMillis() - date.time > 24 * 60 * 60 * 1000) {
                     // archive is older than 24 hours, create a new archive
-                    archiveUrl(chain, url) ?: Pair(it, url)
+                    archiveUrl(chain, url) ?: Pair(dateStr, url)
                 } else {
                     // archive is recent
-                    Pair(it, url)
+                    Pair(dateStr, url)
                 }
             }
 
@@ -69,10 +72,10 @@ class WaybackMachineInterceptor(
 
         // resolve all redirects
         while (response.isRedirect) {
-            response = response.use {
+            response = response.use { response ->
                 getImmediateResponse(
                     chain,
-                    it
+                    response
                         .request
                         .newBuilder()
                         .url(response.request.header("Location")!!)
@@ -118,12 +121,12 @@ class WaybackMachineInterceptor(
     private fun archiveUrl(
         chain: Interceptor.Chain,
         url: HttpUrl,
-    ): Pair<String, HttpUrl>? = getDateStr(chain, "$SAVE_PREFIX$url")?.let {
-        Pair(it, url)
+    ): Pair<String, HttpUrl>? = getDateStr(chain, "$SAVE_PREFIX$url")?.let { dateStr ->
+        Pair(dateStr, url)
     } ?: getRetryUrl(url).let { retryUrl ->
         // Retry archive with a new URL
-        getDateStr(chain, "$SAVE_PREFIX$retryUrl")?.let {
-            Pair(it, retryUrl)
+        getDateStr(chain, "$SAVE_PREFIX$retryUrl")?.let { dateStr ->
+            Pair(dateStr, retryUrl)
         }
     }
 

--- a/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/waybackmachineinterceptor/WaybackMachineInterceptor.kt
+++ b/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/waybackmachineinterceptor/WaybackMachineInterceptor.kt
@@ -32,8 +32,10 @@ class WaybackMachineInterceptor(
             .newBuilder()
             .url(archiveUrl)
             .build(),
-    ).use {
-        it.header("Location")?.substring(WEB_PREFIX.length, WEB_PREFIX.length + 14)
+    ).use { response ->
+        response.header("Location")?.let {
+            TIMESTAMP_REGEX.find(it)?.value
+        }
     }
 
     /**
@@ -150,6 +152,7 @@ class WaybackMachineInterceptor(
         private const val RANDOM_QUERY_PARAM = "__WaybackMachineInterceptor_RANDOM_QUERY_PARAM__"
         private const val SNAPSHOT_MAX_AGE_MS = 24 * 60 * 60 * 1000
         private const val URL_CACHE_MAX_ENTRIES = 250
+        private val TIMESTAMP_REGEX = """(?<=://${Regex.escape(HOST)})/web/)\d{14}""".toRegex()
         private val DATE_FORMAT = SimpleDateFormat("yyyyMMddHHmmss", Locale.ROOT).apply {
             timeZone = TimeZone.getTimeZone("UTC")
         }

--- a/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/waybackmachineinterceptor/WaybackMachineInterceptor.kt
+++ b/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/waybackmachineinterceptor/WaybackMachineInterceptor.kt
@@ -54,6 +54,10 @@ class WaybackMachineInterceptor(
         .setQueryParameter(RANDOM_QUERY_PARAM, UUID.randomUUID().toString())
         .build()
 
+    private fun timestampIsExpired(timestamp: String): Boolean = System.currentTimeMillis() - DATE_FORMAT.parse(
+        timestamp,
+    )!!.time > SNAPSHOT_MAX_AGE_MS
+
     /**
      * Gets the response from the Wayback Machine without following redirects
      */
@@ -62,13 +66,24 @@ class WaybackMachineInterceptor(
         url: HttpUrl,
     ): Response = chain.proceed(
         chain.request().newBuilder().url(
-            urlCache[url] ?: if (url.host == HOST || !include.matches(url.toString())) {
+            urlCache[url]?.let { cachedUrl ->
+                if (TIMESTAMP_REGEX.find(cachedUrl.toString())?.value?.let {
+                        timestampIsExpired(it)
+                    } ?: false
+                ) {
+                    // URL expired
+                    urlCache.remove(url)
+                    null
+                } else {
+                    cachedUrl
+                }
+            } ?: if (url.host == HOST || !include.matches(url.toString())) {
                 // url is a Wayback Machine URL or isn't matched, do nothing
                 url
             } else {
                 getTimestamp(chain, "$WEB_PREFIX$url".toHttpUrl())?.let { timestamp ->
-                    if (System.currentTimeMillis() - DATE_FORMAT.parse(timestamp)!!.time > SNAPSHOT_MAX_AGE_MS) {
-                        // snapshot is older than SNAPSHOT_MAX_AGE_MS, attempt to create a new snapshot
+                    if (timestampIsExpired(timestamp)) {
+                        // snapshot is expired, attempt to create a new snapshot
                         snapshot(chain, url) ?: getSnapshotUrl(timestamp, url)
                     } else {
                         // snapshot is recent

--- a/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/waybackmachineinterceptor/WaybackMachineInterceptor.kt
+++ b/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/waybackmachineinterceptor/WaybackMachineInterceptor.kt
@@ -4,8 +4,6 @@ import android.util.Log
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.asResponseBody
 import okio.Buffer
@@ -16,78 +14,90 @@ import java.util.TimeZone
 import java.util.UUID
 
 class WaybackMachineInterceptor(
-    private val regex: Regex = ".*".toRegex(),
+    private val include: Regex = ".*".toRegex(),
 ) : Interceptor {
-    // LinkedHashMap with a capacity of 250. When exceeding the capacity the oldest entry is removed.
+    // LinkedHashMap with a capacity of URL_CACHE_MAX_ENTRIES. When exceeding the capacity the oldest entry is removed.
     private val urlCache = object : LinkedHashMap<HttpUrl, HttpUrl>() {
-        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<HttpUrl, HttpUrl>?): Boolean = size > 250
+        override fun removeEldestEntry(
+            eldest: MutableMap.MutableEntry<HttpUrl, HttpUrl>?,
+        ): Boolean = size > URL_CACHE_MAX_ENTRIES
     }
+
+    /**
+     * Get a timestamp from a Wayback Machine URL without a timestamp
+     */
+    private fun getTimestamp(chain: Interceptor.Chain, archiveUrl: HttpUrl): String? = chain.proceed(
+        chain
+            .request()
+            .newBuilder()
+            .url(archiveUrl)
+            .build(),
+    ).use {
+        it.header("Location")?.substring(WEB_PREFIX.length, WEB_PREFIX.length + 14)
+    }
+
+    /**
+     * Get the "id_" url, which points to the raw, unmodified content
+     */
+    private fun getSnapshotUrl(
+        timestamp: String,
+        url: HttpUrl,
+    ): HttpUrl = "$WEB_PREFIX${timestamp}id_/$url".toHttpUrl()
+
+    /**
+     * Create a new URL to retry the snapshot
+     */
+    private fun getRetryUrl(url: HttpUrl): HttpUrl = url
+        .newBuilder()
+        .setQueryParameter(RANDOM_QUERY_PARAM, UUID.randomUUID().toString())
+        .build()
 
     /**
      * Gets the response from the Wayback Machine without following redirects
      */
     private fun getImmediateResponse(
         chain: Interceptor.Chain,
-        request: Request,
-    ): Response = urlCache[request.url]?.let {
-        // url is cached, use cached url
-        chain.proceed(request.newBuilder().url(it).build())
-    } ?: request.url.let { url ->
-        if (url.host == HOST) {
-            // url is a Wayback Machine URL, do nothing
-            chain.proceed(request)
-        } else {
-            val (dateStr, newUrl) = getDateStr(chain, "$WEB_PREFIX$url")?.let { dateStr ->
-                val date = DATE_FORMAT.parse(dateStr)!!
-                if (System.currentTimeMillis() - date.time > 24 * 60 * 60 * 1000) {
-                    // archive is older than 24 hours, create a new archive
-                    archiveUrl(chain, url) ?: Pair(dateStr, url)
-                } else {
-                    // archive is recent
-                    Pair(dateStr, url)
+        url: HttpUrl,
+    ): Response = chain.proceed(
+        chain.request().newBuilder().url(
+            urlCache[url] ?: if (url.host == HOST || !include.matches(url.toString())) {
+                // url is a Wayback Machine URL or isn't matched, do nothing
+                url
+            } else {
+                getTimestamp(chain, "$WEB_PREFIX$url".toHttpUrl())?.let { timestamp ->
+                    if (System.currentTimeMillis() - DATE_FORMAT.parse(timestamp)!!.time > SNAPSHOT_MAX_AGE_MS) {
+                        // snapshot is older than SNAPSHOT_MAX_AGE_MS, attempt to create a new snapshot
+                        snapshot(chain, url) ?: getSnapshotUrl(timestamp, url)
+                    } else {
+                        // snapshot is recent
+                        getSnapshotUrl(timestamp, url)
+                    }
                 }
-            }
 
-                // archive doesn't exist, create a new archive
-                ?: archiveUrl(chain, url)
+                    // snapshot doesn't exist, create a new snapshot
+                    ?: snapshot(chain, url)
 
-                // archiving failed
-                ?: throw Exception("Failed to archive page")
-
-            // use the "id_" url, which points to the raw, unmodified content
-            val finalUrl = "$WEB_PREFIX${dateStr}id_/$newUrl".toHttpUrl()
-            chain.proceed(request.newBuilder().url(finalUrl).build())
-        }
-    }
+                    // archiving failed
+                    ?: throw Exception("Failed to archive page")
+            },
+        ).build(),
+    )
 
     override fun intercept(chain: Interceptor.Chain): Response {
-        val request = chain.request()
-
-        if (!regex.matches(request.url.toString())) {
-            // url does not match regex, do nothing
-            return chain.proceed(request)
-        }
-
-        var response = getImmediateResponse(chain, request)
+        val url = chain.request().url
+        var response = getImmediateResponse(chain, url)
 
         // resolve all redirects
         while (response.isRedirect) {
-            response = response.use { response ->
-                getImmediateResponse(
-                    chain,
-                    response
-                        .request
-                        .newBuilder()
-                        .url(response.request.header("Location")!!)
-                        .build(),
-                )
-            }
+            val newUrl = response.header("Location")?.toHttpUrl() ?: break
+            response.close()
+            response = getImmediateResponse(chain, newUrl)
         }
 
         // Cache the url
-        urlCache[request.url] = response.request.url
+        urlCache[url] = response.request.url
 
-        if (response.body.contentType()?.type == "text") {
+        if (response.request.url.host == HOST && response.body.contentType()?.type == "text") {
             // Sometimes, the response is truncated. This prevents an EOFException
             response = response.use { response ->
                 response.newBuilder().headers(
@@ -110,7 +120,7 @@ class WaybackMachineInterceptor(
                                 break
                             }
                         }
-                    }.asResponseBody(response.header("Content-Type")?.toMediaType()),
+                    }.asResponseBody(response.body.contentType()),
                 ).build()
             }
         }
@@ -118,38 +128,28 @@ class WaybackMachineInterceptor(
         return response
     }
 
-    private fun archiveUrl(
+    /**
+     * Creates a snapshot and returns the snapshot URL
+     */
+    private fun snapshot(
         chain: Interceptor.Chain,
         url: HttpUrl,
-    ): Pair<String, HttpUrl>? = getDateStr(chain, "$SAVE_PREFIX$url")?.let { dateStr ->
-        Pair(dateStr, url)
+    ): HttpUrl? = getTimestamp(chain, "$SAVE_PREFIX$url".toHttpUrl())?.let { timestamp ->
+        getSnapshotUrl(timestamp, url)
     } ?: getRetryUrl(url).let { retryUrl ->
-        // Retry archive with a new URL
-        getDateStr(chain, "$SAVE_PREFIX$retryUrl")?.let { dateStr ->
-            Pair(dateStr, retryUrl)
+        // Retry snapshot with a new URL
+        getTimestamp(chain, "$SAVE_PREFIX$retryUrl".toHttpUrl())?.let { timestamp ->
+            getSnapshotUrl(timestamp, retryUrl)
         }
     }
 
     companion object {
-        private fun getDateStr(chain: Interceptor.Chain, archiveUrl: String): String? = chain.proceed(
-            chain
-                .request()
-                .newBuilder()
-                .url(archiveUrl)
-                .build(),
-        ).use {
-            it.header("Location")?.substring(WEB_PREFIX.length, WEB_PREFIX.length + 14)
-        }
-
-        private fun getRetryUrl(url: HttpUrl): HttpUrl = url
-            .newBuilder()
-            .setQueryParameter(RANDOM_QUERY_PARAM, UUID.randomUUID().toString())
-            .build()
-
         private const val HOST = "web.archive.org"
         private const val SAVE_PREFIX = "https://$HOST/save/"
         private const val WEB_PREFIX = "https://$HOST/web/"
         private const val RANDOM_QUERY_PARAM = "__WaybackMachineInterceptor_RANDOM_QUERY_PARAM__"
+        private const val SNAPSHOT_MAX_AGE_MS = 24 * 60 * 60 * 1000
+        private const val URL_CACHE_MAX_ENTRIES = 250
         private val DATE_FORMAT = SimpleDateFormat("yyyyMMddHHmmss", Locale.ROOT).apply {
             timeZone = TimeZone.getTimeZone("UTC")
         }


### PR DESCRIPTION
Asmodeus Scans has apparently been IP-banning those who use third-party apps instead of a web browser.

Recently, I tried to open an asmotoon source only to get a 404 response. I tried a VPN, and it worked until I got a 404 response a few minutes later. I also tried other VPN locations, but they all got IP-banned within minutes.

This change adds support for redirecting requests to the Wayback Machine (web.archive.org) as a way to circumvent this.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
