### PR TITLE
Raijinscans: Fix chapter page load

### DIFF
--- a/src/fr/raijinscans/build.gradle
+++ b/src/fr/raijinscans/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Raijin Scans'
     extClass = '.RaijinScans'
-    extVersionCode = 64
+    extVersionCode = 65
     isNsfw = false
 }
 

--- a/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
+++ b/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
@@ -17,9 +17,12 @@ import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -283,74 +286,68 @@ class RaijinScans :
         val config = String(Base64.decode(b64, Base64.DEFAULT)).parseAs<JsonObject>()
         val shuffled = config["d"]!!.jsonArray
         val perm = config["m"]!!.jsonArray.map { it.jsonPrimitive.int }
+        val order = config["l"]!!.jsonArray.map { it.jsonPrimitive.int }
 
-        // The config is shuffled: 'm' is a permutation that descrambles 'd' into its
-        // canonical layout via ordered[m[i]] = d[i] (the same logic the reader JS uses).
-        // Reading fixed positions of the descrambled array is robust to the two key arrays
-        // changing length (which previously broke a size-based heuristic and caused HTTP 400).
+        // The reader uses two permutations to assemble the request. 'm' descrambles 'd' into
+        // an intermediate array via ordered[m[i]] = d[i]; 'l' then maps that into the canonical
+        // request layout via vals[i] = ordered[l[i]]. The manifest is randomized on every page
+        // load (arrays/values land at different positions each time), so reading fixed positions
+        // of the descrambled array is NOT reliable — both permutations must be applied.
         val ordered = arrayOfNulls<JsonElement>(shuffled.size)
         perm.forEachIndexed { i, p -> ordered[p] = shuffled[i] }
-        fun at(index: Int): JsonElement = ordered.getOrNull(index)
-            ?: throw Exception("Reader manifest layout changed. Open the chapter in WebView.")
+        val vals = order.map {
+            ordered.getOrNull(it)
+                ?: throw Exception("Reader manifest layout changed. Open the chapter in WebView.")
+        }
 
-        /* Canonical layout of the descrambled array:
-         *  2  : Token (64 hex chars)
-         *  3  : Instance ID
-         *  4  : Manga ID
-         *  5  : Chapter number/slug (== last URL segment)
-         *  7  : Root ("rjfr-<mangaId>-<chapterId>", also in the DOM)
-         * 12  : Form action ("rjfr_...")
-         * 13  : reqKeys  - request form field names
-         * 14  : respKeys - response field names
-         * others (0,1,6,8,9,10,11) are the ajax url / constants / ignored values.
-         */
-        val token = at(2).jsonPrimitive.content
-        val instanceId = at(3).jsonPrimitive.content
-        val mangaId = at(4).jsonPrimitive.content
-        val action = at(12).jsonPrimitive.content
-        val reqKeys = at(13).jsonArray.map { it.jsonPrimitive.content }
-        val respKeys = at(14).jsonArray.map { it.jsonPrimitive.content }
+        // Canonical layout of vals:
+        //  1..6 : request content values, passed positionally to keyArr[0..5]
+        //         (["", token, X, mangaId, chapterSlug, instanceId] — order matters, identity does not)
+        //  12   : form action ("rjfr_...")
+        //  13   : keyArr - request form field names (first 10 used)
+        val action = vals[12].jsonPrimitive.content
+        val keyArr = vals[13].jsonArray.map { it.jsonPrimitive.content }
+        val contentValues = (1..6).map { vals[it].jsonPrimitive.content }
 
-        val chapterSlug = response.request.url.pathSegments.last { it.isNotEmpty() }
         val rjfrValue = document.select("[data-rj-free-reader-root]").attr("data-rj-free-reader-root")
 
         val pages = mutableListOf<Page>()
-        var offset = "0"
         var cursor = ""
         var run = true
         var guard = 0
 
         while (run && guard++ < MAX_PAGE_REQUESTS) {
-            val body = MultipartBody.Builder().setType(MultipartBody.FORM)
+            val builder = MultipartBody.Builder().setType(MultipartBody.FORM)
                 .addFormDataPart("action", action)
-                .addFormDataPart(reqKeys[0], "")
-                .addFormDataPart(reqKeys[1], token)
-                .addFormDataPart(reqKeys[2], instanceId)
-                .addFormDataPart(reqKeys[3], mangaId)
-                .addFormDataPart(reqKeys[4], chapterSlug)
-                .addFormDataPart(reqKeys[5], "local")
-                .addFormDataPart(reqKeys[6], "0")
-                .addFormDataPart(reqKeys[7], offset)
-                .addFormDataPart(reqKeys[8], rjfrValue)
-                .addFormDataPart(reqKeys[9], cursor)
-                .build()
+            contentValues.forEachIndexed { j, v -> builder.addFormDataPart(keyArr[j], v) }
+            builder.addFormDataPart(keyArr[6], "0")
+                .addFormDataPart(keyArr[7], "0") // offset, always 0; pagination is cursor-only
+                .addFormDataPart(keyArr[8], rjfrValue)
+                .addFormDataPart(keyArr[9], cursor)
+            val body = builder.build()
 
             val response = client.newCall(POST("$baseUrl/wp-admin/admin-ajax.php", ajaxHeaders, body)).execute()
 
             if (!response.isSuccessful) error("Failed to get page: ${response.code}")
             val root = response.parseAs<JsonObject>()
 
-            val payload = root[respKeys[1]]!!.jsonObject
-            val images = payload[respKeys[2]]!!.jsonArray
+            // Parse structurally so we don't depend on the (also randomized) response key names:
+            // payload = the only object in the root; images = the only array in the payload;
+            // url = the only http string per image; cursor = the only string; hasMore = the only boolean.
+            val payload = root.values.filterIsInstance<JsonObject>().first()
+            val images = payload.values.first { it is JsonArray }.jsonArray
 
             images.forEach { image ->
-                val url = image.jsonObject[respKeys[4]]!!.jsonPrimitive.content
+                val url = image.jsonObject.values
+                    .map { it.jsonPrimitive.content }
+                    .first { it.startsWith("http") }
                 pages.add(Page(pages.size, imageUrl = url))
             }
 
-            offset = payload[respKeys[7]]?.jsonPrimitive?.content ?: ""
-            cursor = payload[respKeys[8]]?.jsonPrimitive?.content ?: ""
-            run = payload[respKeys[9]]?.jsonPrimitive?.boolean ?: false
+            cursor = payload.values.filterIsInstance<JsonPrimitive>()
+                .firstOrNull { it.isString }?.content ?: ""
+            run = payload.values.filterIsInstance<JsonPrimitive>()
+                .firstOrNull { it.booleanOrNull != null }?.boolean ?: false
         }
 
         return pages


### PR DESCRIPTION
## Explanation

The reader manifest now ships a second permutation `l` and randomizes
the descrambled array layout on every page load, so the old fixed-index
extraction crashed with "JsonLiteral is not a JsonArray".

Apply both permutations (ordered[m[i]]=d[i], then vals[i]=ordered[l[i]])
to recover the request layout, and parse the response structurally so it
no longer depends on the (also randomized) response key names.

Closes : #16476

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

I’d be happy to take any advice