### PR TITLE
MangaInUa, Faust: Update filters functionality

### DIFF
--- a/src/uk/faust/build.gradle
+++ b/src/uk/faust/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Faust'
     extClass = '.Faust'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/uk/faust/src/eu/kanade/tachiyomi/extension/uk/faust/Faust.kt
+++ b/src/uk/faust/src/eu/kanade/tachiyomi/extension/uk/faust/Faust.kt
@@ -22,12 +22,12 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.add
 import okhttp3.Request
 import okhttp3.Response
 import java.text.SimpleDateFormat
-import java.time.Year
+import java.util.Calendar
 import java.util.Locale
+import java.util.TimeZone
 import kotlin.collections.joinToString
 import kotlin.collections.orEmpty
 import kotlin.text.ifEmpty
@@ -49,7 +49,7 @@ class Faust :
         .build()
 
     override fun headersBuilder() = super.headersBuilder()
-        .add("Origin", baseUrl)
+        .add("Origin", "$baseUrl/")
         .add("Content-Type", "application/json")
 
     // ============================== Search ===============================
@@ -70,68 +70,60 @@ class Faust :
     }
 
     // ============================== Search/Utility ===============================
-    private fun makeSearchRequest(sort: String? = null, page: Int, query: String? = "", filters: FilterList = getFilterList()): Request {
+    private fun makeSearchRequest(sort: String? = null, page: Int, query: String? = "", filters: FilterList? = null): Request {
         val url = "$apiUrl/titles/search/library"
-
-        // Prepare the data for serialization
+        val checkYear = Calendar.getInstance().get(Calendar.YEAR) + 1
         val requestBodyData = SearchRequestBody(
             searchQuery = query,
             page = page,
             pageSize = 30,
         )
 
-        // Apply filters to the requestBodyData
-        filters.forEach { filter ->
+        filters?.forEach { filter ->
             when (filter) {
                 is OrderBy -> {
                     val asc = if (filter.state?.ascending == true) "-" else "+"
-                    requestBodyData.sortBy = sort ?: "$asc${filter.selected}"
+                    requestBodyData.sortBy = "$asc${filter.selected}"
                 }
                 is CategoriesFilter -> filter.selected?.let { requestBodyData.mangaType = it }
                 is TranslationStatusFilter -> filter.selected?.let { requestBodyData.translationStatus = it }
                 is PublicationStatusFilter -> filter.selected?.let { requestBodyData.publicationStatus = it }
                 is AgeStatusFilter -> filter.selected?.let { requestBodyData.ageBracket = it }
                 is YearRangeFilter -> {
-                    filter.minValue?.let { requestBodyData.yearFrom = checkMinRange(it, 1970, Year.now().value + 1) }
-                    filter.maxValue?.let { requestBodyData.yearTo = checkMaxRange(it, 1970, Year.now().value + 1) }
+                    filter.minValue?.let { requestBodyData.yearFrom = checkMinRange(it, 1970, checkYear) }
+                    filter.maxValue?.let { requestBodyData.yearTo = checkMaxRange(it, 1970, checkYear) }
                 }
                 is ChaptersRangeFilter -> {
                     filter.minValue?.let { requestBodyData.minChapters = checkMinRange(it, 0, 3000) }
                     filter.maxValue?.let { requestBodyData.maxChapters = checkMaxRange(it, 0, 3000) }
                 }
                 is GenresFilter -> {
-                    filter.included?.let {
-                        requestBodyData.genreIds = JsonArray(it.map { genreId -> JsonPrimitive(genreId) })
-                    }
-                    filter.excluded?.let {
-                        val allExcluded = it.plus(ignoreGenres()).distinct()
-                        requestBodyData.excludeGenreIds = JsonArray(allExcluded.map { genreId -> JsonPrimitive(genreId) })
-                    } ?: run {
-                        if (ignoreGenres().isNotEmpty()) {
-                            requestBodyData.excludeGenreIds = JsonArray(ignoreGenres().map { genreId -> JsonPrimitive(genreId) })
-                        }
-                    }
+                    filter.included?.let { requestBodyData.genreIds = JsonArray(it.map(::JsonPrimitive)) }
+                    filter.excluded?.let { requestBodyData.excludeGenreIds = JsonArray(it.map(::JsonPrimitive)) }
                 }
                 is TagsFilter -> {
-                    filter.included?.let {
-                        requestBodyData.tagIds = JsonArray(it.map { tagId -> JsonPrimitive(tagId) })
-                    }
-                    filter.excluded?.let {
-                        requestBodyData.excludeTagIds = JsonArray(it.map { tagId -> JsonPrimitive(tagId) })
-                    }
+                    filter.included?.let { requestBodyData.tagIds = JsonArray(it.map(::JsonPrimitive)) }
+                    filter.excluded?.let { requestBodyData.excludeTagIds = JsonArray(it.map(::JsonPrimitive)) }
                 }
                 else -> {}
             }
         }
 
-        // Convert the data class to JSON request body
-        val body = requestBodyData.toJsonRequestBody() // Assuming toJsonRequestBody() handles serialization
+        if (filters.isNullOrEmpty()) {
+            val ignoredGenres = ignoreGenres()
+            if (ignoredGenres.isNotEmpty()) {
+                requestBodyData.excludeGenreIds = JsonArray(ignoredGenres.map(::JsonPrimitive))
+            }
+            requestBodyData.sortBy = sort
+        }
+
+        val body = requestBodyData.toJsonRequestBody()
 
         return POST(url, headers, body)
     }
 
     // ============================== Popular ===============================
-    override fun popularMangaRequest(page: Int) = makeSearchRequest(sort = "-rating", page = page)
+    override fun popularMangaRequest(page: Int) = makeSearchRequest(sort = "-popularity", page = page)
 
     override fun popularMangaParse(response: Response) = searchMangaParse(response)
 
@@ -228,10 +220,10 @@ class Faust :
             genresDeferred?.await()
             tagsDeferred?.await()
         }
-        val filters = mutableListOf<Filter<*>>(
+        val filters = mutableListOf(
             OrderBy(),
             Filter.Separator(),
-            GenresFilter(),
+            GenresFilter(ignoreGenres()),
             Filter.Separator(),
             TagsFilter(),
             Filter.Separator(),
@@ -334,11 +326,12 @@ class Faust :
         }.let(screen::addPreference)
     }
 
-    private fun parseDate(dateStr: String?): Long = dateFormatSite.tryParse(dateStr)
+    private fun parseDate(dateStr: String?): Long = dateFormatSite.tryParse(dateStr?.substringBefore("."))
 
     companion object {
-        private val dateFormatSite = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSX", Locale.ROOT)
-
+        private val dateFormatSite = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
         private const val SITE_GENRES_PREF = "site_hidden_genres"
         private const val SITE_GENRES_PREF_TITLES = "site_hidden_genres_titles"
         private const val SITE_GENRES_PREF_TITLE = "Приховані категорії"

--- a/src/uk/faust/src/eu/kanade/tachiyomi/extension/uk/faust/Filters.kt
+++ b/src/uk/faust/src/eu/kanade/tachiyomi/extension/uk/faust/Filters.kt
@@ -27,7 +27,16 @@ abstract class TriStateGroup(
     val excluded get() = state.filter { it.isExcluded() }.map { it.value }.takeUnless { it.isEmpty() }
 }
 
-class GenresFilter : TriStateGroup("Жанри", options) {
+class GenresFilter(blockedGenres: Set<String>) : TriStateGroup("Жанри", options) {
+    init {
+        if (blockedGenres.isNotEmpty()) {
+            state.forEach { filter ->
+                if (blockedGenres.contains(filter.value)) {
+                    filter.state = 2
+                }
+            }
+        }
+    }
     companion object {
         var options = emptyList<Pair<String, String>>()
     }
@@ -61,7 +70,7 @@ internal class OrderBy :
             "Останні оновлення" to "updated",
             "Нові тайтли" to "newest",
         ),
-        Selection(0, true),
+        Selection(1, true),
     )
 internal class CategoriesFilter :
     SelectFilter(

--- a/src/uk/mangainua/build.gradle
+++ b/src/uk/mangainua/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MangaInUa'
     extClass = '.Mangainua'
-    extVersionCode = 11
+    extVersionCode = 12
     isNsfw = true
 }
 

--- a/src/uk/mangainua/src/eu/kanade/tachiyomi/extension/uk/mangainua/Filters.kt
+++ b/src/uk/mangainua/src/eu/kanade/tachiyomi/extension/uk/mangainua/Filters.kt
@@ -89,7 +89,16 @@ class SizeFilter :
         ),
     )
 
