### PR TITLE
Mangadotnet [EN]: Fix Genre Blocklist Preference Crash

### DIFF
--- a/src/en/mangadotnet/build.gradle
+++ b/src/en/mangadotnet/build.gradle
@@ -1,7 +1,7 @@
 ext {
 	extName = 'Mangadotnet'
 	extClass = '.Mangadotnet'
-	extVersionCode = 5
+	extVersionCode = 6
 	isNsfw = true
 }
 

--- a/src/en/mangadotnet/src/eu/kanade/tachiyomi/extension/en/mangadotnet/Mangadotnet.kt
+++ b/src/en/mangadotnet/src/eu/kanade/tachiyomi/extension/en/mangadotnet/Mangadotnet.kt
@@ -515,6 +515,7 @@ class Mangadotnet :
             summary = "Exclude genres when browsing without 18+ content."
             this.entries = normalEntries.toTypedArray()
             entryValues = normalEntries.toTypedArray()
+            setDefaultValue(emptySet<String>())
             setEnabled((genres.normal != null || excludedNormal.isNotEmpty()) && mode == "none")
         }.also(screen::addPreference)
 
@@ -526,6 +527,7 @@ class Mangadotnet :
             summary = "Exclude genres when browsing with 18+ content."
             this.entries = adultEntries.toTypedArray()
             entryValues = adultEntries.toTypedArray()
+            setDefaultValue(emptySet<String>())
             setEnabled((genres.adult != null || excludedAdult.isNotEmpty()) && (mode == "1" || mode == "both"))
         }.also(screen::addPreference)
 


### PR DESCRIPTION
Closes #16070.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
