### PR TITLE
fix(plottwistnofansub): update chapter loading API and selectors

### DIFF
--- a/src/es/plottwistnofansub/build.gradle
+++ b/src/es/plottwistnofansub/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Plot Twist No Fansub'
     extClass = '.PlotTwistNoFansub'
-    extVersionCode = 14
+    extVersionCode = 15
     isNsfw = true
 }
 

--- a/src/es/plottwistnofansub/src/eu/kanade/tachiyomi/extension/es/plottwistnofansub/Dto.kt
+++ b/src/es/plottwistnofansub/src/eu/kanade/tachiyomi/extension/es/plottwistnofansub/Dto.kt
@@ -4,18 +4,13 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-class ChapterApiResponse(
-    @SerialName("chapters_to_display") val chaptersToDisplay: List<ChapterDto> = emptyList(),
-    @SerialName("nav_items") val navItems: List<ChapterDto> = emptyList(),
-) {
-    val chapters: List<ChapterDto>
-        get() = chaptersToDisplay.ifEmpty { navItems }
-}
+class ChapterAjaxResponse(
+    val success: Boolean = false,
+    val data: ChapterAjaxData = ChapterAjaxData(),
+)
 
 @Serializable
-class ChapterDto(
-    val name: String,
-    @SerialName("name_extend") val nameExtend: String = "",
-    val link: String,
-    val date: String,
+class ChapterAjaxData(
+    val html: String = "",
+    @SerialName("has_more") val hasMore: Boolean = false,
 )

--- a/src/es/plottwistnofansub/src/eu/kanade/tachiyomi/extension/es/plottwistnofansub/PlotTwistNoFansub.kt
+++ b/src/es/plottwistnofansub/src/eu/kanade/tachiyomi/extension/es/plottwistnofansub/PlotTwistNoFansub.kt
@@ -55,9 +55,9 @@ class PlotTwistNoFansub : HttpSource() {
     override fun popularMangaParse(response: Response): MangasPage {
         val document = response.asJsoup()
 
-        val mangas = document.select("div.page-listing-item figure").map { element ->
+        val mangas = document.select("div.manga-grid-v2 figure").map { element ->
             SManga.create().apply {
-                val a = element.selectFirst("a")!!
+                val a = element.selectFirst("a[href]")!!
                 setUrlWithoutDomain(a.attr("abs:href").ifEmpty { a.attr("href") })
                 title = a.attr("title").takeIf { it.isNotEmpty() }
                     ?: element.selectFirst("figcaption")?.text()
@@ -66,7 +66,7 @@ class PlotTwistNoFansub : HttpSource() {
             }
         }
 
-        val hasNextPage = document.selectFirst("a.next.page-numbers, a.next") != null
+        val hasNextPage = document.selectFirst("a.next.page-numbers, a.next, a:contains(Siguiente)") != null
         return MangasPage(mangas, hasNextPage)
     }
 
@@ -108,26 +108,7 @@ class PlotTwistNoFansub : HttpSource() {
         return GET(url.build(), headers)
     }
 
-    override fun searchMangaParse(response: Response): MangasPage {
-        val document = response.asJsoup()
-        val isTextSearch = response.request.url.queryParameter("s") != null
-
-        if (!isTextSearch) return popularMangaParse(response)
-
-        val mangas = document.select("div.c-tabs-item__content").map { element ->
-            SManga.create().apply {
-                val a = element.selectFirst(".post-title a") ?: element.selectFirst("a")!!
-                setUrlWithoutDomain(a.attr("abs:href").ifEmpty { a.attr("href") })
-                title = a.text().takeIf { it.isNotEmpty() }
-                    ?: element.selectFirst("a")?.attr("title")
-                    ?: throw Exception("Missing title for manga at ${a.attr("href")}")
-                thumbnail_url = element.selectFirst("img")?.imgAttr()
-            }
-        }
-
-        val hasNextPage = document.selectFirst("a.next.page-numbers, a.next") != null
-        return MangasPage(mangas, hasNextPage)
-    }
+    override fun searchMangaParse(response: Response): MangasPage = popularMangaParse(response)
 
     override fun getFilterList(): FilterList = FilterList()
 
@@ -137,41 +118,30 @@ class PlotTwistNoFansub : HttpSource() {
     override fun mangaDetailsParse(response: Response): SManga {
         val document = response.asJsoup()
         return SManga.create().apply {
-            title = document.selectFirst("p.mn-title-block")?.text()
-                ?: document.selectFirst("p.titleMangaSingle")?.text()
-                ?: document.selectFirst(".post-title h1, .post-title h3")?.text()
+            title = document.selectFirst("h1.mn-detail-title")?.text()
+                ?: document.selectFirst(".post-title h1")?.text()
                 ?: throw Exception("Manga title not found")
 
-            thumbnail_url = document.selectFirst(".mn-cover-frame img")?.imgAttr()
-                ?: document.selectFirst(".thumble-container img")?.imgAttr()
-                ?: document.selectFirst(".summary_image img")?.imgAttr()
+            thumbnail_url = document.selectFirst(".mn-detail-cover-frame img")?.imgAttr()
 
-            description = document.selectFirst("h2:contains(Sinopsis) + div")?.text()
-                ?: document.selectFirst("#section-sinopsis p.font-light.text-white")?.text()
+            description = document.selectFirst(".mn-detail-synopsis")?.text()
                 ?: document.selectFirst(".summary__content")?.text()
 
-            val genresList = document.select("div.text-white:contains(Gé:) + div a, #section-sinopsis div:contains(Generos:) + div a").map { it.text() }
-            genre = if (genresList.isNotEmpty()) {
-                genresList.joinToString()
-            } else {
-                document.select(".genres-content a").joinToString { it.text() }
-            }
+            genre = document.select(".mn-detail-genres-desktop a").joinToString { it.text() }
+                .ifEmpty { document.select(".genres-content a").joinToString { it.text() } }
 
-            author = document.selectFirst("div.text-white:contains(Creación:) + div a, #section-sinopsis div:contains(Autor:) + div a")?.text()
+            author = document.selectFirst(".mn-detail-pill-label:contains(Autor) + .mn-detail-pill-value")?.text()
                 ?: document.selectFirst(".author-content a")?.text()
 
-            val statusText = (
-                document.selectFirst("button.mn-chip")?.text()
-                    ?: document.selectFirst(".btn-completed")?.text()
-                    ?: document.selectFirst(".btn-ongoing")?.text()
-                    ?: document.selectFirst("button:contains(Finalizado), button:contains(En curso)")?.text()
-                    ?: document.selectFirst(".post-status .summary-content")?.text()
-                    ?: ""
-                ).lowercase()
+            val statusPill = document.selectFirst(".mn-detail-pill-value")?.text() ?: ""
+            val statusClass = document.selectFirst(".mn-detail-pill-value")?.classNames()
+                ?.firstOrNull { it.startsWith("mn-st-") } ?: ""
 
             status = when {
-                statusText.contains("en emisión") || statusText.contains("en curso") || statusText.contains("ongoing") -> SManga.ONGOING
-                statusText.contains("finalizado") || statusText.contains("completed") -> SManga.COMPLETED
+                statusClass == "mn-st-emit" || statusPill.contains("en emisión", true) || statusPill.contains("en curso", true) -> SManga.ONGOING
+                statusClass == "mn-st-comp" || statusPill.contains("finalizado", true) || statusPill.contains("completado", true) -> SManga.COMPLETED
+                statusClass == "mn-st-cancel" || statusPill.contains("cancelado", true) -> SManga.CANCELLED
+                statusClass == "mn-st-pause" || statusPill.contains("en espera", true) -> SManga.ON_HIATUS
                 else -> SManga.UNKNOWN
             }
         }
@@ -181,135 +151,82 @@ class PlotTwistNoFansub : HttpSource() {
     override fun chapterListParse(response: Response): List<SChapter> {
         val document = response.asJsoup()
 
-        val mangaId = document.selectFirst("script:containsData(mnWpMangaId)")
-            ?.data()
-            ?.let { MANGA_ID_REGEX.find(it)?.groupValues?.get(1) }
+        val mangaId = document.selectFirst("#mn-detail-load-more")?.attr("data-manga")
+            ?: document.selectFirst("script:containsData(mnWpMangaId)")
+                ?.data()
+                ?.let { MANGA_ID_REGEX.find(it)?.groupValues?.get(1) }
             ?: document.selectFirst("script:containsData(manga_id)")
                 ?.data()
                 ?.let { OLD_MANGA_ID_REGEX.find(it)?.groupValues?.get(1) }
             ?: throw Exception("No se pudo encontrar el ID del manga")
 
-        val scriptData = document.selectFirst("script:containsData(mnSeriesNavBundle)")?.data()
-
         val chapters = mutableListOf<SChapter>()
 
-        // Fallback for new theme HTML chapters
-        document.select(".contenedor-capitulo-miniatura a").forEach { a ->
+        // Initial chapters rendered in HTML (new theme: mn-detail-chapter-item)
+        document.select("a.mn-detail-chapter-item").forEach { a ->
             val url = a.attr("abs:href").ifEmpty { a.attr("href") }
             if (url.isNotEmpty()) {
+                val num = a.selectFirst(".mn-detail-chapter-name")?.text() ?: ""
+                val extend = a.selectFirst(".mn-detail-chapter-extend")?.text() ?: ""
+                val dateText = a.selectFirst(".mn-detail-chapter-date")?.text()
+                    ?.replace(HTML_TAG_REGEX, "")
+                    ?: ""
                 chapters.add(
                     SChapter.create().apply {
-                        setUrlWithoutDomain(url)
-                        val divs = a.select("div.text-sm")
-                        val num = divs.getOrNull(0)?.text() ?: ""
-                        val title = divs.getOrNull(1)?.text() ?: ""
+                        setUrlWithoutDomain(url.substringAfter(baseUrl))
                         name = buildString {
                             append("Capítulo $num")
-                            if (title.isNotEmpty()) append(" - $title")
+                            if (extend.isNotEmpty()) append(" - $extend")
                         }
-                        date_upload = dateFormat.tryParse(a.selectFirst("time")?.text()?.replace(HTML_TAG_REGEX, ""))
+                        date_upload = dateFormat.tryParse(dateText)
                     },
                 )
             }
         }
 
-        if (scriptData != null) {
-            val navCsrf = CSRF_REGEX.find(scriptData)?.groupValues?.get(1)
-                ?: throw Exception("No se pudo encontrar el token")
+        // AJAX-loaded chapters via admin-ajax.php
+        // New endpoint: action=plot_load_chapters&manga_id=X&page=N
+        var page = 2
+        var hasNextPage = chapters.isNotEmpty()
 
-            val batchUrl = BATCH_URL_REGEX.find(scriptData)?.groupValues?.get(1)?.replace("\\/", "/")
-                ?: throw Exception("No se pudo encontrar la URL de la API")
+        while (hasNextPage) {
+            val form = FormBody.Builder()
+                .add("action", "plot_load_chapters")
+                .add("manga_id", mangaId)
+                .add("page", page.toString())
+                .build()
 
-            val totalPagesText = document.selectFirst("script:containsData(totalPageCount)")?.data()
-            val totalPages = totalPagesText?.let { TOTAL_PAGES_REGEX.find(it)?.groupValues?.get(1)?.toIntOrNull() } ?: 1
+            val apiResponse = client.newCall(
+                POST("$baseUrl/wp-admin/admin-ajax.php", headers, form),
+            ).execute().use { it.body.string() }
 
-            // First page is already fetched in HTML, begin on Page 2 if needed
-            var page = if (chapters.isEmpty()) 1 else 2
-            var hasNextPage = page <= totalPages
+            val apiData = apiResponse.parseAs<ChapterAjaxResponse>()
 
-            while (hasNextPage) {
-                val form = FormBody.Builder()
-                    .add("page", page.toString())
-                    .add("seriesPost", mangaId)
-                    .add("navCsrf", navCsrf)
-                    .build()
-
-                val apiResponse = client.newCall(
-                    POST(batchUrl, headers, form),
-                ).execute()
-
-                val apiData = apiResponse.parseAs<ChapterApiResponse>()
-
-                if (apiData.chapters.isEmpty()) {
-                    hasNextPage = false
-                } else {
-                    apiData.chapters.forEach { chapter ->
+            if (apiData.data.html.isEmpty() || !apiData.data.hasMore) {
+                hasNextPage = false
+            } else {
+                val fragment = org.jsoup.Jsoup.parseBodyFragment(apiData.data.html)
+                fragment.body().select("a.mn-detail-chapter-item").forEach { a ->
+                    val url = a.attr("abs:href").ifEmpty { a.attr("href") }
+                    if (url.isNotEmpty()) {
+                        val num = a.selectFirst(".mn-detail-chapter-name")?.text() ?: ""
+                        val extend = a.selectFirst(".mn-detail-chapter-extend")?.text() ?: ""
+                        val dateText = a.selectFirst(".mn-detail-chapter-date")?.text()
+                            ?.replace(HTML_TAG_REGEX, "")
+                            ?: ""
                         chapters.add(
                             SChapter.create().apply {
-                                setUrlWithoutDomain(chapter.link)
+                                setUrlWithoutDomain(url.substringAfter(baseUrl))
                                 name = buildString {
-                                    append("Capítulo ${chapter.name}")
-                                    if (chapter.nameExtend.isNotEmpty()) {
-                                        append(" - ${chapter.nameExtend}")
-                                    }
+                                    append("Capítulo $num")
+                                    if (extend.isNotEmpty()) append(" - $extend")
                                 }
-                                date_upload = dateFormat.tryParse(chapter.date.replace(HTML_TAG_REGEX, ""))
+                                date_upload = dateFormat.tryParse(dateText)
                             },
                         )
                     }
-                    page++
-                    if (page > totalPages) {
-                        hasNextPage = false
-                    }
                 }
-            }
-        } else {
-            // Old API method (fallback)
-            val getcapsJson = document.selectFirst("script:containsData(plotGetcaps)")?.data()
-            if (getcapsJson != null) {
-                val secret = SECRET_REGEX.find(getcapsJson)?.groupValues?.get(1)
-                    ?: throw Exception("No se pudo encontrar el secreto")
-
-                val apiUrl = REST_URL_REGEX.find(getcapsJson)?.groupValues?.get(1)?.replace("\\/", "/")
-                    ?: throw Exception("No se pudo encontrar la URL de la API")
-
-                var page = 1
-                var hasNextPage = true
-
-                while (hasNextPage) {
-                    val form = FormBody.Builder()
-                        .add("action", "plot_anti_hack")
-                        .add("page", page.toString())
-                        .add("mangaid", mangaId)
-                        .add("secret", secret)
-                        .build()
-
-                    val apiResponse = client.newCall(
-                        POST(apiUrl, headers, form),
-                    ).execute()
-
-                    val apiData = apiResponse.parseAs<ChapterApiResponse>()
-
-                    if (apiData.chapters.isEmpty()) {
-                        hasNextPage = false
-                    } else {
-                        apiData.chapters.forEach { chapter ->
-                            chapters.add(
-                                SChapter.create().apply {
-                                    setUrlWithoutDomain(chapter.link)
-                                    name = buildString {
-                                        append("Capítulo ${chapter.name}")
-                                        if (chapter.nameExtend.isNotEmpty()) {
-                                            append(" - ${chapter.nameExtend}")
-                                        }
-                                    }
-                                    date_upload = dateFormat.tryParse(chapter.date.replace(HTML_TAG_REGEX, ""))
-                                },
-                            )
-                        }
-                        page++
-                    }
-                }
+                page++
             }
         }
 
@@ -338,17 +255,12 @@ class PlotTwistNoFansub : HttpSource() {
     }
 
     private val dateFormat by lazy {
-        SimpleDateFormat("dd-MM-yyyy", Locale.ENGLISH)
+        SimpleDateFormat("MMMM d, yyyy", Locale("es"))
     }
 
     companion object {
         private val MANGA_ID_REGEX = Regex("""mnWpMangaId\s*=\s*(\d+)""")
         private val OLD_MANGA_ID_REGEX = Regex(""""manga_id"\s*:\s*"(\d+)"""")
-        private val TOTAL_PAGES_REGEX = Regex("""totalPageCount\s*=\s*(\d+)""")
-        private val SECRET_REGEX = Regex(""""secret"\s*:\s*"([^"]+)"""")
-        private val REST_URL_REGEX = Regex(""""restUrl"\s*:\s*"([^"]+)"""")
-        private val CSRF_REGEX = Regex(""""navCsrf"\s*:\s*"([^"]+)"""")
-        private val BATCH_URL_REGEX = Regex(""""batchUrl"\s*:\s*"([^"]+)"""")
         private val HTML_TAG_REGEX = Regex("<[^>]*>")
     }
 }

--- a/src/es/plottwistnofansub/src/eu/kanade/tachiyomi/extension/es/plottwistnofansub/PlotTwistNoFansub.kt
+++ b/src/es/plottwistnofansub/src/eu/kanade/tachiyomi/extension/es/plottwistnofansub/PlotTwistNoFansub.kt
@@ -173,7 +173,7 @@ class PlotTwistNoFansub : HttpSource() {
                     ?: ""
                 chapters.add(
                     SChapter.create().apply {
-                        setUrlWithoutDomain(url.substringAfter(baseUrl))
+                        setUrlWithoutDomain(url)
                         name = buildString {
                             append("Capítulo $num")
                             if (extend.isNotEmpty()) append(" - $extend")
@@ -205,7 +205,7 @@ class PlotTwistNoFansub : HttpSource() {
             if (apiData.data.html.isEmpty() || !apiData.data.hasMore) {
                 hasNextPage = false
             } else {
-                val fragment = org.jsoup.Jsoup.parseBodyFragment(apiData.data.html)
+                val fragment = org.jsoup.Jsoup.parseBodyFragment(apiData.data.html, baseUrl)
                 fragment.body().select("a.mn-detail-chapter-item").forEach { a ->
                     val url = a.attr("abs:href").ifEmpty { a.attr("href") }
                     if (url.isNotEmpty()) {
@@ -216,7 +216,7 @@ class PlotTwistNoFansub : HttpSource() {
                             ?: ""
                         chapters.add(
                             SChapter.create().apply {
-                                setUrlWithoutDomain(url.substringAfter(baseUrl))
+                                setUrlWithoutDomain(url)
                                 name = buildString {
                                     append("Capítulo $num")
                                     if (extend.isNotEmpty()) append(" - $extend")


### PR DESCRIPTION
## Changes

- Replace broken mnSeriesNavBundle/atchUrl with plot_load_chapters AJAX endpoint
- Update manga details selectors for new theme (mn-detail-*)
- Update popular/latest/search selector from page-listing-item to manga-grid-v2
- Update imports to keiyoushi.network.rateLimit with Kotlin Duration
- Replace 
etwork.cloudflareClient with 
etwork.client
- Add ChapterAjaxResponse DTO for new API format
- Bump version 14 -> 15

## Testing

Verified against live site:
- Popular: iblioteca3?m_orderby=trending ✅
- Latest: iblioteca3?m_orderby=latest3 ✅
- Search: ?s=query&post_type=wp-manga ✅
- Manga details: selectors match new theme ✅
- Chapters: AJAX loading works with plot_load_chapters ✅