### PR TITLE
ManhwaWeb: Fix 403 on pages

### DIFF
--- a/src/es/manhwaweb/build.gradle
+++ b/src/es/manhwaweb/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ManhwaWeb'
     extClass = '.ManhwaWeb'
-    extVersionCode = 10
+    extVersionCode = 11
     isNsfw = true
 }
 

--- a/src/es/manhwaweb/src/eu/kanade/tachiyomi/extension/es/manhwaweb/ManhwaWeb.kt
+++ b/src/es/manhwaweb/src/eu/kanade/tachiyomi/extension/es/manhwaweb/ManhwaWeb.kt
@@ -159,5 +159,12 @@ class ManhwaWeb : HttpSource() {
             .mapIndexed { i, img -> Page(i, imageUrl = img) }
     }
 
+    override fun imageRequest(page: Page): Request {
+        val headers = headersBuilder()
+            .add("Referer", "$baseUrl/")
+            .build()
+        return GET(page.imageUrl!!, headers)
+    }
+
     override fun imageUrlParse(response: Response) = throw UnsupportedOperationException()
 }


### PR DESCRIPTION
Closes #16410

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
