### PR TITLE
MGKomik (ID): update `rateLimit`

### DIFF
--- a/src/id/mgkomik/build.gradle
+++ b/src/id/mgkomik/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MGKomik'
     themePkg = 'madara'
     baseUrl = 'https://id.mgkomik.cc'
-    overrideVersionCode = 19
+    overrideVersionCode = 20
     isNsfw = false
 }
 

--- a/src/id/mgkomik/src/eu/kanade/tachiyomi/extension/id/mgkomik/MGKomik.kt
+++ b/src/id/mgkomik/src/eu/kanade/tachiyomi/extension/id/mgkomik/MGKomik.kt
@@ -25,7 +25,6 @@ class MGKomik :
     override val mangaSubString = "komik"
 
     override fun headersBuilder() = super.headersBuilder().apply {
-        set("Sec-Fetch-Site", "same-origin")
         set("Upgrade-Insecure-Requests", "1")
         set("Referer", "$baseUrl/")
         set("Sec-Fetch-Site", "none")
@@ -40,7 +39,7 @@ class MGKomik :
 
             chain.proceed(request.newBuilder().headers(headers).build())
         }
-        .rateLimit(9, 2)
+        .rateLimit(2)
         .build()
 
     // ================================== Popular ======================================


### PR DESCRIPTION
- Set rate limit to 2 requests per second to mitigate Cloudflare blocking.
- Remove redundant duplicate header definition in headersBuilder.
- Bump version code to 20.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have Exploit kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
