### PR TITLE
Kagane fix cover for old entries

### DIFF
--- a/src/all/kagane/build.gradle
+++ b/src/all/kagane/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Kagane'
     extClass = '.KaganeFactory'
-    extVersionCode = 25
+    extVersionCode = 26
     isNsfw = true
 }
 

--- a/src/all/kagane/src/eu/kanade/tachiyomi/extension/all/kagane/Dto.kt
+++ b/src/all/kagane/src/eu/kanade/tachiyomi/extension/all/kagane/Dto.kt
@@ -123,6 +123,8 @@ class DetailsDto(
     val editionInfo: String? = null,
     @SerialName("tracker_id")
     val trackerId: String? = null,
+    @SerialName("series_covers")
+    val covers: List<SeriesCover> = emptyList(),
 ) {
     @Serializable
     class SeriesStaff(
@@ -148,10 +150,17 @@ class DetailsDto(
         val label: String?,
     )
 
-    fun toSManga(sourceName: String? = null, baseUrl: String = "", showEdition: Boolean = false, showSource: Boolean = false): SManga = SManga.create().apply {
+    @Serializable
+    class SeriesCover(
+        @SerialName("image_id")
+        val imageId: String,
+    )
+
+    fun toSManga(domain: String, sourceName: String? = null, baseUrl: String = "", showEdition: Boolean = false, showSource: Boolean = false): SManga = SManga.create().apply {
         val base = this@DetailsDto.title.trim()
         val withEdition = if (showEdition && !this@DetailsDto.editionInfo.isNullOrBlank()) "$base (${this@DetailsDto.editionInfo})" else base
         title = if (showSource && sourceName != null) "$withEdition [$sourceName]" else withEdition
+        thumbnail_url = covers.firstOrNull()?.imageId?.let { "$domain/api/v2/image/$it" }
         val desc = StringBuilder()
 
         // Add main description

--- a/src/all/kagane/src/eu/kanade/tachiyomi/extension/all/kagane/Kagane.kt
+++ b/src/all/kagane/src/eu/kanade/tachiyomi/extension/all/kagane/Kagane.kt
@@ -320,7 +320,7 @@ abstract class Kagane(
                     null
                 }
         }
-        return dto.toSManga(sourceName, baseUrl, preferences.showEdition, preferences.showSource)
+        return dto.toSManga(apiUrl, sourceName, baseUrl, preferences.showEdition, preferences.showSource)
     }
 
     override fun mangaDetailsRequest(manga: SManga): Request = mangaDetailsRequest(manga.url)


### PR DESCRIPTION
closes #16487

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
