### PR TITLE
[EN] Harimanga: Update base URL handling and fix search endpoint (/home)

### DIFF
--- a/src/en/harimanga/build.gradle
+++ b/src/en/harimanga/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Harimanga'
     extClass = '.Harimanga'
     themePkg = 'madara'
-    baseUrl = 'https://harimanga.me'
-    overrideVersionCode = 4
+    baseUrl = 'https://www.harimanga.co.uk'
+    overrideVersionCode = 5
     isNsfw = true
 }
 

--- a/src/en/harimanga/src/eu/kanade/tachiyomi/extension/en/harimanga/Harimanga.kt
+++ b/src/en/harimanga/src/eu/kanade/tachiyomi/extension/en/harimanga/Harimanga.kt
@@ -3,15 +3,67 @@ package eu.kanade.tachiyomi.extension.en.harimanga
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 
+import eu.kanade.tachiyomi.network.GET
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Request
+import eu.kanade.tachiyomi.source.model.FilterList
+
 class Harimanga :
     Madara(
         "Harimanga",
-        "https://harimanga.me",
+        "https://www.harimanga.co.uk",
         "en",
     ) {
+
     override val client = super.client.newBuilder()
         .rateLimit(3)
         .build()
 
     override val useLoadMoreRequest = LoadMoreStrategy.Never
+
+    override fun searchRequest(
+        page: Int,
+        query: String,
+        filters: FilterList,
+    ): Request {
+
+        val url = "$baseUrl/home/${searchPage(page)}".toHttpUrl().newBuilder()
+
+        url.addQueryParameter("s", query)
+        url.addQueryParameter("post_type", "wp-manga")
+
+        // keep Madara filters working (important)
+        filters.forEach { filter ->
+            when (filter) {
+                is AuthorFilter -> if (filter.state.isNotBlank())
+                    url.addQueryParameter("author", filter.state)
+
+                is ArtistFilter -> if (filter.state.isNotBlank())
+                    url.addQueryParameter("artist", filter.state)
+
+                is YearFilter -> if (filter.state.isNotBlank())
+                    url.addQueryParameter("release", filter.state)
+
+                is StatusFilter -> filter.state.forEach {
+                    if (it.state) url.addQueryParameter("status[]", it.id)
+                }
+
+                is OrderByFilter -> if (filter.state != 0)
+                    url.addQueryParameter("m_orderby", filter.toUriPart())
+
+                is AdultContentFilter ->
+                    url.addQueryParameter("adult", filter.toUriPart())
+
+                is GenreConditionFilter ->
+                    url.addQueryParameter("op", filter.toUriPart())
+
+                is GenreList ->
+                    filter.state.filter { it.state }.forEach {
+                        url.addQueryParameter("genre[]", it.id)
+                    }
+            }
+        }
+
+        return GET(url.build(), headers)
+    }
 }


### PR DESCRIPTION
Related to #16151

Checklist:

- [x] Updated overrideVersionCode or baseVersionCode as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body
- [x] Added the isNsfw = true flag in build.gradle when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the id if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed web_hi_res_512.png when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop


Fix Harimanga search by routing requests through /home endpoint due to site structure change.

Base URL aligned with currently active Harimanga domain.

Tested search, popular, latest, manga details, and chapter loading via website behavior (browser verification).