### PR TITLE
Fix Mangadotnet empty filter results

### DIFF
--- a/src/en/mangadotnet/build.gradle
+++ b/src/en/mangadotnet/build.gradle
@@ -1,7 +1,7 @@
 ext {
 	extName = 'Mangadotnet'
 	extClass = '.Mangadotnet'
-	extVersionCode = 10
+	extVersionCode = 11
 	isNsfw = true
 }
 

--- a/src/en/mangadotnet/src/eu/kanade/tachiyomi/extension/en/mangadotnet/Dto.kt
+++ b/src/en/mangadotnet/src/eu/kanade/tachiyomi/extension/en/mangadotnet/Dto.kt
@@ -21,13 +21,13 @@ class Data<T>(
 @Serializable
 class MangaList(
     @JsonNames("results", "manga_list")
-    val mangaList: List<BrowseManga>,
-    private val pagination: Pagination,
+    val mangaList: List<BrowseManga>? = emptyList(),
+    private val pagination: Pagination? = null,
     val allGenres: List<String> = emptyList(),
 ) {
     fun hasNextPage() = when {
-        pagination.current != null && pagination.total != null -> pagination.current < pagination.total
-        pagination.nextCursor != null -> true
+        pagination?.current != null && pagination.total != null -> pagination.current < pagination.total
+        pagination?.nextCursor != null -> true
         else -> false
     }
 

--- a/src/en/mangadotnet/src/eu/kanade/tachiyomi/extension/en/mangadotnet/Mangadotnet.kt
+++ b/src/en/mangadotnet/src/eu/kanade/tachiyomi/extension/en/mangadotnet/Mangadotnet.kt
@@ -162,7 +162,7 @@ class Mangadotnet :
         updateGenres(data.allGenres)
 
         return MangasPage(
-            data.data.mangaList.map { it.toSManga(baseUrl) },
+            data.data.mangaList.orEmpty().map { it.toSManga(baseUrl) },
             data.data.hasNextPage(),
         )
     }
@@ -335,7 +335,7 @@ class Mangadotnet :
         val data = response.decodeRscAs<Data<MangaList>>().data
         updateGenres(data.allGenres)
 
-        return MangasPage(data.mangaList.map { it.toSManga(baseUrl) }, data.hasNextPage())
+        return MangasPage(data.mangaList.orEmpty().map { it.toSManga(baseUrl) }, data.hasNextPage())
     }
 
     // ============================== Details ==============================


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

Fixes Mangadotnet search/filter crash when the default filter request returns `results: null` and `pagination: null`.

The extension now treats null results as an empty list and null pagination as no next page, allowing the filter UI/search page to load normally.