### PR TITLE
Comix: Prevent duplicate WebView capture hooks

### DIFF
--- a/src/en/comix/build.gradle
+++ b/src/en/comix/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comix'
     extClass = '.Comix'
-    extVersionCode = 27
+    extVersionCode = 28
     isNsfw = true
 }
 

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
@@ -365,8 +365,10 @@ class Comix :
                         return originalOpen.apply(this, arguments);
                     };
 
+                    if (JSON.parse.__comixChapterCaptureInstalled) return;
                     const originalParse = JSON.parse;
                     const seen = new Set();
+                    const nextClicks = new Set();
                     const items = [];
                     let submitted = false;
                     const submit = function () {
@@ -375,7 +377,7 @@ class Comix :
                         window.$$interfaceName.passPayload(JSON.stringify(items));
                     };
 
-                    JSON.parse = new Proxy(originalParse, {
+                    const proxiedParse = new Proxy(originalParse, {
                         apply(target, thisArg, args) {
                             const parsed = Reflect.apply(target, thisArg, args);
                             try {
@@ -393,7 +395,8 @@ class Comix :
                                     if (!seen.has(page)) {
                                         seen.add(page);
                                         for (const it of parsed.result.items) items.push(it);
-                                        if (meta && meta.hasNext) {
+                                        if (meta && meta.hasNext && !nextClicks.has(page)) {
+                                            nextClicks.add(page);
                                             window.$$interfaceName.resetTimer();
                                             let tries = 0;
                                             const iv = setInterval(function () {
@@ -415,6 +418,8 @@ class Comix :
                             return parsed;
                         }
                     });
+                    proxiedParse.__comixChapterCaptureInstalled = true;
+                    JSON.parse = proxiedParse;
                 })();
                 """.trimIndent()
             },
@@ -495,8 +500,9 @@ class Comix :
             buildScript = { interfaceName ->
                 """
                 (function () {
+                    if (JSON.parse.__comixPageCaptureInstalled) return;
                     const originalParse = JSON.parse;
-                    JSON.parse = new Proxy(originalParse, {
+                    const proxiedParse = new Proxy(originalParse, {
                         apply(target, thisArg, args) {
                             const parsed = Reflect.apply(target, thisArg, args);
                             try {
@@ -507,6 +513,8 @@ class Comix :
                             return parsed;
                         }
                     });
+                    proxiedParse.__comixPageCaptureInstalled = true;
+                    JSON.parse = proxiedParse;
                 })();
                 """.trimIndent()
             },


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

I noticed that Comix can trigger the same page navigation more than once while loading chapter lists. This adds extra stress on the site and, during larger library updates, could contribute to timeouts.

This change should reduce unneeded calls and lower the load on the source.

Tested on Suwa and Mihon works well
