### PR TITLE
ScanManga: Fix search url

### DIFF
--- a/src/fr/scanmanga/build.gradle
+++ b/src/fr/scanmanga/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Scan-Manga'
     extClass = '.ScanManga'
-    extVersionCode = 22
+    extVersionCode = 23
     isNsfw = true
 }
 

--- a/src/fr/scanmanga/src/eu/kanade/tachiyomi/extension/fr/scanmanga/ScanManga.kt
+++ b/src/fr/scanmanga/src/eu/kanade/tachiyomi/extension/fr/scanmanga/ScanManga.kt
@@ -44,8 +44,10 @@ class ScanManga :
     ConfigurableSource {
     override val name = "Scan-Manga"
 
-    override val baseUrl = "https://m.scan-manga.com"
-    private val baseImageUrl = "https://static.scan-manga.com/img/manga"
+    private val domain = "scan-manga.com"
+    override val baseUrl = "https://m.$domain"
+    private val baseImageUrl = "https://static.$domain/img/manga"
+    private val baseSearchUrl = "https://bqj.$domain/search/quick.json"
 
     override val lang = "fr"
 
@@ -125,7 +127,7 @@ class ScanManga :
 
     // Search
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        val url = "$baseUrl/api/search/quick.json"
+        val url = baseSearchUrl
             .toHttpUrl().newBuilder()
             .addQueryParameter("term", query)
             .build()


### PR DESCRIPTION
Just change the search url with the new subdomain 

Closes : None find

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
