### PR TITLE
Raijinscans: Fix chapter manifest load

### DIFF
--- a/src/fr/raijinscans/build.gradle
+++ b/src/fr/raijinscans/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Raijin Scans'
     extClass = '.RaijinScans'
-    extVersionCode = 66
+    extVersionCode = 67
     isNsfw = false
 }
 

--- a/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
+++ b/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
@@ -61,7 +61,7 @@ class RaijinScans :
     private val nonceRegex = """"nonce"\s*:\s*"([^"]+)"""".toRegex()
     private val numberRegex = """(\d+)""".toRegex()
     private val descriptionScriptRegex = """content\.innerHTML = `([\s\S]+?)`;""".toRegex()
-    private val manifestPushRegex = """push\((\{.*\})\);""".toRegex()
+    private val manifestObjectRegex = """(\{"m":"[\s\S]*\})""".toRegex()
     private val imageExtRegex = """\.(webp|jpe?g|png|gif|avif)""".toRegex(RegexOption.IGNORE_CASE)
     private val json: Json by lazy {
         Json {
@@ -267,17 +267,20 @@ class RaijinScans :
             .add("Origin", baseUrl)
             .build()
 
-        // window["rjfr_xxx"].push({
-        //   "m": "hex1|...",  // order of fragments
-        //   "c": {               // key-value pairs of b64 fragments
-        //     "hex1": "base64fragment1", ... }
-        // })
+        // The chapter HTML injects a manifest object into a window["rjfr_xxx"] array. The
+        // injection syntax has varied over time (e.g. `.push({...})` and `[…length] = {...}`),
+        // so we extract the object literal directly rather than depend on the surrounding code:
+        //   {
+        //     "m": "hex1|...",  // order of fragments
+        //     "c": {               // key-value pairs of b64 fragments
+        //       "hex1": "base64fragment1", ... }
+        //   }
         // config = m.split("|").map { key -> c[key] }.joinToString("") -> Base64 decode
 
         val manifestScript = document.select("script").find { it.data().contains("rjfr_") }
             ?: throw Exception("No reader manifest found. Open the chapter in WebView.")
         val scriptData = manifestScript.data()
-        val match = manifestPushRegex.find(scriptData) ?: throw Exception("Invalid manifest format")
+        val match = manifestObjectRegex.find(scriptData) ?: throw Exception("Invalid manifest format")
 
         val manifestJson = match.groupValues[1].parseAs<JsonObject>()
         val mOrder = manifestJson["m"]!!.jsonPrimitive.content.split("|")


### PR DESCRIPTION
The site changed how it injects the reader manifest into the chapter page. It used to push the {m, c} object onto the window["rjfr_xxx"] array

Closes : #16717

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
