### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-/src/zh/ @stevenyomi


### PR DESCRIPTION
@stevenyomi is not active in the project, but his review is required for all of `/src/zh`; I can merge those prs by bypassing merge requirements as admin, but I would prefer not to do that. (since I can only do it on github webui and not from gh cli to merge approved prs)