### PR TITLE
ComicK Fanmade: fix date parsing

### DIFF
--- a/src/en/comickfan/build.gradle
+++ b/src/en/comickfan/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'ComicK Fanmade'
     extClass = '.ComicKFan'
     baseUrl = 'https://comickfan.com'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/en/comickfan/src/eu/kanade/tachiyomi/extension/en/comickfan/ComicKFan.kt
+++ b/src/en/comickfan/src/eu/kanade/tachiyomi/extension/en/comickfan/ComicKFan.kt
@@ -18,6 +18,7 @@ import org.jsoup.nodes.Element
 import rx.Observable
 import java.text.SimpleDateFormat
 import java.util.Locale
+import java.util.TimeZone
 
 class ComicKFan : HttpSource() {
 
@@ -26,7 +27,9 @@ class ComicKFan : HttpSource() {
     override val lang = "en"
     override val supportsLatest = true
 
-    private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.ROOT)
+    private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssSSSSSS'Z'", Locale.ROOT).apply {
+        timeZone = TimeZone.getTimeZone("UTC")
+    }
 
     override fun headersBuilder() = super.headersBuilder()
         .add("Referer", "$baseUrl/")


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
