### PR TITLE
Update domain for 11 extensions

### DIFF
--- a/src/en/suryascans/build.gradle
+++ b/src/en/suryascans/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Genz Toons'
     extClass = '.GenzToons'
     themePkg = 'keyoapp'
-    baseUrl = 'https://genzupdates.com'
-    overrideVersionCode = 31
+    baseUrl = 'https://genztoons.org'
+    overrideVersionCode = 32
     isNsfw = false
 }
 

--- a/src/en/suryascans/src/eu/kanade/tachiyomi/extension/en/suryascans/GenzToons.kt
+++ b/src/en/suryascans/src/eu/kanade/tachiyomi/extension/en/suryascans/GenzToons.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit
 class GenzToons :
     Keyoapp(
         "Genz Toons",
-        "https://genzupdates.com",
+        "https://genztoons.org",
         "en",
     ) {
 

--- a/src/es/lectormangalat/build.gradle
+++ b/src/es/lectormangalat/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'LectorManga.lat'
     extClass = '.LectorMangaLat'
     themePkg = 'madara'
-    baseUrl = 'https://lectormangaa.com'
-    overrideVersionCode = 2
+    baseUrl = 'https://lectormangass.com'
+    overrideVersionCode = 3
     isNsfw = true
 }
 

--- a/src/es/lectormangalat/src/eu/kanade/tachiyomi/extension/es/lectormangalat/LectorMangaLat.kt
+++ b/src/es/lectormangalat/src/eu/kanade/tachiyomi/extension/es/lectormangalat/LectorMangaLat.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit
 class LectorMangaLat :
     Madara(
         "LectorManga.lat",
-        "https://lectormangaa.com",
+        "https://lectormangass.com",
         "es",
         dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("es")),
     ),

