### PR TITLE
feat(fr/raijinscans): externalize page-list reader to updatable JS

### DIFF
--- a/src/fr/raijinscans/build.gradle
+++ b/src/fr/raijinscans/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Raijin Scans'
     extClass = '.RaijinScans'
-    extVersionCode = 67
+    extVersionCode = 68
     isNsfw = false
 }
 

--- a/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/PageListInterpreter.kt
+++ b/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/PageListInterpreter.kt
@@ -1,0 +1,248 @@
+package eu.kanade.tachiyomi.extension.fr.raijinscans
+
+import android.annotation.SuppressLint
+import android.app.Application
+import android.util.Log
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import eu.kanade.tachiyomi.network.await
+import eu.kanade.tachiyomi.source.model.Page
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import okhttp3.Headers
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Runs an external page-list script ([ReaderScriptManager.getScript]) inside a headless WebView and
+ * collects the resulting image urls.
+ *
+ * ## JS contract
+ * The script must define `async function rjGetPages(ctx, host)` returning an array of image-url
+ * strings (or `{ url }` objects).
+ *
+ *  - `ctx`  = `{ baseUrl, chapterUrl, html, ajaxHeaders, maxPageRequests }`.
+ *  - `host.fetch(spec)` -> Promise of `{ ok, status, body }`. `spec` =
+ *    `{ url, method?, headers?, multipart?: [[name, value], ...], body?, contentType? }`. The request
+ *    is performed by okhttp on the app's network stack; the WebView itself never hits the network.
+ *  - `host.log(msg)` logs to logcat.
+ *
+ * The WebView is the only JS engine available to extensions (SetJavaScriptEnabled), so the bridge is
+ * wired through `addJavascriptInterface`. Bridge calls land on a binder thread; network runs on IO
+ * and results are posted back via `evaluateJavascript`, so the JS engine thread is never blocked.
+ */
+class PageListInterpreter(private val client: OkHttpClient) {
+
+    private val mutex = Mutex()
+
+    @SuppressLint("SetJavaScriptEnabled")
+    suspend fun getPages(
+        script: String,
+        baseUrl: String,
+        chapterUrl: String,
+        html: String,
+        ajaxHeaders: Headers,
+        maxPageRequests: Int,
+    ): List<Page> = mutex.withLock {
+        withContext(Dispatchers.Main.immediate) {
+            withTimeout(REQUEST_TIMEOUT) {
+                val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+                var webView: WebView? = null
+                try {
+                    suspendCancellableCoroutine { continuation ->
+                        val context = Injekt.get<Application>()
+                        val wv = WebView(context)
+                        webView = wv
+                        with(wv.settings) {
+                            javaScriptEnabled = true
+                            domStorageEnabled = true
+                            blockNetworkLoads = true // every request must go through the host bridge
+                        }
+
+                        wv.addJavascriptInterface(Bridge(scope, { webView }, continuation), BRIDGE_NAME)
+
+                        val ctx = JSONObject().apply {
+                            put("baseUrl", baseUrl)
+                            put("chapterUrl", chapterUrl)
+                            put("html", html)
+                            put("maxPageRequests", maxPageRequests)
+                            put("ajaxHeaders", JSONObject().apply { ajaxHeaders.forEach { (k, v) -> put(k, v) } })
+                        }
+                        val injection = buildInjection(ctx.toString(), script)
+
+                        wv.webViewClient = object : WebViewClient() {
+                            override fun onPageFinished(view: WebView, url: String) {
+                                view.evaluateJavascript(injection, null)
+                            }
+                        }
+                        wv.loadDataWithBaseURL(baseUrl, BLANK_PAGE, "text/html", "utf-8", null)
+                    }
+                } finally {
+                    scope.cancel()
+                    webView?.apply {
+                        stopLoading()
+                        removeJavascriptInterface(BRIDGE_NAME)
+                        destroy()
+                    }
+                }
+            }
+        }
+    }
+
+    private inner class Bridge(
+        private val scope: CoroutineScope,
+        private val webViewProvider: () -> WebView?,
+        private val continuation: CancellableContinuation<List<Page>>,
+    ) {
+        @JavascriptInterface
+        fun fetch(id: String, specJson: String) {
+            scope.launch {
+                val result = withContext(Dispatchers.IO) { runCatching { doFetch(specJson) } }
+                val wv = webViewProvider() ?: return@launch
+                val call = result.fold(
+                    onSuccess = { "window.__rjResolveFetch(${JSONObject.quote(id)}, ${JSONObject.quote(it)})" },
+                    onFailure = { "window.__rjRejectFetch(${JSONObject.quote(id)}, ${JSONObject.quote(it.message ?: it.toString())})" },
+                )
+                wv.evaluateJavascript(call, null)
+            }
+        }
+
+        @JavascriptInterface
+        fun resolve(json: String) {
+            if (continuation.isActive) {
+                runCatching { parsePages(json) }.fold(
+                    onSuccess = { continuation.resume(it) },
+                    onFailure = { continuation.resumeWithException(it) },
+                )
+            }
+        }
+
+        @JavascriptInterface
+        fun reject(message: String) {
+            if (continuation.isActive) continuation.resumeWithException(Exception(message))
+        }
+
+        @JavascriptInterface
+        fun log(message: String) {
+            Log.d(LOG_TAG, message)
+        }
+    }
+
+    private suspend fun doFetch(specJson: String): String {
+        val spec = JSONObject(specJson)
+        client.newCall(buildRequest(spec)).await().use { response ->
+            return JSONObject().apply {
+                put("ok", response.isSuccessful)
+                put("status", response.code)
+                put("body", response.body.string())
+            }.toString()
+        }
+    }
+
+    private fun buildRequest(spec: JSONObject): Request {
+        val method = spec.optString("method", "GET").uppercase()
+        val headers = Headers.Builder().apply {
+            spec.optJSONObject("headers")?.let { h ->
+                h.keys().forEach { k -> add(k, h.getString(k)) }
+            }
+        }.build()
+        val body = when {
+            spec.has("multipart") -> {
+                val builder = MultipartBody.Builder().setType(MultipartBody.FORM)
+                val parts = spec.getJSONArray("multipart")
+                for (i in 0 until parts.length()) {
+                    val pair = parts.getJSONArray(i)
+                    builder.addFormDataPart(pair.getString(0), pair.getString(1))
+                }
+                builder.build()
+            }
+            spec.has("body") -> {
+                val mediaType = spec.optString("contentType", "text/plain; charset=utf-8").toMediaTypeOrNull()
+                spec.getString("body").toRequestBody(mediaType)
+            }
+            method == "POST" -> ByteArray(0).toRequestBody(null)
+            else -> null
+        }
+        return Request.Builder().url(spec.getString("url")).headers(headers).method(method, body).build()
+    }
+
+    private fun parsePages(json: String): List<Page> {
+        val array = JSONArray(json)
+        return (0 until array.length()).map { i ->
+            val element = array.get(i)
+            val url = (element as? JSONObject)?.optString("url") ?: element.toString()
+            Page(i, imageUrl = url)
+        }
+    }
+
+    private fun buildInjection(ctxJson: String, script: String): String = buildString {
+        append("window.__RJ_CTX__ = JSON.parse(").append(JSONObject.quote(ctxJson)).append(");\n")
+        append(HOST_SHIM).append("\n")
+        append(script).append("\n")
+        append(RUNNER)
+    }
+
+    companion object {
+        private val REQUEST_TIMEOUT = 60.seconds
+        private const val BRIDGE_NAME = "__rjbridge"
+        private const val LOG_TAG = "RaijinScans"
+        private const val BLANK_PAGE = "<html><head></head><body></body></html>"
+
+        // Promise-based shim over the synchronous binder bridge. `host.fetch` registers a pending
+        // promise and hands the request to Kotlin; Kotlin calls back __rjResolveFetch/__rjRejectFetch.
+        private val HOST_SHIM = """
+            window.__rjpending = {};
+            window.__rjseq = 0;
+            window.__rjResolveFetch = function (id, jsonText) {
+              var cb = window.__rjpending[id]; delete window.__rjpending[id];
+              if (cb) { try { cb.resolve(JSON.parse(jsonText)); } catch (e) { cb.reject(e); } }
+            };
+            window.__rjRejectFetch = function (id, msg) {
+              var cb = window.__rjpending[id]; delete window.__rjpending[id];
+              if (cb) cb.reject(new Error(msg));
+            };
+            window.__rjhost = {
+              fetch: function (spec) {
+                return new Promise(function (resolve, reject) {
+                  var id = String(++window.__rjseq);
+                  window.__rjpending[id] = { resolve: resolve, reject: reject };
+                  __rjbridge.fetch(id, JSON.stringify(spec));
+                });
+              },
+              log: function (m) { __rjbridge.log(String(m)); }
+            };
+        """.trimIndent()
+
+        private val RUNNER = """
+            (function () {
+              try {
+                Promise.resolve(rjGetPages(window.__RJ_CTX__, window.__rjhost))
+                  .then(function (p) { __rjbridge.resolve(JSON.stringify(p)); })
+                  .catch(function (e) { __rjbridge.reject(String((e && e.stack) || e)); });
+              } catch (e) {
+                __rjbridge.reject(String((e && e.stack) || e));
+              }
+            })();
+        """.trimIndent()
+    }
+}

