### PR TITLE
TheManga: update url and restore old search

### DIFF
--- a/src/id/themanga/build.gradle
+++ b/src/id/themanga/build.gradle
@@ -1,8 +1,7 @@
 ext {
     extName = 'TheManga'
     extClass = '.TheManga'
-    baseUrl = 'https://themanga.my.id'
-    extVersionCode = 47
+    extVersionCode = 48
     isNsfw = true
 }
 

--- a/src/id/themanga/src/eu/kanade/tachiyomi/extension/id/themanga/Filters.kt
+++ b/src/id/themanga/src/eu/kanade/tachiyomi/extension/id/themanga/Filters.kt
@@ -22,18 +22,6 @@ abstract class SelectFilter(
     }
 }
 
-class SortFilter :
-    SelectFilter(
-        "Sort",
-        "sort",
-        arrayOf(
-            "Default" to "title",
-            "Latest Update" to "latest_update",
-            "Popularity" to "popular",
-            "Rating" to "rating",
-        ),
-    )
-
 class StatusFilter :
     SelectFilter(
         "Status",

--- a/src/id/themanga/src/eu/kanade/tachiyomi/extension/id/themanga/TheManga.kt
+++ b/src/id/themanga/src/eu/kanade/tachiyomi/extension/id/themanga/TheManga.kt
@@ -22,7 +22,7 @@ import java.util.Locale
 class TheManga : HttpSource() {
 
     override val name = "TheManga"
-    override val baseUrl = "https://themanga.my.id"
+    override val baseUrl = "https://themanga.site"
     override val lang = "id"
     override val supportsLatest = true
 

--- a/src/id/themanga/src/eu/kanade/tachiyomi/extension/id/themanga/TheManga.kt
+++ b/src/id/themanga/src/eu/kanade/tachiyomi/extension/id/themanga/TheManga.kt
@@ -33,16 +33,29 @@ class TheManga : HttpSource() {
     // =============================== Popular ================================
     override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/?q=&sort=popular&page=$page", headers)
 
-    override fun popularMangaParse(response: Response): MangasPage = searchMangaParse(response)
+    override fun popularMangaParse(response: Response): MangasPage {
+        val document = response.asJsoup()
+
+        val mangas = document.select("a.card").map { element ->
+            SManga.create().apply {
+                setUrlWithoutDomain(element.attr("href"))
+                title = element.selectFirst(".card-title")!!.text()
+                thumbnail_url = element.selectFirst(".card-cover img")?.absUrl("src")
+            }
+        }
+
+        val hasNextPage = document.selectFirst(".explore-pagination__btn[rel=next]") != null
+        return MangasPage(mangas, hasNextPage)
+    }
 
     // =============================== Latest =================================
     override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/?q=&sort=latest_update&page=$page", headers)
 
-    override fun latestUpdatesParse(response: Response): MangasPage = searchMangaParse(response)
+    override fun latestUpdatesParse(response: Response): MangasPage = popularMangaParse(response)
 
     // =============================== Search =================================
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        val url = baseUrl.toHttpUrl().newBuilder().apply {
+        val url = "$baseUrl/explore".toHttpUrl().newBuilder().apply {
             addQueryParameter("q", query)
             addQueryParameter("page", page.toString())
 
@@ -55,15 +68,15 @@ class TheManga : HttpSource() {
     override fun searchMangaParse(response: Response): MangasPage {
         val document = response.asJsoup()
 
-        val mangas = document.select("a.card").map { element ->
+        val mangas = document.select("a.manga-card").map { element ->
             SManga.create().apply {
                 setUrlWithoutDomain(element.attr("href"))
                 title = element.selectFirst(".card-title")!!.text()
-                thumbnail_url = element.selectFirst(".card-cover img")?.absUrl("src")
+                thumbnail_url = element.selectFirst(".cover img")?.absUrl("src")
             }
         }
 
-        val hasNextPage = document.selectFirst(".explore-pagination__btn[rel=next]") != null
+        val hasNextPage = document.selectFirst("a[rel=next]") != null
         return MangasPage(mangas, hasNextPage)
     }
 
@@ -141,7 +154,6 @@ class TheManga : HttpSource() {
 
     // ============================== Filters ===============================
     override fun getFilterList(): FilterList = FilterList(
-        SortFilter(),
         StatusFilter(),
         GenreFilter(),
         Filter.Separator(),


### PR DESCRIPTION
Close: #16391

- Update URL 
- Restore old search ```/explore``` this removes the sort filter, but the other one doesn't return correct results for query.
- Removes the leftover ```BaseUrl``` in build.gradle from its time as madara extension.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
