### PR TITLE
Softkomik (ID): Fix token endpoint and fallback

### DIFF
--- a/src/id/softkomik/build.gradle
+++ b/src/id/softkomik/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Softkomik'
     extClass = '.Softkomik'
-    extVersionCode = 11
+    extVersionCode = 12
     isNsfw = false
 }
 

--- a/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
+++ b/src/id/softkomik/src/eu/kanade/tachiyomi/extension/id/softkomik/Softkomik.kt
@@ -314,23 +314,12 @@ class Softkomik : HttpSource() {
         val route = resolveSessionRoute(request.url)
         val sessionResult = getSession(route)
         val newRequest = request.newBuilder()
-            .header("X-Token", sessionResult.token)
-            .header("X-Sign", sessionResult.sign)
+            // Clean garabage at trailing
+            .header("X-Token", sessionResult.token.substringBeforeLast('=') + '=')
+            .header("X-Sign", sessionResult.sign.take(64))
             .build()
 
-        var response = chain.proceed(newRequest)
-        if (response.code != 200) { // they now change the response status code
-            response.close()
-
-            // retry once with session from WebView, in case the session from api is invalid but WebView has valid session
-            val cookieSession = getSessionViaWebView(route)
-            val retryRequest = request.newBuilder()
-                .header("X-Token", cookieSession.token)
-                .header("X-Sign", cookieSession.sign)
-                .build()
-            response = chain.proceed(retryRequest)
-        }
-        return response
+        return chain.proceed(newRequest)
     }
 
     private fun getBearerTokenFromCookie(): BearerTokenDto? {
@@ -375,9 +364,9 @@ class Softkomik : HttpSource() {
         val sessionKey = if (isChapterImageRequest) sessionKeyChapterImage else sessionKeyChapterList
 
         val sessionApiUrl = if (isChapterImageRequest) {
-            "$baseUrl/api/sessions/chapter"
+            "$baseUrl/api/session/chapter"
         } else {
-            "$baseUrl/api/sessions/kajsijas"
+            "$baseUrl/api/session/amsnuy"
         }
         val webViewUrl = if (isChapterImageRequest) {
             val chapterSegment = resolveWebViewChapterSegment(url)


### PR DESCRIPTION
Remove unneeded data at end of sig before using as signature & For webview fallback, first request that used to be captured was returning random chars at end of token & sig too intentionally and remove duplicate getSessionViaWebView call

make do with this for now as second request with cleaned version isn't being made due to environmental checks, to not bother yet

Closes #15977
Closes #14927

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop