### PR TITLE
RaijinScans: Fix chapter page load broken by decoy data

### DIFF
--- a/src/fr/raijinscans/build.gradle
+++ b/src/fr/raijinscans/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Raijin Scans'
     extClass = '.RaijinScans'
-    extVersionCode = 65
+    extVersionCode = 66
     isNsfw = false
 }
 

--- a/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
+++ b/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
@@ -23,6 +23,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -61,6 +62,7 @@ class RaijinScans :
     private val numberRegex = """(\d+)""".toRegex()
     private val descriptionScriptRegex = """content\.innerHTML = `([\s\S]+?)`;""".toRegex()
     private val manifestPushRegex = """push\((\{.*\})\);""".toRegex()
+    private val imageExtRegex = """\.(webp|jpe?g|png|gif|avif)""".toRegex(RegexOption.IGNORE_CASE)
     private val json: Json by lazy {
         Json {
             ignoreUnknownKeys = true
@@ -303,9 +305,11 @@ class RaijinScans :
         // Canonical layout of vals:
         //  1..6 : request content values, passed positionally to keyArr[0..5]
         //         (["", token, X, mangaId, chapterSlug, instanceId] — order matters, identity does not)
-        //  12   : form action ("rjfr_...")
         //  13   : keyArr - request form field names (first 10 used)
-        val action = vals[12].jsonPrimitive.content
+        // The form action ("rjfr_...") is picked by content: it is the only string starting with
+        // "rjfr_" (the rjfr instance token uses a hyphen, "rjfr-", so it won't collide).
+        val action = vals.mapNotNull { (it as? JsonPrimitive)?.contentOrNull }
+            .first { it.startsWith("rjfr_") }
         val keyArr = vals[13].jsonArray.map { it.jsonPrimitive.content }
         val contentValues = (1..6).map { vals[it].jsonPrimitive.content }
 
@@ -331,17 +335,16 @@ class RaijinScans :
             if (!response.isSuccessful) error("Failed to get page: ${response.code}")
             val root = response.parseAs<JsonObject>()
 
-            // Parse structurally so we don't depend on the (also randomized) response key names:
-            // payload = the only object in the root; images = the only array in the payload;
-            // url = the only http string per image; cursor = the only string; hasMore = the only boolean.
-            val payload = root.values.filterIsInstance<JsonObject>().first()
-            val images = payload.values.first { it is JsonArray }.jsonArray
+            // Parse by content, not position, so we don't depend on the (randomized) response key
+            // names, the response nesting depth, or decoy wrapper objects/arrays the site mixes in:
+            // images = the array of image objects found anywhere in the tree (an image object holds
+            // an http string whose path is an actual image); payload = its parent object, which also
+            // carries the cursor (its only string primitive) and hasMore (its only boolean primitive).
+            val (payload, images) = findImages(root)
+                ?: throw Exception("Reader response format changed. Open the chapter in WebView.")
 
             images.forEach { image ->
-                val url = image.jsonObject.values
-                    .map { it.jsonPrimitive.content }
-                    .first { it.startsWith("http") }
-                pages.add(Page(pages.size, imageUrl = url))
+                image.imageUrlOrNull()?.let { pages.add(Page(pages.size, imageUrl = it)) }
             }
 
             cursor = payload.values.filterIsInstance<JsonPrimitive>()
@@ -351,6 +354,28 @@ class RaijinScans :
         }
 
         return pages
+    }
+
+    // The real image url = the http string whose path is an actual image. Each image object also
+    // carries a decoy http string (the admin-ajax endpoint), so a plain "starts with http" is not enough.
+    private fun JsonElement.imageUrlOrNull(): String? = (this as? JsonObject)?.values
+        ?.filterIsInstance<JsonPrimitive>()
+        ?.map { it.content }
+        ?.firstOrNull { it.startsWith("http") && imageExtRegex.containsMatchIn(it) }
+
+    private fun JsonArray.isImageArray(): Boolean = firstOrNull()?.imageUrlOrNull() != null
+
+    // Find the array of image objects anywhere in the tree and return it with its parent object.
+    private fun findImages(element: JsonElement): Pair<JsonObject, JsonArray>? {
+        when (element) {
+            is JsonObject -> {
+                element.values.forEach { if (it is JsonArray && it.isImageArray()) return element to it }
+                element.values.forEach { child -> findImages(child)?.let { return it } }
+            }
+            is JsonArray -> element.forEach { child -> findImages(child)?.let { return it } }
+            else -> {}
+        }
+        return null
     }
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException("Not used.")


### PR DESCRIPTION
Reading any chapter failed with `Collection contains no element matching the predicate.`

The site added decoy data to the reader's `admin-ajax.php` response, which defeated the
"pick the only object / array / http string" heuristics in `pageListParse`:

- The response root now contains a **decoy metadata object** alongside the real payload object.
- The payload contains a **decoy array** before the real images array.
- Each image object now holds **two http URLs** — a decoy `…/admin-ajax.php` listed *before*
  the real `…/uploads/…/image-NN.webp`.

The previous code picked the first object/array/URL by position, so it either crashed or would
have pointed every page at the decoy.

### Fix

Select everything by **content** instead of position:
- The image array is located by a recursive, depth-independent tree search for the array whose
  elements are objects containing an http URL with an image extension; its parent object is the
  payload.
- The image URL is the http string matching an image extension, so the `admin-ajax.php` decoy is
  ignored.
- The form `action` is matched by its `rjfr_` prefix rather than a fixed manifest index.

The request-building (field-name array + content values) is unchanged: those are opaque,
order-only token pairs from the site's canonical layout with nothing to content-match against.

Closes : #16580 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

I’d be happy to take any advice