### PR TITLE
RawZO: Switch to image proxy urls

### DIFF
--- a/src/ja/rawxz/build.gradle
+++ b/src/ja/rawxz/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'RawZO'
     extClass = '.RawXZ'
     baseUrl = 'https://rawzo.net'
-    extVersionCode = 50
+    extVersionCode = 51
     isNsfw = true
 }
 

--- a/src/ja/rawxz/src/eu/kanade/tachiyomi/extension/ja/rawxz/RawXZ.kt
+++ b/src/ja/rawxz/src/eu/kanade/tachiyomi/extension/ja/rawxz/RawXZ.kt
@@ -11,7 +11,6 @@ import eu.kanade.tachiyomi.util.asJsoup
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
-import java.net.URLDecoder
 import java.util.Calendar
 
 class RawXZ : HttpSource() {
@@ -31,7 +30,7 @@ class RawXZ : HttpSource() {
         val mangas = document.select(".manga-card").map { element ->
             SManga.create().apply {
                 title = element.selectFirst(".manga-card-title")!!.text()
-                setUrlWithoutDomain(element.selectFirst("a.manga-card-thumb")!!.attr("href"))
+                setUrlWithoutDomain(element.selectFirst("a.manga-card-thumb")!!.absUrl("href"))
                 thumbnail_url = element.selectFirst(".manga-card-thumb img")?.absUrl("src")
             }
         }
@@ -94,7 +93,7 @@ class RawXZ : HttpSource() {
             SChapter.create().apply {
                 val link = element.selectFirst(".md-chapter-name a")!!
                 name = link.ownText()
-                setUrlWithoutDomain(link.attr("href"))
+                setUrlWithoutDomain(link.absUrl("href"))
                 date_upload = parseRelativeDate(element.selectFirst(".md-chapter-time")?.text())
             }
         }
@@ -112,16 +111,21 @@ class RawXZ : HttpSource() {
     override fun pageListParse(response: Response): List<Page> {
         val document = response.asJsoup()
 
-        return document.select(".reader-page img").mapIndexed { idx, image ->
-            val url = image.absUrl("src")
-            val imageUrl = if (url.contains("img-proxy.php?url=")) {
-                URLDecoder.decode(url.substringAfter("img-proxy.php?url="), "UTF-8")
-            } else {
-                url
-            }
-
-            Page(idx, imageUrl = imageUrl)
+        return document.select(".reader-page img").mapIndexed { index, img ->
+            Page(
+                index = index,
+                imageUrl = toProxyUrl(img.absUrl("src")),
+            )
         }
+    }
+
+    private fun toProxyUrl(url: String): String {
+        if (url.isBlank() || url.contains("img-proxy.php?url=")) return url
+
+        return baseUrl.toHttpUrl().newBuilder().apply {
+            addPathSegments("wp-content/themes/manga-theme-MangaVerse/img-proxy.php")
+            addQueryParameter("url", url)
+        }.build().toString()
     }
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()


### PR DESCRIPTION
Close: #16159

This fixes the images showing "No image" in some regions: https://github.com/keiyoushi/extensions-source/issues/16159#issuecomment-4543750315

The problem is site-side, as it shows no images on the site too if the site is using a direct url for it.
 
But the images using proxy urls show up fine, so using proxy urls for all images now.

Tested with the Hong Kong region using a vpn and it's working now.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
