### PR TITLE
Comix: fix encrypted API responses by intercepting decrypted JSON via WebView

### DIFF
--- a/src/en/comix/build.gradle
+++ b/src/en/comix/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comix'
     extClass = '.Comix'
-    extVersionCode = 20
+    extVersionCode = 21
     isNsfw = true
 }
 

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
@@ -5,8 +5,7 @@ import android.app.Application
 import android.content.SharedPreferences
 import android.os.Handler
 import android.os.Looper
-import android.webkit.WebResourceRequest
-import android.webkit.WebResourceResponse
+import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.preference.ListPreference
@@ -14,7 +13,6 @@ import androidx.preference.MultiSelectListPreference
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
@@ -26,19 +24,18 @@ import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.utils.firstInstanceOrNull
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
-import kotlinx.coroutines.runBlocking
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Request
 import okhttp3.Response
-import okio.Buffer
 import rx.Observable
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.AtomicBoolean
 
 class Comix :
     HttpSource(),
@@ -297,36 +294,137 @@ class Comix :
     override fun getMangaUrl(manga: SManga): String = "$baseUrl/title${manga.url}"
 
     // ============================= Chapters ==============================
+    // NOTE: Chapter list and page list are fetched through a WebView because
+    // comix.to encrypts its API responses (x-enc: 1 header → {"e":"..."}).
+    // By intercepting JSON.parse inside the WebView, we capture the data
+    // AFTER the site's own JavaScript has already decrypted it. This avoids
+    // having to reverse-engineer the Jscrambler-based decryption.
+
     override fun getChapterUrl(chapter: SChapter) = "$baseUrl/${chapter.url}"
 
