### PR TITLE
feat(core/nextjs): resolve outlined-model path references

### DIFF
--- a/core/src/main/kotlin/keiyoushi/utils/NextJs.kt
+++ b/core/src/main/kotlin/keiyoushi/utils/NextJs.kt
@@ -50,7 +50,9 @@ private fun <T> extractValueNextJs(
  *   ([ReactFlightNumber] parses it to the real `Double`; JSON itself has no Infinity/NaN).
  * - `$Q<id>` -> Map, the outlined model at `<id>` is an array of `[key, value]` entries.
  * - `$W<id>` -> Set, the outlined model at `<id>` is an array of values.
- * - `$<id>` -> Looks up the ID in our ByteText cache.
+ * - `$<id>` / `$<id>:<path>` -> Outlined model reference ([ReactFlightServer]'s `getOutlinedModel`).
+ *   `<id>` is looked up in the ByteText [chunkCache] then the [modelCache]; any `:`-separated
+ *   `<path>` segments walk into the model by object key or array index.
  *
  * [modelCache] holds outlined JSON model rows by hex id (for `$Q`/`$W` and lazy refs);
  * [chunkCache] holds binary ByteText chunks by hex id. [resolving] guards against
@@ -78,13 +80,71 @@ private fun resolveNextJsRefs(
                 str[1] == 'n' -> JsonPrimitive(str.substring(2)) // BigInt -> strip '$n' for ReactFlightBigInt
                 str[1] == 'Q' -> resolveMapRef(str.substring(2), chunkCache, modelCache, resolving) ?: element
                 str[1] == 'W' -> resolveSetRef(str.substring(2), chunkCache, modelCache, resolving) ?: element
-                // RSC chunk reference -> look up in cache and replace with content if found
-                else -> chunkCache[str.substring(1)]?.let { JsonPrimitive(it) } ?: element
+                // RSC reference (`$<id>` or `$<id>:<path>`) -> resolve via chunk/model cache.
+                else -> resolveModelRef(str.substring(1), chunkCache, modelCache, resolving) ?: element
             }
         } else {
             element
         }
     }
+}
+
+/**
+ * Resolves a flight reference of the form `<id>` or `<id>:<seg>:<seg>...` into the referenced
+ * element, mirroring React's
+ * [getOutlinedModel](https://github.com/facebook/react/blob/main/packages/react-server/src/ReactFlightServer.js).
+ *
+ * A bare `<id>` first resolves against the binary [chunkCache] (ByteText). Otherwise `<id>` is
+ * looked up in the outlined [modelCache] and the remaining `:`-separated segments walk into that
+ * model row by object key or array index; the reached element is then resolved recursively, with
+ * `<id>` added to the [resolving] cycle guard. Returns `null` if the reference can't be resolved.
+ *
+ * React elements travel on the wire as `["$", type, key, props]` tuples (the leading `"$"` is
+ * [REACT_ELEMENT_TYPE]); the client turns them into element objects before walking. We mirror that
+ * by mapping the `type`/`key`/`props` segments onto tuple indices 1/2/3. A reference encountered
+ * mid-walk (e.g. a lazily-outlined `props`) is resolved before the next segment indexes into it.
+ */
+private fun resolveModelRef(
+    reference: String,
+    chunkCache: Map<String, String>,
+    modelCache: Map<String, JsonElement>,
+    resolving: Set<String>,
+): JsonElement? {
+    val segments = reference.split(':')
+    val id = segments[0]
+    // Bare reference: prefer the binary ByteText chunk if present.
+    if (segments.size == 1) {
+        chunkCache[id]?.let { return JsonPrimitive(it) }
+    }
+    if (id in resolving) return null // cycle
+    val guard = resolving + id
+    var value: JsonElement = modelCache[id] ?: return null
+    for (i in 1 until segments.size) {
+        // A node reached mid-walk may itself be a `$`-reference; resolve it before indexing in.
+        if (value is JsonPrimitive && value.isString && value.content.startsWith("$")) {
+            value = resolveNextJsRefs(value, chunkCache, modelCache, guard)
+        }
+        value = walkRefSegment(value, segments[i]) ?: return null
+    }
+    return resolveNextJsRefs(value, chunkCache, modelCache, guard)
+}
+
+/** Indexes [value] by a single path [segment], honouring the React element tuple shape. */
+private fun walkRefSegment(value: JsonElement, segment: String): JsonElement? = when (value) {
+    is JsonObject -> value[segment]
+    is JsonArray ->
+        // React element tuple ["$", type, key, props] -> map named props to their indices.
+        if (value.size >= 4 && (value[0] as? JsonPrimitive)?.takeIf { it.isString }?.content == "$") {
+            when (segment) {
+                "type" -> value[1]
+                "key" -> value[2]
+                "props" -> value[3]
+                else -> segment.toIntOrNull()?.let { value.getOrNull(it) }
+            }
+        } else {
+            segment.toIntOrNull()?.let { value.getOrNull(it) }
+        }
+    else -> null
 }
 
 /** Resolves the outlined model at [id] (a row of `[key, value]` pairs) into a [JsonObject]. */

