### PR TITLE
ZeistManga: improve date and fix some child ext

### DIFF
--- a/lib-multisrc/zeistmanga/build.gradle.kts
+++ b/lib-multisrc/zeistmanga/build.gradle.kts
@@ -4,4 +4,4 @@ plugins {
     alias(kei.plugins.multisrc)
 }
 
-baseVersionCode = 12
+baseVersionCode = 13

--- a/lib-multisrc/zeistmanga/src/eu/kanade/tachiyomi/multisrc/zeistmanga/ZeistManga.kt
+++ b/lib-multisrc/zeistmanga/src/eu/kanade/tachiyomi/multisrc/zeistmanga/ZeistManga.kt
@@ -9,6 +9,7 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.tryParse
 import kotlinx.serialization.json.Json
 import okhttp3.Headers
 import okhttp3.HttpUrl
@@ -17,6 +18,8 @@ import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
 import uy.kohesive.injekt.injectLazy
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 abstract class ZeistManga(
     override val name: String,
@@ -208,6 +211,14 @@ abstract class ZeistManga(
         return json.decodeFromString<ZeistMangaDto>(res.body.string())
     }
 
+    protected open val dateFormat: SimpleDateFormat by lazy {
+        SimpleDateFormat("yyyy-MM-dd", Locale.ROOT)
+    }
+
+    protected open fun parseDate(dateStr: String): Long = dateFormat.tryParse(dateStr)
+
+    open val preferChapterUpdatedDate: Boolean = false
+
     override fun chapterListParse(response: Response): List<SChapter> {
         val document = response.asJsoup()
         val allEntries = mutableListOf<ZeistMangaEntryDto>()
@@ -231,7 +242,18 @@ abstract class ZeistManga(
         }
         return allEntries
             .filter { it.category.orEmpty().any { cat -> cat.term == chapterCategory } }
-            .map { it.toSChapter(baseUrl) }
+            .map { entry ->
+                val updated = entry.getUpdatedDate()
+                val published = entry.getPublishedDate()
+
+                val dateStr = if (preferChapterUpdatedDate) {
+                    updated ?: published
+                } else {
+                    published ?: updated
+                }
+
+                entry.toSChapter(baseUrl, parseDate(dateStr))
+            }
     }
 
     protected open val useNewChapterFeed = false

--- a/lib-multisrc/zeistmanga/src/eu/kanade/tachiyomi/multisrc/zeistmanga/ZeistMangaDto.kt
+++ b/lib-multisrc/zeistmanga/src/eu/kanade/tachiyomi/multisrc/zeistmanga/ZeistMangaDto.kt
@@ -5,15 +5,6 @@ import eu.kanade.tachiyomi.source.model.SManga
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.jsoup.Jsoup
-import java.text.SimpleDateFormat
-import java.util.Locale
-
-private val DATE_FORMATTER by lazy {
-    SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
-}
-
-private fun parseDate(dateStr: String): Long = runCatching { DATE_FORMATTER.parse(dateStr)?.time }
-    .getOrNull() ?: 0L
 
 @Serializable
 data class ZeistMangaDto(
@@ -31,6 +22,7 @@ data class ZeistMangaFeedDto(
 data class ZeistMangaEntryDto(
     val title: ZeistMangaEntryTitleDto? = null,
     val published: ZeistMangaEntryPublishedDto? = null,
+    val updated: ZeistMangaEntryUpdatedDto? = null,
     val category: List<ZeistMangaEntryCategory>? = emptyList(),
     @SerialName("link") val url: List<ZeistMangaEntryLink>? = emptyList(),
     val content: ZeistMangaEntryContentDto? = null,
@@ -46,12 +38,15 @@ data class ZeistMangaEntryDto(
         }
     }
 
-    fun toSChapter(baseurl: String): SChapter = SChapter.create().apply {
+    fun toSChapter(baseurl: String, dateUpload: Long = 0L): SChapter = SChapter.create().apply {
         name = this@ZeistMangaEntryDto.title!!.t
         url = getChapterLink(this@ZeistMangaEntryDto.url!!).substringAfter(baseurl)
-        val chapterDate = this@ZeistMangaEntryDto.published!!.t.trim()
-        date_upload = parseDate(chapterDate)
+        date_upload = dateUpload
     }
+
+    fun getPublishedDate(): String = published?.t?.trim().orEmpty()
+
+    fun getUpdatedDate(): String = updated?.t?.trim().orEmpty()
 
     private fun getChapterLink(list: List<ZeistMangaEntryLink>): String = list.first { it.rel == "alternate" }.href
 
@@ -71,6 +66,11 @@ data class ZeistMangaEntryTitleDto(
 
 @Serializable
 data class ZeistMangaEntryPublishedDto(
+    @SerialName("\$t") val t: String,
+)
+
+@Serializable
+data class ZeistMangaEntryUpdatedDto(
     @SerialName("\$t") val t: String,
 )
 

--- a/src/ar/yokai/build.gradle
+++ b/src/ar/yokai/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Yokai'
     themePkg = 'zeistmanga'
     baseUrl = 'https://yokai-team.blogspot.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
 }
 

--- a/src/ar/yokai/src/eu/kanade/tachiyomi/extension/ar/yokai/Yokai.kt
+++ b/src/ar/yokai/src/eu/kanade/tachiyomi/extension/ar/yokai/Yokai.kt
@@ -45,7 +45,6 @@ class Yokai : ZeistManga("Yokai", "https://yokai-team.blogspot.com", "ar") {
                     val text = element.text().trim()
                     name = text
                     chapter_number = text.substringBefore(' ').toFloatOrNull() ?: 1F
-                    date_upload = 0L
                 }
             }
 

--- a/src/ar/yokai/src/eu/kanade/tachiyomi/extension/ar/yokai/Yokai.kt
+++ b/src/ar/yokai/src/eu/kanade/tachiyomi/extension/ar/yokai/Yokai.kt
@@ -1,38 +1,59 @@
 package eu.kanade.tachiyomi.extension.ar.yokai
 
 import eu.kanade.tachiyomi.multisrc.zeistmanga.ZeistManga
-import eu.kanade.tachiyomi.multisrc.zeistmanga.ZeistMangaDto
-import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.SChapter
-import eu.kanade.tachiyomi.util.asJsoup
-import kotlinx.serialization.json.decodeFromStream
 import okhttp3.Response
+import org.jsoup.Jsoup
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
 
 class Yokai : ZeistManga("Yokai", "https://yokai-team.blogspot.com", "ar") {
 
-    // ============================== Chapters ==============================
+    override val preferChapterUpdatedDate = true
+
+    override val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.ROOT).apply {
+        timeZone = TimeZone.getTimeZone("Asia/Dubai")
+    }
+
     override fun chapterListParse(response: Response): List<SChapter> {
-        val document = response.use { it.asJsoup() }
+        val document = Jsoup.parse(
+            response.peekBody(Long.MAX_VALUE).string(),
+            response.request.url.toString(),
+        )
 
-        val url = getChapterFeedUrl(document)
+        val originalList = super.chapterListParse(response)
+            .map { chapter ->
+                val chapterNumberStr: String? = if (
+                    chapter.name.startsWith("Chapter", ignoreCase = true)
+                ) {
+                    val numberPart = chapter.name.substringAfter("Chapter").trim().substringBefore(" ")
+                    chapter.name = "الفصل $numberPart"
+                    numberPart
+                } else {
+                    arabicChapterRegex.find(chapter.name)?.groupValues?.get(1)
+                }
 
-        val result = client.newCall(GET(url, headers)).execute()
-            .use { json.decodeFromStream<ZeistMangaDto>(it.body.byteStream()) }
-
-        val originalList = result.feed?.entry
-            ?.filter { it.category.orEmpty().any { category -> category.term == chapterCategory } }
-            ?.map { it.toSChapter(baseUrl) }
-            ?: throw Exception("Failed to parse from chapter API")
-
-        val additionalChapters = document.select("div#download > div.index-list > a").map {
-            SChapter.create().apply {
-                setUrlWithoutDomain(it.attr("href"))
-                val text = it.text().trim()
-                name = text
-                chapter_number = text.substringBefore(' ').toFloatOrNull() ?: 1F
+                chapterNumberStr?.toFloatOrNull()?.let { chapter.chapter_number = it }
+                chapter
             }
-        }
 
-        return originalList + additionalChapters
+        val additionalChapters = document.select("div#download > div.index-list > a")
+            .map { element ->
+                SChapter.create().apply {
+                    setUrlWithoutDomain(element.absUrl("href"))
+                    val text = element.text().trim()
+                    name = text
+                    chapter_number = text.substringBefore(' ').toFloatOrNull() ?: 1F
+                    date_upload = 0L
+                }
+            }
+
+        return (originalList + additionalChapters)
+            .distinctBy { it.url.substringBefore("?") }
+    }
+
+    companion object {
+        private val arabicChapterRegex = Regex("""الفصل\s*(\d+(?:\.\d+)?)""")
     }
 }

--- a/src/es/gistamishouse/build.gradle
+++ b/src/es/gistamishouse/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.GistamisHouse'
     themePkg = 'zeistmanga'
     baseUrl = 'https://gistamishousefansub.blogspot.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/es/gistamishouse/src/eu/kanade/tachiyomi/extension/es/gistamishouse/GistamisHouse.kt
+++ b/src/es/gistamishouse/src/eu/kanade/tachiyomi/extension/es/gistamishouse/GistamisHouse.kt
@@ -90,7 +90,7 @@ class GistamisHouse :
 
         val result = json.decodeFromString<ZeistMangaDto>(res.body.string())
         return result.feed?.entry?.filter { it.category.orEmpty().any { category -> chapterCategories.contains(category.term) } }
-            ?.map { it.toSChapter(baseUrl) }
+            ?.map { it.toSChapter(baseUrl, parseDate(it.getPublishedDate())) }
             ?: throw Exception("Failed to parse from chapter API")
     }
 

--- a/src/id/aarlas/build.gradle
+++ b/src/id/aarlas/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Aarlas'
     extClass = '.Aarlas'
     themePkg = 'zeistmanga'
-    baseUrl = 'https://aarlas.blogspot.com'
-    overrideVersionCode = 2
+    baseUrl = 'https://www.arlas.online'
+    overrideVersionCode = 3
     isNsfw = true
 }
 

--- a/src/id/aarlas/src/eu/kanade/tachiyomi/extension/id/aarlas/Aarlas.kt
+++ b/src/id/aarlas/src/eu/kanade/tachiyomi/extension/id/aarlas/Aarlas.kt
@@ -1,5 +1,19 @@
 package eu.kanade.tachiyomi.extension.id.aarlas
 
 import eu.kanade.tachiyomi.multisrc.zeistmanga.ZeistManga
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
 
-class Aarlas : ZeistManga("Aarlas", "https://aarlas.blogspot.com", "id")
+class Aarlas :
+    ZeistManga(
+        "Aarlas",
+        "https://www.arlas.online",
+        "id",
+    ) {
+    override val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.ROOT).apply {
+        timeZone = TimeZone.getTimeZone("Asia/Jakarta")
+    }
+
+    override val preferChapterUpdatedDate = true
+}


### PR DESCRIPTION
Closes #16382

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [X] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

Aarlas
- Change domain
- Fix chapter date

Yokai
- Fix chapter parsing
- Fix chapter date

GistamisHouse - fix for new use of `toSChapter`

ZeinstManga
- Allow `dateFormat` to be overridden
- Add `preferChapterUpdatedDate` var to choose between updated or released date

I listen to all feedback with great interest. I'm currently lacking direction

This part is open to debate for example. I don't know if I made a good choice or not 
(`lib-multisrc/zeistmanga/src/eu/kanade/tachiyomi/multisrc/zeistmanga/ZeistManga.kt:246`)
```kt
val updated = entry.getUpdatedDate()
val published = entry.getPublishedDate()

val dateStr = if (preferChapterUpdatedDate) {
    updated ?: published
} else {
    published ?: updated
}
``` 