### PR TITLE
MangaK: fix unable to resolve host when opening chapters

### DIFF
--- a/src/en/mangabuddy/build.gradle
+++ b/src/en/mangabuddy/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaK'
     extClass = '.MangaK'
-    extVersionCode = 27
+    extVersionCode = 28
     isNsfw = true
 }
 

--- a/src/en/mangabuddy/src/eu/kanade/tachiyomi/extension/en/mangabuddy/MangaK.kt
+++ b/src/en/mangabuddy/src/eu/kanade/tachiyomi/extension/en/mangabuddy/MangaK.kt
@@ -207,8 +207,7 @@ class MangaK :
 
     // `chapter.url` may be relative or already absolute depending on the API response,
     // so resolve it against baseUrl instead of blindly concatenating.
-    override fun getChapterUrl(chapter: SChapter): String =
-        baseUrl.toHttpUrl().resolve(chapter.url)?.toString() ?: (baseUrl + chapter.url)
+    override fun getChapterUrl(chapter: SChapter): String = baseUrl.toHttpUrl().resolve(chapter.url)?.toString() ?: (baseUrl + chapter.url)
 
     override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> {
         if (!manga.url.contains("#")) {

--- a/src/en/mangabuddy/src/eu/kanade/tachiyomi/extension/en/mangabuddy/MangaK.kt
+++ b/src/en/mangabuddy/src/eu/kanade/tachiyomi/extension/en/mangabuddy/MangaK.kt
@@ -185,7 +185,12 @@ class MangaK :
 
     // ============================== Details ==============================
 
-    override fun getMangaUrl(manga: SManga): String = baseUrl + manga.url.substringBefore("#")
+    override fun getMangaUrl(manga: SManga): String {
+        val path = manga.url.substringBefore("#")
+        // `path` may be relative or already absolute depending on the API response,
+        // so resolve it against baseUrl instead of blindly concatenating.
+        return baseUrl.toHttpUrl().resolve(path)?.toString() ?: (baseUrl + path)
+    }
 
     override fun mangaDetailsRequest(manga: SManga): Request = GET(getMangaUrl(manga), headers)
 
@@ -200,7 +205,10 @@ class MangaK :
 
     // ============================= Chapters ==============================
 
-    override fun getChapterUrl(chapter: SChapter): String = baseUrl + chapter.url
+    // `chapter.url` may be relative or already absolute depending on the API response,
+    // so resolve it against baseUrl instead of blindly concatenating.
+    override fun getChapterUrl(chapter: SChapter): String =
+        baseUrl.toHttpUrl().resolve(chapter.url)?.toString() ?: (baseUrl + chapter.url)
 
     override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> {
         if (!manga.url.contains("#")) {


### PR DESCRIPTION
Fixes #16357

**Problem**
Opening a chapter can fail with `Unable to resolve host mangak.iohttps`. The host `mangak.iohttps` is `mangak.io` immediately followed by `https` — the signature of `baseUrl` being concatenated onto an already-absolute URL: `"https://mangak.io" + "https://..." -> "https://mangak.iohttps://..."`. `getChapterUrl` (used by `pageListRequest`) does `baseUrl + chapter.url` and `getMangaUrl` does the same, so any `SChapter.url` / `SManga.url` that is already absolute mangles the host.

**Who hits it (and why "works for me" is also true)**
The current MangaK API returns **relative** urls (e.g. `/chess-piece`, `/chess-piece/season-3-chapter-94`), so `baseUrl + url` resolves correctly and freshly added titles open fine — which is why the "works for me" reports are genuine. The crash comes from **migrated library entries** that still hold an **absolute** url from a pre-migration source: this extension reuses MangaBuddy's id for migration, and the old MadTheme-based sources stored an absolute url for external chapters. So a freshly added entry on the current site won't reproduce it, but a migrated entry carrying an absolute url does.

**Fix**
Resolve the path against `baseUrl` with `HttpUrl.resolve()` instead of blindly concatenating. `resolve()` resolves a relative input against the base (identical to today's behavior for the common case) and returns an absolute input unchanged, so the malformed `mangak.iohttps` host can no longer be produced. No new imports (`toHttpUrl` is already imported). `extVersionCode` bumped 27 -> 28.

**Scope**
Resolving leaves an absolute url intact and resolves a relative one against the base, so the malformed `mangak.iohttps` host can no longer form for either shape. For any stale absolute url that points off-domain, re-migrating into MangaK (which refetches relative urls) remains the clean reset.

**Testing**
Built and sideloaded this change, then opened a chapter on:
- a migrated entry that previously failed with `Unable to resolve host` -> now opens the reader.
- a freshly added title -> opens correctly (unchanged behavior).

Also verified directly that the search and chapters API endpoints return relative paths.