### PR TITLE
TeamX: use high-res cover

### DIFF
--- a/src/ar/teamx/build.gradle
+++ b/src/ar/teamx/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Team X'
     extClass = '.TeamX'
-    extVersionCode = 27
+    extVersionCode = 28
     isNsfw = false
 }
 

--- a/src/ar/teamx/src/eu/kanade/tachiyomi/extension/ar/teamx/TeamX.kt
+++ b/src/ar/teamx/src/eu/kanade/tachiyomi/extension/ar/teamx/TeamX.kt
@@ -93,6 +93,8 @@ class TeamX :
         return GET(baseUrl + if (page > 1) "?page=$page" else "", headers)
     }
 
+    private val thumbnailSuffix = "thumbnail_"
+
     override fun latestUpdatesParse(response: Response): MangasPage {
         val document = response.asJsoup()
 
@@ -105,7 +107,7 @@ class TeamX :
                         val linkElement = element.select("div.info a")
                         title = linkElement.select("h3").text()
                         setUrlWithoutDomain(linkElement.first()!!.attr("href"))
-                        thumbnail_url = element.select("div.imgu img").first()!!.absUrl("src")
+                        thumbnail_url = element.select("div.imgu img").first()!!.absUrl("src").replace(thumbnailSuffix, "")
                     }
                 }.distinctBy {
                     it.title


### PR DESCRIPTION
- low-res: `/images/manga/thumbnail_7720148322072660026.jpeg`
- high-res: `/images/manga/7720148322072660026.jpeg`

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
