### PR TITLE
Update KunManga URL to kunmanga.co.uk

### DIFF
--- a/src/en/kunmanga/src/eu/kanade/tachiyomi/extension/en/kunmanga/KunManga.kt
+++ b/src/en/kunmanga/src/eu/kanade/tachiyomi/extension/en/kunmanga/KunManga.kt
@@ -2,4 +2,4 @@ package eu.kanade.tachiyomi.extension.en.kunmanga
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 
-class KunManga : Madara("Kun Manga", "https://kunmanga.com", "en")
+class KunManga : Madara("Kun Manga", "https://kunmanga.co.uk", "en")


### PR DESCRIPTION
KunManga domain changed.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
