### PR TITLE
Add jspecify dependency for annotations used by Jsoup

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,9 @@ quickjs = { module = "app.cash.quickjs:quickjs-android", version = "0.9.2" }
 rxjava = { module = "io.reactivex:rxjava", version = "1.3.8" }
 tachiyomi-lib = { module = "com.github.keiyoushi:extensions-lib", version = "18a8e26be2" }
 
+# Required by Kotlin 2.x compiler to resolve type-use annotations (e.g. org.jspecify.annotations.Nullable) used in Jsoup's API signatures
+jspecify = { module = "org.jspecify:jspecify", version = "1.0.0" }
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle" }
 android-library = { id = "com.android.library", version.ref = "android-gradle" }
@@ -44,4 +47,4 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 
 [bundles]
-common = ["kotlin-stdlib", "coroutines-core", "coroutines-android", "injekt-core", "rxjava", "kotlin-protobuf", "kotlin-json", "kotlin-json-okio", "jsoup", "okhttp", "tachiyomi-lib", "quickjs"]
+common = ["kotlin-stdlib", "coroutines-core", "coroutines-android", "injekt-core", "rxjava", "kotlin-protobuf", "kotlin-json", "kotlin-json-okio", "jsoup", "jspecify", "okhttp", "tachiyomi-lib", "quickjs"]


### PR DESCRIPTION
Fixes this warning:
```
Type annotation class 'org.jspecify.annotations.Nullable' of the inferred type is inaccessible. Check the module classpath for missing or
  conflicting dependencies. This will become an error in language version 2.4. See https://youtrack.jetbrains.com/issue/KT-80247.
```

Basically `Jsoup` uses `jspecify` Annotations like `Nullable` in it's java code, and these annotations are not part of consumer classpath, which is fine for javac but not for kotinc 2.x