### PR TITLE
MangaHub (multisrc) : escape search query

### DIFF
--- a/lib-multisrc/mangahub/build.gradle.kts
+++ b/lib-multisrc/mangahub/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(kei.plugins.multisrc)
 }
 
-baseVersionCode = 34
+baseVersionCode = 35
 
 dependencies {
     //noinspection UseTomlInstead

--- a/lib-multisrc/mangahub/src/eu/kanade/tachiyomi/multisrc/mangahub/MangaHubQueries.kt
+++ b/lib-multisrc/mangahub/src/eu/kanade/tachiyomi/multisrc/mangahub/MangaHubQueries.kt
@@ -1,13 +1,16 @@
 package eu.kanade.tachiyomi.multisrc.mangahub
 
+import kotlinx.serialization.json.JsonPrimitive
+
 class GraphQLTag(
     val refreshUrl: String? = null,
 )
 
 val searchQuery = { mangaSource: String, query: String, genre: String, order: String, page: Int ->
+    val escapedQuery = JsonPrimitive(query).toString().removeSurrounding("\"")
     """
         {
-            search(x: $mangaSource, q: "$query", genre: "$genre", mod: $order, offset: ${(page - 1) * 30}) {
+            search(x: $mangaSource, q: "$escapedQuery", genre: "$genre", mod: $order, offset: ${(page - 1) * 30}) {
                 rows {
                     title,
                     author,


### PR DESCRIPTION
Closes #16463

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