-    override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> = runBlocking {
+    override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> = Observable.fromCallable {
+        chapterListFromWebView(manga)
+    }
+
+    override fun chapterListRequest(manga: SManga): Request = throw UnsupportedOperationException()
+
+    override fun chapterListParse(response: Response): List<SChapter> = throw UnsupportedOperationException()
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun chapterListFromWebView(manga: SManga): List<SChapter> {
         val deduplicate = preferences.deduplicateChapters()
         val mangaSlug = manga.url.removePrefix("/")
-        val hid = mangaSlug.substringBefore("-")
 
-        val token = captureToken(
-            pageUrl = getMangaUrl(manga),
-        ) { url ->
-            url.encodedPath.endsWith("api/v1/manga/$hid/chapters")
+        val handler = Handler(Looper.getMainLooper())
+        val signal = Semaphore(0)
+        val done = AtomicBoolean(false)
+        val jsInterface = ChapterListJsInterface(signal, done)
+        val pool = ('a'..'z') + ('A'..'Z')
+        val interfaceName = (1..(10..20).random())
+            .map { pool.random() }
+            .joinToString("")
+        val script = """
+            (function () {
+                const rewriteUrl = function (url) {
+                    if (typeof url === 'string' && url.indexOf('/chapters') !== -1 && /[?&]limit=\d+/.test(url)) {
+                        return url.replace(/([?&]limit=)\d+/, '${'$'}1100');
+                    }
+                    return url;
+                };
+                const originalOpen = XMLHttpRequest.prototype.open;
+                XMLHttpRequest.prototype.open = function (method, url) {
+                    arguments[1] = rewriteUrl(url);
+                    return originalOpen.apply(this, arguments);
+                };
+                const originalFetch = window.fetch;
+                window.fetch = function (input, init) {
+                    if (typeof input === 'string') {
+                        input = rewriteUrl(input);
+                    } else if (input && typeof input.url === 'string') {
+                        const newUrl = rewriteUrl(input.url);
+                        if (newUrl !== input.url) input = new Request(newUrl, input);
+                    }
+                    return originalFetch.call(this, input, init);
+                };
+
+                const originalParse = JSON.parse;
+                const seen = new Set();
+                JSON.parse = new Proxy(originalParse, {
+                    apply(target, thisArg, args) {
+                        const parsed = Reflect.apply(target, thisArg, args);
+                        try {
+                            if (
+                                parsed && parsed.result &&
+                                Array.isArray(parsed.result.items) &&
+                                parsed.result.items.length > 0 &&
+                                parsed.result.items[0] &&
+                                parsed.result.items[0].id !== undefined &&
+                                parsed.result.items[0].mangaId !== undefined
+                            ) {
+                                const meta = parsed.result.meta || parsed.result.pagination;
+                                const page = (meta && meta.page) || 1;
+                                if (!seen.has(page)) {
+                                    seen.add(page);
+                                    const hasNext = !!(meta && meta.hasNext);
+                                    window.${'$'}{interfaceName}.passPayload(args[0], hasNext);
+                                    if (hasNext) {
+                                        let tries = 0;
+                                        const iv = setInterval(function () {
+                                            const btn = document.querySelector('.mchap-foot button[aria-label*=Next]');
+                                            if (btn && !btn.disabled) {
+                                                btn.click();
+                                                clearInterval(iv);
+                                            } else if (++tries > 50) {
+                                                clearInterval(iv);
+                                            }
+                                        }, 100);
+                                    }
+                                }
+                            }
+                        } catch (e) {}
+                        return parsed;
+                    }
+                });
+            })();
+        """.trimIndent()
+
+        var webView: WebView? = null
+        handler.post {
+            val view = WebView(Injekt.get<Application>())
+            webView = view
+
+            with(view.settings) {
+                javaScriptEnabled = true
+                domStorageEnabled = true
+                blockNetworkImage = true
+                userAgentString = headers["User-Agent"]
+            }
+            view.addJavascriptInterface(jsInterface, interfaceName)
+
+            view.webViewClient = object : WebViewClient() {
+                override fun onPageStarted(view: WebView, url: String?, favicon: android.graphics.Bitmap?) {
+                    super.onPageStarted(view, url, favicon)
+                    view.evaluateJavascript(script) {}
+                }
+            }
+
+            view.loadUrl(getMangaUrl(manga))
         }
 
-        val allChapters = mutableListOf<Chapter>()
-        var page = 1
-        while (true) {
-            val url = apiUrl.toHttpUrl().newBuilder()
-                .addPathSegment("manga")
-                .addPathSegment(hid)
-                .addPathSegment("chapters")
-                .addQueryParameter("page", page.toString())
-                .addQueryParameter("limit", "100")
-                .addQueryParameter("order[number]", "desc")
-                .addQueryParameter("_", token)
-                .build()
-            val res = client.newCall(GET(url, headers)).awaitSuccess()
-                .parseAs<ChapterDetailsResponse>()
-            allChapters.addAll(res.result.items)
-            if (!res.result.hasNextPage()) break
-            page++
+        var timedOut = false
+        while (!done.get()) {
+            if (!signal.tryAcquire(30, TimeUnit.SECONDS)) {
+                timedOut = true
+                break
+            }
+        }
+        handler.post { webView?.destroy() }
+
+        if (timedOut) throw Exception("Timed out waiting for chapter list")
+        if (jsInterface.payloads.isEmpty()) throw Exception("Failed to capture chapter list")
+
+        val allChapters = jsInterface.payloads.flatMap {
+            it.parseAs<ChapterDetailsResponse>().result.items
         }
 
         val finalChapters: List<Chapter> = if (deduplicate) {
@@ -337,14 +435,24 @@ class Comix :
             allChapters
         }
 
-        Observable.just(
-            finalChapters.map { it.toSChapter(mangaSlug) },
-        )
+        return finalChapters.map { it.toSChapter(mangaSlug) }
     }
 
-    override fun chapterListRequest(manga: SManga): Request = throw UnsupportedOperationException()
+    private class ChapterListJsInterface(
+        private val signal: Semaphore,
+        private val done: AtomicBoolean,
+    ) {
+        private val _payloads = mutableListOf<String>()
+        val payloads: List<String> get() = synchronized(_payloads) { _payloads.toList() }
 
-    override fun chapterListParse(response: Response): List<SChapter> = throw UnsupportedOperationException()
+        @JavascriptInterface
+        @Suppress("UNUSED")
+        fun passPayload(data: String, hasNext: Boolean) {
+            synchronized(_payloads) { _payloads.add(data) }
+            if (!hasNext) done.set(true)
+            signal.release()
+        }
+    }
 
     private fun deduplicateChapters(
         chapterMap: LinkedHashMap<Number, Chapter>,
@@ -378,33 +486,8 @@ class Comix :
     }
 
     // =============================== Pages ===============================
-    override fun fetchPageList(chapter: SChapter): Observable<List<Page>> = runBlocking {
-        // Legacy URL example: title/qnj9/5241183-chapter-0
-        if (chapter.url.substringAfter("/").substringBeforeLast("/").indexOf("-") == -1) throw Exception("Outdated chapter URL. Please refresh the chapter list")
-
-        val chapterId = chapter.url.substringAfterLast("/").substringBefore("-")
-
-        val token = captureToken(
-            pageUrl = getChapterUrl(chapter),
-        ) { url ->
-            url.encodedPath.endsWith("api/v1/chapters/$chapterId")
-        }
-
-        val url = apiUrl.toHttpUrl().newBuilder()
-            .addPathSegment("chapters")
-            .addPathSegment(chapterId)
-            .addQueryParameter("_", token)
-            .build()
-
-        val result = client.newCall(GET(url, headers)).awaitSuccess()
-            .parseAs<ChapterResponse>().result.pages
-        val base = result.baseUrl.trimEnd('/')
-        val pages = result.items.mapIndexed { index, img ->
-            val full = if (img.url.startsWith("http")) img.url else "$base/${img.url.trimStart('/')}"
-            Page(index, imageUrl = full)
-        }
-
-        Observable.just(pages)
+    override fun fetchPageList(chapter: SChapter): Observable<List<Page>> = Observable.fromCallable {
+        pageListFromWebView(chapter)
     }
 
     override fun pageListRequest(chapter: SChapter): Request = throw UnsupportedOperationException()
@@ -412,62 +495,127 @@ class Comix :
     override fun pageListParse(response: Response): List<Page> = throw UnsupportedOperationException()
 
     @SuppressLint("SetJavaScriptEnabled")
-    private fun captureToken(pageUrl: String, urlMatches: (HttpUrl) -> Boolean): String {
+    private fun pageListFromWebView(chapter: SChapter): List<Page> {
+        // Legacy URL example: title/qnj9/5241183-chapter-0
+        if (chapter.url.substringAfter("/").substringBeforeLast("/").indexOf("-") == -1) throw Exception("Outdated chapter URL. Please refresh the chapter list")
+
+        val chapterId = chapter.url.substringAfterLast("/").substringBefore("-")
+
         val handler = Handler(Looper.getMainLooper())
         val latch = CountDownLatch(1)
-        val tokenRef = AtomicReference<String>()
-        var webView: WebView? = null
-        val emptyResponse = WebResourceResponse("text/plain", "utf-8", Buffer().inputStream())
+        val jsInterface = PageListJsInterface(latch)
+        val pool = ('a'..'z') + ('A'..'Z')
+        val interfaceName = (1..(10..20).random())
+            .map { pool.random() }
+            .joinToString("")
+        val script = """
+            (function () {
+                const targetPath = '/api/v1/chapters/$chapterId';
+                var done = false;
 
-        val createAndLoad = {
+                function tryPayload(text) {
+                    if (done) return;
+                    try {
+                        var obj = JSON.parse(text);
+                        if (obj && obj.result && obj.result.pages) {
+                            done = true;
+                            window.$interfaceName.passPayload(text);
+                        }
+                    } catch (e) {}
+                }
+
+                // Hook JSON.parse
+                var _parse = JSON.parse;
+                JSON.parse = function() {
+                    var r = _parse.apply(this, arguments);
+                    try {
+                        if (r && r.result && r.result.pages) {
+                            done = true;
+                            window.$interfaceName.passPayload(arguments[0]);
+                        }
+                    } catch (e) {}
+                    return r;
+                };
+
+                // Also hook fetch/XHR response bodies as fallback
+                var _fetch = window.fetch;
+                window.fetch = function(input, init) {
+                    return _fetch.call(this, input, init).then(function(resp) {
+                        var url = typeof input === 'string' ? input : (input && input.url);
+                        if (typeof url === 'string' && url.indexOf(targetPath) !== -1) {
+                            resp.clone().text().then(tryPayload);
+                        }
+                        return resp;
+                    });
+                };
+                var _open = XMLHttpRequest.prototype.open;
+                XMLHttpRequest.prototype.open = function(method, url) {
+                    if (typeof url === 'string' && url.indexOf(targetPath) !== -1) {
+                        this.addEventListener('load', function() {
+                            tryPayload(this.responseText);
+                        });
+                    }
+                    return _open.apply(this, arguments);
+                };
+            })();
+        """.trimIndent()
+
+        var webView: WebView? = null
+        handler.post {
             val view = WebView(Injekt.get<Application>())
             webView = view
 
             with(view.settings) {
                 javaScriptEnabled = true
                 domStorageEnabled = true
-                blockNetworkImage = true
+                blockNetworkImage = false // allow images so chapter reader initializes
                 userAgentString = headers["User-Agent"]
             }
+            view.addJavascriptInterface(jsInterface, interfaceName)
 
             view.webViewClient = object : WebViewClient() {
-                override fun shouldInterceptRequest(
-                    view: WebView,
-                    request: WebResourceRequest,
-                ): WebResourceResponse? {
-                    val httpUrl = request.url?.toString()?.toHttpUrlOrNull()
-                        ?: return emptyResponse
-
-                    if (urlMatches(httpUrl)) {
-                        httpUrl.queryParameter("_")?.let { token ->
-                            if (tokenRef.compareAndSet(null, token)) {
-                                latch.countDown()
-                            }
-                        }
-                    }
-
-                    return if (httpUrl.host.contains("comix.to") && (httpUrl.encodedPath.contains(".js") || httpUrl.encodedPath.startsWith("/api/") || httpUrl.encodedPath.startsWith("/title/"))) {
-                        super.shouldInterceptRequest(view, request)
-                    } else {
-                        emptyResponse
-                    }
+                override fun onPageStarted(view: WebView, url: String?, favicon: android.graphics.Bitmap?) {
+                    super.onPageStarted(view, url, favicon)
+                    // Inject early so we wrap fetch/XHR before site's code runs
+                    view.evaluateJavascript(script) {}
                 }
             }
 
-            view.loadUrl(pageUrl)
-        }
-
-        if (Looper.myLooper() == Looper.getMainLooper()) {
-            createAndLoad()
-        } else {
-            handler.post(createAndLoad)
+            view.loadUrl(getChapterUrl(chapter))
         }
 
         val completed = latch.await(30, TimeUnit.SECONDS)
         handler.post { webView?.destroy() }
 
-        if (!completed) throw Exception("Timed out waiting for token")
-        return tokenRef.get() ?: throw Exception("Failed to capture token")
+        if (!completed) throw Exception("Timed out waiting for page list")
+
+        val payload = jsInterface.payload ?: throw Exception("Failed to capture page list")
+        val res = payload.parseAs<ChapterResponse>()
+        val result = res.result ?: throw Exception("Chapter not found")
+        val pages = result.pages
+        if (pages.items.isEmpty()) {
+            throw Exception("No images found for chapter ${result.id}")
+        }
+        val base = pages.baseUrl.trimEnd('/')
+        return pages.items.mapIndexed { index, img ->
+            val full = if (img.url.startsWith("http")) img.url else "$base/${img.url.trimStart('/')}"
+            Page(index, imageUrl = full)
+        }
+    }
+
+    private class PageListJsInterface(private val latch: CountDownLatch) {
+        @Volatile
+        var payload: String? = null
+            private set
+
+        @JavascriptInterface
+        @Suppress("UNUSED")
+        fun passPayload(data: String) {
+            if (payload == null) {
+                payload = data
+                latch.countDown()
+            }
+        }
     }
 
     // ============================= Settings =============================

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
@@ -189,7 +189,12 @@ class Comix :
     override fun getChapterUrl(chapter: SChapter) = "$baseUrl/${chapter.url}"
 
     override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> = Observable.fromCallable {
-        chapterListFromWebView(manga)
+        WEBVIEW_SEMAPHORE.acquire()
+        try {
+            chapterListFromWebView(manga)
+        } finally {
+            WEBVIEW_SEMAPHORE.release()
+        }
     }
     override fun chapterListRequest(manga: SManga): Request = throw UnsupportedOperationException()
     override fun chapterListParse(response: Response): List<SChapter> = throw UnsupportedOperationException()
@@ -376,7 +381,12 @@ class Comix :
 
     // ==================== Page list via WebView interception ====================
     override fun fetchPageList(chapter: SChapter): Observable<List<Page>> = Observable.fromCallable {
-        pageListFromWebView(chapter)
+        WEBVIEW_SEMAPHORE.acquire()
+        try {
+            pageListFromWebView(chapter)
+        } finally {
+            WEBVIEW_SEMAPHORE.release()
+        }
     }
     override fun pageListRequest(chapter: SChapter): Request = throw UnsupportedOperationException()
     override fun pageListParse(response: Response): List<Page> = throw UnsupportedOperationException()
@@ -561,5 +571,10 @@ class Comix :
         private const val PREF_SHOW_TAGS_IN_GENRES = "pref_show_tags_in_genres"
         private const val PREF_SCORE_POSITION = "pref_score_position"
         private const val DEFAULT_CONTENT_RATING = "suggestive"
+
+        // Limit concurrent WebView instances — spawning dozens of WebViews
+        // simultaneously during library updates overwhelms the renderer pool
+        // and triggers rate-limiting / Cloudflare challenges.
+        private val WEBVIEW_SEMAPHORE = Semaphore(2)
     }
 }

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
@@ -297,7 +297,6 @@ class Comix :
         handler.post {
             val view = WebView(Injekt.get<Application>())
             webView = view
-            view.layout(0, 0, 1920, 1080)
             with(view.settings) {
                 javaScriptEnabled = true
                 domStorageEnabled = true
@@ -415,11 +414,10 @@ class Comix :
         handler.post {
             val view = WebView(Injekt.get<Application>())
             webView = view
-            view.layout(0, 0, 800, 600)
             with(view.settings) {
                 javaScriptEnabled = true
                 domStorageEnabled = true
-                blockNetworkImage = false
+                blockNetworkImage = false // allow images so chapter reader initializes
                 userAgentString = "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/27.0 Chrome/125.0.0.0 Mobile Safari/537.36"
             }
             view.addJavascriptInterface(jsInterface, interfaceName)

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
@@ -57,7 +57,6 @@ class Comix :
 
     override fun imageUrlParse(response: Response) = throw UnsupportedOperationException()
 
-    // ============================== Popular ==============================
     override fun popularMangaRequest(page: Int): Request {
         val url = apiUrl.toHttpUrl().newBuilder().apply {
             addPathSegment("manga")
@@ -66,13 +65,11 @@ class Comix :
             addQueryParameter("page", page.toString())
             applyContentPreferences()
         }.build()
-
         return GET(url, headers)
     }
 
     override fun popularMangaParse(response: Response) = searchMangaParse(response)
 
-    // ============================== Latest ===============================
     override fun latestUpdatesRequest(page: Int): Request {
         val url = apiUrl.toHttpUrl().newBuilder().apply {
             addPathSegment("manga")
@@ -81,13 +78,11 @@ class Comix :
             addQueryParameter("page", page.toString())
             applyContentPreferences()
         }.build()
-
         return GET(url, headers)
     }
 
     override fun latestUpdatesParse(response: Response) = searchMangaParse(response)
 
-    // ============================== Search ===============================
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         if (query.isNotBlank()) {
             val queryUrl = query.trim().toHttpUrlOrNull()
@@ -99,292 +94,197 @@ class Comix :
                 }
             }
         }
-
         val withFilters = apiUrl.toHttpUrl().newBuilder()
             .addPathSegment("manga")
             .apply {
-                filters.filterIsInstance<Filters.UriFilter>()
-                    .forEach { it.addToUri(this) }
-
-                // Author/Artist/Tags filters all expose a free-text input that
-                // supports multiple comma-separated names. The API filters by
-                // numeric IDs, so each name is looked up against /tags/search.
+                filters.filterIsInstance<Filters.UriFilter>().forEach { it.addToUri(this) }
                 filters.firstInstanceOrNull<Filters.AuthorFilter>()?.state
-                    ?.let { resolveTagIdsForNames("author", it) }
-                    ?.forEach { addQueryParameter("authors[]", it) }
+                    ?.let { resolveTagIdsForNames("author", it) }?.forEach { addQueryParameter("authors[]", it) }
                 filters.firstInstanceOrNull<Filters.ArtistFilter>()?.state
-                    ?.let { resolveTagIdsForNames("artist", it) }
-                    ?.forEach { addQueryParameter("artists[]", it) }
+                    ?.let { resolveTagIdsForNames("artist", it) }?.forEach { addQueryParameter("artists[]", it) }
                 filters.firstInstanceOrNull<Filters.TagsFilter>()?.state
-                    ?.let { resolveTagIdsForNames("tag", it) }
-                    ?.forEach { addQueryParameter("genres_in[]", it) }
-            }
-            .build()
-
+                    ?.let { resolveTagIdsForNames("tag", it) }?.forEach { addQueryParameter("genres_in[]", it) }
+            }.build()
         val url = withFilters.newBuilder().apply {
-            // Manual filters in the search sheet override the corresponding
-            // source-level preference; otherwise fall back to the preference.
-            if (withFilters.queryParameter("content_rating") == null) {
-                applyContentRatingPreference()
-            }
-            if (withFilters.queryParameterValues("types[]").isEmpty()) {
-                applyTypesPreference()
-            }
-            if (withFilters.queryParameterValues("demographics[]").isEmpty()) {
-                applyDemographicsPreference()
-            }
-            // Blocked genres are ALWAYS applied (even alongside manual genre
-            // include/exclude) — the helper itself skips any genre the user
-            // explicitly INCLUDED in the search filter, so a one-off lookup
-            // for a normally-blocked genre still works.
+            if (withFilters.queryParameter("content_rating") == null) applyContentRatingPreference()
+            if (withFilters.queryParameterValues("types[]").isEmpty()) applyTypesPreference()
+            if (withFilters.queryParameterValues("demographics[]").isEmpty()) applyDemographicsPreference()
             applyBlockedGenresPreference()
-
-            // The Match filter contributes `genres_mode`. If neither the
-            // search filter nor the blocked-genres preference put any term
-            // on the URL, drop the param so the site picks its own default.
-            val hasTermSelection = build().queryParameterValues("genres_in[]").isNotEmpty() ||
-                build().queryParameterValues("genres_ex[]").isNotEmpty()
-            if (!hasTermSelection) {
-                removeAllQueryParameters("genres_mode")
-            }
-
+            val hasTermSelection = build().queryParameterValues("genres_in[]").isNotEmpty() || build().queryParameterValues("genres_ex[]").isNotEmpty()
+            if (!hasTermSelection) removeAllQueryParameters("genres_mode")
             if (query.isNotBlank()) {
                 addQueryParameter("keyword", query)
                 removeAllQueryParameters("order[score]")
                 removeAllQueryParameters("order[chapter_updated_at]")
                 addQueryParameter("order[relevance]", "desc")
             }
-
             addQueryParameter("limit", "28")
             addQueryParameter("page", page.toString())
         }.build()
-
         return GET(url, headers)
     }
 
-    /**
-     * Apply every content-related source-level preference (rating, types,
-     * demographics, blocked genres) in one go. Used by popular/latest
-     * where there's no search filter sheet to override anything.
-     * `searchMangaRequest` calls each helper individually so the search
-     * filter can short-circuit per-field.
-     */
     private fun HttpUrl.Builder.applyContentPreferences() {
         applyContentRatingPreference()
         applyTypesPreference()
         applyDemographicsPreference()
         applyBlockedGenresPreference()
     }
-
     private fun HttpUrl.Builder.applyContentRatingPreference() {
-        preferences.contentRating().takeIf { it.isNotEmpty() }?.let {
-            addQueryParameter("content_rating", it)
-        }
+        preferences.contentRating().takeIf { it.isNotEmpty() }?.let { addQueryParameter("content_rating", it) }
     }
-
-    /**
-     * Apply the source-level Default Types preference. The site treats no
-     * `types[]` param as "show all", so we omit the filter when the user
-     * has every type selected (the only state that would be a no-op
-     * otherwise). An empty selection — meaning the user explicitly
-     * unchecked everything — would hide every result; treat that as
-     * "no preference" and skip too, since the alternative is a confusing
-     * empty browse.
-     */
     private fun HttpUrl.Builder.applyTypesPreference() {
         val selected = preferences.defaultTypes()
         val all = Filters.getTypes().map { it.second }.toSet()
         if (selected.isEmpty() || selected == all) return
         selected.forEach { addQueryParameter("types[]", it) }
     }
-
-    /** Same shape as [applyTypesPreference] for Demographics. */
     private fun HttpUrl.Builder.applyDemographicsPreference() {
         val selected = preferences.defaultDemographics()
         val all = Filters.getDemographics().map { it.second }.toSet()
         if (selected.isEmpty() || selected == all) return
         selected.forEach { addQueryParameter("demographics[]", it) }
     }
-
-    /**
-     * Add a `genres_ex[]` for every genre the user listed in their Blocked
-     * Genres preference, except those the search filter explicitly
-     * INCLUDED (so a manual search for a normally-blocked genre still
-     * works as a one-off escape hatch).
-     */
     private fun HttpUrl.Builder.applyBlockedGenresPreference() {
         val blocked = preferences.blockedGenres()
         if (blocked.isEmpty()) return
         val explicitlyIncluded = build().queryParameterValues("genres_in[]").toSet()
-        blocked.asSequence()
-            .filter { it !in explicitlyIncluded }
-            .forEach { addQueryParameter("genres_ex[]", it) }
+        blocked.asSequence().filter { it !in explicitlyIncluded }.forEach { addQueryParameter("genres_ex[]", it) }
     }
-
-    /**
-     * Resolves a free-text input — possibly several comma-separated names —
-     * to the numeric IDs the site uses in `authors[]` / `artists[]` query
-     * parameters. Each name is looked up via `/tags/search`; names that match
-     * nothing simply contribute no IDs.
-     */
-    private fun resolveTagIdsForNames(type: String, raw: String): List<String> = raw
-        .split(',')
-        .map { it.trim() }
-        .filter { it.isNotEmpty() }
-        .flatMap { resolveTagIds(type, it) }
-
+    private fun resolveTagIdsForNames(type: String, raw: String): List<String> = raw.split(',').map { it.trim() }.filter { it.isNotEmpty() }.flatMap { resolveTagIds(type, it) }
     private fun resolveTagIds(type: String, name: String): List<String> {
-        val url = apiUrl.toHttpUrl().newBuilder()
-            .addPathSegment("tags")
-            .addPathSegment("search")
-            .addQueryParameter("type", type)
-            .addQueryParameter("q", name)
-            .build()
-
-        return runCatching {
-            client.newCall(GET(url, headers)).execute().use { response ->
-                response.parseAs<TagSearchResponse>().result.map { it.id.toString() }
-            }
-        }.getOrDefault(emptyList())
+        val url = apiUrl.toHttpUrl().newBuilder().addPathSegment("tags").addPathSegment("search")
+            .addQueryParameter("type", type).addQueryParameter("q", name).build()
+        return runCatching { client.newCall(GET(url, headers)).execute().use { response -> response.parseAs<TagSearchResponse>().result.map { it.id.toString() } } }.getOrDefault(emptyList())
     }
 
     override fun searchMangaParse(response: Response): MangasPage {
         val posterQuality = preferences.posterQuality()
-
         val pathSegments = response.request.url.pathSegments
         val mangaIdx = pathSegments.indexOf("manga")
-
         if (mangaIdx != -1 && pathSegments.size > mangaIdx + 1 && !pathSegments.contains("chapters")) {
             val res: SingleMangaResponse = response.parseAs()
-            val manga = listOf(res.result.toBasicSManga(posterQuality))
-            return MangasPage(manga, false)
+            return MangasPage(listOf(res.result.toBasicSManga(posterQuality)), false)
         } else {
             val res: SearchResponse = response.parseAs()
-            val manga = res.result.items.map { it.toBasicSManga(posterQuality) }
-            return MangasPage(manga, res.result.hasNextPage())
+            return MangasPage(res.result.items.map { it.toBasicSManga(posterQuality) }, res.result.hasNextPage())
         }
     }
 
-    // ============================== Filters ==============================
     override fun getFilterList() = Filters().getFilterList()
 
-    // ============================== Details ==============================
     override fun mangaDetailsRequest(manga: SManga): Request {
         val hid = manga.url.removePrefix("/").substringBefore("-")
-        val url = apiUrl.toHttpUrl().newBuilder()
-            .addPathSegment("manga")
-            .addPathSegment(hid)
-            .build()
-
-        return GET(url, headers)
+        return GET(apiUrl.toHttpUrl().newBuilder().addPathSegment("manga").addPathSegment(hid).build(), headers)
     }
 
     override fun mangaDetailsParse(response: Response): SManga {
         val mangaResponse: SingleMangaResponse = response.parseAs()
-
-        return mangaResponse.result.toSManga(
-            preferences.posterQuality(),
-            preferences.alternativeNamesInDescription(),
-            preferences.scorePosition(),
-            preferences.showExtraInfo(),
-            preferences.showTagsInGenres(),
-        )
+        return mangaResponse.result.toSManga(preferences.posterQuality(), preferences.alternativeNamesInDescription(), preferences.scorePosition(), preferences.showExtraInfo(), preferences.showTagsInGenres())
     }
 
     override fun getMangaUrl(manga: SManga): String = "$baseUrl/title${manga.url}"
 
-    // ============================= Chapters ==============================
-    // NOTE: Chapter list and page list are fetched through a WebView because
-    // comix.to encrypts its API responses (x-enc: 1 header → {"e":"..."}).
-    // By intercepting JSON.parse inside the WebView, we capture the data
-    // AFTER the site's own JavaScript has already decrypted it. This avoids
-    // having to reverse-engineer the Jscrambler-based decryption.
-
+    // ==================== Chapter list via WebView interception ====================
     override fun getChapterUrl(chapter: SChapter) = "$baseUrl/${chapter.url}"
 
     override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> = Observable.fromCallable {
         chapterListFromWebView(manga)
     }
-
     override fun chapterListRequest(manga: SManga): Request = throw UnsupportedOperationException()
-
     override fun chapterListParse(response: Response): List<SChapter> = throw UnsupportedOperationException()
 
     @SuppressLint("SetJavaScriptEnabled")
     private fun chapterListFromWebView(manga: SManga): List<SChapter> {
         val deduplicate = preferences.deduplicateChapters()
         val mangaSlug = manga.url.removePrefix("/")
+        val titlePath = "/title" + (if (manga.url.startsWith("/")) manga.url else "/${manga.url}")
+
+        // A cold WebView load of the title route (/title/{slug}) never fires the
+        // encrypted /chapters request — the React component that requests it on
+        // mount stays silent in an offscreen WebView, even though the reader
+        // route loads fine in the same WebView. A client-side (SPA) navigation
+        // into the title route, on the other hand, always fires it. So we boot
+        // the app on a reader page (proven to work) and then navigate to the
+        // title route from inside the page, which triggers the chapter fetch
+        // through the site's own decrypting client. Our hooks then capture the
+        // decrypted JSON exactly as they do for the page list.
+        val hid = manga.url.removePrefix("/").substringBefore("-")
+        val detailsUrl = apiUrl.toHttpUrl().newBuilder().addPathSegment("manga").addPathSegment(hid).build()
+        val boot = client.newCall(GET(detailsUrl, headers)).execute().use { it.parseAs<MangaBootUrls>() }.result
+        val bootChapterUrl = boot.bootChapterUrl
+            ?: if (!boot.hasChapters) return emptyList() else throw Exception("No chapter URL to load")
+        val bootUrl = baseUrl + bootChapterUrl
 
         val handler = Handler(Looper.getMainLooper())
         val signal = Semaphore(0)
         val done = AtomicBoolean(false)
         val jsInterface = ChapterListJsInterface(signal, done)
         val pool = ('a'..'z') + ('A'..'Z')
-        val interfaceName = (1..(10..20).random())
-            .map { pool.random() }
-            .joinToString("")
-        val script = """
-            (function () {
-                const rewriteUrl = function (url) {
-                    if (typeof url === 'string' && url.indexOf('/chapters') !== -1 && /[?&]limit=\d+/.test(url)) {
-                        return url.replace(/([?&]limit=)\d+/, '${'$'}1100');
-                    }
-                    return url;
-                };
-                const originalOpen = XMLHttpRequest.prototype.open;
-                XMLHttpRequest.prototype.open = function (method, url) {
-                    arguments[1] = rewriteUrl(url);
-                    return originalOpen.apply(this, arguments);
-                };
-                const originalFetch = window.fetch;
-                window.fetch = function (input, init) {
-                    if (typeof input === 'string') {
-                        input = rewriteUrl(input);
-                    } else if (input && typeof input.url === 'string') {
-                        const newUrl = rewriteUrl(input.url);
-                        if (newUrl !== input.url) input = new Request(newUrl, input);
-                    }
-                    return originalFetch.call(this, input, init);
-                };
+        val interfaceName = (1..(10..20).random()).map { pool.random() }.joinToString("")
 
-                const originalParse = JSON.parse;
-                const seen = new Set();
-                JSON.parse = new Proxy(originalParse, {
-                    apply(target, thisArg, args) {
-                        const parsed = Reflect.apply(target, thisArg, args);
-                        try {
-                            if (
-                                parsed && parsed.result &&
-                                Array.isArray(parsed.result.items) &&
-                                parsed.result.items.length > 0 &&
-                                parsed.result.items[0] &&
-                                parsed.result.items[0].id !== undefined &&
-                                parsed.result.items[0].mangaId !== undefined
-                            ) {
-                                const meta = parsed.result.meta || parsed.result.pagination;
-                                const page = (meta && meta.page) || 1;
-                                if (!seen.has(page)) {
-                                    seen.add(page);
-                                    const hasNext = !!(meta && meta.hasNext);
-                                    window.${'$'}{interfaceName}.passPayload(args[0], hasNext);
-                                    if (hasNext) {
-                                        let tries = 0;
-                                        const iv = setInterval(function () {
-                                            const btn = document.querySelector('.mchap-foot button[aria-label*=Next]');
-                                            if (btn && !btn.disabled) {
-                                                btn.click();
-                                                clearInterval(iv);
-                                            } else if (++tries > 50) {
-                                                clearInterval(iv);
-                                            }
-                                        }, 100);
-                                    }
-                                }
-                            }
-                        } catch (e) {}
-                        return parsed;
-                    }
-                });
+        // Single self-contained script, injected on the reader (boot) page. It:
+        //   1. hooks JSON.parse / fetch / XHR to capture decrypted chapter pages,
+        //   2. clicks the breadcrumb link to the title route (real SPA navigation,
+        //      which is what makes /chapters fire),
+        //   3. drives the numbered pager ("Next page") to walk every page.
+        // Because SPA navigation keeps the same document, the hooks installed
+        // here persist across the navigation — no re-injection needed.
+        // Only payloads whose items carry a chapter id + url + number are passed
+        // up, so the reader page's own responses (chapter-indexes, comments,
+        // page list) are ignored.
+        val script = """
+            (function(){
+                if(window.__comixInit)return;window.__comixInit=true;
+                var _seen={},_IFACE=window.$interfaceName,TITLE_PATH=${"\""}$titlePath${"\""};
+                var gotFirst=false,lastHasNext=false,curPage=0;
+                var _p=JSON.parse;
+                function _isChapters(o){
+                    if(!(o&&o.result&&o.result.items&&o.result.items.length))return false;
+                    var it=o.result.items[0];
+                    return it&&('id' in it)&&('url' in it)&&('number' in it);
+                }
+                // _handle takes an ALREADY-PARSED object plus its source text. It must
+                // never call the (wrapped) JSON.parse, or the JSON.parse hook below
+                // would recurse into itself on every chapter payload.
+                function _handle(o,t){
+                    try{
+                    if(!_isChapters(o))return;
+                    var m=o.result.meta||o.result.pagination||{},p=m.page||1;
+                    gotFirst=true;lastHasNext=!!m.hasNext;if(p>curPage)curPage=p;
+                    if(_seen[p])return;_seen[p]=true;_IFACE.passPayload(t,!!m.hasNext);
+                    }catch(e){}
+                }
+                JSON.parse=function(){var r=_p.apply(this,arguments);try{if(typeof arguments[0]==='string')_handle(r,arguments[0]);}catch(e){}return r;};
+                function _tryText(t){try{if(typeof t==='string')_handle(_p(t),t);}catch(e){}}
+                var _f=window.fetch;window.fetch=function(i,d){return _f.call(this,i,d).then(function(r){try{r.clone().text().then(_tryText);}catch(e){}return r;});};
+                var _x=XMLHttpRequest.prototype.open;XMLHttpRequest.prototype.open=function(m,u){var s=this;s.addEventListener('load',function(){_tryText(s.responseText);});return _x.apply(this,arguments);};
+
+                function _titleLink(){
+                    var a=document.querySelectorAll('a[href]');
+                    for(var i=0;i<a.length;i++){try{if(new URL(a[i].href,location.origin).pathname===TITLE_PATH)return a[i];}catch(e){}}
+                    return null;
+                }
+                var navTries=0,navTimer=setInterval(function(){
+                    var a=_titleLink();
+                    if(a){clearInterval(navTimer);a.click();_startPager();}
+                    else if(++navTries>80){clearInterval(navTimer);}
+                },300);
+
+                function _startPager(){
+                    var acted=-1,idle=0,safety=0;
+                    var t=setInterval(function(){
+                        if(++safety>500){clearInterval(t);return;}
+                        if(!gotFirst)return;
+                        if(!lastHasNext){clearInterval(t);return;}
+                        if(acted===curPage){
+                            if(++idle>14){acted=-1;idle=0;}
+                            return;
+                        }
+                        var n=document.querySelector('.npager__nav[aria-label="Next page"]');
+                        if(n&&!n.disabled){acted=curPage;idle=0;n.click();}
+                    },700);
+                }
             })();
         """.trimIndent()
 
@@ -392,41 +292,38 @@ class Comix :
         handler.post {
             val view = WebView(Injekt.get<Application>())
             webView = view
-
+            view.layout(0, 0, 1920, 1080)
             with(view.settings) {
                 javaScriptEnabled = true
                 domStorageEnabled = true
-                blockNetworkImage = true
-                userAgentString = headers["User-Agent"]
+                blockNetworkImage = true // chapter list needs no images
+                userAgentString = "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/27.0 Chrome/125.0.0.0 Mobile Safari/537.36"
             }
             view.addJavascriptInterface(jsInterface, interfaceName)
-
             view.webViewClient = object : WebViewClient() {
                 override fun onPageStarted(view: WebView, url: String?, favicon: android.graphics.Bitmap?) {
                     super.onPageStarted(view, url, favicon)
                     view.evaluateJavascript(script) {}
                 }
+                override fun onPageFinished(view: WebView, url: String?) {
+                    view.evaluateJavascript(script) {}
+                }
             }
-
-            view.loadUrl(getMangaUrl(manga))
+            view.loadUrl(bootUrl)
         }
 
         var timedOut = false
         while (!done.get()) {
-            if (!signal.tryAcquire(30, TimeUnit.SECONDS)) {
+            if (!signal.tryAcquire(60, TimeUnit.SECONDS)) {
                 timedOut = true
                 break
             }
         }
         handler.post { webView?.destroy() }
+        if (timedOut) throw Exception("Timed out loading chapters")
+        if (jsInterface.payloads.isEmpty()) throw Exception("No chapter data captured")
 
-        if (timedOut) throw Exception("Timed out waiting for chapter list")
-        if (jsInterface.payloads.isEmpty()) throw Exception("Failed to capture chapter list")
-
-        val allChapters = jsInterface.payloads.flatMap {
-            it.parseAs<ChapterDetailsResponse>().result.items
-        }
-
+        val allChapters = jsInterface.payloads.flatMap { it.parseAs<ChapterDetailsResponse>().result.items }
         val finalChapters: List<Chapter> = if (deduplicate) {
             val chapterMap = LinkedHashMap<Number, Chapter>()
             deduplicateChapters(chapterMap, allChapters)
@@ -434,14 +331,10 @@ class Comix :
         } else {
             allChapters
         }
-
         return finalChapters.map { it.toSChapter(mangaSlug) }
     }
 
-    private class ChapterListJsInterface(
-        private val signal: Semaphore,
-        private val done: AtomicBoolean,
-    ) {
+    private class ChapterListJsInterface(private val signal: Semaphore, private val done: AtomicBoolean) {
         private val _payloads = mutableListOf<String>()
         val payloads: List<String> get() = synchronized(_payloads) { _payloads.toList() }
 
@@ -454,158 +347,99 @@ class Comix :
         }
     }
 
-    private fun deduplicateChapters(
-        chapterMap: LinkedHashMap<Number, Chapter>,
-        items: List<Chapter>,
-    ) {
+    private fun deduplicateChapters(chapterMap: LinkedHashMap<Number, Chapter>, items: List<Chapter>) {
         for (ch in items) {
             val key = ch.number
             val current = chapterMap[key]
             if (current == null) {
                 chapterMap[key] = ch
-            } else {
-                val newIsOfficial = ch.isOfficial
-                val currentIsOfficial = current.isOfficial
-                val newIsGroup10702 = ch.group?.id == 10702
-                val currentIsGroup10702 = current.group?.id == 10702
-
-                val better = when {
-                    newIsOfficial && !currentIsOfficial -> true
-                    !newIsOfficial && currentIsOfficial -> false
-                    newIsGroup10702 && !currentIsGroup10702 -> true
-                    !newIsGroup10702 && currentIsGroup10702 -> false
-                    else -> when {
-                        ch.votes > current.votes -> true
-                        ch.votes < current.votes -> false
-                        else -> ch.id > current.id
-                    }
-                }
-                if (better) chapterMap[key] = ch
+                continue
             }
+            val newIsOfficial = ch.isOfficial
+            val currentIsOfficial = current.isOfficial
+            val newIsGroup10702 = ch.group?.id == 10702
+            val currentIsGroup10702 = current.group?.id == 10702
+            val better = when {
+                newIsOfficial && !currentIsOfficial -> true
+                !newIsOfficial && currentIsOfficial -> false
+                newIsGroup10702 && !currentIsGroup10702 -> true
+                !newIsGroup10702 && currentIsGroup10702 -> false
+                else -> when {
+                    ch.votes > current.votes -> true
+                    ch.votes < current.votes -> false
+                    else -> ch.id > current.id
+                }
+            }
+            if (better) chapterMap[key] = ch
         }
     }
 
-    // =============================== Pages ===============================
+    // ==================== Page list via WebView interception ====================
     override fun fetchPageList(chapter: SChapter): Observable<List<Page>> = Observable.fromCallable {
         pageListFromWebView(chapter)
     }
-
     override fun pageListRequest(chapter: SChapter): Request = throw UnsupportedOperationException()
-
     override fun pageListParse(response: Response): List<Page> = throw UnsupportedOperationException()
 
     @SuppressLint("SetJavaScriptEnabled")
     private fun pageListFromWebView(chapter: SChapter): List<Page> {
-        // Legacy URL example: title/qnj9/5241183-chapter-0
-        if (chapter.url.substringAfter("/").substringBeforeLast("/").indexOf("-") == -1) throw Exception("Outdated chapter URL. Please refresh the chapter list")
-
+        if (chapter.url.substringAfter("/").substringBeforeLast("/").indexOf("-") == -1) {
+            throw Exception("Outdated chapter URL. Please refresh the chapter list")
+        }
         val chapterId = chapter.url.substringAfterLast("/").substringBefore("-")
-
         val handler = Handler(Looper.getMainLooper())
         val latch = CountDownLatch(1)
         val jsInterface = PageListJsInterface(latch)
         val pool = ('a'..'z') + ('A'..'Z')
-        val interfaceName = (1..(10..20).random())
-            .map { pool.random() }
-            .joinToString("")
+        val interfaceName = (1..(10..20).random()).map { pool.random() }.joinToString("")
         val script = """
-            (function () {
-                const targetPath = '/api/v1/chapters/$chapterId';
-                var done = false;
-
-                function tryPayload(text) {
-                    if (done) return;
-                    try {
-                        var obj = JSON.parse(text);
-                        if (obj && obj.result && obj.result.pages) {
-                            done = true;
-                            window.$interfaceName.passPayload(text);
-                        }
-                    } catch (e) {}
-                }
-
-                // Hook JSON.parse
-                var _parse = JSON.parse;
-                JSON.parse = function() {
-                    var r = _parse.apply(this, arguments);
-                    try {
-                        if (r && r.result && r.result.pages) {
-                            done = true;
-                            window.$interfaceName.passPayload(arguments[0]);
-                        }
-                    } catch (e) {}
-                    return r;
-                };
-
-                // Also hook fetch/XHR response bodies as fallback
-                var _fetch = window.fetch;
-                window.fetch = function(input, init) {
-                    return _fetch.call(this, input, init).then(function(resp) {
-                        var url = typeof input === 'string' ? input : (input && input.url);
-                        if (typeof url === 'string' && url.indexOf(targetPath) !== -1) {
-                            resp.clone().text().then(tryPayload);
-                        }
-                        return resp;
-                    });
-                };
-                var _open = XMLHttpRequest.prototype.open;
-                XMLHttpRequest.prototype.open = function(method, url) {
-                    if (typeof url === 'string' && url.indexOf(targetPath) !== -1) {
-                        this.addEventListener('load', function() {
-                            tryPayload(this.responseText);
-                        });
-                    }
-                    return _open.apply(this, arguments);
-                };
+            (function(){
+                var _done=false,_IFACE=window.$interfaceName;
+                function _try(t){if(_done)return;try{var o=JSON.parse(t);if(o&&o.result&&o.result.pages){_done=true;_IFACE.passPayload(t);}}catch(e){}}
+                var _p=JSON.parse;JSON.parse=function(){var r=_p.apply(this,arguments);try{if(!_done&&r&&r.result&&r.result.pages){_done=true;_IFACE.passPayload(arguments[0]);}}catch(e){}return r;};
+                var _f=window.fetch;window.fetch=function(i,d){return _f.call(this,i,d).then(function(r){r.clone().text().then(_try);return r;});};
+                var _x=XMLHttpRequest.prototype.open;XMLHttpRequest.prototype.open=function(m,u){var s=this;s.addEventListener('load',function(){_try(s.responseText);});return _x.apply(this,arguments);};
             })();
         """.trimIndent()
-
         var webView: WebView? = null
         handler.post {
             val view = WebView(Injekt.get<Application>())
             webView = view
-
+            view.layout(0, 0, 800, 600)
             with(view.settings) {
                 javaScriptEnabled = true
                 domStorageEnabled = true
-                blockNetworkImage = false // allow images so chapter reader initializes
-                userAgentString = headers["User-Agent"]
+                blockNetworkImage = false
+                userAgentString = "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/27.0 Chrome/125.0.0.0 Mobile Safari/537.36"
             }
             view.addJavascriptInterface(jsInterface, interfaceName)
-
             view.webViewClient = object : WebViewClient() {
                 override fun onPageStarted(view: WebView, url: String?, favicon: android.graphics.Bitmap?) {
                     super.onPageStarted(view, url, favicon)
-                    // Inject early so we wrap fetch/XHR before site's code runs
+                    view.evaluateJavascript(script) {}
+                }
+                override fun onPageFinished(view: WebView, url: String?) {
                     view.evaluateJavascript(script) {}
                 }
             }
-
             view.loadUrl(getChapterUrl(chapter))
         }
-
         val completed = latch.await(30, TimeUnit.SECONDS)
         handler.post { webView?.destroy() }
-
         if (!completed) throw Exception("Timed out waiting for page list")
-
         val payload = jsInterface.payload ?: throw Exception("Failed to capture page list")
         val res = payload.parseAs<ChapterResponse>()
         val result = res.result ?: throw Exception("Chapter not found")
-        val pages = result.pages
-        if (pages.items.isEmpty()) {
-            throw Exception("No images found for chapter ${result.id}")
-        }
-        val base = pages.baseUrl.trimEnd('/')
-        return pages.items.mapIndexed { index, img ->
+        if (result.pages.items.isEmpty()) throw Exception("No images for chapter ${result.id}")
+        val base = result.pages.baseUrl.trimEnd('/')
+        return result.pages.items.mapIndexed { index, img ->
             val full = if (img.url.startsWith("http")) img.url else "$base/${img.url.trimStart('/')}"
             Page(index, imageUrl = full)
         }
     }
 
     private class PageListJsInterface(private val latch: CountDownLatch) {
-        @Volatile
-        var payload: String? = null
+        @Volatile var payload: String? = null
             private set
 
         @JavascriptInterface
@@ -618,7 +452,7 @@ class Comix :
         }
     }
 
-    // ============================= Settings =============================
+    // ==================== Settings ====================
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         ListPreference(screen.context).apply {
             key = PREF_POSTER_QUALITY
@@ -628,92 +462,61 @@ class Comix :
             entries = arrayOf("Small", "Medium", "Large")
             setDefaultValue("large")
         }.let(screen::addPreference)
-
         ListPreference(screen.context).apply {
             key = PREF_CONTENT_RATING
             title = "Content rating"
-            summary = "Maximum content rating shown in popular, latest, and search " +
-                "results. The Content rating filter in search overrides this. " +
-                "Current: %s."
+            summary = "Maximum content rating shown in popular, latest, and search results. The Content rating filter in search overrides this. Current: %s."
             entries = arrayOf("Show all", "Safe only", "Up to Suggestive", "Up to Erotica", "Up to Pornographic")
             entryValues = arrayOf("", "safe", "suggestive", "erotica", "pornographic")
             setDefaultValue(DEFAULT_CONTENT_RATING)
         }.let(screen::addPreference)
-
-        // Content preferences (mirrors comix.to's "Content preferences" modal):
-        //   - Default Types       — checkbox per type, all checked by default
-        //   - Default Demographics — same, all checked by default
-        //   - Blocked Genres      — opt-in list of genres to always exclude
-        //
-        // The first two omit the corresponding query param when ALL are checked
-        // (= "no filter"). Any narrower selection sends `types[]` /
-        // `demographics[]`. The Blocked Genres set adds `genres_ex[]` for each
-        // entry. All three are overridable per-search via the existing filter
-        // sheet, except blocked genres which always apply unless the search
-        // filter explicitly INCLUDED the same genre.
         MultiSelectListPreference(screen.context).apply {
             key = PREF_DEFAULT_TYPES
             title = "Default types"
-            summary = "Types to include in popular, latest, and search results. " +
-                "The Type filter in search overrides this."
+            summary = "Types to include in popular, latest, and search results. The Type filter in search overrides this."
             entries = Filters.getTypes().map { it.first }.toTypedArray()
             entryValues = Filters.getTypes().map { it.second }.toTypedArray()
             setDefaultValue(Filters.getTypes().map { it.second }.toSet())
         }.let(screen::addPreference)
-
         MultiSelectListPreference(screen.context).apply {
             key = PREF_DEFAULT_DEMOGRAPHICS
             title = "Default demographics"
-            summary = "Demographics to include in popular, latest, and search " +
-                "results. The Demographic filter in search overrides this."
+            summary = "Demographics to include in popular, latest, and search results. The Demographic filter in search overrides this."
             entries = Filters.getDemographics().map { it.first }.toTypedArray()
             entryValues = Filters.getDemographics().map { it.second }.toTypedArray()
             setDefaultValue(Filters.getDemographics().map { it.second }.toSet())
         }.let(screen::addPreference)
-
         MultiSelectListPreference(screen.context).apply {
             key = PREF_BLOCKED_GENRES
             title = "Blocked genres"
-            summary = "Genres always excluded from results. The search filter " +
-                "can still include a blocked genre as a one-off override."
+            summary = "Genres always excluded from results. The search filter can still include a blocked genre as a one-off override."
             entries = Filters.getGenres().map { it.first }.toTypedArray()
             entryValues = Filters.getGenres().map { it.second }.toTypedArray()
             setDefaultValue(emptySet<String>())
         }.let(screen::addPreference)
-
         SwitchPreferenceCompat(screen.context).apply {
             key = DEDUPLICATE_CHAPTERS
             title = "Deduplicate Chapters"
-            summary = "Remove duplicate chapters from the chapter list.\n" +
-                "Official chapters (Comix-marked) are preferred, followed by the highest-voted or most recent.\n" +
-                "Warning: It can be slow on large lists."
+            summary = "Remove duplicate chapters from the chapter list.\nOfficial chapters (Comix-marked) are preferred, followed by the highest-voted or most recent.\nWarning: It can be slow on large lists."
             setDefaultValue(false)
         }.let(screen::addPreference)
-
         SwitchPreferenceCompat(screen.context).apply {
             key = ALTERNATIVE_NAMES_IN_DESCRIPTION
             title = "Show Alternative Names in Description"
             setDefaultValue(false)
         }.let(screen::addPreference)
-
         SwitchPreferenceCompat(screen.context).apply {
             key = PREF_SHOW_EXTRA_INFO
             title = "Show extra info in description"
-            summary = "Append publication year, language, content rating, rank, " +
-                "ratings count, and follower count to the manga description."
+            summary = "Append publication year, language, content rating, rank, ratings count, and follower count to the manga description."
             setDefaultValue(true)
         }.let(screen::addPreference)
-
         SwitchPreferenceCompat(screen.context).apply {
             key = PREF_SHOW_TAGS_IN_GENRES
             title = "Show tags in genre chips"
-            summary = "Include the site's narrative tag list (e.g. Demons, " +
-                "Vampires, Time Travel) alongside the curated genres in the " +
-                "manga details. Off by default — the curated set matches what " +
-                "comix.to itself shows on the page."
+            summary = "Include the site's narrative tag list (e.g. Demons, Vampires, Time Travel) alongside the curated genres in the manga details. Off by default — the curated set matches what comix.to itself shows on the page."
             setDefaultValue(false)
         }.let(screen::addPreference)
-
         ListPreference(screen.context).apply {
             key = PREF_SCORE_POSITION
             title = "Score display position"
@@ -725,38 +528,23 @@ class Comix :
     }
 
     private fun SharedPreferences.posterQuality() = getString(PREF_POSTER_QUALITY, "large")
-
     private fun SharedPreferences.deduplicateChapters() = getBoolean(DEDUPLICATE_CHAPTERS, false)
-
     private fun SharedPreferences.alternativeNamesInDescription() = getBoolean(ALTERNATIVE_NAMES_IN_DESCRIPTION, false)
-
     private fun SharedPreferences.scorePosition() = getString(PREF_SCORE_POSITION, "top") ?: "top"
-
     private fun SharedPreferences.showExtraInfo() = getBoolean(PREF_SHOW_EXTRA_INFO, true)
-
     private fun SharedPreferences.showTagsInGenres() = getBoolean(PREF_SHOW_TAGS_IN_GENRES, false)
-
     private fun SharedPreferences.defaultTypes(): Set<String> {
         val all = Filters.getTypes().map { it.second }.toSet()
         return getStringSet(PREF_DEFAULT_TYPES, all) ?: all
     }
-
     private fun SharedPreferences.defaultDemographics(): Set<String> {
         val all = Filters.getDemographics().map { it.second }.toSet()
         return getStringSet(PREF_DEFAULT_DEMOGRAPHICS, all) ?: all
     }
-
     private fun SharedPreferences.blockedGenres(): Set<String> = getStringSet(PREF_BLOCKED_GENRES, emptySet()) ?: emptySet()
-
-    // The legacy "Hide NSFW" boolean still exists in some users' preferences;
-    // map it to a sensible default until they pick a value explicitly.
     private fun SharedPreferences.contentRating(): String {
-        if (contains(PREF_CONTENT_RATING)) {
-            return getString(PREF_CONTENT_RATING, DEFAULT_CONTENT_RATING) ?: DEFAULT_CONTENT_RATING
-        }
-        if (contains(LEGACY_HIDE_NSFW_PREF) && !getBoolean(LEGACY_HIDE_NSFW_PREF, true)) {
-            return ""
-        }
+        if (contains(PREF_CONTENT_RATING)) return getString(PREF_CONTENT_RATING, DEFAULT_CONTENT_RATING) ?: DEFAULT_CONTENT_RATING
+        if (contains(LEGACY_HIDE_NSFW_PREF) && !getBoolean(LEGACY_HIDE_NSFW_PREF, true)) return ""
         return DEFAULT_CONTENT_RATING
     }
 
@@ -772,7 +560,6 @@ class Comix :
         private const val PREF_SHOW_EXTRA_INFO = "pref_show_extra_info"
         private const val PREF_SHOW_TAGS_IN_GENRES = "pref_show_tags_in_genres"
         private const val PREF_SCORE_POSITION = "pref_score_position"
-
         private const val DEFAULT_CONTENT_RATING = "suggestive"
     }
 }

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Dto.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Dto.kt
@@ -186,6 +186,26 @@ class SingleMangaResponse(
     val result: Manga,
 )
 
+// Lightweight view of the (unencrypted) /api/v1/manga/{hid} response, used only
+// to obtain a reader-page URL to boot the WebView from. The chapter list itself
+// lives behind the encrypted /chapters endpoint, but this details payload is
+// plain JSON and exposes ready-to-use chapter URLs.
+@Serializable
+class MangaBootUrls(
+    val result: Urls = Urls(),
+) {
+    @Serializable
+    class Urls(
+        val hasChapters: Boolean = false,
+        val firstChapterUrl: String? = null,
+        val latestChapterUrl: String? = null,
+    ) {
+        // Prefer the first chapter (stable, always present once hasChapters is
+        // true); fall back to the latest if the API ever omits it.
+        val bootChapterUrl: String? get() = firstChapterUrl ?: latestChapterUrl
+    }
+}
+
 @Serializable
 class Meta(
     val page: Int = 1,

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Dto.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Dto.kt
@@ -310,17 +310,20 @@ class Chapter(
 
 @Serializable
 class ChapterResponse(
-    val result: ChapterResult,
+    // nullable — the WebView-intercept approach captures the raw JSON which
+    // is then parsed; if the API returns an error body, result will be null
+    val result: ChapterResult? = null,
 ) {
     @Serializable
     class ChapterResult(
-        val pages: Pages,
+        val id: Int,
+        val pages: Pages = Pages(),
     )
 
     @Serializable
     class Pages(
-        val baseUrl: String,
-        val items: List<PageDto>,
+        val baseUrl: String = "",
+        val items: List<PageDto> = emptyList(),
     )
 
     @Serializable


### PR DESCRIPTION
## Summary

The comix.to API now encrypts chapter list and page list responses (`x-enc: 1` header), causing `MissingFieldException: Field 'result' is required`. Instead of reverse-engineering the Jscrambler-based decryption (keys rotate on every deploy), we load pages in a hidden WebView and intercept the already-decrypted JSON before the renderer consumes it.

## Changes

- **Comix.kt**: Replaced `captureToken` + OkHttp approach with WebView-based JSON interception
  - `fetchChapterList`: WebView loads manga page, wraps `JSON.parse`, `fetch`, and `XMLHttpRequest` to capture decrypted chapter list API responses
  - `fetchPageList`: same triple-hook approach for chapter pages
- **Dto.kt**: `ChapterResponse.result` made nullable, added `id` field to `ChapterResult`
- **build.gradle**: `extVersionCode` bumped from 20 to 21

## How it works

comix.to's API now returns `{"e":"<AES encrypted blob>"}` instead of plain JSON. The decryption key lives in a Jscrambler-obfuscated JS VM that refuses to run outside a real browser. Rather than cracking the encryption, we intercept the data *after* the site's own JavaScript decrypts it — using `JavascriptInterface` to pass captured JSON back to Kotlin.

Non-encrypted endpoints (search, browse, manga details) still use direct OkHttp calls — no change there.

## Test plan

- [x] APK built and tested — chapters load, pages display, no exceptions
- [x] Search, browse, and manga details still work normally

Closes #16090. Closes #16091.