### PR TITLE
utils: add binary utils

### DIFF
--- a/core/src/main/kotlin/keiyoushi/utils/Binary.kt
+++ b/core/src/main/kotlin/keiyoushi/utils/Binary.kt
@@ -72,6 +72,17 @@ fun ByteArray.writeIntBigEndian(offset: Int, value: Int) {
 fun ByteArray.readUShortLittleEndian(offset: Int): Int = (this[offset].toInt() and 0xFF) or ((this[offset + 1].toInt() and 0xFF) shl 8)
 
 /**
+ * Reads two bytes starting at [offset] as a big-endian unsigned 16-bit value, returned as an [Int].
+ *
+ * The byte at [offset] is the most significant; the byte at `offset + 1` is the least significant.
+ *
+ * @param offset the index of the first (most significant) byte to read
+ * @return the decoded value, in `0..65535`
+ * @throws IndexOutOfBoundsException if fewer than two bytes are available at [offset]
+ */
+fun ByteArray.readUShortBigEndian(offset: Int): Int = ((this[offset].toInt() and 0xFF) shl 8) or (this[offset + 1].toInt() and 0xFF)
+
+/**
  * Reads four bytes starting at [offset] as a little-endian unsigned 32-bit value, returned as a [Long].
  *
  * The byte at [offset] is the least significant; the byte at `offset + 3` is the most significant.

--- a/core/src/main/kotlin/keiyoushi/utils/Binary.kt
+++ b/core/src/main/kotlin/keiyoushi/utils/Binary.kt
@@ -1,0 +1,104 @@
+package keiyoushi.utils
+
+/**
+ * Reads four bytes starting at [offset] as a little-endian signed 32-bit [Int].
+ *
+ * The byte at [offset] is the least significant; the byte at `offset + 3` is the most significant.
+ *
+ * @param offset the index of the first (least significant) byte to read
+ * @return the decoded 32-bit value
+ * @throws IndexOutOfBoundsException if fewer than four bytes are available at [offset]
+ */
+fun ByteArray.readIntLittleEndian(offset: Int): Int = (this[offset].toInt() and 0xFF) or
+    ((this[offset + 1].toInt() and 0xFF) shl 8) or
+    ((this[offset + 2].toInt() and 0xFF) shl 16) or
+    ((this[offset + 3].toInt() and 0xFF) shl 24)
+
+/**
+ * Reads four bytes starting at [offset] as a big-endian signed 32-bit [Int].
+ *
+ * The byte at [offset] is the most significant; the byte at `offset + 3` is the least significant.
+ *
+ * @param offset the index of the first (most significant) byte to read
+ * @return the decoded 32-bit value
+ * @throws IndexOutOfBoundsException if fewer than four bytes are available at [offset]
+ */
+fun ByteArray.readIntBigEndian(offset: Int): Int = ((this[offset].toInt() and 0xFF) shl 24) or
+    ((this[offset + 1].toInt() and 0xFF) shl 16) or
+    ((this[offset + 2].toInt() and 0xFF) shl 8) or
+    (this[offset + 3].toInt() and 0xFF)
+
+/**
+ * Writes the signed 32-bit [value] as four little-endian bytes into this array, starting at [offset].
+ *
+ * The byte at [offset] is the least significant; the byte at `offset + 3` is the most significant.
+ *
+ * @param offset the index of the first (least significant) byte to write
+ * @param value the 32-bit value to encode
+ * @throws IndexOutOfBoundsException if fewer than four bytes are available at [offset]
+ */
+fun ByteArray.writeIntLittleEndian(offset: Int, value: Int) {
+    this[offset] = value.toByte()
+    this[offset + 1] = (value ushr 8).toByte()
+    this[offset + 2] = (value ushr 16).toByte()
+    this[offset + 3] = (value ushr 24).toByte()
+}
+
+/**
+ * Writes the signed 32-bit [value] as four big-endian bytes into this array, starting at [offset].
+ *
+ * The byte at [offset] is the most significant; the byte at `offset + 3` is the least significant.
+ *
+ * @param offset the index of the first (most significant) byte to write
+ * @param value the 32-bit value to encode
+ * @throws IndexOutOfBoundsException if fewer than four bytes are available at [offset]
+ */
+fun ByteArray.writeIntBigEndian(offset: Int, value: Int) {
+    this[offset] = (value ushr 24).toByte()
+    this[offset + 1] = (value ushr 16).toByte()
+    this[offset + 2] = (value ushr 8).toByte()
+    this[offset + 3] = value.toByte()
+}
+
+/**
+ * Reads two bytes starting at [offset] as a little-endian unsigned 16-bit value, returned as an [Int].
+ *
+ * The byte at [offset] is the least significant; the byte at `offset + 1` is the most significant.
+ *
+ * @param offset the index of the first (least significant) byte to read
+ * @return the decoded value, in `0..65535`
+ * @throws IndexOutOfBoundsException if fewer than two bytes are available at [offset]
+ */
+fun ByteArray.readUShortLittleEndian(offset: Int): Int = (this[offset].toInt() and 0xFF) or ((this[offset + 1].toInt() and 0xFF) shl 8)
+
+/**
+ * Reads four bytes starting at [offset] as a little-endian unsigned 32-bit value, returned as a [Long].
+ *
+ * The byte at [offset] is the least significant; the byte at `offset + 3` is the most significant.
+ *
+ * @param offset the index of the first (least significant) byte to read
+ * @return the decoded value, in `0..4294967295`
+ * @throws IndexOutOfBoundsException if fewer than four bytes are available at [offset]
+ */
+fun ByteArray.readUIntLittleEndian(offset: Int): Long = (this[offset].toLong() and 0xFF) or
+    ((this[offset + 1].toLong() and 0xFF) shl 8) or
+    ((this[offset + 2].toLong() and 0xFF) shl 16) or
+    ((this[offset + 3].toLong() and 0xFF) shl 24)
+
+/**
+ * Reads eight bytes starting at [offset] as a little-endian signed 64-bit [Long].
+ *
+ * The byte at [offset] is the least significant; the byte at `offset + 7` is the most significant.
+ *
+ * @param offset the index of the first (least significant) byte to read
+ * @return the decoded 64-bit value
+ * @throws IndexOutOfBoundsException if fewer than eight bytes are available at [offset]
+ */
+fun ByteArray.readLongLittleEndian(offset: Int): Long = (this[offset].toLong() and 0xFF) or
+    ((this[offset + 1].toLong() and 0xFF) shl 8) or
+    ((this[offset + 2].toLong() and 0xFF) shl 16) or
+    ((this[offset + 3].toLong() and 0xFF) shl 24) or
+    ((this[offset + 4].toLong() and 0xFF) shl 32) or
+    ((this[offset + 5].toLong() and 0xFF) shl 40) or
+    ((this[offset + 6].toLong() and 0xFF) shl 48) or
+    ((this[offset + 7].toLong() and 0xFF) shl 56)

--- a/src/ja/readerstore/src/eu/kanade/tachiyomi/extension/ja/readerstore/Decoder.kt
+++ b/src/ja/readerstore/src/eu/kanade/tachiyomi/extension/ja/readerstore/Decoder.kt
@@ -1,7 +1,7 @@
 package eu.kanade.tachiyomi.extension.ja.readerstore
 
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
+import keiyoushi.utils.readIntLittleEndian
+import keiyoushi.utils.writeIntLittleEndian
 
 class Decoder {
     private val schedule = IntArray(SCHEDULE_SIZE)
@@ -156,17 +156,14 @@ class Decoder {
     }
 
     private fun ByteArray.toLeIntArray(): IntArray {
-        val result = IntArray((size + 3) / 4)
-        val buffer = ByteBuffer.wrap(copyOf(result.size * 4)).order(ByteOrder.LITTLE_ENDIAN)
-        for (i in result.indices) result[i] = buffer.int
-        return result
+        val padded = copyOf((size + 3) / 4 * 4)
+        return IntArray(padded.size / 4) { padded.readIntLittleEndian(it * 4) }
     }
 
     private fun IntArray.toLeByteArray(byteSize: Int): ByteArray {
         val result = ByteArray(byteSize)
         val full = byteSize / 4
-        val buffer = ByteBuffer.wrap(result).order(ByteOrder.LITTLE_ENDIAN)
-        for (i in 0 until full) buffer.putInt(this[i])
+        for (i in 0 until full) result.writeIntLittleEndian(i * 4, this[i])
         val rem = byteSize and 3
         if (rem != 0) {
             val last = this[full]

--- a/src/ja/readerstore/src/eu/kanade/tachiyomi/extension/ja/readerstore/ImageInterceptor.kt
+++ b/src/ja/readerstore/src/eu/kanade/tachiyomi/extension/ja/readerstore/ImageInterceptor.kt
@@ -6,6 +6,7 @@ import android.graphics.Canvas
 import android.graphics.Rect
 import keiyoushi.utils.decodeHex
 import keiyoushi.utils.parseAs
+import keiyoushi.utils.readIntLittleEndian
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
@@ -180,14 +181,9 @@ class ImageInterceptor : Interceptor {
 
     private fun sliceEncryptedHeader(page: ByteArray): ByteArray {
         val start = HEADER_SIZE_PREFIX + MAC_SIZE
-        val end = page.leInt(0) + HEADER_SIZE_PREFIX
+        val end = page.readIntLittleEndian(0) + HEADER_SIZE_PREFIX
         return page.copyOfRange(start, end)
     }
-
-    private fun ByteArray.leInt(offset: Int): Int = (this[offset].toInt() and 0xFF) or
-        ((this[offset + 1].toInt() and 0xFF) shl 8) or
-        ((this[offset + 2].toInt() and 0xFF) shl 16) or
-        ((this[offset + 3].toInt() and 0xFF) shl 24)
 
     private fun parseScrambleOrder(decryptedHeader: ByteArray): Pair<Int, List<Int>> {
         if (decryptedHeader.size < SCRAMBLE_ORDER_OFFSET + 4) return 0 to emptyList()

--- a/src/pt/kuromangas/src/eu/kanade/tachiyomi/extension/pt/kuromangas/KuroMangasDecryptor.kt
+++ b/src/pt/kuromangas/src/eu/kanade/tachiyomi/extension/pt/kuromangas/KuroMangasDecryptor.kt
@@ -2,6 +2,8 @@ package eu.kanade.tachiyomi.extension.pt.kuromangas
 
 import android.util.Base64
 import keiyoushi.utils.parseAs
+import keiyoushi.utils.readIntBigEndian
+import keiyoushi.utils.readIntLittleEndian
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonObject
 import okhttp3.Interceptor
@@ -84,10 +86,7 @@ class Rabbit {
     fun setup(key: ByteArray, iv: ByteArray) {
         val kw = IntArray(4)
         for (i in 0 until 4) {
-            kw[i] = (key[i * 4 + 3].toInt() and 0xFF shl 24) or
-                (key[i * 4 + 2].toInt() and 0xFF shl 16) or
-                (key[i * 4 + 1].toInt() and 0xFF shl 8) or
-                (key[i * 4].toInt() and 0xFF)
+            kw[i] = key.readIntLittleEndian(i * 4)
         }
 
         x[0] = kw[0]
@@ -117,14 +116,8 @@ class Rabbit {
         }
 
         if (iv.isNotEmpty()) {
-            val iv0 = (iv[0].toInt() and 0xFF shl 24) or
-                (iv[1].toInt() and 0xFF shl 16) or
-                (iv[2].toInt() and 0xFF shl 8) or
-                (iv[3].toInt() and 0xFF)
-            val iv1 = (iv[4].toInt() and 0xFF shl 24) or
-                (iv[5].toInt() and 0xFF shl 16) or
-                (iv[6].toInt() and 0xFF shl 8) or
-                (iv[7].toInt() and 0xFF)
+            val iv0 = iv.readIntBigEndian(0)
+            val iv1 = iv.readIntBigEndian(4)
 
             fun swap(w: Int) = ((w and 0xFF) shl 24) or
                 ((w and 0xFF00) shl 8) or

--- a/src/vi/moetruyen/src/eu/kanade/tachiyomi/extension/vi/moetruyen/ImageDecryptor.kt
+++ b/src/vi/moetruyen/src/eu/kanade/tachiyomi/extension/vi/moetruyen/ImageDecryptor.kt
@@ -2,6 +2,8 @@ package eu.kanade.tachiyomi.extension.vi.moetruyen
 
 import android.util.Base64
 import keiyoushi.utils.parseAs
+import keiyoushi.utils.readIntBigEndian
+import keiyoushi.utils.readUShortBigEndian
 import kotlinx.serialization.Serializable
 import javax.crypto.Cipher
 import javax.crypto.spec.GCMParameterSpec
@@ -42,7 +44,7 @@ object ImageDecryptor {
             return decryptV3AesGcm(imgxData, grant, storageKey)
         }
 
-        val headerSize = (imgxData[6].toUByte().toInt() shl 8) or imgxData[7].toUByte().toInt()
+        val headerSize = imgxData.readUShortBigEndian(6)
         val headerBytes = imgxData.copyOfRange(8, 8 + headerSize)
         val header = String(headerBytes, Charsets.UTF_8).parseAs<ImgxV3Header>()
 
@@ -61,8 +63,8 @@ object ImageDecryptor {
     private fun decryptV3AesGcm(imgxData: ByteArray, grant: ImgxGrant, storageKey: String): ByteArray {
         require(imgxData.size > 41) { "IMGX v3 payload empty" }
 
-        val width = readUInt32(imgxData, 5)
-        val height = readUInt32(imgxData, 9)
+        val width = imgxData.readIntBigEndian(5)
+        val height = imgxData.readIntBigEndian(9)
         require(width > 0 && height > 0) { "IMGX dimensions invalid" }
 
         val key = unwrapContentKey(grant, storageKey)
@@ -168,14 +170,6 @@ object ImageDecryptor {
             .toByteArray(Charsets.UTF_8)
     }
 
-    private fun readUInt32(data: ByteArray, offset: Int): Int {
-        require(data.size >= offset + 4) { "IMGX header invalid" }
-        return (data[offset].toUByte().toInt() shl 24) or
-            (data[offset + 1].toUByte().toInt() shl 16) or
-            (data[offset + 2].toUByte().toInt() shl 8) or
-            data[offset + 3].toUByte().toInt()
-    }
-
     private fun deriveKeyFromString(input: String, length: Int): ByteArray {
         val key = ByteArray(length)
         var hash = fnv1a(input.toByteArray(Charsets.UTF_8))
@@ -230,10 +224,7 @@ object ImageDecryptor {
 
     private fun seedFromKey(key: ByteArray): UInt {
         require(key.size >= 4) { "IMGX key invalid" }
-        val seed = (key[0].toUByte().toUInt() shl 24) or
-            (key[1].toUByte().toUInt() shl 16) or
-            (key[2].toUByte().toUInt() shl 8) or
-            key[3].toUByte().toUInt()
+        val seed = key.readIntBigEndian(0).toUInt()
         return if (seed == 0u) GOLDEN_RATIO else seed
     }
 

--- a/src/vi/tuitruyen/src/eu/kanade/tachiyomi/extension/vi/tuitruyen/ImageDecryptor.kt
+++ b/src/vi/tuitruyen/src/eu/kanade/tachiyomi/extension/vi/tuitruyen/ImageDecryptor.kt
@@ -2,6 +2,8 @@ package eu.kanade.tachiyomi.extension.vi.tuitruyen
 
 import android.util.Base64
 import keiyoushi.utils.parseAs
+import keiyoushi.utils.readIntBigEndian
+import keiyoushi.utils.readUShortBigEndian
 import kotlinx.serialization.Serializable
 import javax.crypto.Cipher
 import javax.crypto.spec.GCMParameterSpec
@@ -42,7 +44,7 @@ object ImageDecryptor {
             return decryptV3AesGcm(imgxData, grant, storageKey)
         }
 
-        val headerSize = (imgxData[6].toUByte().toInt() shl 8) or imgxData[7].toUByte().toInt()
+        val headerSize = imgxData.readUShortBigEndian(6)
         val headerBytes = imgxData.copyOfRange(8, 8 + headerSize)
         val header = String(headerBytes, Charsets.UTF_8).parseAs<ImgxV3Header>()
 
@@ -61,8 +63,8 @@ object ImageDecryptor {
     private fun decryptV3AesGcm(imgxData: ByteArray, grant: ImgxGrant, storageKey: String): ByteArray {
         require(imgxData.size > 41) { "IMGX v3 payload empty" }
 
-        val width = readUInt32(imgxData, 5)
-        val height = readUInt32(imgxData, 9)
+        val width = imgxData.readIntBigEndian(5)
+        val height = imgxData.readIntBigEndian(9)
         require(width > 0 && height > 0) { "IMGX dimensions invalid" }
 
         val key = unwrapContentKey(grant, storageKey)
@@ -168,14 +170,6 @@ object ImageDecryptor {
             .toByteArray(Charsets.UTF_8)
     }
 
-    private fun readUInt32(data: ByteArray, offset: Int): Int {
-        require(data.size >= offset + 4) { "IMGX header invalid" }
-        return (data[offset].toUByte().toInt() shl 24) or
-            (data[offset + 1].toUByte().toInt() shl 16) or
-            (data[offset + 2].toUByte().toInt() shl 8) or
-            data[offset + 3].toUByte().toInt()
-    }
-
     private fun deriveKeyFromString(input: String, length: Int): ByteArray {
         val key = ByteArray(length)
         var hash = fnv1a(input.toByteArray(Charsets.UTF_8))
@@ -230,10 +224,7 @@ object ImageDecryptor {
 
     private fun seedFromKey(key: ByteArray): UInt {
         require(key.size >= 4) { "IMGX key invalid" }
-        val seed = (key[0].toUByte().toUInt() shl 24) or
-            (key[1].toUByte().toUInt() shl 16) or
-            (key[2].toUByte().toUInt() shl 8) or
-            key[3].toUByte().toUInt()
+        val seed = key.readIntBigEndian(0).toUInt()
         return if (seed == 0u) GOLDEN_RATIO else seed
     }
 

--- a/src/zh/happymh/src/eu/kanade/tachiyomi/extension/zh/happymh/Decoder.kt
+++ b/src/zh/happymh/src/eu/kanade/tachiyomi/extension/zh/happymh/Decoder.kt
@@ -1,10 +1,11 @@
 package eu.kanade.tachiyomi.extension.zh.happymh
 
 import android.util.Base64
+import keiyoushi.utils.decodeHex
+import keiyoushi.utils.writeIntBigEndian
 import okio.Buffer
 import okio.InflaterSource
 import okio.buffer
-import okio.source
 import java.security.MessageDigest
 import java.util.zip.Inflater
 
@@ -23,8 +24,8 @@ class Decoder {
 
         // key, nonce, and ciphertext from offsets
         val str = encryptedScans
-        val key = hexToBytes(str.substring(off1 + 8, off1 + 72))
-        val nonce = hexToBytes(str.substring(off1 + 72 + off2, off1 + 72 + off2 + 32))
+        val key = str.substring(off1 + 8, off1 + 72).decodeHex()
+        val nonce = str.substring(off1 + 72 + off2, off1 + 72 + off2 + 32).decodeHex()
         val ciphertext = Base64.decode(str.substring(off1 + 72 + off2 + 32 + off3), Base64.DEFAULT)
 
         // CTR: key (32) + nonce (16) + counter (4)
@@ -36,10 +37,7 @@ class Decoder {
         for (i in ciphertext.indices step 32) {
             val blockIdx = i / 32
             // counter from 48-51 positions
-            state[48] = (blockIdx ushr 24).toByte()
-            state[49] = (blockIdx ushr 16).toByte()
-            state[50] = (blockIdx ushr 8).toByte()
-            state[51] = blockIdx.toByte()
+            state.writeIntBigEndian(48, blockIdx)
 
             val keystream = sha256(state)
             val blockSize = minOf(32, ciphertext.size - i)
@@ -57,12 +55,6 @@ class Decoder {
     }
 
     private fun sha256(data: ByteArray) = MessageDigest.getInstance("SHA-256").digest(data)
-
-    private fun hexToBytes(hex: String): ByteArray = ByteArray(hex.length / 2).also { bytes ->
-        for (i in hex.indices step 2) {
-            bytes[i / 2] = hex.substring(i, i + 2).toInt(16).toByte()
-        }
-    }
 
     private fun zlibDecompress(data: ByteArray): ByteArray {
         val inflater = Inflater(true)

--- a/src/zh/happymh/src/eu/kanade/tachiyomi/extension/zh/happymh/Happymh.kt
+++ b/src/zh/happymh/src/eu/kanade/tachiyomi/extension/zh/happymh/Happymh.kt
@@ -3,11 +3,6 @@ package eu.kanade.tachiyomi.extension.zh.happymh
 import android.widget.Toast
 import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.extension.zh.happymh.ChapterByPageResponse
-import eu.kanade.tachiyomi.extension.zh.happymh.ChapterByPageResponseData
-import eu.kanade.tachiyomi.extension.zh.happymh.Decoder
-import eu.kanade.tachiyomi.extension.zh.happymh.PageListResponseDto
-import eu.kanade.tachiyomi.extension.zh.happymh.PopularResponseDto
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.source.ConfigurableSource
@@ -20,7 +15,6 @@ import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferences
 import keiyoushi.utils.parseAs
-import kotlinx.serialization.json.Json
 import okhttp3.Cookie
 import okhttp3.FormBody
 import okhttp3.Headers
@@ -32,7 +26,6 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.asResponseBody
 import rx.Observable
-import uy.kohesive.injekt.injectLazy
 
 const val PREF_KEY_CUSTOM_UA = "pref_key_custom_ua_"
 
@@ -42,12 +35,9 @@ class Happymh :
     override val name: String = "嗨皮漫画"
     override val lang: String = "zh"
     override val supportsLatest: Boolean = true
-
     override val baseUrl: String = "https://m.happymh.com"
-    private val json: Json by injectLazy()
 
     private val preferences = getPreferences()
-
     private val decoder = Decoder()
 
     init {


### PR DESCRIPTION
basically these methods converted to kotlin: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView
more can be added later if needed.

for [example](https://pl.kotl.in/nNQSQx9Sc): `ByteBuffer.wrap(arr).order(ByteOrder.LITTLE_ENDIAN).getInt(offset)` would do the same as the `readIntLittleEndian` but allocates a ByteBuffer on every call, has more call sites and is slower. Most sources are already using it like this, just moving to utils here.