### PR TITLE
Mango Toons (pt-BR): Fix api path and headers

### DIFF
--- a/src/pt/mangotoons/build.gradle
+++ b/src/pt/mangotoons/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangoToons'
     themePkg = 'mangotheme'
     baseUrl = 'https://mangotoons.com'
-    overrideVersionCode = 5
+    overrideVersionCode = 6
     isNsfw = false
 }
 

--- a/src/pt/mangotoons/src/eu/kanade/tachiyomi/extension/pt/mangotoons/MangoToons.kt
+++ b/src/pt/mangotoons/src/eu/kanade/tachiyomi/extension/pt/mangotoons/MangoToons.kt
@@ -8,6 +8,12 @@ class MangoToons : MangoTheme() {
 
     override val baseUrl = "https://mangotoons.com"
 
+    override val apiUrl = "https://api.mangotoons.com/api"
+
+    override fun headersBuilder() = super.headersBuilder()
+        .set("User-Agent", "-")
+        .set("sec-fetch-mode", "none")
+
     override val lang = "pt-BR"
 
     override val encryptionKey = "abmPisXlFjOLVTnYhbYQTpkWJtOGKwVttzLqstfjRBNVaEtQYG"


### PR DESCRIPTION
for the Headers, if no headers supplied (at all) requests works
if "valid" user-agent exists, requests work only when valid sec-ch-ua is supplied

with the two above, cache-control mustn't be supplied which okhttp always adds
however cache-control can supplied if sec-fetch-mode exists with non empty value

So, choosing the shortest path to not hardcode user-agent and sec-ch-ua, we set sec-fetch-mode with a corrupted userAgent

Closes #16387 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop 
