### PR TITLE
(lib) e4p: refactor

### DIFF
--- a/lib/e4p/src/keiyoushi/lib/e4p/E4PDecoder.kt
+++ b/lib/e4p/src/keiyoushi/lib/e4p/E4PDecoder.kt
@@ -2,13 +2,13 @@ package keiyoushi.lib.e4p
 
 import android.util.Base64
 import keiyoushi.utils.decodeProto
+import keiyoushi.utils.inflate
 import keiyoushi.utils.rc4
-import okio.Buffer
-import okio.InflaterSource
-import okio.buffer
+import keiyoushi.utils.readIntBigEndian
+import keiyoushi.utils.readIntLittleEndian
+import keiyoushi.utils.writeIntBigEndian
 import org.kotlincrypto.hash.blake2.BLAKE2b
 import java.security.MessageDigest
-import java.util.zip.Inflater
 
 class DecodedManifest(val pub: ProtoPub, val pbexSeed: ByteArray?)
 
@@ -34,7 +34,7 @@ class E4PDecoder {
 
         val inflated = when (wrapper.dataType) {
             DataType.PROTOPUB -> payload
-            DataType.PROTOPUB_ZLIB -> zlibInflate(payload)
+            DataType.PROTOPUB_ZLIB -> payload.inflate()
             else -> throw Exception("Unsupported dataType: ${wrapper.dataType}")
         }
 
@@ -162,17 +162,6 @@ class E4PDecoder {
         return key
     }
 
-    private fun zlibInflate(data: ByteArray): ByteArray {
-        val inflater = Inflater()
-        return try {
-            val buffer = Buffer().write(data)
-            val inflated = InflaterSource(buffer, inflater).buffer()
-            inflated.readByteArray()
-        } finally {
-            inflater.end()
-        }
-    }
-
     companion object {
         // vA6 table in drm_worker.js, 19-byte XOR-mask table
         private val A6 = intArrayOf(
@@ -208,19 +197,14 @@ class E4PDecoder {
             0xAD.toByte(),
         )
 
-        private fun le32(b: ByteArray, off: Int): Int = (b[off].toInt() and 0xFF) or
-            ((b[off + 1].toInt() and 0xFF) shl 8) or
-            ((b[off + 2].toInt() and 0xFF) shl 16) or
-            ((b[off + 3].toInt() and 0xFF) shl 24)
-
         // Blowfish-CBC decrypt with custom P-array and S-boxes (drm_worker.js)
         private class BlowfishTables(val p: IntArray, val s: Array<IntArray>)
 
         private val BLOWFISH: BlowfishTables by lazy {
             val sBytes = rc4(UNDEFINED_KEY, Base64.decode(BLOWFISH_S_B64, Base64.NO_WRAP), 769)
             val pBytes = rc4(UNDEFINED_KEY, Base64.decode(BLOWFISH_P_B64, Base64.NO_WRAP), 769)
-            val p = IntArray(18) { i -> le32(pBytes, i * 4) }
-            val s = Array(4) { box -> IntArray(256) { i -> le32(sBytes, (box * 256 + i) * 4) } }
+            val p = IntArray(18) { i -> pBytes.readIntLittleEndian(i * 4) }
+            val s = Array(4) { box -> IntArray(256) { i -> sBytes.readIntLittleEndian((box * 256 + i) * 4) } }
             BlowfishTables(p, s)
         }
 
@@ -232,19 +216,19 @@ class E4PDecoder {
             val t = BLOWFISH
 
             // IV split into two big-endian uint32s
-            var prevL = be32(iv, 0)
-            var prevR = be32(iv, 4)
+            var prevL = iv.readIntBigEndian(0)
+            var prevR = iv.readIntBigEndian(4)
 
             val out = ByteArray(ciphertext.size)
             var off = 0
             while (off < ciphertext.size) {
-                val cl = be32(ciphertext, off)
-                val cr = be32(ciphertext, off + 4)
+                val cl = ciphertext.readIntBigEndian(off)
+                val cr = ciphertext.readIntBigEndian(off + 4)
                 val (dl, dr) = blowfishDecryptBlock(cl, cr, t)
                 val pl = dl xor prevL
                 val pr = dr xor prevR
-                writeBe32(out, off, pl)
-                writeBe32(out, off + 4, pr)
+                out.writeIntBigEndian(off, pl)
+                out.writeIntBigEndian(off + 4, pr)
                 prevL = cl
                 prevR = cr
                 off += 8
@@ -288,18 +272,6 @@ class E4PDecoder {
             val c = (x ushr 8) and 0xFF
             val d = x and 0xFF
             return ((t.s[0][a] + t.s[1][b]) xor t.s[2][c]) + t.s[3][d]
-        }
-
-        private fun be32(buf: ByteArray, off: Int): Int = ((buf[off].toInt() and 0xFF) shl 24) or
-            ((buf[off + 1].toInt() and 0xFF) shl 16) or
-            ((buf[off + 2].toInt() and 0xFF) shl 8) or
-            (buf[off + 3].toInt() and 0xFF)
-
-        private fun writeBe32(buf: ByteArray, off: Int, v: Int) {
-            buf[off] = (v ushr 24).toByte()
-            buf[off + 1] = (v ushr 16).toByte()
-            buf[off + 2] = (v ushr 8).toByte()
-            buf[off + 3] = v.toByte()
         }
 
         // vA0_0x5cc756.Er

--- a/lib/e4p/src/keiyoushi/lib/e4p/E4PInterceptor.kt
+++ b/lib/e4p/src/keiyoushi/lib/e4p/E4PInterceptor.kt
@@ -1,6 +1,7 @@
 package keiyoushi.lib.e4p
 
 import keiyoushi.utils.decodeHex
+import keiyoushi.utils.readIntLittleEndian
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Protocol
@@ -8,30 +9,23 @@ import okhttp3.Response
 import okhttp3.ResponseBody.Companion.asResponseBody
 import okio.Buffer
 import java.io.IOException
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
 
 // drm_worker.js f128 + wasm xebp_render
 class E4PInterceptor : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
-        val response = chain.proceed(request)
-        val url = request.url
-        val fragmentParts = url.fragment?.split("\n")
+        val fragmentParts = request.url.fragment?.split("\n")
         val qscKey = fragmentParts?.firstOrNull()
 
-        if (qscKey.isNullOrEmpty() || !response.isSuccessful) {
-            return response
-        }
+        if (qscKey.isNullOrEmpty()) return chain.proceed(request)
 
-        response.close()
-
-        val dirRequest = request.newBuilder()
-            .header("Range", "bytes=0-${QscArchive.DIR_SIZE - 1}")
-            .build()
-
-        val dirResponse = chain.proceed(dirRequest)
-        val dirBytes = dirResponse.body.bytes().also { dirResponse.close() }
+        val dirResponse = chain.proceed(
+            request.newBuilder()
+                .header("Range", "bytes=0-${QscArchive.DIR_SIZE - 1}")
+                .build(),
+        )
+        if (!dirResponse.isSuccessful) return dirResponse
+        val dirBytes = dirResponse.body.bytes()
 
         val entry = QscArchive.findEntry(dirBytes, qscKey)
             ?: throw IOException("QSC file not found: $qscKey")
@@ -43,7 +37,7 @@ class E4PInterceptor : Interceptor {
             .build()
 
         val fileResponse = chain.proceed(fileRequest)
-        val xebpBytes = fileResponse.body.bytes().also { fileResponse.close() }
+        val xebpBytes = fileResponse.body.bytes()
 
         val ctx = if (fragmentParts.size == 5) {
             XebpContext(
@@ -55,13 +49,12 @@ class E4PInterceptor : Interceptor {
         } else {
             null
         }
-        val (finalBytes, mediaType) = if (ctx != null) {
-            XebpDecoder.decrypt(xebpBytes, ctx) to WEBP_MEDIA_TYPE
-        } else {
-            stripToWebp(xebpBytes) to WEBP_MEDIA_TYPE
-        }
 
-        val body = Buffer().apply { write(finalBytes) }.asResponseBody(mediaType, finalBytes.size.toLong())
+        val body = if (ctx != null) {
+            XebpDecoder.decrypt(xebpBytes, ctx)
+        } else {
+            stripToWebp(xebpBytes)
+        }.let { it.asResponseBody(WEBP_MEDIA_TYPE, it.size) }
 
         return fileResponse.newBuilder()
             .removeHeader("Content-Range")
@@ -73,29 +66,21 @@ class E4PInterceptor : Interceptor {
             .build()
     }
 
-    private fun stripToWebp(xebp: ByteArray): ByteArray {
-        if (xebp.size < 20 ||
-            xebp[0] != 'R'.code.toByte() || xebp[1] != 'I'.code.toByte() ||
-            xebp[2] != 'F'.code.toByte() || xebp[3] != 'F'.code.toByte()
-        ) {
-            return xebp
-        }
+    private fun stripToWebp(xebp: ByteArray): Buffer {
+        val out = Buffer()
+        val isRiff = xebp.size >= 20 &&
+            xebp[0] == 'R'.code.toByte() && xebp[1] == 'I'.code.toByte() &&
+            xebp[2] == 'F'.code.toByte() && xebp[3] == 'F'.code.toByte()
+        if (!isRiff) return out.write(xebp)
 
-        val vp8Size = ByteBuffer.wrap(xebp, 16, 4)
-            .order(ByteOrder.LITTLE_ENDIAN).int
+        val vp8Size = xebp.readIntLittleEndian(16)
         val webpEnd = 20 + vp8Size + (vp8Size and 1)
-        if (webpEnd > xebp.size) return xebp
+        if (webpEnd > xebp.size) return out.write(xebp)
 
-        val out = xebp.copyOf(webpEnd)
-        val newRiffSize = webpEnd - 8
-        out[4] = (newRiffSize and 0xFF).toByte()
-        out[5] = ((newRiffSize ushr 8) and 0xFF).toByte()
-        out[6] = ((newRiffSize ushr 16) and 0xFF).toByte()
-        out[7] = ((newRiffSize ushr 24) and 0xFF).toByte()
-        out[8] = 'W'.code.toByte()
-        out[9] = 'E'.code.toByte()
-        out[10] = 'B'.code.toByte()
-        out[11] = 'P'.code.toByte()
+        out.writeUtf8("RIFF")
+        out.writeIntLe(webpEnd - 8)
+        out.writeUtf8("WEBP")
+        out.write(xebp, 12, webpEnd - 12)
         return out
     }
 
@@ -142,10 +127,7 @@ object QscArchive {
         var runningOffset = 0
         for (i in 0 until ENTRY_COUNT) {
             val base = 32 + i * ENTRY_SIZE
-            val size = (directory[base + 4].toInt() and 0xFF) or
-                ((directory[base + 5].toInt() and 0xFF) shl 8) or
-                ((directory[base + 6].toInt() and 0xFF) shl 16) or
-                ((directory[base + 7].toInt() and 0xFF) shl 24)
+            val size = directory.readIntLittleEndian(base + 4)
             if (size == 0) break
             val fourCC = String(directory, base, 4, Charsets.ISO_8859_1)
             val rawName = String(directory, base + 8, 24, Charsets.ISO_8859_1)

--- a/lib/e4p/src/keiyoushi/lib/e4p/E4PManifestReader.kt
+++ b/lib/e4p/src/keiyoushi/lib/e4p/E4PManifestReader.kt
@@ -37,10 +37,10 @@ class E4PManifestReader(private val client: OkHttpClient, private val requestHea
             ) {
                 val xebpFragment = listOf(
                     withAuth.fragment.orEmpty(),
-                    XebpDecoder.hex(iv),
+                    iv.toHexString(),
                     ticketBytes.contentId,
-                    XebpDecoder.hex(consumerId),
-                    XebpDecoder.hex(decoded.pbexSeed),
+                    consumerId.toHexString(),
+                    decoded.pbexSeed.toHexString(),
                 ).joinToString("\n")
                 withAuth.newBuilder().fragment(xebpFragment).build()
             } else {

--- a/lib/e4p/src/keiyoushi/lib/e4p/TiffDecoder.kt
+++ b/lib/e4p/src/keiyoushi/lib/e4p/TiffDecoder.kt
@@ -1,13 +1,14 @@
 package keiyoushi.lib.e4p
 
+import keiyoushi.utils.readIntLittleEndian
+import keiyoushi.utils.readUShortLittleEndian
 import okio.Buffer
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
+import okio.BufferedSink
 
 // https://cs.opensource.google/go/x/image
 // https://pkg.go.dev/golang.org/x/image/tiff/lzw
 object TiffDecoder {
-    class RgbaImage(val width: Int, val height: Int, val rgba: ByteArray)
+    class Argb8888(val width: Int, val height: Int, val pixels: IntArray)
 
     // TIFF tags we care about
     private const val TAG_IMAGE_WIDTH = 256
@@ -29,15 +30,13 @@ object TiffDecoder {
     private const val TYPE_LONG = 4
     private const val TYPE_RATIONAL = 5
 
-    fun decode(tiff: ByteArray): RgbaImage {
+    fun decode(tiff: ByteArray): Argb8888 {
         require(tiff.size >= 8) { "TIFF too small: ${tiff.size}" }
         require(tiff[0] == 0x49.toByte() && tiff[1] == 0x49.toByte()) { "TIFF must be little-endian" }
         require(tiff[2] == 0x2A.toByte() && tiff[3] == 0x00.toByte()) { "TIFF magic mismatch" }
 
-        val bb = ByteBuffer.wrap(tiff).order(ByteOrder.LITTLE_ENDIAN)
-        val ifdOffset = bb.getInt(4)
-
-        val numEntries = bb.getShort(ifdOffset).toInt() and 0xFFFF
+        val ifdOffset = tiff.readIntLittleEndian(4)
+        val numEntries = tiff.readUShortLittleEndian(ifdOffset)
 
         var width = 0
         var height = 0
@@ -53,12 +52,12 @@ object TiffDecoder {
 
         for (i in 0 until numEntries) {
             val entryOff = ifdOffset + 2 + i * 12
-            val tag = bb.getShort(entryOff).toInt() and 0xFFFF
-            val type = bb.getShort(entryOff + 2).toInt() and 0xFFFF
-            val count = bb.getInt(entryOff + 4)
+            val tag = tiff.readUShortLittleEndian(entryOff)
+            val type = tiff.readUShortLittleEndian(entryOff + 2)
+            val count = tiff.readIntLittleEndian(entryOff + 4)
             val valueOff = entryOff + 8
 
-            val readValue = { readValues(bb, type, count, valueOff) }
+            val readValue = { readValues(tiff, type, count, valueOff) }
 
             when (tag) {
                 TAG_IMAGE_WIDTH -> width = readValue().first()
@@ -88,31 +87,29 @@ object TiffDecoder {
         val h = height
         val spp = samplesPerPixel
 
-        val decompressedStrips = stripOffsets.indices.map { i ->
-            val raw = ByteArray(stripByteCounts[i])
-            System.arraycopy(tiff, stripOffsets[i], raw, 0, stripByteCounts[i])
-            if (compression == 5) decompressLzw(raw) else raw
-        }
-        val rawBytes = ByteArray(decompressedStrips.sumOf { it.size })
-        var dst = 0
-        for (strip in decompressedStrips) {
-            System.arraycopy(strip, 0, rawBytes, dst, strip.size)
-            dst += strip.size
+        val rawBytes: ByteArray = if (stripOffsets.size == 1 && compression == 1) {
+            val off = stripOffsets[0]
+            tiff.copyOfRange(off, off + stripByteCounts[0])
+        } else {
+            val out = Buffer()
+            for (i in stripOffsets.indices) {
+                val start = stripOffsets[i]
+                val end = start + stripByteCounts[i]
+                if (compression == 5) {
+                    decompressLzw(out, tiff, start, end)
+                } else {
+                    out.write(tiff, start, end - start)
+                }
+            }
+            out.readByteArray()
         }
 
         if (predictor == 2) {
             val rowBytes = w * spp
-            @Suppress("EmptyRange")
             for (row in 0 until h) {
-                val rs = row * rowBytes
-                for (x in 1 until w) {
-                    for (c in 0 until spp) {
-                        rawBytes[rs + x * spp + c] =
-                            (
-                                (rawBytes[rs + (x - 1) * spp + c].toInt() and 0xFF) +
-                                    (rawBytes[rs + x * spp + c].toInt() and 0xFF)
-                                ).toByte()
-                    }
+                val rowStart = row * rowBytes
+                for (i in rowStart + spp until rowStart + rowBytes) {
+                    rawBytes[i] = (rawBytes[i] + rawBytes[i - spp]).toByte()
                 }
             }
         }
@@ -131,23 +128,20 @@ object TiffDecoder {
         bps: IntArray,
         spp: Int,
         raw: ByteArray,
-    ): RgbaImage {
+    ): Argb8888 {
         require(bps.all { it == 8 }) { "RGB TIFF: only 8bps supported, got ${bps.toList()}" }
         require(spp == 3 || spp == 4) { "RGB TIFF: spp must be 3 or 4, got $spp" }
 
-        val hasAlpha = spp == 4
-        val rgba = ByteArray(width * height * 4)
+        val pixels = IntArray(width * height)
         var src = 0
-        var dst = 0
-        (0 until width * height).forEach { _ ->
-            rgba[dst] = raw[src] // R
-            rgba[dst + 1] = raw[src + 1] // G
-            rgba[dst + 2] = raw[src + 2] // B
-            rgba[dst + 3] = if (hasAlpha) raw[src + 3] else 0xFF.toByte()
+        for (p in 0 until width * height) {
+            val r = raw[src].toInt() and 0xFF
+            val g = raw[src + 1].toInt() and 0xFF
+            val b = raw[src + 2].toInt() and 0xFF
+            pixels[p] = (0xFF shl 24) or (r shl 16) or (g shl 8) or b
             src += spp
-            dst += 4
         }
-        return RgbaImage(width, height, rgba)
+        return Argb8888(width, height, pixels)
     }
 
     private fun decodeGrayscale(
@@ -157,25 +151,19 @@ object TiffDecoder {
         spp: Int,
         raw: ByteArray,
         invert: Boolean,
-    ): RgbaImage {
+    ): Argb8888 {
         require(bps.size == 1 && bps[0] == 8) { "Grayscale: only 8bps supported" }
         require(spp == 1 || spp == 2) { "Grayscale: spp must be 1 or 2, got $spp" }
 
-        val hasAlpha = spp == 2
-        val rgba = ByteArray(width * height * 4)
+        val pixels = IntArray(width * height)
         var src = 0
-        var dst = 0
-        (0 until width * height).forEach { _ ->
-            val v = if (invert) (raw[src].toInt() and 0xFF).inv() and 0xFF else raw[src].toInt() and 0xFF
-            val b = v.toByte()
-            rgba[dst] = b
-            rgba[dst + 1] = b
-            rgba[dst + 2] = b
-            rgba[dst + 3] = if (hasAlpha) raw[src + 1] else 0xFF.toByte()
+        for (p in 0 until width * height) {
+            var v = raw[src].toInt() and 0xFF
+            if (invert) v = v.inv() and 0xFF
+            pixels[p] = (0xFF shl 24) or (v shl 16) or (v shl 8) or v
             src += spp
-            dst += 4
         }
-        return RgbaImage(width, height, rgba)
+        return Argb8888(width, height, pixels)
     }
 
     private fun decodePalette(
@@ -185,7 +173,7 @@ object TiffDecoder {
         spp: Int,
         raw: ByteArray,
         colorMap: IntArray,
-    ): RgbaImage {
+    ): Argb8888 {
         require(bps.size == 1 && bps[0] == 8) { "Palette: only 8bps supported" }
         require(spp == 1) { "Palette: spp must be 1, got $spp" }
         // Palette: 3 * 2^bits entries, each uint16. Order: all reds, then all greens, then all blues
@@ -194,20 +182,18 @@ object TiffDecoder {
             "ColorMap size mismatch: ${colorMap.size} vs ${3 * nColors}"
         }
 
-        val rgba = ByteArray(width * height * 4)
-        var dst = 0
-        for (src in 0 until width * height) {
-            val idx = raw[src].toInt() and 0xFF
-            rgba[dst] = (colorMap[idx] ushr 8).toByte()
-            rgba[dst + 1] = (colorMap[nColors + idx] ushr 8).toByte()
-            rgba[dst + 2] = (colorMap[2 * nColors + idx] ushr 8).toByte()
-            rgba[dst + 3] = 0xFF.toByte()
-            dst += 4
+        val pixels = IntArray(width * height)
+        for (p in 0 until width * height) {
+            val idx = raw[p].toInt() and 0xFF
+            val r = (colorMap[idx] ushr 8) and 0xFF
+            val g = (colorMap[nColors + idx] ushr 8) and 0xFF
+            val b = (colorMap[2 * nColors + idx] ushr 8) and 0xFF
+            pixels[p] = (0xFF shl 24) or (r shl 16) or (g shl 8) or b
         }
-        return RgbaImage(width, height, rgba)
+        return Argb8888(width, height, pixels)
     }
 
-    private fun readValues(bb: ByteBuffer, type: Int, count: Int, valueOff: Int): IntArray {
+    private fun readValues(tiff: ByteArray, type: Int, count: Int, valueOff: Int): IntArray {
         val elemSize = when (type) {
             TYPE_BYTE, TYPE_ASCII -> 1
             TYPE_SHORT -> 2
@@ -216,45 +202,45 @@ object TiffDecoder {
             else -> throw Exception("Unsupported TIFF type: $type")
         }
         val totalSize = elemSize * count
-        val base = if (totalSize <= 4) valueOff else bb.getInt(valueOff)
+        val base = if (totalSize <= 4) valueOff else tiff.readIntLittleEndian(valueOff)
 
         val out = IntArray(count)
         for (i in 0 until count) {
             out[i] = when (type) {
-                TYPE_BYTE -> bb.get(base + i).toInt() and 0xFF
-                TYPE_SHORT -> bb.getShort(base + i * 2).toInt() and 0xFFFF
-                TYPE_LONG -> bb.getInt(base + i * 4)
+                TYPE_BYTE -> tiff[base + i].toInt() and 0xFF
+                TYPE_SHORT -> tiff.readUShortLittleEndian(base + i * 2)
+                TYPE_LONG -> tiff.readIntLittleEndian(base + i * 4)
                 else -> throw Exception("Unexpected type in readValues: $type")
             }
         }
         return out
     }
 
-    private fun decompressLzw(input: ByteArray): ByteArray {
-        val out = Buffer()
-
+    private fun decompressLzw(sink: BufferedSink, input: ByteArray, start: Int, end: Int) {
         val clearCode = 256
         val eoiCode = 257
 
-        // Dictionary: each entry is a byte sequence
-        // Pre-fill 0..255 with single-byte values; 256 and 257 are reserved
-        val dict = ArrayList<ByteArray>(4096)
-        for (i in 0 until 256) dict.add(byteArrayOf(i.toByte()))
-        dict.add(ByteArray(0)) // 256 = clear
-        dict.add(ByteArray(0)) // 257 = eoi
+        // Dictionary as prefix-link + suffix-byte per code; strings rebuilt via the stack
+        val prefix = IntArray(4096)
+        val suffix = ByteArray(4096)
+        val stack = ByteArray(4096)
+        for (i in 0 until 256) suffix[i] = i.toByte()
+
+        var nextCode = 258
+        var codeWidth = 9
+        var prevCode = -1
+        var firstByte = 0
 
         var bitBuf = 0L
         var bitCount = 0
-        var inputPos = 0
-        var codeWidth = 9
-        var prevCode = -1
+        var inputPos = start
 
         while (true) {
             // Refill bit buffer until we have enough bits for one code
             while (bitCount < codeWidth) {
-                if (inputPos >= input.size) {
+                if (inputPos >= end) {
                     // Stream ended without EOI, treat as clean end
-                    return out.readByteArray()
+                    return
                 }
                 bitBuf = (bitBuf shl 8) or (input[inputPos].toLong() and 0xFF)
                 inputPos++
@@ -266,43 +252,59 @@ object TiffDecoder {
 
             if (code == eoiCode) break
             if (code == clearCode) {
-                while (dict.size > 258) dict.removeAt(dict.size - 1)
+                nextCode = 258
                 codeWidth = 9
                 prevCode = -1
                 continue
             }
 
-            val entry: ByteArray = when {
-                code < dict.size -> dict[code]
-                code == dict.size && prevCode >= 0 -> {
-                    // KwKwK case: code == nextAvailable
-                    val prev = dict[prevCode]
-                    val ext = ByteArray(prev.size + 1)
-                    System.arraycopy(prev, 0, ext, 0, prev.size)
-                    ext[prev.size] = prev[0]
-                    ext
+            var sp = 0
+            when {
+                code < nextCode -> {
+                    var c = code
+                    while (c >= 256) {
+                        stack[sp++] = suffix[c]
+                        c = prefix[c]
+                    }
+                    firstByte = c
+                    stack[sp++] = c.toByte()
                 }
-                else -> throw Exception(
-                    "LZW invalid code $code (dict size ${dict.size}, prev $prevCode)",
-                )
+                code == nextCode && prevCode >= 0 -> {
+                    // KwKwK: string == previous string + its own first byte
+                    stack[sp++] = firstByte.toByte()
+                    var c = prevCode
+                    while (c >= 256) {
+                        stack[sp++] = suffix[c]
+                        c = prefix[c]
+                    }
+                    firstByte = c
+                    stack[sp++] = c.toByte()
+                }
+                else -> throw Exception("LZW invalid code $code (next $nextCode, prev $prevCode)")
             }
-            out.write(entry)
 
-            // Add new dictionary entry: prevEntry + entry[0]
-            if (prevCode >= 0 && dict.size < 4096) {
-                val prev = dict[prevCode]
-                val newEntry = ByteArray(prev.size + 1)
-                System.arraycopy(prev, 0, newEntry, 0, prev.size)
-                newEntry[prev.size] = entry[0]
-                dict.add(newEntry)
+            // stack holds the string reversed
+            var lo = 0
+            var hi = sp - 1
+            while (lo < hi) {
+                val t = stack[lo]
+                stack[lo] = stack[hi]
+                stack[hi] = t
+                lo++
+                hi--
+            }
+            sink.write(stack, 0, sp)
 
-                // TIFF "early change"
-                if (dict.size == (1 shl codeWidth) - 1 && codeWidth < 12) {
+            // New entry = prevString + firstByte(currentString); TIFF "early change" width bump
+            if (prevCode >= 0 && nextCode < 4096) {
+                prefix[nextCode] = prevCode
+                suffix[nextCode] = firstByte.toByte()
+                nextCode++
+                if (nextCode == (1 shl codeWidth) - 1 && codeWidth < 12) {
                     codeWidth++
                 }
             }
             prevCode = code
         }
-        return out.readByteArray()
     }
 }

--- a/lib/e4p/src/keiyoushi/lib/e4p/XebpDecoder.kt
+++ b/lib/e4p/src/keiyoushi/lib/e4p/XebpDecoder.kt
@@ -1,13 +1,12 @@
 package keiyoushi.lib.e4p
 
 import android.graphics.Bitmap
-import android.graphics.Bitmap.createBitmap
+import android.graphics.BitmapFactory
 import android.graphics.BitmapFactory.decodeByteArray
-import android.graphics.Canvas
 import keiyoushi.utils.decodeHex
+import keiyoushi.utils.readIntLittleEndian
+import keiyoushi.utils.writeIntLittleEndian
 import okio.Buffer
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
 
 // XEBP watermark remover
 // Watermark also contains a barcode to identify the user.
@@ -20,23 +19,22 @@ object XebpDecoder {
     // TIFF little-endian magic "II*\x00", must appear after tfix decrypt
     private val TIFF_MAGIC_LE = byteArrayOf(0x49, 0x49, 0x2A, 0x00)
 
-    fun decrypt(xebpBytes: ByteArray, ctx: XebpContext): ByteArray {
+    fun decrypt(xebpBytes: ByteArray, ctx: XebpContext): Buffer {
         val container = parseContainer(xebpBytes)
         val zstrMeta = parseZstr(container.zstr)
-        val encryptedPayload = ctx.pbexSeed.copyOfRange(16, 48)
-        val perImageKey = ByteArray(32) { i ->
-            (encryptedPayload[i].toInt() xor ctx.iv[i].toInt()).toByte()
+        val perImageKey = ByteArray(32) {
+            (ctx.pbexSeed[16 + it].toInt() xor ctx.iv[it].toInt()).toByte()
         }
 
         // WASM f_ln(c+80, ..., 1821454, ...)
-        val workspace = container.tfix.copyOf()
-        val xorLen = minOf(zstrMeta.xorLen, workspace.size)
-        for (i in 0 until xorLen) workspace[i] = (workspace[i].toInt() xor 0x11).toByte()
-        val tiffBytes = chaCha8Decrypt(workspace, perImageKey, zstrMeta.nonce, zstrMeta.xorLen.toLong())
+        val tfix = container.tfix
+        val xorLen = minOf(zstrMeta.xorLen, tfix.size)
+        for (i in 0 until xorLen) tfix[i] = (tfix[i].toInt() xor 0x11).toByte()
+        val tiffBytes = chaCha8Decrypt(tfix, perImageKey, zstrMeta.nonce, zstrMeta.xorLen.toLong())
 
         if (!tiffBytes.copyOfRange(0, 4).contentEquals(TIFF_MAGIC_LE)) {
             throw IllegalStateException(
-                "tfix did not decrypt to TIFF (expected II*\\0, got ${hex(tiffBytes.copyOfRange(0, 4))})",
+                "tfix did not decrypt to TIFF (expected II*\\0, got ${(tiffBytes.copyOfRange(0, 4)).toHexString()})",
             )
         }
 
@@ -45,7 +43,6 @@ object XebpDecoder {
     }
 
     private class Container(
-        val vp8: ByteArray,
         val vp8RiffAsWebp: ByteArray,
         val zstr: ByteArray,
         val tfix: ByteArray,
@@ -58,7 +55,6 @@ object XebpDecoder {
                 xebp[2] == 'F'.code.toByte() && xebp[3] == 'F'.code.toByte(),
         ) { "XEBP missing RIFF magic" }
 
-        val bb = ByteBuffer.wrap(xebp).order(ByteOrder.LITTLE_ENDIAN)
         // Skip RIFF + size; next 4 bytes are WEBP
         // Then chunks: 4 fourcc + 4 size + payload (padded to even)
         var off = 12
@@ -70,7 +66,7 @@ object XebpDecoder {
         var tfixLen = -1
         while (off + 8 <= xebp.size) {
             val fourCC = String(xebp, off, 4, Charsets.ISO_8859_1)
-            val size = bb.getInt(off + 4)
+            val size = xebp.readIntLittleEndian(off + 4)
             val payloadStart = off + 8
             when (fourCC) {
                 "VP8 ", "VP8L", "VP8X" -> {
@@ -98,10 +94,7 @@ object XebpDecoder {
             val out = ByteArray(vp8ChunkEnd)
             System.arraycopy(xebp, 0, out, 0, vp8ChunkEnd)
             val newSize = vp8ChunkEnd - 8
-            out[4] = (newSize and 0xFF).toByte()
-            out[5] = ((newSize ushr 8) and 0xFF).toByte()
-            out[6] = ((newSize ushr 16) and 0xFF).toByte()
-            out[7] = ((newSize ushr 24) and 0xFF).toByte()
+            out.writeIntLittleEndian(4, newSize)
             out[8] = 'W'.code.toByte()
             out[9] = 'E'.code.toByte()
             out[10] = 'B'.code.toByte()
@@ -112,7 +105,6 @@ object XebpDecoder {
         }
 
         return Container(
-            vp8 = if (vp8Start >= 0) xebp.copyOfRange(vp8Start + 8, vp8Start + 8 + vp8Len) else ByteArray(0),
             vp8RiffAsWebp = vp8RiffAsWebp,
             zstr = xebp.copyOfRange(zstrStart, zstrStart + zstrLen),
             tfix = xebp.copyOfRange(tfixStart, tfixStart + tfixLen),
@@ -145,7 +137,7 @@ object XebpDecoder {
 
         val encrypted = encryptedHex.decodeHex()
         val u32s = IntArray(countU32)
-        for (i in 0 until countU32) u32s[i] = le32(encrypted, i * 4)
+        for (i in 0 until countU32) u32s[i] = encrypted.readIntLittleEndian(i * 4)
 
         xxteaDecrypt(u32s, XXTEA_KEY)
 
@@ -177,9 +169,9 @@ object XebpDecoder {
         state[1] = 0x3320646E // "nd 3"
         state[2] = 0x79622D32 // "2-by"
         state[3] = 0x6B206574 // "te k"
-        for (i in 0 until 8) state[4 + i] = le32(key, i * 4)
-        state[14] = le32(nonce, 0)
-        state[15] = le32(nonce, 4)
+        for (i in 0 until 8) state[4 + i] = key.readIntLittleEndian(i * 4)
+        state[14] = nonce.readIntLittleEndian(0)
+        state[15] = nonce.readIntLittleEndian(4)
 
         val out = ByteArray(data.size)
         val work = IntArray(16)
@@ -231,7 +223,7 @@ object XebpDecoder {
     private fun xxteaDecrypt(v: IntArray, keyBytes: ByteArray) {
         val n = v.size
         if (n < 2) return
-        val k = IntArray(4) { le32(keyBytes, it * 4) }
+        val k = IntArray(4) { keyBytes.readIntLittleEndian(it * 4) }
         val rounds = 6 + 52 / n
         var sum = (rounds * DELTA.toLong()).toInt()
         var y = v[0]
@@ -253,46 +245,19 @@ object XebpDecoder {
         }
     }
 
-    private fun compositePatch(vp8Webp: ByteArray, patch: TiffDecoder.RgbaImage): ByteArray {
-        val decoded = decodeByteArray(vp8Webp, 0, vp8Webp.size)
-            ?: throw Exception("Failed to decode VP8 WebP (${vp8Webp.size} bytes)")
+    private fun compositePatch(vp8Webp: ByteArray, patch: TiffDecoder.Argb8888): Buffer {
+        val opts = BitmapFactory.Options().apply {
+            inMutable = true
+        }
 
-        val result = createBitmap(
-            decoded.width,
-            decoded.height,
-            Bitmap.Config.ARGB_8888,
-        )
-        Canvas(result).drawBitmap(decoded, 0f, 0f, null)
-        decoded.recycle()
-
+        val result = decodeByteArray(vp8Webp, 0, vp8Webp.size, opts)
         val pw = minOf(patch.width, result.width)
         val ph = minOf(patch.height, result.height)
-        val px = IntArray(pw * ph)
-        for (y in 0 until ph) {
-            for (x in 0 until pw) {
-                val srcOff = (y * patch.width + x) * 4
-                val r = patch.rgba[srcOff].toInt() and 0xFF
-                val g = patch.rgba[srcOff + 1].toInt() and 0xFF
-                val b = patch.rgba[srcOff + 2].toInt() and 0xFF
-                px[y * pw + x] = (0xFF shl 24) or (r shl 16) or (g shl 8) or b
-            }
-        }
-        result.setPixels(px, 0, pw, 0, 0, pw, ph)
+        result.setPixels(patch.pixels, 0, patch.width, 0, 0, pw, ph)
 
-        val out = Buffer()
-        result.compress(Bitmap.CompressFormat.WEBP, 100, out.outputStream())
+        val buffer = Buffer()
+        result.compress(Bitmap.CompressFormat.WEBP, 100, buffer.outputStream())
         result.recycle()
-        return out.readByteArray()
-    }
-
-    private fun le32(b: ByteArray, off: Int): Int = (b[off].toInt() and 0xFF) or
-        ((b[off + 1].toInt() and 0xFF) shl 8) or
-        ((b[off + 2].toInt() and 0xFF) shl 16) or
-        ((b[off + 3].toInt() and 0xFF) shl 24)
-
-    internal fun hex(b: ByteArray): String {
-        val sb = StringBuilder(b.size * 2)
-        for (x in b) sb.append(String.format("%02x", x.toInt() and 0xFF))
-        return sb.toString()
+        return buffer
     }
 }

--- a/src/en/bookwalker/build.gradle
+++ b/src/en/bookwalker/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'BookWalker'
     extClass = '.BookWalker'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = true
 }
 

--- a/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/BookWalker.kt
+++ b/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/BookWalker.kt
@@ -18,7 +18,8 @@ import eu.kanade.tachiyomi.extension.en.bookwalker.dto.SearchResponseDto
 import eu.kanade.tachiyomi.extension.en.bookwalker.dto.SeriesFormat
 import eu.kanade.tachiyomi.extension.en.bookwalker.dto.SortDto
 import eu.kanade.tachiyomi.extension.en.bookwalker.dto.TagKind
-import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.extension.en.bookwalker.dto.ViewerRequestBody
+import eu.kanade.tachiyomi.extension.en.bookwalker.dto.ViewerResponse
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.asObservableSuccess
 import eu.kanade.tachiyomi.source.ConfigurableSource
@@ -28,17 +29,15 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
-import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.lib.e4p.E4PInterceptor
 import keiyoushi.lib.e4p.E4PManifestReader
-import keiyoushi.utils.extractNextJs
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAsProto
-import kotlinx.serialization.Serializable
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import rx.Observable
+import java.io.IOException
 
 class BookWalker :
     HttpSource(),
@@ -58,6 +57,14 @@ class BookWalker :
 
     override val client = network.client.newBuilder()
         .addInterceptor(E4PInterceptor())
+        .addInterceptor {
+            val request = it.request()
+            val response = it.proceed(request)
+            if (response.code == 400 && request.url.encodedPath == "/api/kyon/kyon.v1.ReadService/Open") {
+                throw IOException("Failed to load. You may need to log in via WebView and purchase it to view.")
+            }
+            response
+        }
         .build()
 
     private val manifestReader = E4PManifestReader(client, headers)
@@ -306,23 +313,28 @@ class BookWalker :
     override fun getMangaUrl(manga: SManga): String = baseUrl + manga.url
     override fun getChapterUrl(chapter: SChapter): String = baseUrl + chapter.url.substringBefore("?")
 
-    override fun fetchPageList(chapter: SChapter): Observable<List<Page>> = client.newCall(GET(getChapterUrl(chapter), headers)).asObservableSuccess().map { response ->
-        val manifestInfo = response.asJsoup().extractNextJs<ManifestContainer>()
-            ?: throw Exception("Failed to load chapter. You may need to log in and purchase it to view.")
+    override fun pageListRequest(chapter: SChapter): Request {
+        val chapterId = "$baseUrl${chapter.url}".toHttpUrl().pathSegments[1]
+        return POST(
+            endpoint("ReadService/Open"),
+            headers,
+            ViewerRequestBody("PRD_$chapterId").toProtoRequestBody(),
+        )
+    }
 
-        when (manifestInfo.mimetype) {
-            "application/vnd.e4p.prpb+deflate+vnd.e4p.qst" ->
-                manifestReader.extractPagesFromEncryptedManifest(manifestInfo.manifestUrl.toHttpUrl())
-            "application/vnd.e4p.prpb" ->
-                manifestReader.extractPagesFromUnencryptedManifest(manifestInfo.manifestUrl.toHttpUrl())
-            else -> throw Exception("Unknown manifest MIME type ${manifestInfo.mimetype}")
+    override fun pageListParse(response: Response): List<Page> {
+        val result = response.parseAsProto<ViewerResponse>().details
+        val manifest = result.manifestUrl
+        return when (result.mimeType) {
+            "application/vnd.e4p.prpb+deflate+vnd.e4p.qst" -> manifestReader.extractPagesFromEncryptedManifest(manifest.toHttpUrl())
+            "application/vnd.e4p.prpb" -> manifestReader.extractPagesFromUnencryptedManifest(manifest.toHttpUrl())
+            else -> throw Exception("Unknown manifest MIME type $manifest")
         }
     }
 
-    override fun pageListParse(response: Response): List<Page> = throw UnsupportedOperationException()
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
 
-    fun checkOldBookWalker(manga: SManga) {
+    private fun checkOldBookWalker(manga: SManga) {
         // This logic can probably be removed at some point, but it is useful to assist existing users with the migration.
         if (manga.url.startsWith("/de") || manga.url.endsWith("/")) {
             throw Exception("This manga is from old BookWalker and needs to be migrated")
@@ -340,7 +352,7 @@ class BookWalker :
     companion object {
         private val fallbackFilters = listOf(TaggedTriState("Press reset to load filters", ""))
 
-        const val PAGE_SIZE = 60
+        private const val PAGE_SIZE = 60
 
         private const val PURCHASE_ICON = "\uD83D\uDCB5" // dollar bill emoji
         private const val PREORDER_ICON = "\uD83D\uDD51" // two-o-clock emoji
@@ -354,6 +366,3 @@ class BookWalker :
         )
     }
 }
-
-@Serializable
-private class ManifestContainer(val mimetype: String, val manifestUrl: String)

--- a/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/dto/Viewer.kt
+++ b/src/en/bookwalker/src/eu/kanade/tachiyomi/extension/en/bookwalker/dto/Viewer.kt
@@ -1,0 +1,24 @@
+package eu.kanade.tachiyomi.extension.en.bookwalker.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoNumber
+
+@Suppress("unused")
+@Serializable
+class ViewerRequestBody(
+    @ProtoNumber(1)
+    @SerialName("product_id")
+    val productId: String,
+)
+
+@Serializable
+class ViewerResponse(
+    @ProtoNumber(2) val details: ViewerDetails,
+)
+
+@Serializable
+class ViewerDetails(
+    @ProtoNumber(1) val manifestUrl: String,
+    @ProtoNumber(6) val mimeType: String,
+)

--- a/src/en/jnovel/build.gradle
+++ b/src/en/jnovel/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'J-Novel'
     extClass = '.JNovel'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = false
 }
 

--- a/src/en/jnovel/src/eu/kanade/tachiyomi/extension/en/jnovel/Dto.kt
+++ b/src/en/jnovel/src/eu/kanade/tachiyomi/extension/en/jnovel/Dto.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.extension.en.jnovel
 
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import okhttp3.HttpUrl.Companion.toHttpUrl
 
@@ -119,4 +120,9 @@ class Time(
 @Serializable
 class Rental(
     val expiresAt: Time?,
+)
+
+@Serializable
+class Manifest(
+    @SerialName("e4p-manifest") val e4pManifest: String,
 )

--- a/src/en/jnovel/src/eu/kanade/tachiyomi/extension/en/jnovel/JNovel.kt
+++ b/src/en/jnovel/src/eu/kanade/tachiyomi/extension/en/jnovel/JNovel.kt
@@ -16,6 +16,7 @@ import keiyoushi.lib.e4p.E4PManifestReader
 import keiyoushi.utils.extractNextJs
 import keiyoushi.utils.firstInstance
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import okhttp3.HttpUrl.Builder
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
@@ -113,10 +114,8 @@ class JNovel :
     override fun pageListParse(response: Response): List<Page> {
         val document = response.asJsoup()
         val embedUrl = document.selectFirst("iframe[src^='$viewerUrl']")?.absUrl("src") ?: throw Exception("Log in via WebView and purchase this chapter to read.")
-        val embedDocument = client.newCall(GET(embedUrl, headers)).execute().asJsoup()
-        val manifestUrlStr = embedDocument.body().absUrl("data-e4p-manifest")
-        val manifestUrl = manifestUrlStr.toHttpUrl()
-        return manifestReader.extractPagesFromEncryptedManifest(manifestUrl)
+        val manifestUrl = client.newCall(GET("$embedUrl/info.json", headers)).execute().parseAs<Manifest>().e4pManifest
+        return manifestReader.extractPagesFromEncryptedManifest(manifestUrl.toHttpUrl())
     }
 
     override fun getFilterList() = FilterList(


### PR DESCRIPTION
and use api to get manifest (J-Novel & Bookwalker)

requires `inflate()` from #16738

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