--- a/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
+++ b/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
@@ -237,11 +237,9 @@ class RaijinScans :
 
     // ========================== Page List =============================
 
-    // The reader descrambles a per-page randomized manifest and walks an obfuscated admin-ajax
-    // response. The site rotates that obfuscation, so the logic lives in an external JS bundle
-    // ([ReaderScriptManager]) run inside a sandboxed WebView ([PageListInterpreter]); it asks for
-    // network through the okhttp host bridge and returns the image-url list. This lets the
-    // descrambler be updated server-side without shipping a new APK.
+    // Descrambler logic lives in an external JS bundle ([ReaderScriptManager]) run in a sandboxed
+    // WebView ([PageListInterpreter]), so it can be updated server-side without a new APK.
+    // Network runs here, off the main thread, not in pageListParse (parse methods must not block).
     override fun fetchPageList(chapter: SChapter): Observable<List<Page>> = Observable.fromCallable {
         client.newCall(pageListRequest(chapter)).execute().use(::pageList)
     }
@@ -252,8 +250,8 @@ class RaijinScans :
         val html = response.body.string()
         val document = Jsoup.parse(html, baseUrl)
 
-        // left connexion check just in case cause url returned by the website is /connexion but then it wont show in chapters list
-        // so i made it so it goes to /{mangaurl}/{chapter number} which should show in almost all case the buy premium page and if it doesnt whatever it throw a 404
+        // /connexion isn't in the chapter list, so we route to /{manga}/{chapter} which lands on the
+        // premium page (or a 404). Treat either signal as premium.
         val isPremium = document.select(".subscription-required-message").isNotEmpty() || response.request.url.toString().contains("connexion")
         if (isPremium) {
             throw Exception("This chapter is premium. Please connect via the webview to view.")
@@ -283,9 +281,8 @@ class RaijinScans :
             try {
                 attempt(script)
             } catch (e: Exception) {
-                // The script that just ran may be a stale/broken cached copy while a fixed one is
-                // already published. Force a fresh fetch and retry once; if it's identical there's
-                // no point retrying, so surface the original error.
+                // Cached script may be stale while a fixed one is published. Refetch and retry once;
+                // if identical, retrying is pointless, so surface the original error.
                 val fresh = scriptManager.refreshScript()
                 if (fresh == script) throw e
                 attempt(fresh)

--- a/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
+++ b/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
@@ -1,7 +1,6 @@
 package eu.kanade.tachiyomi.extension.fr.raijinscans
 
 import android.content.SharedPreferences
-import android.util.Base64
 import androidx.preference.CheckBoxPreference
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.network.GET
@@ -16,21 +15,9 @@ import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.boolean
-import kotlinx.serialization.json.booleanOrNull
-import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.int
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.coroutines.runBlocking
 import okhttp3.FormBody
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.MultipartBody
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.Jsoup
@@ -61,14 +48,9 @@ class RaijinScans :
     private val nonceRegex = """"nonce"\s*:\s*"([^"]+)"""".toRegex()
     private val numberRegex = """(\d+)""".toRegex()
     private val descriptionScriptRegex = """content\.innerHTML = `([\s\S]+?)`;""".toRegex()
-    private val manifestObjectRegex = """(\{"m":"[\s\S]*\})""".toRegex()
-    private val imageExtRegex = """\.(webp|jpe?g|png|gif|avif)""".toRegex(RegexOption.IGNORE_CASE)
-    private val json: Json by lazy {
-        Json {
-            ignoreUnknownKeys = true
-            isLenient = true
-        }
-    }
+
+    private val scriptManager by lazy { ReaderScriptManager(client, preferences) }
+    private val pageListInterpreter by lazy { PageListInterpreter(client) }
 
     override fun headersBuilder() = super.headersBuilder().add("Referer", "$baseUrl/")
 
@@ -249,8 +231,14 @@ class RaijinScans :
 
     // ========================== Page List =============================
 
+    // The reader descrambles a per-page randomized manifest and walks an obfuscated admin-ajax
+    // response. The site rotates that obfuscation, so the logic lives in an external JS bundle
+    // ([ReaderScriptManager]) run inside a sandboxed WebView ([PageListInterpreter]); it asks for
+    // network through the okhttp host bridge and returns the image-url list. This lets the
+    // descrambler be updated server-side without shipping a new APK.
     override fun pageListParse(response: Response): List<Page> {
-        val document = response.asJsoup()
+        val html = response.body.string()
+        val document = Jsoup.parse(html, baseUrl)
 
         // left connexion check just in case cause url returned by the website is /connexion but then it wont show in chapters list
         // so i made it so it goes to /{mangaurl}/{chapter number} which should show in almost all case the buy premium page and if it doesnt whatever it throw a 404
@@ -267,118 +255,16 @@ class RaijinScans :
             .add("Origin", baseUrl)
             .build()
 
-        // The chapter HTML injects a manifest object into a window["rjfr_xxx"] array. The
-        // injection syntax has varied over time (e.g. `.push({...})` and `[…length] = {...}`),
-        // so we extract the object literal directly rather than depend on the surrounding code:
-        //   {
-        //     "m": "hex1|...",  // order of fragments
-        //     "c": {               // key-value pairs of b64 fragments
-        //       "hex1": "base64fragment1", ... }
-        //   }
-        // config = m.split("|").map { key -> c[key] }.joinToString("") -> Base64 decode
-
-        val manifestScript = document.select("script").find { it.data().contains("rjfr_") }
-            ?: throw Exception("No reader manifest found. Open the chapter in WebView.")
-        val scriptData = manifestScript.data()
-        val match = manifestObjectRegex.find(scriptData) ?: throw Exception("Invalid manifest format")
-
-        val manifestJson = match.groupValues[1].parseAs<JsonObject>()
-        val mOrder = manifestJson["m"]!!.jsonPrimitive.content.split("|")
-        val cObj = manifestJson["c"]!!.jsonObject
-        val fragments = mOrder.map { cObj[it]!!.jsonPrimitive.content }
-        val b64 = fragments.joinToString("")
-
-        val config = String(Base64.decode(b64, Base64.DEFAULT)).parseAs<JsonObject>()
-        val shuffled = config["d"]!!.jsonArray
-        val perm = config["m"]!!.jsonArray.map { it.jsonPrimitive.int }
-        val order = config["l"]!!.jsonArray.map { it.jsonPrimitive.int }
-
-        // The reader uses two permutations to assemble the request. 'm' descrambles 'd' into
-        // an intermediate array via ordered[m[i]] = d[i]; 'l' then maps that into the canonical
-        // request layout via vals[i] = ordered[l[i]]. The manifest is randomized on every page
-        // load (arrays/values land at different positions each time), so reading fixed positions
-        // of the descrambled array is NOT reliable — both permutations must be applied.
-        val ordered = arrayOfNulls<JsonElement>(shuffled.size)
-        perm.forEachIndexed { i, p -> ordered[p] = shuffled[i] }
-        val vals = order.map {
-            ordered.getOrNull(it)
-                ?: throw Exception("Reader manifest layout changed. Open the chapter in WebView.")
+        return runBlocking {
+            pageListInterpreter.getPages(
+                script = scriptManager.getScript(),
+                baseUrl = baseUrl,
+                chapterUrl = chapterUrl,
+                html = html,
+                ajaxHeaders = ajaxHeaders,
+                maxPageRequests = MAX_PAGE_REQUESTS,
+            )
         }
-
-        // Canonical layout of vals:
-        //  1..6 : request content values, passed positionally to keyArr[0..5]
-        //         (["", token, X, mangaId, chapterSlug, instanceId] — order matters, identity does not)
-        //  13   : keyArr - request form field names (first 10 used)
-        // The form action ("rjfr_...") is picked by content: it is the only string starting with
-        // "rjfr_" (the rjfr instance token uses a hyphen, "rjfr-", so it won't collide).
-        val action = vals.mapNotNull { (it as? JsonPrimitive)?.contentOrNull }
-            .first { it.startsWith("rjfr_") }
-        val keyArr = vals[13].jsonArray.map { it.jsonPrimitive.content }
-        val contentValues = (1..6).map { vals[it].jsonPrimitive.content }
-
-        val rjfrValue = document.select("[data-rj-free-reader-root]").attr("data-rj-free-reader-root")
-
-        val pages = mutableListOf<Page>()
-        var cursor = ""
-        var run = true
-        var guard = 0
-
-        while (run && guard++ < MAX_PAGE_REQUESTS) {
-            val builder = MultipartBody.Builder().setType(MultipartBody.FORM)
-                .addFormDataPart("action", action)
-            contentValues.forEachIndexed { j, v -> builder.addFormDataPart(keyArr[j], v) }
-            builder.addFormDataPart(keyArr[6], "0")
-                .addFormDataPart(keyArr[7], "0") // offset, always 0; pagination is cursor-only
-                .addFormDataPart(keyArr[8], rjfrValue)
-                .addFormDataPart(keyArr[9], cursor)
-            val body = builder.build()
-
-            val response = client.newCall(POST("$baseUrl/wp-admin/admin-ajax.php", ajaxHeaders, body)).execute()
-
-            if (!response.isSuccessful) error("Failed to get page: ${response.code}")
-            val root = response.parseAs<JsonObject>()
-
-            // Parse by content, not position, so we don't depend on the (randomized) response key
-            // names, the response nesting depth, or decoy wrapper objects/arrays the site mixes in:
-            // images = the array of image objects found anywhere in the tree (an image object holds
-            // an http string whose path is an actual image); payload = its parent object, which also
-            // carries the cursor (its only string primitive) and hasMore (its only boolean primitive).
-            val (payload, images) = findImages(root)
-                ?: throw Exception("Reader response format changed. Open the chapter in WebView.")
-
-            images.forEach { image ->
-                image.imageUrlOrNull()?.let { pages.add(Page(pages.size, imageUrl = it)) }
-            }
-
-            cursor = payload.values.filterIsInstance<JsonPrimitive>()
-                .firstOrNull { it.isString }?.content ?: ""
-            run = payload.values.filterIsInstance<JsonPrimitive>()
-                .firstOrNull { it.booleanOrNull != null }?.boolean ?: false
-        }
-
-        return pages
-    }
-
-    // The real image url = the http string whose path is an actual image. Each image object also
-    // carries a decoy http string (the admin-ajax endpoint), so a plain "starts with http" is not enough.
-    private fun JsonElement.imageUrlOrNull(): String? = (this as? JsonObject)?.values
-        ?.filterIsInstance<JsonPrimitive>()
-        ?.map { it.content }
-        ?.firstOrNull { it.startsWith("http") && imageExtRegex.containsMatchIn(it) }
-
-    private fun JsonArray.isImageArray(): Boolean = firstOrNull()?.imageUrlOrNull() != null
-
-    // Find the array of image objects anywhere in the tree and return it with its parent object.
-    private fun findImages(element: JsonElement): Pair<JsonObject, JsonArray>? {
-        when (element) {
-            is JsonObject -> {
-                element.values.forEach { if (it is JsonArray && it.isImageArray()) return element to it }
-                element.values.forEach { child -> findImages(child)?.let { return it } }
-            }
-            is JsonArray -> element.forEach { child -> findImages(child)?.let { return it } }
-            else -> {}
-        }
-        return null
     }
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException("Not used.")

--- a/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
+++ b/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
@@ -261,14 +261,28 @@ class RaijinScans :
             .build()
 
         return runBlocking {
-            pageListInterpreter.getPages(
-                script = scriptManager.getScript(),
-                baseUrl = baseUrl,
-                chapterUrl = chapterUrl,
-                html = html,
-                ajaxHeaders = ajaxHeaders,
-                maxPageRequests = MAX_PAGE_REQUESTS,
-            )
+            val attempt: suspend (String) -> List<Page> = { script ->
+                pageListInterpreter.getPages(
+                    script = script,
+                    baseUrl = baseUrl,
+                    chapterUrl = chapterUrl,
+                    html = html,
+                    ajaxHeaders = ajaxHeaders,
+                    maxPageRequests = MAX_PAGE_REQUESTS,
+                )
+            }
+
+            val script = scriptManager.getScript()
+            try {
+                attempt(script)
+            } catch (e: Exception) {
+                // The script that just ran may be a stale/broken cached copy while a fixed one is
+                // already published. Force a fresh fetch and retry once; if it's identical there's
+                // no point retrying, so surface the original error.
+                val fresh = scriptManager.refreshScript()
+                if (fresh == script) throw e
+                attempt(fresh)
+            }
         }
     }
 

--- a/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
+++ b/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
@@ -23,6 +23,7 @@ import okhttp3.Response
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
+import rx.Observable
 import java.net.URI
 import java.util.Calendar
 import java.util.Locale
@@ -241,7 +242,13 @@ class RaijinScans :
     // ([ReaderScriptManager]) run inside a sandboxed WebView ([PageListInterpreter]); it asks for
     // network through the okhttp host bridge and returns the image-url list. This lets the
     // descrambler be updated server-side without shipping a new APK.
-    override fun pageListParse(response: Response): List<Page> {
+    override fun fetchPageList(chapter: SChapter): Observable<List<Page>> = Observable.fromCallable {
+        client.newCall(pageListRequest(chapter)).execute().use(::pageList)
+    }
+
+    override fun pageListParse(response: Response): List<Page> = throw UnsupportedOperationException("Handled in fetchPageList.")
+
+    private fun pageList(response: Response): List<Page> {
         val html = response.body.string()
         val document = Jsoup.parse(html, baseUrl)
 

--- a/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
+++ b/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/RaijinScans.kt
@@ -47,7 +47,12 @@ class RaijinScans :
     private val preferences: SharedPreferences by getPreferencesLazy()
     private val nonceRegex = """"nonce"\s*:\s*"([^"]+)"""".toRegex()
     private val numberRegex = """(\d+)""".toRegex()
-    private val descriptionScriptRegex = """content\.innerHTML = `([\s\S]+?)`;""".toRegex()
+
+    // Capture only within a single template literal (no backtick inside). The page also has a
+    // "view all" toggle whose `content.innerHTML = ``` assignments are empty; a [\s\S]+? capture
+    // would span across them and yield garbage, so a description-less page must fail to match here
+    // and fall back to div.description-content.
+    private val descriptionScriptRegex = """content\.innerHTML = `([^`]+)`;""".toRegex()
 
     private val scriptManager by lazy { ReaderScriptManager(client, preferences) }
     private val pageListInterpreter by lazy { PageListInterpreter(client) }

--- a/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/ReaderScriptManager.kt
+++ b/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/ReaderScriptManager.kt
@@ -54,6 +54,13 @@ class ReaderScriptManager(
         return fetchWithRetry()
     }
 
+    /**
+     * Force a fresh fetch, bypassing both caches. Used to recover when a script returned by
+     * [getScript] fails at *runtime*: the cached copy may be stale/broken while the remote one has
+     * already been fixed. Updates the cache with whatever it resolves (remote or [DEFAULT_SCRIPT]).
+     */
+    fun refreshScript(): String = fetchWithRetry()
+
     private fun fetchWithRetry(): String {
         return (1..3).firstNotNullOfOrNull {
             runCatching {

--- a/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/ReaderScriptManager.kt
+++ b/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/ReaderScriptManager.kt
@@ -14,24 +14,17 @@ class RemoteScriptBasic(
 @Serializable
 class RemoteScript(
     val validVersion: List<Int>,
-    // Bare filename (no path) of the JS bundle in the same release. The actual `rjGetPages(ctx, host)`
-    // source is downloaded separately from RELEASE_BASE + script. See PageListInterpreter for the contract.
+    // Bare filename of the JS bundle, fetched from RELEASE_BASE + script.
     val script: String,
 )
 
 /**
- * Loads the page-list reader script. The reader for raijin-scans descrambles a per-page randomized
- * manifest and walks an obfuscated admin-ajax response; the site rotates that obfuscation, so the
- * descrambler lives in an external JS bundle that can be updated without shipping a new APK
- * (same idea as scanmanga's external markers, but executable). The bundle runs inside a sandboxed
- * WebView and talks to okhttp through the [PageListInterpreter] host bridge.
+ * Loads the page-list reader script. The descrambler lives in an external JS bundle so it can be
+ * updated without a new APK; it runs in a sandboxed WebView via the [PageListInterpreter] bridge.
  *
- * The remote manifest ([RemoteScript]) only names a JS *filename*; the source is fetched separately
- * from the same release. The filename is validated to be a bare name (no path) so it cannot point
- * outside the release directory.
- *
- * Resolution order: in-memory cache -> prefs cache (within TTL) -> remote fetch -> [DEFAULT_SCRIPT].
- * The remote manifest is version-gated against [PARSER_VERSION] so an incompatible bundle is ignored.
+ * The manifest ([RemoteScript]) only names a bare JS filename (validated, no path), fetched from the
+ * same release. Resolution: in-memory cache -> prefs cache (within TTL) -> remote fetch ->
+ * [DEFAULT_SCRIPT]; the manifest is version-gated against [PARSER_VERSION].
  */
 class ReaderScriptManager(
     private val client: OkHttpClient,
@@ -55,9 +48,9 @@ class ReaderScriptManager(
     }
 
     /**
-     * Force a fresh fetch, bypassing both caches. Used to recover when a script returned by
-     * [getScript] fails at *runtime*: the cached copy may be stale/broken while the remote one has
-     * already been fixed. Updates the cache with whatever it resolves (remote or [DEFAULT_SCRIPT]).
+     * Force a fresh fetch, bypassing both caches. Recovers when a [getScript] result fails at
+     * runtime: the cached copy may be stale while the remote one is already fixed. A successful
+     * remote fetch updates the cache; the [DEFAULT_SCRIPT] fallback does not.
      */
     fun refreshScript(): String = fetchWithRetry()
 
@@ -108,10 +101,7 @@ class ReaderScriptManager(
 
         private const val PARSER_VERSION = 1
 
-        // Bundled fallback. Mirrors the previous Kotlin descrambler 1:1 (see git history of
-        // RaijinScans.pageListParse). Entry point: `rjGetPages(ctx, host)` returning an array of
-        // image-url strings. `ctx` carries baseUrl/chapterUrl/html/ajaxHeaders/maxPageRequests;
-        // `host.fetch(spec)` performs an okhttp request and resolves to { ok, status, body }.
+        // Bundled fallback
         val DEFAULT_SCRIPT = """
             async function rjGetPages(ctx, host) {
               var doc = new DOMParser().parseFromString(ctx.html, "text/html");

--- a/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/ReaderScriptManager.kt
+++ b/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/ReaderScriptManager.kt
@@ -1,0 +1,248 @@
+package eu.kanade.tachiyomi.extension.fr.raijinscans
+
+import android.content.SharedPreferences
+import keiyoushi.utils.parseAs
+import kotlinx.serialization.Serializable
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+@Serializable
+class RemoteScriptBasic(
+    val validVersion: List<Int>,
+)
+
+@Serializable
+class RemoteScript(
+    val validVersion: List<Int>,
+    // Bare filename (no path) of the JS bundle in the same release. The actual `rjGetPages(ctx, host)`
+    // source is downloaded separately from RELEASE_BASE + script. See PageListInterpreter for the contract.
+    val script: String,
+)
+
+/**
+ * Loads the page-list reader script. The reader for raijin-scans descrambles a per-page randomized
+ * manifest and walks an obfuscated admin-ajax response; the site rotates that obfuscation, so the
+ * descrambler lives in an external JS bundle that can be updated without shipping a new APK
+ * (same idea as scanmanga's external markers, but executable). The bundle runs inside a sandboxed
+ * WebView and talks to okhttp through the [PageListInterpreter] host bridge.
+ *
+ * The remote manifest ([RemoteScript]) only names a JS *filename*; the source is fetched separately
+ * from the same release. The filename is validated to be a bare name (no path) so it cannot point
+ * outside the release directory.
+ *
+ * Resolution order: in-memory cache -> prefs cache (within TTL) -> remote fetch -> [DEFAULT_SCRIPT].
+ * The remote manifest is version-gated against [PARSER_VERSION] so an incompatible bundle is ignored.
+ */
+class ReaderScriptManager(
+    private val client: OkHttpClient,
+    private val preferences: SharedPreferences,
+) {
+    private var cachedScript: String? = null
+
+    fun getScript(): String {
+        val lastUpdate = preferences.getString(PREF_SCRIPT_LAST_UPDATE, "0")?.toLongOrNull() ?: 0L
+        val cachedSource = preferences.getString(PREF_SCRIPT_SOURCE, null)
+        val cacheExpired = (System.currentTimeMillis() - lastUpdate) >= CACHE_TTL_MS
+
+        cachedScript?.let { if (!cacheExpired) return it }
+
+        if (cachedSource != null && !cacheExpired) {
+            cachedScript = cachedSource
+            return cachedSource
+        }
+
+        return fetchWithRetry()
+    }
+
+    private fun fetchWithRetry(): String {
+        return (1..3).firstNotNullOfOrNull {
+            runCatching {
+                val manifest = client.newCall(Request.Builder().url(MANIFEST_URL).build()).execute().use { response ->
+                    if (!response.isSuccessful) return@runCatching null
+                    val bodyString = response.body.string()
+
+                    // Incompatible bundle: don't retry, fall back to the bundled script.
+                    if (PARSER_VERSION !in bodyString.parseAs<RemoteScriptBasic>().validVersion) return DEFAULT_SCRIPT
+
+                    bodyString.parseAs<RemoteScript>()
+                }
+
+                val filename = manifest.script
+                require(filename.matches(FILENAME_REGEX) && ".." !in filename) {
+                    "Rejected reader script filename: $filename"
+                }
+
+                client.newCall(Request.Builder().url(RELEASE_BASE + filename).build()).execute().use { jsResponse ->
+                    if (!jsResponse.isSuccessful) return@runCatching null
+
+                    jsResponse.body.string().also { source ->
+                        cachedScript = source
+                        preferences.edit()
+                            .putString(PREF_SCRIPT_SOURCE, source)
+                            .putString(PREF_SCRIPT_LAST_UPDATE, System.currentTimeMillis().toString())
+                            .apply()
+                    }
+                }
+            }.getOrNull()
+        } ?: DEFAULT_SCRIPT
+    }
+
+    companion object {
+        private const val RELEASE_BASE =
+            "https://github.com/Starmania/raijin-scans/releases/latest/download/"
+        private const val MANIFEST_URL = RELEASE_BASE + "reader.json"
+
+        // Bare filename only: no '/', '\', or other path characters; ".." additionally rejected above.
+        private val FILENAME_REGEX = """[A-Za-z0-9._-]+""".toRegex()
+
+        const val PREF_SCRIPT_SOURCE = "external_reader_script_source"
+        const val PREF_SCRIPT_LAST_UPDATE = "external_reader_script_last_update"
+        private const val CACHE_TTL_MS = 12 * 60 * 60 * 1000L // 12 hours
+
+        private const val PARSER_VERSION = 1
+
+        // Bundled fallback. Mirrors the previous Kotlin descrambler 1:1 (see git history of
+        // RaijinScans.pageListParse). Entry point: `rjGetPages(ctx, host)` returning an array of
+        // image-url strings. `ctx` carries baseUrl/chapterUrl/html/ajaxHeaders/maxPageRequests;
+        // `host.fetch(spec)` performs an okhttp request and resolves to { ok, status, body }.
+        val DEFAULT_SCRIPT = """
+            async function rjGetPages(ctx, host) {
+              var doc = new DOMParser().parseFromString(ctx.html, "text/html");
+
+              var manifestScript = null;
+              var scripts = doc.querySelectorAll("script");
+              for (var i = 0; i < scripts.length; i++) {
+                var t = scripts[i].textContent || "";
+                if (t.indexOf("rjfr_") >= 0) { manifestScript = t; break; }
+              }
+              if (!manifestScript) throw new Error("No reader manifest found. Open the chapter in WebView.");
+
+              // The manifest object is injected either as `.push({"m":...,"c":{...}})` or as
+              // `window["rjfr_..."][...length]={"m":...,"c":{...}}`. Locate the `{"m":...}` object and
+              // brace-match it (respecting strings) so both forms — and the nested `c` object — parse.
+              var start = manifestScript.search(/\{\s*"m"\s*:/);
+              if (start < 0) throw new Error("Invalid manifest format");
+              var manifest = JSON.parse(extractObject(manifestScript, start));
+
+              // config = manifest.m.split("|").map(k => manifest.c[k]).join("") -> base64 -> JSON
+              var mOrder = manifest.m.split("|");
+              var cObj = manifest.c;
+              var b64 = mOrder.map(function (k) { return cObj[k]; }).join("");
+              var config = JSON.parse(decodeBase64(b64));
+
+              // Two permutations: ordered[m[i]] = d[i]; then vals[i] = ordered[l[i]].
+              var shuffled = config.d;
+              var perm = config.m;
+              var order = config.l;
+              var ordered = new Array(shuffled.length);
+              perm.forEach(function (p, i) { ordered[p] = shuffled[i]; });
+              var vals = order.map(function (o) {
+                if (ordered[o] === undefined) throw new Error("Reader manifest layout changed. Open the chapter in WebView.");
+                return ordered[o];
+              });
+
+              // action = the only "rjfr_" string; keyArr = field names; contentValues = vals[1..6].
+              var action = vals.filter(function (v) { return typeof v === "string" && v.indexOf("rjfr_") === 0; })[0];
+              var keyArr = vals[13];
+              var contentValues = [vals[1], vals[2], vals[3], vals[4], vals[5], vals[6]];
+
+              var rootEl = doc.querySelector("[data-rj-free-reader-root]");
+              var rjfrValue = rootEl ? rootEl.getAttribute("data-rj-free-reader-root") : "";
+
+              var pages = [];
+              var cursor = "";
+              var run = true;
+              var guard = 0;
+
+              while (run && guard++ < ctx.maxPageRequests) {
+                var multipart = [["action", action]];
+                contentValues.forEach(function (v, j) { multipart.push([keyArr[j], String(v)]); });
+                multipart.push([keyArr[6], String(pages.length)]); // count of pages already loaded
+                multipart.push([keyArr[7], "0"]); // offset, always 0
+                multipart.push([keyArr[8], rjfrValue]);
+                multipart.push([keyArr[9], cursor]);
+
+                var resp = await host.fetch({
+                  url: ctx.baseUrl + "/wp-admin/admin-ajax.php",
+                  method: "POST",
+                  headers: ctx.ajaxHeaders,
+                  multipart: multipart,
+                });
+                if (!resp.ok) throw new Error("Failed to get page: " + resp.status);
+
+                var root = JSON.parse(resp.body);
+                var found = findImages(root);
+                if (!found) throw new Error("Reader response format changed. Open the chapter in WebView.");
+
+                found.images.forEach(function (img) {
+                  var u = imageUrlOrNull(img);
+                  if (u) pages.push(u);
+                });
+
+                // cursor = payload's only string primitive; run = its only boolean primitive.
+                var pv = Object.keys(found.payload).map(function (k) { return found.payload[k]; });
+                cursor = pv.filter(function (x) { return typeof x === "string"; })[0] || "";
+                run = pv.filter(function (x) { return typeof x === "boolean"; })[0] || false;
+              }
+
+              return pages;
+
+              function decodeBase64(s) {
+                s = s.replace(/=+${'$'}/, "");
+                while (s.length % 4) s += "=";
+                return decodeURIComponent(escape(atob(s)));
+              }
+
+              // Brace-match a JSON object starting at `start`, ignoring braces inside string literals.
+              function extractObject(s, start) {
+                var depth = 0, inStr = false, esc = false;
+                for (var i = start; i < s.length; i++) {
+                  var ch = s[i];
+                  if (inStr) {
+                    if (esc) esc = false;
+                    else if (ch === "\\") esc = true;
+                    else if (ch === '"') inStr = false;
+                  } else if (ch === '"') inStr = true;
+                  else if (ch === "{") depth++;
+                  else if (ch === "}") { depth--; if (depth === 0) return s.slice(start, i + 1); }
+                }
+                throw new Error("Unterminated manifest object");
+              }
+
+              // The real image url = the http string whose path is an actual image (a decoy http
+              // string to the admin-ajax endpoint also lives in each object).
+              function imageUrlOrNull(obj) {
+                if (!obj || typeof obj !== "object" || Array.isArray(obj)) return null;
+                var keys = Object.keys(obj);
+                for (var i = 0; i < keys.length; i++) {
+                  var v = obj[keys[i]];
+                  if (typeof v === "string" && v.indexOf("http") === 0 && /\.(webp|jpe?g|png|gif|avif)/i.test(v)) return v;
+                }
+                return null;
+              }
+              function isImageArray(arr) {
+                return Array.isArray(arr) && arr.length > 0 && imageUrlOrNull(arr[0]) !== null;
+              }
+              // Find the image-object array anywhere in the tree, with its parent object.
+              function findImages(el) {
+                if (el && typeof el === "object" && !Array.isArray(el)) {
+                  var keys = Object.keys(el);
+                  for (var i = 0; i < keys.length; i++) {
+                    if (isImageArray(el[keys[i]])) return { payload: el, images: el[keys[i]] };
+                  }
+                  for (var j = 0; j < keys.length; j++) {
+                    var r = findImages(el[keys[j]]);
+                    if (r) return r;
+                  }
+                } else if (Array.isArray(el)) {
+                  for (var k = 0; k < el.length; k++) {
+                    var r2 = findImages(el[k]);
+                    if (r2) return r2;
+                  }
+                }
+                return null;
+              }
+            }
+        """.trimIndent()
+    }
+}

--- a/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/ReaderScriptManager.kt
+++ b/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/ReaderScriptManager.kt
@@ -117,10 +117,13 @@ class ReaderScriptManager(
               }
               if (!manifestScript) throw new Error("No reader manifest found. Open the chapter in WebView.");
 
-              // The manifest object is injected either as `.push({"m":...,"c":{...}})` or as
-              // `window["rjfr_..."][...length]={"m":...,"c":{...}}`. Locate the `{"m":...}` object and
-              // brace-match it (respecting strings) so both forms — and the nested `c` object — parse.
-              var start = manifestScript.search(/\{\s*"m"\s*:/);
+              // The manifest object is injected either as `.push({...,"m":...,"c":{...}})` or as
+              // `window["rjfr_..."][...length]={...,"m":...,"c":{...}}`. The first key is randomized
+              // (e.g. {"rj<hex>":1,"m":...}), so anchor on the "m" key and walk back to the enclosing
+              // "{" rather than requiring "m" to be first, then brace-match forward (respecting strings).
+              var mKey = manifestScript.search(/"m"\s*:/);
+              if (mKey < 0) throw new Error("Invalid manifest format");
+              var start = manifestScript.lastIndexOf("{", mKey);
               if (start < 0) throw new Error("Invalid manifest format");
               var manifest = JSON.parse(extractObject(manifestScript, start));
 

--- a/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/ReaderScriptManager.kt
+++ b/src/fr/raijinscans/src/eu/kanade/tachiyomi/extension/fr/raijinscans/ReaderScriptManager.kt
@@ -102,7 +102,7 @@ class ReaderScriptManager(
         private const val PARSER_VERSION = 1
 
         // Bundled fallback
-        val DEFAULT_SCRIPT = """
+        val DEFAULT_SCRIPT = $$"""
             async function rjGetPages(ctx, host) {
               var doc = new DOMParser().parseFromString(ctx.html, "text/html");
 
@@ -188,7 +188,7 @@ class ReaderScriptManager(
               return pages;
 
               function decodeBase64(s) {
-                s = s.replace(/=+${'$'}/, "");
+                s = s.replace(/=+$/, "");
                 while (s.length % 4) s += "=";
                 return decodeURIComponent(escape(atob(s)));
               }


### PR DESCRIPTION
Let's moves the descrambler into an external JS bundle so we can fix it at runtime :)

- `ReaderScriptManager` — fetches a version-gated `reader.json` manifest naming a JS filename only; JS source fetched separately, cached 12h, with a bundled `DEFAULT_SCRIPT` fallback.
- `PageListInterpreter` — runs the script in a headless WebView with a Promise-based `host.fetch`bridge to okhttp, returning the page list.
- `pageListParse` — keeps the premium check and delegates.
- Refetch-on-failure — a cached script can be stale while a fixed one is published. On a runtime error, force a fresh fetch and retry once, unless the refetched script is identical to the one that failed. 

Also fixes a description regex that spanned the empty "view all" toggle on synopsis-less pages; now restricted to a single template literal so those pages fall back to `div.description-content`.

Closes #16744

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
