### PR TITLE
MangaTV (ES): Fix chapter selector

### DIFF
--- a/src/es/mangatv/build.gradle
+++ b/src/es/mangatv/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaTV'
     themePkg = 'mangathemesia'
     baseUrl = 'https://mangatv.net'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
     isNsfw = true
 }
 

--- a/src/es/mangatv/src/eu/kanade/tachiyomi/extension/es/mangatv/MangaTV.kt
+++ b/src/es/mangatv/src/eu/kanade/tachiyomi/extension/es/mangatv/MangaTV.kt
@@ -24,6 +24,7 @@ class MangaTV :
     ) {
 
     override val seriesDescriptionSelector = "b:contains(Sinopsis) + span"
+    override fun chapterListSelector() = "#chapterlist ul.clstyle li:has(.dt a)"
 
     override fun pageListParse(document: Document): List<Page> {
         val unpackedScript = document.selectFirst("script:containsData(eval)")!!.data()


### PR DESCRIPTION
Closes #16200 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop 
__