### PR TITLE
fix(ono): send age-confirmed header for +18 content

### DIFF
--- a/src/fr/ono/build.gradle
+++ b/src/fr/ono/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Ono'
     extClass = '.Ono'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/fr/ono/src/eu/kanade/tachiyomi/extension/fr/ono/Ono.kt
+++ b/src/fr/ono/src/eu/kanade/tachiyomi/extension/fr/ono/Ono.kt
@@ -101,6 +101,7 @@ class Ono :
         headersBuilder()
             .add("Origin", baseUrl)
             .add("Referer", "$baseUrl/")
+            .add("age-confirmed", "true")
             .add("ono-platform", "website")
             .add("ono-product", "FR")
             .build()


### PR DESCRIPTION
GraphQL reading-session gated adult series on the `age-confirmed: true` header. Without it the API returns UserHasNotAccess/AdultVerificationRequired, surfaced as a misleading premium error.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
