### PR TITLE
HentaiNexus move popular to latest and make popular use "Popular Now" page plus next pages use "sort:popular"

### DIFF
--- a/src/en/hentainexus/build.gradle
+++ b/src/en/hentainexus/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = "HentaiNexus"
     extClass = ".HentaiNexus"
-    extVersionCode = 15
+    extVersionCode = 16
     isNsfw = true
 }
 

--- a/src/en/hentainexus/src/eu/kanade/tachiyomi/extension/en/hentainexus/HentaiNexus.kt
+++ b/src/en/hentainexus/src/eu/kanade/tachiyomi/extension/en/hentainexus/HentaiNexus.kt
@@ -46,12 +46,7 @@ class HentaiNexus : HttpSource() {
 
     private val json: Json by injectLazy()
 
-    override fun popularMangaRequest(page: Int) = GET(
-        baseUrl + (if (page > 1) "/page/$page" else ""),
-        headers,
-    )
-
-    override fun popularMangaParse(response: Response): MangasPage {
+    private fun parseResponse(response: Response): MangasPage {
         val document = response.asJsoup()
         val mangas = document.select(".container .column").map { element ->
             SManga.create().apply {
@@ -60,13 +55,27 @@ class HentaiNexus : HttpSource() {
                 thumbnail_url = element.selectFirst(".card-image img")?.absUrl("src")
             }
         }
-        val hasNextPage = document.selectFirst("a.pagination-next[href]") != null
+        val isPopularNow = response.request.url.encodedPath == POPULAR_NOW_PATH
+        val hasNextPage = isPopularNow || document.selectFirst("a.pagination-next[href]") != null
         return MangasPage(mangas, hasNextPage)
     }
 
-    override fun latestUpdatesRequest(page: Int) = throw UnsupportedOperationException()
+    override fun latestUpdatesRequest(page: Int) = GET(
+        baseUrl + (if (page > 1) "/page/$page" else ""),
+        headers,
+    )
 
-    override fun latestUpdatesParse(response: Response): MangasPage = throw UnsupportedOperationException()
+    override fun latestUpdatesParse(response: Response): MangasPage = parseResponse(response)
+
+    override fun popularMangaRequest(page: Int): Request {
+        return if (page > 1) {
+            searchMangaRequest(page - 1, "sort:popular", getFilterList())
+        } else {
+            GET(baseUrl + POPULAR_NOW_PATH, headers)
+        }
+    }
+
+    override fun popularMangaParse(response: Response): MangasPage = parseResponse(response)
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
         if (query.startsWith("https://")) {
@@ -100,7 +109,7 @@ class HentaiNexus : HttpSource() {
         return GET(url, headers)
     }
 
-    override fun searchMangaParse(response: Response) = popularMangaParse(response)
+    override fun searchMangaParse(response: Response) = parseResponse(response)
 
     private val tagCountRegex = Regex("""\s*\([\d,]+\)$""")
 
@@ -196,5 +205,6 @@ class HentaiNexus : HttpSource() {
 
     companion object {
         const val PREFIX_ID_SEARCH = "id:"
+        const val POPULAR_NOW_PATH = "/explore/hot"
     }
 }

--- a/src/en/hentainexus/src/eu/kanade/tachiyomi/extension/en/hentainexus/HentaiNexus.kt
+++ b/src/en/hentainexus/src/eu/kanade/tachiyomi/extension/en/hentainexus/HentaiNexus.kt
@@ -67,12 +67,10 @@ class HentaiNexus : HttpSource() {
 
     override fun latestUpdatesParse(response: Response): MangasPage = parseResponse(response)
 
-    override fun popularMangaRequest(page: Int): Request {
-        return if (page > 1) {
-            searchMangaRequest(page - 1, "sort:popular", getFilterList())
-        } else {
-            GET(baseUrl + POPULAR_NOW_PATH, headers)
-        }
+    override fun popularMangaRequest(page: Int): Request = if (page > 1) {
+        searchMangaRequest(page - 1, "sort:popular", getFilterList())
+    } else {
+        GET(baseUrl + POPULAR_NOW_PATH, headers)
     }
 
     override fun popularMangaParse(response: Response): MangasPage = parseResponse(response)

--- a/src/en/hentainexus/src/eu/kanade/tachiyomi/extension/en/hentainexus/HentaiNexus.kt
+++ b/src/en/hentainexus/src/eu/kanade/tachiyomi/extension/en/hentainexus/HentaiNexus.kt
@@ -34,7 +34,7 @@ class HentaiNexus : HttpSource() {
 
     override val baseUrl = "https://hentainexus.com"
 
-    override val supportsLatest = false
+    override val supportsLatest = true
 
     // Images on this site go through the free Jetpack Photon CDN.
     override val client = network.client.newBuilder()


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
