### PR TITLE
ResetScans and Utoon Add correct year parsing

### DIFF
--- a/src/en/resetscans/build.gradle
+++ b/src/en/resetscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ResetScans'
     themePkg = 'madara'
     baseUrl = 'https://reset-scans.org'
-    overrideVersionCode = 11
+    overrideVersionCode = 12
     isNsfw = false
 }
 

--- a/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
+++ b/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
@@ -1,7 +1,10 @@
 package eu.kanade.tachiyomi.extension.en.resetscans
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.source.model.SChapter
+import okhttp3.Response
 import java.text.SimpleDateFormat
+import java.util.Calendar
 import java.util.Locale
 
 class ResetScans :
@@ -17,4 +20,47 @@ class ResetScans :
     override val useNewChapterEndpoint = true
 
     override fun chapterListSelector() = "li.wp-manga-chapter:not(:has(a[href*='#']))"
+
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val chapters = super.chapterListParse(response)
+
+        var currentYear = Calendar.getInstance().get(Calendar.YEAR)
+        var previousMonth = -1
+
+        for (chapter in chapters) {
+            if (chapter.date_upload > 0L) {
+                val cal = Calendar.getInstance()
+                cal.timeInMillis = chapter.date_upload
+
+                // 1970 means the date was parsed without a year
+                if (cal.get(Calendar.YEAR) == 1970) {
+                    val month = cal.get(Calendar.MONTH)
+
+                    if (previousMonth != -1) {
+                        // Month jumping forward (e.g. Jan to Dec) means we crossed into the previous year
+                        if (month - previousMonth >= 6) {
+                            currentYear--
+                        }
+                    } else {
+                        // If the first parsed date is in the future (+7 day buffer), it belongs to last year
+                        cal.set(Calendar.YEAR, currentYear)
+                        if (cal.timeInMillis > System.currentTimeMillis() + 604_800_000L) {
+                            currentYear--
+                        }
+                    }
+
+                    cal.set(Calendar.YEAR, currentYear)
+                    chapter.date_upload = cal.timeInMillis
+
+                    previousMonth = month
+                } else {
+                    // Update tracking variables using dates that already have a valid year
+                    currentYear = cal.get(Calendar.YEAR)
+                    previousMonth = cal.get(Calendar.MONTH)
+                }
+            }
+        }
+
+        return chapters
+    }
 }

--- a/src/en/utoon/build.gradle
+++ b/src/en/utoon/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Utoon'
     themePkg = 'madara'
     baseUrl = 'https://utoon.net'
-    overrideVersionCode = 3
+    overrideVersionCode = 4
     isNsfw = false
 }
 

--- a/src/en/utoon/src/eu/kanade/tachiyomi/extension/en/utoon/Utoon.kt
+++ b/src/en/utoon/src/eu/kanade/tachiyomi/extension/en/utoon/Utoon.kt
@@ -2,7 +2,7 @@ package eu.kanade.tachiyomi.extension.en.utoon
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.source.model.SChapter
-import org.jsoup.nodes.Element
+import okhttp3.Response
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
@@ -12,7 +12,7 @@ class Utoon :
         "Utoon",
         "https://utoon.net",
         "en",
-        SimpleDateFormat("dd MMM yyyy", Locale.US),
+        SimpleDateFormat("dd MMM", Locale.US),
     ) {
     override val useNewChapterEndpoint = true
 
@@ -20,17 +20,46 @@ class Utoon :
 
     override fun chapterListSelector() = "li.wp-manga-chapter:not(.premium-block)"
 
-    override fun chapterFromElement(element: Element): SChapter = super.chapterFromElement(element).apply {
-        // Unfortunately Utoon doesn't include the year in the upload date.
-        // As a workaround, assume it's from the current year, or last year
-        // if the date is in the future.
-        val currentYear = Calendar.getInstance().get(Calendar.YEAR)
-        val upload = element.selectFirst("span a")?.attr("title")?.let { parseRelativeDate(it) } ?: parseChapterDate("${element.selectFirst(chapterDateSelector())?.text()} $currentYear")
-        val now = System.currentTimeMillis()
-        date_upload = if (now < upload) {
-            parseChapterDate("${element.selectFirst(chapterDateSelector())?.text()} ${currentYear - 1}")
-        } else {
-            upload
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val chapters = super.chapterListParse(response)
+
+        var currentYear = Calendar.getInstance().get(Calendar.YEAR)
+        var previousMonth = -1
+
+        for (chapter in chapters) {
+            if (chapter.date_upload > 0L) {
+                val cal = Calendar.getInstance()
+                cal.timeInMillis = chapter.date_upload
+
+                // 1970 means the date was parsed without a year
+                if (cal.get(Calendar.YEAR) == 1970) {
+                    val month = cal.get(Calendar.MONTH)
+
+                    if (previousMonth != -1) {
+                        // Month jumping forward (e.g. Jan to Dec) means we crossed into the previous year
+                        if (month - previousMonth >= 6) {
+                            currentYear--
+                        }
+                    } else {
+                        // If the first parsed date is in the future (+7 day buffer), it belongs to last year
+                        cal.set(Calendar.YEAR, currentYear)
+                        if (cal.timeInMillis > System.currentTimeMillis() + 604_800_000L) {
+                            currentYear--
+                        }
+                    }
+
+                    cal.set(Calendar.YEAR, currentYear)
+                    chapter.date_upload = cal.timeInMillis
+
+                    previousMonth = month
+                } else {
+                    // Update tracking variables using dates that already have a valid year
+                    currentYear = cal.get(Calendar.YEAR)
+                    previousMonth = cal.get(Calendar.MONTH)
+                }
+            }
         }
+
+        return chapters
     }
 }


### PR DESCRIPTION
Closes #8610

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
