### PR TITLE
Reset Scans (EN): Fix selectors

### DIFF
--- a/src/en/resetscans/build.gradle
+++ b/src/en/resetscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ResetScans'
     themePkg = 'madara'
     baseUrl = 'https://reset-scans.org'
-    overrideVersionCode = 12
+    overrideVersionCode = 13
     isNsfw = false
 }
 

--- a/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
+++ b/src/en/resetscans/src/eu/kanade/tachiyomi/extension/en/resetscans/ResetScans.kt
@@ -21,6 +21,12 @@ class ResetScans :
 
     override fun chapterListSelector() = "li.wp-manga-chapter:not(:has(a[href*='#']))"
 
+    override fun searchMangaSelector() = ".rs-manga-library__card"
+    override val searchMangaUrlSelector = ".rs-manga-library__card-title a"
+
+    override fun popularMangaSelector() = searchMangaSelector()
+    override val popularMangaUrlSelector = searchMangaUrlSelector
+
     override fun chapterListParse(response: Response): List<SChapter> {
         val chapters = super.chapterListParse(response)
 


### PR DESCRIPTION
Closes #16687 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop 
