### PR TITLE
RateLimit implementation

### DIFF
--- a/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
+++ b/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
@@ -78,16 +78,16 @@ private class RateLimitInterceptor : Interceptor {
 
         if (call.isCanceled()) throw IOException("Canceled")
 
-        val matched = rateLimits.firstOrNull { it.shouldLimit(request.url) }
+        val rateLimit = rateLimits.firstOrNull { it.shouldLimit(request.url) }
             ?: return chain.proceed(request)
 
-        val id = matched.acquireSlot(call)
+        val id = rateLimit.acquireSlot(call)
         try {
             val response = chain.proceed(request)
-            if (response.networkResponse == null) matched.releaseSlot(id)
+            if (response.networkResponse == null) rateLimit.releaseSlot(id)
             return response
         } catch (e: Exception) {
-            matched.releaseSlot(id)
+            rateLimit.releaseSlot(id)
             throw e
         }
     }

--- a/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
+++ b/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
@@ -77,7 +77,7 @@ fun OkHttpClient.Builder.rateLimit(
     period: Duration = 1.seconds,
     interval: Duration = Duration.ZERO,
     shouldLimit: (HttpUrl) -> Boolean = { true },
-): RateLimitBuilder = RateLimitBuilder(this).rateLimit(permits, period, interval, shouldLimit)
+): RateLimitBuilder = RateLimitBuilder(this, listOf(RateLimitRule(permits, period, interval, shouldLimit)))
 
 internal class RateLimitRule(
     val permits: Int,

--- a/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
+++ b/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
@@ -8,6 +8,7 @@ import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Response
 import java.io.IOException
+import java.util.ArrayDeque
 import java.util.concurrent.locks.Condition
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
@@ -53,13 +54,17 @@ private class RateLimitInterceptor : Interceptor {
         val interval: Duration,
         val shouldLimit: (HttpUrl) -> Boolean,
     ) {
-        val timestamps = ArrayList<Duration>(permits)
-        val ids = ArrayList<Long>(permits)
+        val queue = ArrayDeque<TimeStamp>(permits)
         val lock = ReentrantLock(true)
         val retryCondition: Condition = lock.newCondition()
         var lastDispatchTime: Duration? = null
         var sequence = 0L
     }
+
+    private class TimeStamp(
+        val id: Long,
+        val timestamp: Duration,
+    )
 
     private val rateLimits = mutableListOf<RateLimit>()
 
@@ -97,15 +102,14 @@ private class RateLimitInterceptor : Interceptor {
             if (call.isCanceled()) throw IOException("Canceled")
 
             val now = SystemClock.elapsedRealtime().milliseconds
-            while (timestamps.isNotEmpty() && now - timestamps.first() > period) {
-                timestamps.removeAt(0)
-                ids.removeAt(0)
+            while (queue.isNotEmpty() && now - queue.first().timestamp > period) {
+                queue.removeFirst()
             }
 
-            val windowWait = if (timestamps.size < permits) {
+            val windowWait = if (queue.size < permits) {
                 Duration.ZERO
             } else {
-                period - (now - timestamps.first())
+                period - (now - queue.first().timestamp)
             }
             val intervalWait = if (lastDispatchTime == null) {
                 Duration.ZERO
@@ -121,17 +125,15 @@ private class RateLimitInterceptor : Interceptor {
 
         val now = SystemClock.elapsedRealtime().milliseconds
         val id = sequence++
-        timestamps.add(now)
-        ids.add(id)
+        queue.addLast(TimeStamp(id, now))
         lastDispatchTime = now
         id
     }
 
     private fun RateLimit.releaseSlot(id: Long): Unit = lock.withLock {
-        val index = ids.indexOf(id)
-        if (index == -1) return
-        ids.removeAt(index)
-        timestamps.removeAt(index)
-        retryCondition.signal()
+        val removed = queue.removeAll { it.id == id }
+        if (removed) {
+            retryCondition.signal()
+        }
     }
 }

--- a/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
+++ b/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
@@ -117,6 +117,6 @@ private class RateLimitInterceptor : Interceptor {
     private fun RateLimit.releaseSlot(timestamp: Long): Unit = lock.withLock {
         if (queue.isEmpty() || timestamp < queue.first()) return
         queue.removeFirstOccurrence(timestamp)
-        retryCondition.signalAll()
+        retryCondition.signal()
     }
 }

--- a/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
+++ b/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
@@ -20,18 +20,8 @@ class RateLimitBuilder internal constructor(
     private val rules: List<RateLimitRule> = emptyList(),
 ) {
     /**
-     * Begins a rate-limited client configuration. Chain further [RateLimitBuilder.rateLimit] calls
-     * for additional rules, then call [RateLimitBuilder.build] to finalize — all other client
-     * configuration should be done on the [OkHttpClient.Builder] before calling this.
-     *
-     * The first rule whose [shouldLimit] matches the request URL is applied;
-     * remaining rules are skipped. Define more specific rules before broader ones:
-     * ```
-     * OkHttpClient.Builder()
-     *     .rateLimit(5)  { it.host == "api.manga.example" }
-     *     .rateLimit(20) { it.host == "img.manga.example" }
-     *     .build()
-     * ```
+     * Adds a rate limit rule. Rules are evaluated in order, first match wins —
+     * define more specific rules before broader ones. Call [build] to finalize.
      *
      * @param permits     Requests allowed per [period].
      * @param period      Sliding-window duration.

--- a/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
+++ b/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
@@ -1,7 +1,6 @@
 package keiyoushi.network
 
 import android.os.SystemClock
-import keiyoushi.utils.firstInstanceOrNull
 import okhttp3.Call
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
@@ -16,15 +15,55 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
+class RateLimitBuilder internal constructor(
+    private val base: OkHttpClient.Builder,
+    private val rules: List<RateLimitRule> = emptyList(),
+) {
+    /**
+     * Begins a rate-limited client configuration. Chain further [RateLimitBuilder.rateLimit] calls
+     * for additional rules, then call [RateLimitBuilder.build] to finalize — all other client
+     * configuration should be done on the [OkHttpClient.Builder] before calling this.
+     *
+     * The first rule whose [shouldLimit] matches the request URL is applied;
+     * remaining rules are skipped. Define more specific rules before broader ones:
+     * ```
+     * OkHttpClient.Builder()
+     *     .rateLimit(5)  { it.host == "api.manga.example" }
+     *     .rateLimit(20) { it.host == "img.manga.example" }
+     *     .build()
+     * ```
+     *
+     * @param permits     Requests allowed per [period].
+     * @param period      Sliding-window duration.
+     * @param interval    Minimum gap between consecutive dispatches. Smooths bursts —
+     *                    `permits=10, interval=100.ms` allows 10/s but spaced ≥100ms apart.
+     * @param shouldLimit Whether this rule applies to a given URL.
+     */
+    fun rateLimit(
+        permits: Int,
+        period: Duration = 1.seconds,
+        interval: Duration = Duration.ZERO,
+        shouldLimit: (HttpUrl) -> Boolean = { true },
+    ) = RateLimitBuilder(base, rules + RateLimitRule(permits, period, interval, shouldLimit))
+
+    fun build(): OkHttpClient = base
+        .addInterceptor(RateLimitInterceptor.TaggingInterceptor)
+        .addNetworkInterceptor(RateLimitInterceptor(rules))
+        .build()
+}
+
 /**
- * Adds an interceptor enforcing one or more rate limits.
+ * Begins a rate-limited client configuration. Chain further [RateLimitBuilder.rateLimit] calls
+ * for additional rules, then call [RateLimitBuilder.build] to finalize — all other client
+ * configuration should be done on the [OkHttpClient.Builder] before calling this.
  *
  * The first rule whose [shouldLimit] matches the request URL is applied;
  * remaining rules are skipped. Define more specific rules before broader ones:
  * ```
- * clientBuilder
+ * OkHttpClient.Builder()
  *     .rateLimit(5)  { it.host == "api.manga.example" }
  *     .rateLimit(20) { it.host == "img.manga.example" }
+ *     .build()
  * ```
  *
  * @param permits     Requests allowed per [period].
@@ -38,20 +77,18 @@ fun OkHttpClient.Builder.rateLimit(
     period: Duration = 1.seconds,
     interval: Duration = Duration.ZERO,
     shouldLimit: (HttpUrl) -> Boolean = { true },
-): OkHttpClient.Builder {
-    val interceptor = networkInterceptors().firstInstanceOrNull<RateLimitInterceptor>()
-        ?: RateLimitInterceptor().also(::addNetworkInterceptor)
+): RateLimitBuilder = RateLimitBuilder(this).rateLimit(permits, period, interval, shouldLimit)
 
-    if (interceptors().none { it === RateLimitInterceptor.TaggingInterceptor }) {
-        addInterceptor(RateLimitInterceptor.TaggingInterceptor)
-    }
+internal class RateLimitRule(
+    val permits: Int,
+    val period: Duration,
+    val interval: Duration,
+    val shouldLimit: (HttpUrl) -> Boolean,
+)
 
-    interceptor.addRateLimit(permits, period, interval, shouldLimit)
-
-    return this
-}
-
-private class RateLimitInterceptor : Interceptor {
+private class RateLimitInterceptor(
+    rules: List<RateLimitRule>,
+) : Interceptor {
 
     private class RateLimitTag(
         var rateLimitApplied: Boolean = false,
@@ -79,16 +116,7 @@ private class RateLimitInterceptor : Interceptor {
         var lastDispatchTime: Duration? = null
     }
 
-    private val rateLimits = mutableListOf<RateLimit>()
-
-    fun addRateLimit(
-        permits: Int,
-        period: Duration,
-        interval: Duration,
-        shouldLimit: (HttpUrl) -> Boolean,
-    ) {
-        rateLimits.add(RateLimit(permits, period, interval, shouldLimit))
-    }
+    private val rateLimits = rules.map { RateLimit(it.permits, it.period, it.interval, it.shouldLimit) }
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val call = chain.call()

--- a/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
+++ b/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
@@ -39,8 +39,12 @@ fun OkHttpClient.Builder.rateLimit(
     interval: Duration = Duration.ZERO,
     shouldLimit: (HttpUrl) -> Boolean = { true },
 ): OkHttpClient.Builder {
-    val interceptor = interceptors().firstInstanceOrNull<RateLimitInterceptor>()
-        ?: RateLimitInterceptor().also(::addInterceptor)
+    val interceptor = networkInterceptors().firstInstanceOrNull<RateLimitInterceptor>()
+        ?: RateLimitInterceptor().also(::addNetworkInterceptor)
+
+    if (interceptors().none { it === RateLimitInterceptor.TaggingInterceptor }) {
+        addInterceptor(RateLimitInterceptor.TaggingInterceptor)
+    }
 
     interceptor.addRateLimit(permits, period, interval, shouldLimit)
 
@@ -48,23 +52,32 @@ fun OkHttpClient.Builder.rateLimit(
 }
 
 private class RateLimitInterceptor : Interceptor {
+
+    private class RateLimitTag(
+        var rateLimitApplied: Boolean = false,
+    )
+
+    object TaggingInterceptor : Interceptor {
+        override fun intercept(chain: Interceptor.Chain): Response {
+            val request = chain.request().newBuilder()
+                .tag(RateLimitTag::class.java, RateLimitTag())
+                .build()
+
+            return chain.proceed(request)
+        }
+    }
+
     private class RateLimit(
         val permits: Int,
         val period: Duration,
         val interval: Duration,
         val shouldLimit: (HttpUrl) -> Boolean,
     ) {
-        val queue = ArrayDeque<TimeStamp>(permits)
+        val queue = ArrayDeque<Duration>(permits)
         val lock = ReentrantLock(true)
         val retryCondition: Condition = lock.newCondition()
         var lastDispatchTime: Duration? = null
-        var sequence = 0L
     }
-
-    private class TimeStamp(
-        val id: Long,
-        val timestamp: Duration,
-    )
 
     private val rateLimits = mutableListOf<RateLimit>()
 
@@ -86,30 +99,30 @@ private class RateLimitInterceptor : Interceptor {
         val rateLimit = rateLimits.firstOrNull { it.shouldLimit(request.url) }
             ?: return chain.proceed(request)
 
-        val id = rateLimit.acquireSlot(call)
-        try {
-            val response = chain.proceed(request)
-            if (response.networkResponse == null) rateLimit.releaseSlot(id)
-            return response
-        } catch (e: Exception) {
-            rateLimit.releaseSlot(id)
-            throw e
+        val state = request.tag(RateLimitTag::class.java)
+
+        if (state?.rateLimitApplied == true) {
+            return chain.proceed(request)
         }
+
+        rateLimit.acquireSlot(call)
+        state?.rateLimitApplied = true
+
+        return chain.proceed(request)
     }
 
-    private fun RateLimit.acquireSlot(call: Call): Long = lock.withLock {
+    private fun RateLimit.acquireSlot(call: Call) = lock.withLock {
         while (true) {
             if (call.isCanceled()) throw IOException("Canceled")
-
             val now = SystemClock.elapsedRealtime().milliseconds
-            while (queue.isNotEmpty() && now - queue.first().timestamp > period) {
+            while (queue.isNotEmpty() && now - queue.first() >= period) {
                 queue.removeFirst()
             }
 
             val windowWait = if (queue.size < permits) {
                 Duration.ZERO
             } else {
-                period - (now - queue.first().timestamp)
+                period - (now - queue.first())
             }
             val intervalWait = if (lastDispatchTime == null) {
                 Duration.ZERO
@@ -118,22 +131,13 @@ private class RateLimitInterceptor : Interceptor {
             }
             val waitTime = maxOf(windowWait, intervalWait, Duration.ZERO)
 
-            if (waitTime == Duration.ZERO) break
-
+            if (waitTime == Duration.ZERO) {
+                val ts = SystemClock.elapsedRealtime().milliseconds
+                queue.addLast(ts)
+                lastDispatchTime = ts
+                break
+            }
             retryCondition.awaitNanos(waitTime.inWholeNanoseconds)
-        }
-
-        val now = SystemClock.elapsedRealtime().milliseconds
-        val id = sequence++
-        queue.addLast(TimeStamp(id, now))
-        lastDispatchTime = now
-        id
-    }
-
-    private fun RateLimit.releaseSlot(id: Long): Unit = lock.withLock {
-        val removed = queue.removeAll { it.id == id }
-        if (removed) {
-            retryCondition.signal()
         }
     }
 }

--- a/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
+++ b/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
@@ -1,0 +1,123 @@
+package keiyoushi.network
+
+import android.os.SystemClock
+import okhttp3.Call
+import okhttp3.HttpUrl
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.Response
+import java.io.IOException
+import java.util.ArrayDeque
+import java.util.concurrent.locks.Condition
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Rate limit rule. Use with [rateLimits] to enforce per-URL request throttling.
+ *
+ * @param permits     Requests allowed per [period].
+ * @param period      Sliding-window duration.
+ * @param interval    Minimum gap between consecutive dispatches. Smooths bursts —
+ *                    `permits=10, interval=100.ms` allows 10/s but spaced ≥100ms apart.
+ * @param shouldLimit Whether this rule applies to a given URL.
+ */
+data class RateLimit(
+    val permits: Int,
+    val period: Duration = 1.seconds,
+    val interval: Duration = Duration.ZERO,
+    val shouldLimit: (HttpUrl) -> Boolean,
+)
+
+/**
+ * Adds an interceptor enforcing one or more rate limits.
+ *
+ * The first rule whose [RateLimit.shouldLimit] matches the request URL is applied;
+ * remaining rules are skipped. Define more specific rules before broader ones:
+ * ```
+ * rateLimits(
+ *     RateLimit(5)  { it.host == "api.manga.example" },
+ *     RateLimit(20) { it.host == "img.manga.example" },
+ * )
+ * ```
+ */
+fun OkHttpClient.Builder.rateLimits(
+    vararg limits: RateLimit,
+): OkHttpClient.Builder = addInterceptor(RateLimitInterceptor(limits.toList()))
+
+/**
+ * Adds an interceptor enforcing a single rate limit.
+ *
+ * For multiple rules, use [rateLimits].
+ *
+ * @param permits     Requests allowed per [period].
+ * @param period      Sliding-window duration.
+ * @param interval    Minimum gap between consecutive dispatches. Smooths bursts —
+ *                    `permits=10, interval=100.ms` allows 10/s but spaced ≥100ms apart.
+ * @param shouldLimit Whether this rule applies to a given URL.
+ */
+fun OkHttpClient.Builder.rateLimit(
+    permits: Int,
+    period: Duration = 1.seconds,
+    interval: Duration = Duration.ZERO,
+    shouldLimit: (HttpUrl) -> Boolean = { true },
+): OkHttpClient.Builder = rateLimits(RateLimit(permits, period, interval, shouldLimit))
+
+private class RateLimitInterceptor(limits: List<RateLimit>) : Interceptor {
+
+    private class Limiter(val rule: RateLimit) {
+        val periodMillis = rule.period.inWholeMilliseconds
+        val intervalMillis = rule.interval.inWholeMilliseconds
+        val queue = ArrayDeque<Long>(rule.permits)
+        val lock = ReentrantLock(true)
+        val retryCondition: Condition = lock.newCondition()
+        var lastDispatchTime = 0L
+    }
+
+    private val limiters = limits.map(::Limiter)
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val call = chain.call()
+        val request = chain.request()
+
+        if (call.isCanceled()) throw IOException("Canceled")
+
+        val matched = limiters.firstOrNull { it.rule.shouldLimit(request.url) }
+            ?: return chain.proceed(request)
+
+        val timestamp = matched.acquireSlot(call)
+        val response = chain.proceed(request)
+
+        if (response.networkResponse == null) matched.releaseSlot(timestamp)
+
+        return response
+    }
+
+    private fun Limiter.acquireSlot(call: Call): Long = lock.withLock {
+        while (true) {
+            if (call.isCanceled()) throw IOException("Canceled")
+
+            val now = SystemClock.elapsedRealtime()
+            while (queue.isNotEmpty() && queue.first() <= now - periodMillis) queue.removeFirst()
+
+            val windowWait = if (queue.size < rule.permits) 0L else queue.first() - (now - periodMillis)
+            val intervalWait = lastDispatchTime + intervalMillis - now
+            val waitTime = maxOf(windowWait, intervalWait, 0L)
+
+            if (waitTime == 0L) break
+            retryCondition.awaitNanos(waitTime * 1_000_000L)
+        }
+
+        val ts = SystemClock.elapsedRealtime()
+        queue.addLast(ts)
+        lastDispatchTime = ts
+        ts
+    }
+
+    private fun Limiter.releaseSlot(timestamp: Long): Unit = lock.withLock {
+        if (queue.isEmpty() || timestamp < queue.first()) return
+        queue.removeFirstOccurrence(timestamp)
+        retryCondition.signalAll()
+    }
+}

--- a/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
+++ b/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
@@ -8,11 +8,11 @@ import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Response
 import java.io.IOException
-import java.util.ArrayDeque
 import java.util.concurrent.locks.Condition
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -53,12 +53,12 @@ private class RateLimitInterceptor : Interceptor {
         val interval: Duration,
         val shouldLimit: (HttpUrl) -> Boolean,
     ) {
-        val periodMillis = period.inWholeMilliseconds
-        val intervalMillis = interval.inWholeMilliseconds
-        val queue = ArrayDeque<Long>(permits)
+        val timestamps = ArrayList<Duration>(permits)
+        val ids = ArrayList<Long>(permits)
         val lock = ReentrantLock(true)
         val retryCondition: Condition = lock.newCondition()
-        var lastDispatchTime = 0L
+        var lastDispatchTime: Duration? = null
+        var sequence = 0L
     }
 
     private val rateLimits = mutableListOf<RateLimit>()
@@ -78,17 +78,16 @@ private class RateLimitInterceptor : Interceptor {
 
         if (call.isCanceled()) throw IOException("Canceled")
 
-        val rateLimit = rateLimits.firstOrNull { it.shouldLimit(request.url) }
+        val matched = rateLimits.firstOrNull { it.shouldLimit(request.url) }
             ?: return chain.proceed(request)
 
-        val timestamp = rateLimit.acquireSlot(call)
-
+        val id = matched.acquireSlot(call)
         try {
             val response = chain.proceed(request)
-            if (response.networkResponse == null) rateLimit.releaseSlot(timestamp)
+            if (response.networkResponse == null) matched.releaseSlot(id)
             return response
         } catch (e: Exception) {
-            rateLimit.releaseSlot(timestamp)
+            matched.releaseSlot(id)
             throw e
         }
     }
@@ -97,26 +96,42 @@ private class RateLimitInterceptor : Interceptor {
         while (true) {
             if (call.isCanceled()) throw IOException("Canceled")
 
-            val now = SystemClock.elapsedRealtime()
-            while (queue.isNotEmpty() && queue.first() <= now - periodMillis) queue.removeFirst()
+            val now = SystemClock.elapsedRealtime().milliseconds
+            while (timestamps.isNotEmpty() && now - timestamps.first() > period) {
+                timestamps.removeAt(0)
+                ids.removeAt(0)
+            }
 
-            val windowWait = if (queue.size < permits) 0L else queue.first() - (now - periodMillis)
-            val intervalWait = lastDispatchTime + intervalMillis - now
-            val waitTime = maxOf(windowWait, intervalWait, 0L)
+            val windowWait = if (timestamps.size < permits) {
+                Duration.ZERO
+            } else {
+                period - (now - timestamps.first())
+            }
+            val intervalWait = if (lastDispatchTime == null) {
+                Duration.ZERO
+            } else {
+                interval - (now - lastDispatchTime!!)
+            }
+            val waitTime = maxOf(windowWait, intervalWait, Duration.ZERO)
 
-            if (waitTime == 0L) break
-            retryCondition.awaitNanos(waitTime * 1_000_000L)
+            if (waitTime == Duration.ZERO) break
+
+            retryCondition.awaitNanos(waitTime.inWholeNanoseconds)
         }
 
-        val ts = SystemClock.elapsedRealtime()
-        queue.addLast(ts)
-        lastDispatchTime = ts
-        ts
+        val now = SystemClock.elapsedRealtime().milliseconds
+        val id = sequence++
+        timestamps.add(now)
+        ids.add(id)
+        lastDispatchTime = now
+        id
     }
 
-    private fun RateLimit.releaseSlot(timestamp: Long): Unit = lock.withLock {
-        if (queue.isEmpty() || timestamp < queue.first()) return
-        queue.removeFirstOccurrence(timestamp)
+    private fun RateLimit.releaseSlot(id: Long): Unit = lock.withLock {
+        val index = ids.indexOf(id)
+        if (index == -1) return
+        ids.removeAt(index)
+        timestamps.removeAt(index)
         retryCondition.signal()
     }
 }

--- a/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
+++ b/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
@@ -1,6 +1,7 @@
 package keiyoushi.network
 
 import android.os.SystemClock
+import keiyoushi.utils.firstInstanceOrNull
 import okhttp3.Call
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
@@ -15,41 +16,15 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 /**
- * Rate limit rule. Use with [rateLimits] to enforce per-URL request throttling.
- *
- * @param permits     Requests allowed per [period].
- * @param period      Sliding-window duration.
- * @param interval    Minimum gap between consecutive dispatches. Smooths bursts —
- *                    `permits=10, interval=100.ms` allows 10/s but spaced ≥100ms apart.
- * @param shouldLimit Whether this rule applies to a given URL.
- */
-data class RateLimit(
-    val permits: Int,
-    val period: Duration = 1.seconds,
-    val interval: Duration = Duration.ZERO,
-    val shouldLimit: (HttpUrl) -> Boolean,
-)
-
-/**
  * Adds an interceptor enforcing one or more rate limits.
  *
- * The first rule whose [RateLimit.shouldLimit] matches the request URL is applied;
+ * The first rule whose [shouldLimit] matches the request URL is applied;
  * remaining rules are skipped. Define more specific rules before broader ones:
  * ```
- * rateLimits(
- *     RateLimit(5)  { it.host == "api.manga.example" },
- *     RateLimit(20) { it.host == "img.manga.example" },
- * )
+ * clientBuilder
+ *     .rateLimit(5)  { it.host == "api.manga.example" }
+ *     .rateLimit(20) { it.host == "img.manga.example" }
  * ```
- */
-fun OkHttpClient.Builder.rateLimits(
-    vararg limits: RateLimit,
-): OkHttpClient.Builder = addInterceptor(RateLimitInterceptor(limits.toList()))
-
-/**
- * Adds an interceptor enforcing a single rate limit.
- *
- * For multiple rules, use [rateLimits].
  *
  * @param permits     Requests allowed per [period].
  * @param period      Sliding-window duration.
@@ -62,20 +37,40 @@ fun OkHttpClient.Builder.rateLimit(
     period: Duration = 1.seconds,
     interval: Duration = Duration.ZERO,
     shouldLimit: (HttpUrl) -> Boolean = { true },
-): OkHttpClient.Builder = rateLimits(RateLimit(permits, period, interval, shouldLimit))
+): OkHttpClient.Builder {
+    val interceptor = interceptors().firstInstanceOrNull<RateLimitInterceptor>()
+        ?: RateLimitInterceptor().also(::addInterceptor)
 
-private class RateLimitInterceptor(limits: List<RateLimit>) : Interceptor {
+    interceptor.addRateLimit(permits, period, interval, shouldLimit)
 
-    private class Limiter(val rule: RateLimit) {
-        val periodMillis = rule.period.inWholeMilliseconds
-        val intervalMillis = rule.interval.inWholeMilliseconds
-        val queue = ArrayDeque<Long>(rule.permits)
+    return this
+}
+
+private class RateLimitInterceptor : Interceptor {
+    private class RateLimit(
+        val permits: Int,
+        val period: Duration,
+        val interval: Duration,
+        val shouldLimit: (HttpUrl) -> Boolean,
+    ) {
+        val periodMillis = period.inWholeMilliseconds
+        val intervalMillis = interval.inWholeMilliseconds
+        val queue = ArrayDeque<Long>(permits)
         val lock = ReentrantLock(true)
         val retryCondition: Condition = lock.newCondition()
         var lastDispatchTime = 0L
     }
 
-    private val limiters = limits.map(::Limiter)
+    private val rateLimits = mutableListOf<RateLimit>()
+
+    fun addRateLimit(
+        permits: Int,
+        period: Duration,
+        interval: Duration,
+        shouldLimit: (HttpUrl) -> Boolean,
+    ) {
+        rateLimits.add(RateLimit(permits, period, interval, shouldLimit))
+    }
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val call = chain.call()
@@ -83,25 +78,29 @@ private class RateLimitInterceptor(limits: List<RateLimit>) : Interceptor {
 
         if (call.isCanceled()) throw IOException("Canceled")
 
-        val matched = limiters.firstOrNull { it.rule.shouldLimit(request.url) }
+        val rateLimit = rateLimits.firstOrNull { it.shouldLimit(request.url) }
             ?: return chain.proceed(request)
 
-        val timestamp = matched.acquireSlot(call)
-        val response = chain.proceed(request)
+        val timestamp = rateLimit.acquireSlot(call)
 
-        if (response.networkResponse == null) matched.releaseSlot(timestamp)
-
-        return response
+        try {
+            val response = chain.proceed(request)
+            if (response.networkResponse == null) rateLimit.releaseSlot(timestamp)
+            return response
+        } catch (e: Exception) {
+            rateLimit.releaseSlot(timestamp)
+            throw e
+        }
     }
 
-    private fun Limiter.acquireSlot(call: Call): Long = lock.withLock {
+    private fun RateLimit.acquireSlot(call: Call): Long = lock.withLock {
         while (true) {
             if (call.isCanceled()) throw IOException("Canceled")
 
             val now = SystemClock.elapsedRealtime()
             while (queue.isNotEmpty() && queue.first() <= now - periodMillis) queue.removeFirst()
 
-            val windowWait = if (queue.size < rule.permits) 0L else queue.first() - (now - periodMillis)
+            val windowWait = if (queue.size < permits) 0L else queue.first() - (now - periodMillis)
             val intervalWait = lastDispatchTime + intervalMillis - now
             val waitTime = maxOf(windowWait, intervalWait, 0L)
 
@@ -115,7 +114,7 @@ private class RateLimitInterceptor(limits: List<RateLimit>) : Interceptor {
         ts
     }
 
-    private fun Limiter.releaseSlot(timestamp: Long): Unit = lock.withLock {
+    private fun RateLimit.releaseSlot(timestamp: Long): Unit = lock.withLock {
         if (queue.isEmpty() || timestamp < queue.first()) return
         queue.removeFirstOccurrence(timestamp)
         retryCondition.signalAll()


### PR DESCRIPTION
- Sliding-window rate limiter as an OkHttp interceptor
- Each RateLimit defines a permit budget over a time window, with an optional minimum dispatch interval to smooth bursts
- Rules are evaluated in order, first match wins — more specific rules should come before broader ones
- `rateLimit` call can be chained, adding multiple rules to same interceptor
- `NetworkInterceptor` so cached response is not waited upon

Why our own implementation?
 - [Upstream is deprecating](https://github.com/mihonapp/tachiyomix/blob/d4936afa6481f8edea10cd4902a97d4ea5090202/library/src/main/java/eu/kanade/tachiyomi/network/interceptor/RateLimitInterceptor.kt#L20-L25)
 - Gives us more control over the ratelimit implementation 