-class TagFilter : TriStateGroup("Жанри", options) {
+class TagFilter(blockedTags: Set<String>) : TriStateGroup("Жанри", options) {
+    init {
+        if (blockedTags.isNotEmpty()) {
+            state.forEach { filter ->
+                if (blockedTags.contains(filter.value)) {
+                    filter.state = 2
+                }
+            }
+        }
+    }
     companion object {
         val options = listOf(
             "Божевілля" to "53",

--- a/src/uk/mangainua/src/eu/kanade/tachiyomi/extension/uk/mangainua/Mangainua.kt
+++ b/src/uk/mangainua/src/eu/kanade/tachiyomi/extension/uk/mangainua/Mangainua.kt
@@ -40,7 +40,8 @@ class Mangainua :
     private val preferences by getPreferencesLazy()
 
     override fun headersBuilder() = super.headersBuilder()
-        .add("Referer", baseUrl)
+        .add("Origin", "$baseUrl/")
+        .add("Referer", "$baseUrl/")
 
     override val client = network.client.newBuilder()
         .rateLimit(1, 2.seconds)
@@ -61,7 +62,7 @@ class Mangainua :
 
     override fun searchMangaParse(response: Response) = mangaParse(response, true)
 
-    private fun makeSearchRequest(sortBy: String? = null, page: Int, query: String = "", filters: FilterList = FilterList()): Request {
+    private fun makeSearchRequest(sortBy: String? = null, page: Int, query: String = "", filters: FilterList? = null): Request {
         // Search by title
         if (query.isNotEmpty()) {
             if (query.length < 3) {
@@ -84,33 +85,25 @@ class Mangainua :
 
         // Search by filters
         val url = "$baseUrl/filter".toHttpUrl().newBuilder().apply {
-            val ignoredTagsSettings = ignoreTags()
-            (if (filters.isEmpty()) getFilterList() else filters).forEach { filter ->
+            filters?.forEach { filter ->
                 when (filter) {
                     is TagFilter -> {
                         filter.included?.let { addPathSegment("cat=${it.joinToString(",")}") }
-                        filter.excluded?.let {
-                            val filter = when {
-                                ignoredTagsSettings.isNotEmpty() -> (ignoredTagsSettings + it).distinct().joinToString(",")
-                                else -> it.joinToString(",")
-                            }
-                            addPathSegment("!cat=$filter")
-                        } ?: run {
-                            if (ignoredTagsSettings.isNotEmpty()) {
-                                addPathSegment("!cat=${ignoredTagsSettings.joinToString(",")}")
-                            }
-                        }
+                        filter.excluded?.let { addPathSegment("!cat=${it.joinToString(",")}") }
                     }
                     is StatusFilter -> filter.selected?.let { addPathSegment("b.tra=$it") }
                     is CategoriesFilter -> filter.selected?.let { addPathSegment("b.type=$it") }
                     is AgeFilter -> filter.selected?.let { addPathSegment("b.vik=$it") }
                     is SizeFilter -> filter.selected?.let { addPathSegment("c.lastchappr=$it") }
                     is YearsFilter -> filter.selected?.let { addPathSegment("c.yer=$it") }
-                    is SortFilter -> {
-                        addPathSegment("sort=${sortBy ?: filter.selected}")
-                    }
+                    is SortFilter -> addPathSegment("sort=${filter.selected}")
                     else -> {}
                 }
+            }
+            if (filters.isNullOrEmpty()) {
+                val ignoredTagsSettings = ignoreTags()
+                if (ignoredTagsSettings.isNotEmpty()) addPathSegment("!cat=${ignoredTagsSettings.joinToString(",")}")
+                addPathSegment("sort=$sortBy")
             }
             if (page > 1) addPathSegments("page/$page/")
         }.build()
@@ -261,7 +254,7 @@ class Mangainua :
         Filter.Header("Фільтри не застосовуються під час пошуку за назвою"),
         CategoriesFilter(),
         StatusFilter(),
-        TagFilter(),
+        TagFilter(ignoreTags()),
         SortFilter("news_read;desc"),
         SizeFilter(),
         AgeFilter(),


### PR DESCRIPTION
Checklist:

Both sites (MangaInUa, Faust): 
- Ignored Genres from preferences now applied to Filters tab on loading.
- Preferences excluded from Filter tab request, prioritizing user input, and simplifying code.
- Ignored genres from preferences should be used when filters are not set (Popular/Latest/Query).
- Proper formatting for Origin and Referer headers
- Time zone set as UTC

Faust only
- Site used inconsistent date format. Generally it was .SSSSSSX (6S), and rarely 5S. X were used in +00:00 format, and SimpleDateFormat prefers +00 or +0000 and might struggle with this syntax. Removing microseconds (and time zone) from parsing should remove both problems. Time zone are now applied as UTC (was +00 anyway in every date in api).

.

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
