### PR TITLE
Onf Mangas (ES): Fix __onf_chk cookie 

### DIFF
--- a/src/es/onfmangas/build.gradle
+++ b/src/es/onfmangas/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ONF MANGAS'
     extClass = '.OnfMangas'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = true
 }
 

--- a/src/es/onfmangas/src/eu/kanade/tachiyomi/extension/es/onfmangas/OnfMangas.kt
+++ b/src/es/onfmangas/src/eu/kanade/tachiyomi/extension/es/onfmangas/OnfMangas.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.extension.es.onfmangas
 
+import app.cash.quickjs.QuickJs
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
@@ -28,8 +29,6 @@ class OnfMangas : HttpSource() {
     override val lang = "es"
     override val supportsLatest = true
 
-    val tokenRegex = Regex("""var token="([^"]+)"""")
-
     override val client = super.client.newBuilder()
         .addInterceptor(::onfTokenInterceptor)
         .build()
@@ -39,13 +38,33 @@ class OnfMangas : HttpSource() {
         val response = chain.proceed(request)
 
         val body = response.peekBody(8192).string()
-        val token = tokenRegex.find(body)?.groupValues?.get(1) ?: return response
+        if (!body.contains("Verificando")) return response
 
-        response.close()
-        val cookie = Cookie.parse(request.url, "__onf_chk=$token; path=/")
+        val cookieString = solveOnfCheck(response) ?: error("Failed to solve cookie challange")
+        val cookie = Cookie.parse(request.url, cookieString)
         client.cookieJar.saveFromResponse(request.url, listOfNotNull(cookie))
 
         return chain.proceed(request)
+    }
+
+    private fun solveOnfCheck(response: Response): String? {
+        val document = response.asJsoup()
+        val script = document.selectFirst("script")?.data() ?: error("Failed to find cookie challange script")
+
+        return QuickJs.create().use { js ->
+            js.evaluate(
+                """
+            var window = { location: {} };
+            var document = { cookie: null };
+            var location = window.location;
+            var setTimeout = function(fn, _) { fn(); };
+
+            $script
+
+            document.cookie;
+                """.trimIndent(),
+            )?.toString()
+        }
     }
 
     // Mimic a standard desktop browser to bypass Cloudflare WAF 403s


### PR DESCRIPTION
Closes  #16708 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop 
