### PR TITLE
Uzaymanga Fix Chapter name parsing

### DIFF
--- a/lib-multisrc/uzaymanga/build.gradle.kts
+++ b/lib-multisrc/uzaymanga/build.gradle.kts
@@ -4,4 +4,4 @@ plugins {
     alias(kei.plugins.multisrc)
 }
 
-baseVersionCode = 3
+baseVersionCode = 4

--- a/lib-multisrc/uzaymanga/src/eu/kanade/tachiyomi/multisrc/uzaymanga/UzayManga.kt
+++ b/lib-multisrc/uzaymanga/src/eu/kanade/tachiyomi/multisrc/uzaymanga/UzayManga.kt
@@ -203,10 +203,10 @@ abstract class UzayManga(
 
             SChapter.create().apply {
                 val chapName = svelte.resolveString(chapObj, "name")
-                val chapOrder = svelte.resolveInt(chapObj, "order")
+                val chapOrder = svelte.resolveString(chapObj, "order")?.removeSuffix(".0")
                 name = buildString {
                     if (chapOrder != null) append("Bölüm $chapOrder")
-                    if (chapName != null && chapName != chapOrder?.toString()) {
+                    if (chapName != null && chapName != chapOrder) {
                         if (isNotEmpty()) append(" - ")
                         append(chapName)
                     }


### PR DESCRIPTION
Closes #16566

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
