### PR TITLE
Manta (ALL): fix MissingFieldException for createdAt

### DIFF
--- a/src/all/manta/build.gradle
+++ b/src/all/manta/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Manta Comics'
     extClass = '.MantaFactory'
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = true
 }
 

--- a/src/all/manta/src/eu/kanade/tachiyomi/extension/all/manta/MantaDto.kt
+++ b/src/all/manta/src/eu/kanade/tachiyomi/extension/all/manta/MantaDto.kt
@@ -10,7 +10,7 @@ private val isoDate by lazy {
 }
 
 private inline val String?.timestamp: Long
-    get() = isoDate.tryParse(this?.substringBefore('.'))
+    get() = isoDate.tryParse(this?.substringBefore('.')?.substringBefore('+')?.substringBefore('Z'))
 
 @Serializable
 class MantaResponse<T>(
@@ -64,13 +64,14 @@ class Details(
 class Episode(
     val id: Int,
     val ord: Int,
-    val data: EpisodeData?,
-    val lockData: LockData,
-    private val createdAt: String,
+    val data: EpisodeData? = null,
+    private val lockData: LockData? = null,
+    private val openAt: String? = null,
+    private val createdAt: String? = null,
     val cutImages: List<Image>? = null,
 ) {
     val timestamp: Long
-        get() = createdAt.timestamp
+        get() = openAt.timestamp.takeIf { it != 0L } ?: createdAt.timestamp
 
     fun asString(lang: String) = buildString {
         val episodeTitle = data?.title
@@ -80,7 +81,7 @@ class Episode(
             append(if (lang == "es") "Episodio" else "Episode")
             append(" $ord")
         }
-        if (lockData.isLocked) append(" 🔒")
+        if (lockData?.isLocked == true) append(" 🔒")
     }
 
     override fun toString() = asString("en")
@@ -90,9 +91,9 @@ class Episode(
 class EpisodeData(val title: String? = null)
 
 @Serializable
-class LockData(private val state: Int) {
+class LockData(private val state: Int? = null) {
     val isLocked: Boolean
-        get() = state !in arrayOf(110, 130)
+        get() = state != null && state !in arrayOf(110, 130)
 }
 
 @Serializable


### PR DESCRIPTION
- Make createdAt, data, and lockData optional in Episode DTO
- Add openAt as the primary timestamp source (matching web UI behavior)
- Improve ISO date string parsing to handle offsets and UTC indicators
- Bump version code to 8

Closes #16364
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
