### PR TITLE
KenScans Fix Chapter date parsing

### DIFF
--- a/src/en/kenscans/build.gradle
+++ b/src/en/kenscans/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.KenScans'
     themePkg = 'iken'
     baseUrl = 'https://kencomics.com'
-    overrideVersionCode = 9
+    overrideVersionCode = 10
     isNsfw = false
 }
 

--- a/src/en/kenscans/src/eu/kanade/tachiyomi/extension/en/kenscans/KenScans.kt
+++ b/src/en/kenscans/src/eu/kanade/tachiyomi/extension/en/kenscans/KenScans.kt
@@ -2,9 +2,11 @@ package eu.kanade.tachiyomi.extension.en.kenscans
 
 import eu.kanade.tachiyomi.multisrc.iken.Iken
 import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import okhttp3.Request
 import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
 
 class KenScans :
     Iken(
@@ -19,6 +21,18 @@ class KenScans :
             throw Exception("Migrate from $name to $name (same extension)")
         }
         return super.chapterListRequest(manga)
+    }
+
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val bodyString = response.body.string()
+            .replace("\"createdAt\":", "\"_createdAt\":")
+            .replace("\"updatedAt\":", "\"createdAt\":")
+
+        val newResponse = response.newBuilder()
+            .body(bodyString.toResponseBody(response.body.contentType()))
+            .build()
+
+        return super.chapterListParse(newResponse)
     }
 
     override fun pageListParse(response: Response): List<Page> {


### PR DESCRIPTION
Closes #16770

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