--- a/core/src/test/kotlin/keiyoushi/utils/NextJsTest.kt
+++ b/core/src/test/kotlin/keiyoushi/utils/NextJsTest.kt
@@ -84,4 +84,23 @@ class NextJsTest {
         assertEquals(mapOf("a" to 1, "b" to 2), c!!.items)
         assertEquals(listOf(10, 20, 30), c.tags)
     }
+
+    @Serializable
+    data class Chapter(val number: Int, val title: String)
+
+    @Serializable
+    data class FullList(val mangaTitle: String, val chapters: List<Chapter>)
+
+    @Test
+    fun realFlightPathRefsFixture() {
+        // full.chapters[0] is emitted as a path reference ($0:preview:0) to the shared object
+        // first written under preview[0]; it must resolve to the full chapter, not stay a string.
+        val full = fixture("pathrefs").extractNextJsRsc<FullList>()
+        assertNotNull(full)
+        full!!
+        assertEquals("My Manga", full.mangaTitle)
+        assertEquals(listOf(3, 1), full.chapters.map { it.number })
+        assertEquals("Newest", full.chapters[0].title) // resolved via $0:preview:0
+        assertEquals("Oldest", full.chapters[1].title)
+    }
 }

--- a/core/src/test/resources/reactflight/pathrefs.txt
+++ b/core/src/test/resources/reactflight/pathrefs.txt
@@ -1,0 +1,2 @@
+:N1780140562198.1553
+0:{"preview":[{"number":3,"title":"Newest"},{"number":2,"title":"Middle"}],"full":{"mangaTitle":"My Manga","chapters":["$0:preview:0",{"number":1,"title":"Oldest"}]}}

--- a/core/src/test/rsc-capture/capture.mjs
+++ b/core/src/test/rsc-capture/capture.mjs
@@ -41,6 +41,20 @@ const models = {
     tags: new Set([10, 20, 30]),
     nested: new Map([["list", new Set(["x", "y"])]]),
   },
+  // A shared object reference appearing twice: React outlines the first occurrence and
+  // emits the second as a path reference ($<id>:preview:0) into the model where it was
+  // first written. Mirrors RimuScans, whose full chapter list references its 3 newest
+  // chapters (already written by the preview component) by path.
+  pathrefs: (() => {
+    const newest = { number: 3, title: "Newest" };
+    return {
+      preview: [newest, { number: 2, title: "Middle" }],
+      full: {
+        mangaTitle: "My Manga",
+        chapters: [newest, { number: 1, title: "Oldest" }],
+      },
+    };
+  })(),
 };
 
 function renderToString(model) {


### PR DESCRIPTION
While updating #16169 I found out that React may create refs to already existing object, this implement the reference

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
