### PR TITLE
MikuDoujin: fix selector page list

### DIFF
--- a/src/th/mikudoujin/build.gradle
+++ b/src/th/mikudoujin/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MikuDoujin'
     extClass = '.MikuDoujin'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = true
 }
 

--- a/src/th/mikudoujin/src/eu/kanade/tachiyomi/extension/th/mikudoujin/MikuDoujin.kt
+++ b/src/th/mikudoujin/src/eu/kanade/tachiyomi/extension/th/mikudoujin/MikuDoujin.kt
@@ -148,7 +148,8 @@ class MikuDoujin : HttpSource() {
 
     override fun pageListParse(response: Response): List<Page> {
         val document = response.asJsoup()
-        return document.select("div#v-pills-tabContent img.lazy").mapIndexed { i, img ->
+        val query = "div#v-pills-tabContent img.lazy, div#v-pills-tabContent img.page-img"
+        return document.select(query).mapIndexed { i, img ->
             val url = if (img.hasAttr("data-src")) {
                 img.attr("abs:data-src")
             } else {


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