--- a/src/ja/dokiraw/build.gradle
+++ b/src/ja/dokiraw/build.gradle
@@ -1,9 +1,9 @@
 ext {
     extName = 'Dokiraw'
     extClass = '.Dokiraw'
-    baseUrl = 'https://dokiraw.tech'
+    baseUrl = 'https://dokiraw.team'
     themePkg = 'liliana'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/ja/dokiraw/src/eu/kanade/tachiyomi/extension/ja/dokiraw/Dokiraw.kt
+++ b/src/ja/dokiraw/src/eu/kanade/tachiyomi/extension/ja/dokiraw/Dokiraw.kt
@@ -17,7 +17,7 @@ import org.jsoup.nodes.Element
 import java.util.Calendar
 import kotlin.text.isNotBlank
 
-class Dokiraw : Liliana("Dokiraw", "https://dokiraw.tech", "ja") {
+class Dokiraw : Liliana("Dokiraw", "https://dokiraw.team", "ja") {
 
     override val supportsLatest = false
 

--- a/src/ja/mangamura/build.gradle
+++ b/src/ja/mangamura/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Manga Mura'
     extClass = '.MangaMura'
     themePkg = 'mangareader'
-    baseUrl = 'https://mangamura.net'
-    overrideVersionCode = 1
+    baseUrl = 'https://mangamura.me'
+    overrideVersionCode = 2
     isNsfw = true
 }
 

--- a/src/ja/mangamura/src/eu/kanade/tachiyomi/extension/ja/mangamura/MangaMura.kt
+++ b/src/ja/mangamura/src/eu/kanade/tachiyomi/extension/ja/mangamura/MangaMura.kt
@@ -8,7 +8,7 @@ import okhttp3.Request
 class MangaMura :
     MangaReader(
         "Manga Mura",
-        "https://mangamura.net",
+        "https://mangamura.me",
         "ja",
     ) {
     override val chapterIdSelect = "ja-chaps"

--- a/src/ja/raw18/build.gradle
+++ b/src/ja/raw18/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Raw18'
     extClass = '.Raw18'
     themePkg = 'wpcomics'
-    baseUrl = 'https://raw18.tel'
-    overrideVersionCode = 3
+    baseUrl = 'https://raw18.cam'
+    overrideVersionCode = 4
     isNsfw = true
 }
 

--- a/src/ja/raw18/src/eu/kanade/tachiyomi/extension/ja/raw18/Raw18.kt
+++ b/src/ja/raw18/src/eu/kanade/tachiyomi/extension/ja/raw18/Raw18.kt
@@ -15,7 +15,7 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
 
-class Raw18 : WPComics("Raw18", "https://raw18.tel", "ja", SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'", Locale.JAPANESE), null) {
+class Raw18 : WPComics("Raw18", "https://raw18.cam", "ja", SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'", Locale.JAPANESE), null) {
     override val searchPath = "search/manga"
 
     override val genresUrlDelimiter = "="

--- a/src/tr/kuroimanga/build.gradle
+++ b/src/tr/kuroimanga/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Kuroi Manga'
     extClass = '.KuroiManga'
     themePkg = 'madara'
-    baseUrl = 'https://www.kuroimanga.top'
-    overrideVersionCode = 3
+    baseUrl = 'https://www.kuroimanga.mom'
+    overrideVersionCode = 4
     isNsfw = true
 }
 

--- a/src/tr/kuroimanga/src/eu/kanade/tachiyomi/extension/tr/kuroimanga/KuroiManga.kt
+++ b/src/tr/kuroimanga/src/eu/kanade/tachiyomi/extension/tr/kuroimanga/KuroiManga.kt
@@ -11,7 +11,7 @@ import java.util.Locale
 class KuroiManga :
     Madara(
         "Kuroi Manga",
-        "https://www.kuroimanga.top",
+        "https://www.kuroimanga.mom",
         "tr",
         dateFormat = SimpleDateFormat("d MMMM yyyy", Locale("tr")),
     ) {

--- a/src/vi/dualeotruyen/build.gradle
+++ b/src/vi/dualeotruyen/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = "Dua Leo Truyen"
     extClass = ".DuaLeoTruyen"
-    extVersionCode = 17
+    extVersionCode = 18
     isNsfw = true
 }
 

--- a/src/vi/dualeotruyen/src/eu/kanade/tachiyomi/extension/vi/dualeotruyen/DuaLeoTruyen.kt
+++ b/src/vi/dualeotruyen/src/eu/kanade/tachiyomi/extension/vi/dualeotruyen/DuaLeoTruyen.kt
@@ -33,7 +33,7 @@ class DuaLeoTruyen :
     override val lang = "vi"
     override val supportsLatest = true
 
-    private val defaultBaseUrl = "https://dualeotruyenhx.com"
+    private val defaultBaseUrl = "https://dualeotruyengl.com"
     private val preferences: SharedPreferences = getPreferences()
 
     override val baseUrl get() = getPrefBaseUrl()

--- a/src/vi/medamtruyen/build.gradle
+++ b/src/vi/medamtruyen/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MeDamTruyen'
     extClass = '.MeDamTruyen'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/vi/medamtruyen/src/eu/kanade/tachiyomi/extension/vi/medamtruyen/MeDamTruyen.kt
+++ b/src/vi/medamtruyen/src/eu/kanade/tachiyomi/extension/vi/medamtruyen/MeDamTruyen.kt
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentHashMap
 class MeDamTruyen : HttpSource() {
     override val name = "MeDamTruyen"
     override val lang = "vi"
-    override val baseUrl = "https://saytongtai.shop"
+    override val baseUrl = "https://saytongtai.site"
     override val supportsLatest = true
 
     private val thumbnailFallbackInterceptor = Interceptor { chain ->

--- a/src/vi/truyenvn/build.gradle
+++ b/src/vi/truyenvn/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'TruyenVN'
     extClass = '.TruyenVN'
     themePkg = 'madara'
-    baseUrl = 'https://truyenvn.shop'
-    overrideVersionCode = 16
+    baseUrl = 'https://truyenvn.sbs'
+    overrideVersionCode = 17
     isNsfw = true
 }
 

--- a/src/vi/truyenvn/src/eu/kanade/tachiyomi/extension/vi/truyenvn/TruyenVN.kt
+++ b/src/vi/truyenvn/src/eu/kanade/tachiyomi/extension/vi/truyenvn/TruyenVN.kt
@@ -12,7 +12,7 @@ import java.util.Locale
 class TruyenVN :
     Madara(
         "TruyenVN",
-        "https://truyenvn.shop",
+        "https://truyenvn.sbs",
         "vi",
         dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.ROOT),
     ),

--- a/src/vi/vinahentai/build.gradle
+++ b/src/vi/vinahentai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'VinaHentai'
     extClass = '.VinaHentai'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/vi/vinahentai/src/eu/kanade/tachiyomi/extension/vi/vinahentai/VinaHentai.kt
+++ b/src/vi/vinahentai/src/eu/kanade/tachiyomi/extension/vi/vinahentai/VinaHentai.kt
@@ -19,7 +19,7 @@ import java.util.Calendar
 class VinaHentai : HttpSource() {
     override val name = "VinaHentai"
     override val lang = "vi"
-    override val baseUrl = "https://vinahentai.asia"
+    override val baseUrl = "https://vinahentai.life"
     override val supportsLatest = true
 
     override val client = network.client.newBuilder()

--- a/src/vi/zettruyen/build.gradle
+++ b/src/vi/zettruyen/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ZetTruyen'
     extClass = '.ZetTruyen'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = false
 }
 

--- a/src/vi/zettruyen/src/eu/kanade/tachiyomi/extension/vi/zettruyen/ZetTruyen.kt
+++ b/src/vi/zettruyen/src/eu/kanade/tachiyomi/extension/vi/zettruyen/ZetTruyen.kt
@@ -23,7 +23,7 @@ import java.util.TimeZone
 class ZetTruyen : HttpSource() {
     override val name = "ZetTruyen"
     override val lang = "vi"
-    override val baseUrl = "https://www.zettruyen.live"
+    override val baseUrl = "https://www.zettruyen.top"
     override val supportsLatest = true
 
     override val client = network.client.newBuilder()


### PR DESCRIPTION
Dokiraw
Dua Leo Truyen
Genz Toons
Kuroi Manga
Manga Mura
MeDamTruyen
Raw18
TruyenVN
VinaHentai
ZetTruyen
LectorManga.lat (Closes #15891)

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
