### PR TITLE
VyvyManga (EN): Fix chapter urls

### DIFF
--- a/src/en/vyvymanga/build.gradle
+++ b/src/en/vyvymanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'VyvyManga'
     extClass = '.VyvyManga'
-    extVersionCode = 39
+    extVersionCode = 40
     isNsfw = true
 }
 

--- a/src/en/vyvymanga/src/eu/kanade/tachiyomi/extension/en/vyvymanga/VyvyManga.kt
+++ b/src/en/vyvymanga/src/eu/kanade/tachiyomi/extension/en/vyvymanga/VyvyManga.kt
@@ -108,7 +108,10 @@ class VyvyManga : HttpSource() {
     }
 
     // Pages
-    override fun pageListRequest(chapter: SChapter): Request = GET(chapter.url, headers)
+    override fun pageListRequest(chapter: SChapter): Request {
+        if (!chapter.url.startsWith("http")) error("Refresh to reload chapters")
+        return GET(chapter.url, headers)
+    }
 
     override fun pageListParse(response: Response): List<Page> {
         val document = response.asJsoup()

--- a/src/en/vyvymanga/src/eu/kanade/tachiyomi/extension/en/vyvymanga/VyvyManga.kt
+++ b/src/en/vyvymanga/src/eu/kanade/tachiyomi/extension/en/vyvymanga/VyvyManga.kt
@@ -100,7 +100,7 @@ class VyvyManga : HttpSource() {
         val document = response.asJsoup()
         return document.select(".list-group > a").map { element ->
             SChapter.create().apply {
-                setUrlWithoutDomain(element.absUrl("href"))
+                url = element.absUrl("href")
                 name = element.selectFirst("span")!!.text()
                 date_upload = parseChapterDate(element.selectFirst("> p")?.text())
             }
@@ -108,7 +108,7 @@ class VyvyManga : HttpSource() {
     }
 
     // Pages
-    override fun pageListRequest(chapter: SChapter): Request = GET(baseUrl + chapter.url, headers)
+    override fun pageListRequest(chapter: SChapter): Request = GET(chapter.url, headers)
 
     override fun pageListParse(response: Response): List<Page> {
         val document = response.asJsoup()


### PR DESCRIPTION
originally it was fetching chapter path on baseUrl, which sometimes used to fail and redirect to google

Chapter urls have randomized ?data query so it's always new on refresh, but added refresh error for stale chapter url so it's clearer error

Closes #12063

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop 
