### PR TITLE
Kayn Scans (EN): fix migration error

### DIFF
--- a/src/en/kaynscans/build.gradle
+++ b/src/en/kaynscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.KaynScans'
     themePkg = 'iken'
     baseUrl = 'https://kaynscan.org'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
     isNsfw = false
 }
 

--- a/src/en/kaynscans/src/eu/kanade/tachiyomi/extension/en/kaynscans/KaynScans.kt
+++ b/src/en/kaynscans/src/eu/kanade/tachiyomi/extension/en/kaynscans/KaynScans.kt
@@ -23,7 +23,7 @@ class KaynScans :
     }
 
     override fun pageListParse(r: Response): List<Page> {
-        if (r.request.url.pathSegments.size > 1) {
+        if (r.request.url.pathSegments.firstOrNull() != "api") {
             throw Exception("Migrate entry from '$name' to '$name'")
         }
         return super.pageListParse(r)


### PR DESCRIPTION
about previous PR, forgot the /api/chapter exists in PageList of IKen, so match based on text not length

Closes #16577

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop 
