### PR TITLE
Manhua Rush (EN): Fix api changes

### DIFF
--- a/src/en/manhuarush/build.gradle
+++ b/src/en/manhuarush/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Manhua Rush'
     extClass = '.ManhuaRush'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = false
 }
 

--- a/src/en/manhuarush/src/eu/kanade/tachiyomi/extension/en/manhuarush/Dto.kt
+++ b/src/en/manhuarush/src/eu/kanade/tachiyomi/extension/en/manhuarush/Dto.kt
@@ -2,20 +2,14 @@ package eu.kanade.tachiyomi.extension.en.manhuarush
 
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
-import eu.kanade.tachiyomi.source.model.SManga
 import keiyoushi.utils.tryParse
 import kotlinx.serialization.Serializable
 
 @Serializable
-class MangaDetailsDto(
-    val text: String? = null,
+class ChaptersDto(
     val chapters: List<ChapterDto>,
     val mangadexId: String,
-) {
-    fun toSManga(): SManga = SManga.create().apply {
-        description = text
-    }
-}
+)
 
 @Serializable
 class ChapterDto(

--- a/src/en/manhuarush/src/eu/kanade/tachiyomi/extension/en/manhuarush/ManhuaRush.kt
+++ b/src/en/manhuarush/src/eu/kanade/tachiyomi/extension/en/manhuarush/ManhuaRush.kt
@@ -27,36 +27,42 @@ class ManhuaRush : HttpSource() {
         headersBuilder().add("RSC", "1").build()
     }
 
-    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/collections/all?p=all", headers)
+    override fun popularMangaRequest(page: Int): Request = GET(baseUrl, headers)
 
     override fun popularMangaParse(response: Response): MangasPage {
         val document = response.asJsoup()
 
-        val mangas = document.select("a.card-link").map { element ->
-            val img = element.selectFirst("img")!!
+        val mangas = document.select("li a.nav-link[href=/ttp-providence]").map { element ->
             SManga.create().apply {
-                url = element.attr("href").substringBefore("?")
-                title = img.attr("alt")
-                thumbnail_url = img.attr("abs:src")
+                url = element.attr("href")
+                title = document.select("footer .footer-tagline strong").text()
+                thumbnail_url = document.select("div[style*=background-image]").attr("style")
+                    .substringAfter("url('")
+                    .substringBefore("'")
+                    .let { "$baseUrl$it" }
             }
         }
 
         return MangasPage(mangas, false)
     }
 
-    override fun mangaDetailsRequest(manga: SManga): Request = GET(baseUrl + manga.url, rscHeaders)
+    override fun mangaDetailsRequest(manga: SManga): Request = GET(baseUrl + manga.url)
 
     override fun mangaDetailsParse(response: Response): SManga {
-        val dto = response.body.string().extractNextJsRsc<MangaDetailsDto>()
-            ?: throw Exception("Failed to extract manga details")
+        val document = response.asJsoup()
 
-        return dto.toSManga()
+        return SManga.create().apply {
+            title = document.select("h1.manga-title").text()
+            description = document.select(".manga-desc p").text()
+            thumbnail_url = document.select(".cover img").attr("abs:src")
+            genre = document.select(".tag-pill").joinToString { it.text() }
+        }
     }
 
-    override fun chapterListRequest(manga: SManga): Request = mangaDetailsRequest(manga)
+    override fun chapterListRequest(manga: SManga): Request = GET(baseUrl + manga.url, rscHeaders)
 
     override fun chapterListParse(response: Response): List<SChapter> {
-        val dto = response.body.string().extractNextJsRsc<MangaDetailsDto>()
+        val dto = response.body.string().extractNextJsRsc<ChaptersDto>()
             ?: throw Exception("Failed to extract chapters")
 
         return dto.chapters.map { it.toSChapter(dto.mangadexId) }

--- a/src/en/manhuarush/src/eu/kanade/tachiyomi/extension/en/manhuarush/ManhuaRush.kt
+++ b/src/en/manhuarush/src/eu/kanade/tachiyomi/extension/en/manhuarush/ManhuaRush.kt
@@ -46,7 +46,7 @@ class ManhuaRush : HttpSource() {
         return MangasPage(mangas, false)
     }
 
-    override fun mangaDetailsRequest(manga: SManga): Request = GET(baseUrl + manga.url)
+    override fun mangaDetailsRequest(manga: SManga): Request = GET(baseUrl + manga.url, headers)
 
     override fun mangaDetailsParse(response: Response): SManga {
         val document = response.asJsoup()


### PR DESCRIPTION
Closes  #16482

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop 
