### PR TITLE
ComicAsura (EN): next page selector

### DIFF
--- a/src/en/comicasura/build.gradle
+++ b/src/en/comicasura/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ComicAsura'
     themePkg = 'mangathemesia'
     baseUrl = 'https://comicasura.net'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/en/comicasura/src/eu/kanade/tachiyomi/extension/en/comicasura/ComicAsura.kt
+++ b/src/en/comicasura/src/eu/kanade/tachiyomi/extension/en/comicasura/ComicAsura.kt
@@ -71,6 +71,8 @@ class ComicAsura :
         setUrlWithoutDomain(element.absUrl("href"))
     }
 
+    override fun searchMangaNextPageSelector() = "a:has(img[alt=Next])"
+
     override val seriesDetailsSelector = """.bg-\[\#222222\]:has(h1)"""
     override val seriesTitleSelector = ".comic-title-content"
     override val seriesThumbnailSelector = "img[alt=poster]"


### PR DESCRIPTION
Closes #15953

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
