### PR TITLE
fix(japscan): potential fix for honeypot chapters showing wrong number/URL

### DIFF
--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -59,7 +59,7 @@ class Japscan :
     // Sometimes an adblock blocker will pop up, preventing the user from opening
     // a cloudflare protected page
     private val internalBaseUrl = "https://www.japscan.foo"
-    override val baseUrl = internalBaseUrl
+    override val baseUrl = "$internalBaseUrl/mangas/?sort=popular&p=1"
 
     override val lang = "fr"
 

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -642,6 +642,10 @@ class Japscan :
         return Observable.just(images)
     }
 
+    override fun pageListParse(response: Response): List<Page> = throw UnsupportedOperationException("Not used")
+
+    override fun imageUrlParse(response: Response): String = ""
+
     // Filters
     private class TextField(name: String) : Filter.Text(name)
 

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -23,7 +23,7 @@ import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.ParsedHttpSource
+import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
@@ -37,7 +37,6 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
-import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import rx.Observable
 import uy.kohesive.injekt.Injekt
@@ -50,7 +49,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.collections.mapIndexed
 
 class Japscan :
-    ParsedHttpSource(),
+    HttpSource(),
     ConfigurableSource {
 
     override val id: Long = 11
@@ -60,7 +59,7 @@ class Japscan :
     // Sometimes an adblock blocker will pop up, preventing the user from opening
     // a cloudflare protected page
     private val internalBaseUrl = "https://www.japscan.foo"
-    override val baseUrl = "$internalBaseUrl/mangas/?sort=popular&p=1"
+    override val baseUrl = internalBaseUrl
 
     override val lang = "fr"
 
@@ -124,28 +123,25 @@ class Japscan :
     // Popular
     override fun popularMangaRequest(page: Int): Request = GET("$internalBaseUrl/mangas/?sort=popular&p=$page", headers)
 
-    override fun popularMangaNextPageSelector() = ".pagination > li:last-child:not(.disabled)"
-
-    override fun popularMangaSelector() = ".mangas-list .manga-block:not(:has(a[href='']))"
-
-    override fun popularMangaFromElement(element: Element): SManga {
-        val manga = SManga.create()
-        element.select("a").first()!!.let {
-            manga.setUrlWithoutDomain(it.attr("href"))
-            manga.title = it.text()
-            manga.thumbnail_url = it.selectFirst("img")?.attr("abs:data-src")
+    override fun popularMangaParse(response: Response): MangasPage {
+        val document = response.asJsoup()
+        val manga = document.select(".mangas-list .manga-block:not(:has(a[href='']))").map { element ->
+            SManga.create().apply {
+                element.select("a").first()!!.let {
+                    setUrlWithoutDomain(it.attr("href"))
+                    title = it.text()
+                    thumbnail_url = it.selectFirst("img")?.attr("abs:data-src")
+                }
+            }
         }
-        return manga
+        val hasNextPage = document.selectFirst(".pagination > li:last-child:not(.disabled)") != null
+        return MangasPage(manga, hasNextPage)
     }
 
     // Latest
     override fun latestUpdatesRequest(page: Int): Request = GET("$internalBaseUrl/mangas/?sort=updated&p=$page", headers)
 
-    override fun latestUpdatesSelector() = popularMangaSelector()
-
-    override fun latestUpdatesFromElement(element: Element): SManga = popularMangaFromElement(element)
-
-    override fun latestUpdatesNextPageSelector(): String = popularMangaNextPageSelector()
+    override fun latestUpdatesParse(response: Response) = popularMangaParse(response)
 
     // Search
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
@@ -175,10 +171,6 @@ class Japscan :
         }
     }
 
-    override fun searchMangaNextPageSelector(): String = popularMangaSelector()
-
-    override fun searchMangaSelector(): String = "div.card div.p-2"
-
     override fun searchMangaParse(response: Response): MangasPage {
         if (response.request.url.pathSegments.first() == "ls") {
             val jsonResult = json.parseToJsonElement(response.body.string()).jsonArray
@@ -191,23 +183,23 @@ class Japscan :
         val baseUrlHost = internalBaseUrl.toHttpUrl().host
         val document = response.asJsoup()
         val manga = document
-            .select(searchMangaSelector())
+            .select("div.card div.p-2")
             .filter { it ->
                 // Filter out ads masquerading as search results
                 it.select("p a").attr("abs:href").toHttpUrl().host == baseUrlHost
             }
-            .map(::searchMangaFromElement)
-        val hasNextPage = document.selectFirst(searchMangaNextPageSelector()) != null
+            .map { element ->
+                SManga.create().apply {
+                    thumbnail_url = element.select("img").attr("abs:src")
+                    element.select("p a").let {
+                        title = it.text()
+                        url = it.attr("href")
+                    }
+                }
+            }
+        val hasNextPage = document.selectFirst(".mangas-list .manga-block:not(:has(a[href='']))") != null
 
         return MangasPage(manga, hasNextPage)
-    }
-
-    override fun searchMangaFromElement(element: Element) = SManga.create().apply {
-        thumbnail_url = element.select("img").attr("abs:src")
-        element.select("p a").let {
-            title = it.text()
-            url = it.attr("href")
-        }
     }
 
     private fun searchMangaFromJson(jsonObj: JsonObject): SManga = SManga.create().apply {
@@ -218,7 +210,8 @@ class Japscan :
 
     override fun mangaDetailsRequest(manga: SManga): Request = GET(internalBaseUrl + manga.url, headers)
 
-    override fun mangaDetailsParse(document: Document): SManga {
+    override fun mangaDetailsParse(response: Response): SManga {
+        val document = response.asJsoup()
         val infoElement = document.selectFirst("#main .card-body")!!
         val manga = SManga.create()
 
@@ -253,7 +246,7 @@ class Japscan :
 
     override fun chapterListRequest(manga: SManga): Request = GET(internalBaseUrl + manga.url, headers)
 
-    override fun chapterListSelector() = "#list_chapters > div.collapse > div.list_chapters" +
+    private fun chapterListSelector() = "#list_chapters > div.collapse > div.list_chapters" +
         if (chapterListPref() == "hide") {
             ":not(:has(.badge:contains(SPOILER),.badge:contains(RAW),.badge:contains(VUS)))"
         } else {
@@ -302,7 +295,6 @@ class Japscan :
         return segments[typeIdx + 1].takeIf { it.isNotEmpty() }
     }
 
-    override fun chapterFromElement(element: Element): SChapter = throw UnsupportedOperationException()
 
     private fun isHidden(el: Element): Boolean {
         if (el.hasClass("d-none")) return true
@@ -650,10 +642,6 @@ class Japscan :
             .filterNotNull()
         return Observable.just(images)
     }
-
-    override fun pageListParse(document: Document) = throw Exception("Not used")
-
-    override fun imageUrlParse(document: Document): String = ""
 
     // Filters
     private class TextField(name: String) : Filter.Text(name)

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -86,6 +86,7 @@ class Japscan :
             "height:0",
             "pointer-events:none",
             "clip-path:inset(100%",
+            "clip-path:circle(0)",
             "clip:rect(0,0,0,0",
             "font-size:0",
             "text-indent:-",
@@ -362,6 +363,7 @@ class Japscan :
                 if (mangaSlug != null && segments[1] != mangaSlug) return@filter false
                 val urlNum = url.trimEnd('/').substringAfterLast('/')
                 if (!urlNum.all { it.isDigit() }) return@filter false
+                if (urlNum.length > 1 && urlNum.startsWith('0')) return@filter false
                 val chapterNum = Regex("""(?i)chapitre\s+([\d.]+)""").find(name)
                     ?.groupValues?.get(1)?.replace(".", "")
                     ?: name.split(Regex("[^0-9.]+")).filter { it.isNotEmpty() }

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -295,7 +295,6 @@ class Japscan :
         return segments[typeIdx + 1].takeIf { it.isNotEmpty() }
     }
 
-
     private fun isHidden(el: Element): Boolean {
         if (el.hasClass("d-none")) return true
         if (el.hasAttr("hidden")) return true


### PR DESCRIPTION
## Problem observed

When browsing a manga chapter list (tested on *Dragon Ball Kakusei*), some chapters display the wrong number and link to a wrong URL that returns 404.

Example: chapter 1 is displayed as **「Chapitre 000005」** and its URL is `/manga/dragon-ball-kakumei/000005/` instead of `/1/`.

## Root cause (best guess — not 100% certain)

Japscan injects honeypot elements into each chapter row. Looking at the DOM, those honeypots use this inline style to stay invisible to readers:

```html
<a style="position:absolute;clip-path:circle(0);overflow:hidden" fyex="/manga/.../000005/">Chapitre 000005</a>
```

`isHidden()` currently catches `clip-path:inset(100%` but **not** `clip-path:circle(0)`, so these elements slip past the hidden-element filter and get picked up instead of the real chapter `<div>`.

Additionally, the number comparison (`chapterNum == urlNum`) passes for these honeypots because both the text **and** the URL share the same zero-padded number (`"000005" == "000005"`), so the existing slug+number heuristic doesn't reject them.

## Changes

1. **`clip-path:circle(0)` added to `HIDDEN_STYLE_TOKENS`** — the most direct fix; this style is the actual hiding mechanism used on the observed honeypots.

2. **Reject zero-padded chapter URL numbers** — real chapter URLs use plain integers (`/1/`, `/1181/`); zero-padded segments like `/000005/` only appear in honeypots, so we explicitly reject them.

## Caveats

- I'm not fully certain this covers all honeypot variants Japscan uses — the site may rotate its obfuscation techniques.
- I haven't been able to build and run the extension locally to confirm; the analysis is based on inspecting the live DOM and reading the source.
- Fix #2 (zero-padding check) is a secondary safety net — fix #1 should be sufficient on its own for the observed pattern.

Happy to adjust or revert either change based on feedback from maintainers who have better visibility into Japscan's anti-scraping patterns.