### PR TITLE
GreenShit (Multisrc): Fix getMangaUrl and handle locked chapters

### DIFF
--- a/lib-multisrc/greenshit/build.gradle.kts
+++ b/lib-multisrc/greenshit/build.gradle.kts
@@ -4,4 +4,4 @@ plugins {
     alias(kei.plugins.multisrc)
 }
 
-baseVersionCode = 9
+baseVersionCode = 10

--- a/lib-multisrc/greenshit/src/eu/kanade/tachiyomi/multisrc/greenshit/GreenShit.kt
+++ b/lib-multisrc/greenshit/src/eu/kanade/tachiyomi/multisrc/greenshit/GreenShit.kt
@@ -5,6 +5,7 @@ import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.asObservable
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
@@ -24,6 +25,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import rx.Observable
 import kotlin.jvm.Synchronized
 
 abstract class GreenShit :
@@ -368,7 +370,7 @@ abstract class GreenShit :
     }
 
     // ============================ Manga Details ============================
-    override fun getMangaUrl(manga: SManga): String = "$baseUrl${manga.url}"
+    override fun getMangaUrl(manga: SManga): String = "$baseUrl${manga.url.replace("obra/", "obras/")}"
 
     override fun mangaDetailsRequest(manga: SManga): Request {
         val id = manga.url.substringAfter("/obra/").substringBefore("/")
@@ -398,6 +400,18 @@ abstract class GreenShit :
         val chapterId = chapter.url.substringAfter("/capitulo/")
         return GET("$apiUrl/capitulos/$chapterId", headers)
     }
+
+    override fun fetchPageList(chapter: SChapter): Observable<List<Page>> = client.newCall(pageListRequest(chapter))
+        .asObservable()
+        .flatMap { response: Response ->
+            if (response.code == 403) {
+                val message = runCatching { response.parseAs<GreenShitErrorDto>().message }
+                    .getOrElse { "Faça login" }
+                response.close()
+                throw Exception(message)
+            }
+            Observable.just(pageListParse(response))
+        }
 
     override fun pageListParse(response: Response): List<Page> {
         val dto = response.parseAs<GreenShitChapterDetailDto>()

--- a/lib-multisrc/greenshit/src/eu/kanade/tachiyomi/multisrc/greenshit/GreenShitDto.kt
+++ b/lib-multisrc/greenshit/src/eu/kanade/tachiyomi/multisrc/greenshit/GreenShitDto.kt
@@ -50,7 +50,10 @@ data class GreenShitChapterSimpleDto(
     @SerialName("cap_nome") val name: String,
     @SerialName("cap_numero") val number: Float? = null,
     @SerialName("cap_criado_em") val createdAt: String? = null,
-)
+    @SerialName("cap_liberado") val released: Boolean = true,
+) {
+    val locked get() = if (!released) "🔒 " else ""
+}
 
 @Serializable
 data class GreenShitMangaDto(
@@ -77,6 +80,11 @@ data class GreenShitChapterDetailDto(
     @SerialName("cap_numero") val number: Float? = null,
     @SerialName("cap_paginas") val pages: List<GreenShitPageSrcDto> = emptyList(),
     @SerialName("obra") val manga: GreenShitMangaDto? = null,
+)
+
+@Serializable
+class GreenShitErrorDto(
+    val message: String,
 )
 
 private fun isWpLikePath(src: String): Boolean = src.startsWith("uploads/") ||
@@ -134,7 +142,7 @@ fun GreenShitMangaDto.toSManga(cdnUrl: String, isDetails: Boolean = false): SMan
 }
 
 fun GreenShitChapterSimpleDto.toSChapter(): SChapter = SChapter.create().apply {
-    name = this@toSChapter.name
+    name = locked + this@toSChapter.name
     chapter_number = number ?: 0f
     url = "/capitulo/$id"
     date_upload = dateFormat.tryParse(createdAt)
@@ -143,7 +151,7 @@ fun GreenShitChapterSimpleDto.toSChapter(): SChapter = SChapter.create().apply {
 fun GreenShitChapterDetailDto.toPageList(cdnUrl: String): List<Page> {
     val obraId = manga?.id ?: 0
     val scanId = manga?.scanId ?: 0
-    val chapterNumber = number.toString()?.removeSuffix(".0") ?: "0"
+    val chapterNumber = number?.toString()?.removeSuffix(".0") ?: "0"
     return pages.mapIndexed { idx, p ->
         val imageUrl = buildImageUrl(path = "/scans/$scanId/obras/$obraId/capitulos/$chapterNumber/", src = p.src, mime = p.mime, width = null, base = cdnUrl)
         Page(idx, imageUrl = imageUrl)


### PR DESCRIPTION
Closes #16333
Closes #15066

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop 
