### PR TITLE
ManhuaNext: Paid Chapter Filter

### DIFF
--- a/src/en/manhuanext/build.gradle
+++ b/src/en/manhuanext/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Manhuanext'
     themePkg = 'madara'
     baseUrl = 'https://manhuanext.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = false
 }
 

--- a/src/en/manhuanext/src/eu/kanade/tachiyomi/extension/en/manhuanext/Manhuanext.kt
+++ b/src/en/manhuanext/src/eu/kanade/tachiyomi/extension/en/manhuanext/Manhuanext.kt
@@ -1,12 +1,38 @@
 package eu.kanade.tachiyomi.extension.en.manhuanext
 
+import androidx.preference.PreferenceScreen
+import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.source.ConfigurableSource
+import keiyoushi.utils.getPreferencesLazy
 
 class Manhuanext :
     Madara(
         "Manhuanext",
         "https://manhuanext.com",
         "en",
-    ) {
+    ),
+    ConfigurableSource {
     override val useNewChapterEndpoint = true
+    private val preferences by getPreferencesLazy()
+    private val hideChapters = if (preferences.getBoolean(HIDE_PREMIUM, true)) {
+        "li.wp-manga-chapter:not(.premium-block)"
+    } else {
+        "li.wp-manga-chapter"
+    }
+    override fun chapterListSelector() = hideChapters
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        SwitchPreferenceCompat(screen.context).apply {
+            key = HIDE_PREMIUM
+            title = HIDE_PREMIUM_TITLE
+            summary = HIDE_PREMIUM_SUM
+            setDefaultValue(true)
+        }.let(screen::addPreference)
+    }
+    companion object {
+        private const val HIDE_PREMIUM = "hide_premium_chapters"
+        private const val HIDE_PREMIUM_TITLE = "Hide premium chapters"
+        private const val HIDE_PREMIUM_SUM = "Restart the app to apply changes"
+    }
 }


### PR DESCRIPTION
Checklist:

Closes #11272
Tried to reduce selector/preference read to a minimum, so that they won't be updated/calculated every time chapterListSelector() is used.

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
