### PR TITLE
IKen (Multisrc): Fix manga details

### DIFF
--- a/lib-multisrc/iken/build.gradle.kts
+++ b/lib-multisrc/iken/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(kei.plugins.multisrc)
 }
 
-baseVersionCode = 22
+baseVersionCode = 23
 
 dependencies {
     api(project(":lib:i18n"))

--- a/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Dto.kt
+++ b/lib-multisrc/iken/src/eu/kanade/tachiyomi/multisrc/iken/Dto.kt
@@ -45,7 +45,6 @@ class Manga(
         description = getDescription(postContent)
         genre = getGenres()
         status = getStatus()
-        initialized = true
     }
 
     fun getDescription(postContent: String?) = buildString {


### PR DESCRIPTION
Most source APIs do not have some fields like description or author initially

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop 
