### PR TITLE
Onf Mangas (ES): Handle token cookie & fallback Page

### DIFF
--- a/src/es/onfmangas/build.gradle
+++ b/src/es/onfmangas/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ONF MANGAS'
     extClass = '.OnfMangas'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/es/onfmangas/src/eu/kanade/tachiyomi/extension/es/onfmangas/Dto.kt
+++ b/src/es/onfmangas/src/eu/kanade/tachiyomi/extension/es/onfmangas/Dto.kt
@@ -40,6 +40,10 @@ class GroupDto(
 @Serializable
 class PageDto(
     private val src: String,
+    private val fallback: String?,
 ) {
-    fun toPage(index: Int) = Page(index, imageUrl = src)
+    fun toPage(index: Int) = Page(
+        index = index,
+        url = if (!fallback.isNullOrBlank()) "$src#fallback=$fallback" else src,
+    )
 }

--- a/src/es/onfmangas/src/eu/kanade/tachiyomi/extension/es/onfmangas/OnfMangas.kt
+++ b/src/es/onfmangas/src/eu/kanade/tachiyomi/extension/es/onfmangas/OnfMangas.kt
@@ -16,6 +16,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
+import rx.Observable
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
@@ -205,6 +206,21 @@ class OnfMangas : HttpSource() {
         val pagesData = jsonString.parseAs<List<PageDto>>()
 
         return pagesData.mapIndexed { index, dto -> dto.toPage(index) }
+    }
+
+    // Decent chance for primary src to fail
+    override fun fetchImageUrl(page: Page): Observable<String> {
+        val src = page.url
+        val fallback = page.url.toHttpUrl().fragment?.removePrefix("fallback=")
+
+        if (fallback.isNullOrBlank()) return Observable.just(src)
+
+        return Observable.fromCallable {
+            val response = client.newCall(Request.Builder().head().url(src).build()).execute()
+            val success = response.isSuccessful
+            response.close()
+            if (success) src else fallback
+        }
     }
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()

--- a/src/es/onfmangas/src/eu/kanade/tachiyomi/extension/es/onfmangas/OnfMangas.kt
+++ b/src/es/onfmangas/src/eu/kanade/tachiyomi/extension/es/onfmangas/OnfMangas.kt
@@ -11,7 +11,9 @@ import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.firstInstanceOrNull
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.tryParse
+import okhttp3.Cookie
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
 import java.text.SimpleDateFormat
@@ -25,20 +27,32 @@ class OnfMangas : HttpSource() {
     override val lang = "es"
     override val supportsLatest = true
 
+    val tokenRegex = Regex("""var token="([^"]+)"""")
+
+    override val client = super.client.newBuilder()
+        .addInterceptor(::onfTokenInterceptor)
+        .build()
+
+    private fun onfTokenInterceptor(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val response = chain.proceed(request)
+
+        val body = response.peekBody(8192).string()
+        val token = tokenRegex.find(body)?.groupValues?.get(1) ?: return response
+
+        response.close()
+        val cookie = Cookie.parse(request.url, "__onf_chk=$token; path=/")
+        client.cookieJar.saveFromResponse(request.url, listOfNotNull(cookie))
+
+        return chain.proceed(request)
+    }
+
     // Mimic a standard desktop browser to bypass Cloudflare WAF 403s
     override fun headersBuilder() = super.headersBuilder()
         .set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0")
         .set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
         .set("Accept-Language", "en-US,en;q=0.9")
-        .set("DNT", "1")
-        .set("Sec-GPC", "1")
-        .set("Connection", "keep-alive")
-        .set("Upgrade-Insecure-Requests", "1")
-        .set("Sec-Fetch-Dest", "document")
-        .set("Sec-Fetch-Mode", "navigate")
         .set("Sec-Fetch-Site", "none")
-        .set("Sec-Fetch-User", "?1")
-        .set("Priority", "u=0, i")
 
     private val dateFormat by lazy {
         SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ROOT).apply {


### PR DESCRIPTION
Can't find a perfect way for fallback one without leading HEAD requests
interceptor-swap flops because of host difference

Closes #16235
Closes #14923

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop