### PR TITLE
add x-scramble-hash handling to comix descrambler

### DIFF
--- a/src/en/comix/build.gradle
+++ b/src/en/comix/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comix'
     extClass = '.Comix'
-    extVersionCode = 30
+    extVersionCode = 31
     isNsfw = true
 }
 

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Descrambler.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Descrambler.kt
@@ -30,12 +30,14 @@ object Descrambler {
         val rawScrambleSeed = response.header("x-scramble-seed")
         val rawScrambleGrid = response.header("x-scramble-grid")
         val rawScrambleAlgo = response.header("x-scramble-algo")
+        val rawScrambleHash = response.header("x-scramble-hash")
         val rawEncSeed = response.header("x-enc-seed")
         val rawEncAlgo = response.header("x-enc-algo")
 
         val encSeed = rawEncSeed?.toLongOrNull()?.toInt()
         val encLen = response.header("x-enc-len")?.toIntOrNull()
         val scrambleSeed = rawScrambleSeed?.toLongOrNull()?.toInt()
+        val scrambleHash = decodeScrambleHash(rawScrambleHash)
 
         val needsXor = encSeed != null && encSeed != 0 && encLen != null
         val shouldDescrambleGrid = rawScrambleGrid == "5x5" &&
@@ -62,7 +64,7 @@ object Descrambler {
                     .body("Failed to decode image".toResponseBody("text/plain".toMediaType()))
                     .build()
 
-            val descrambled = descramble(bitmap, scrambleSeed, rawScrambleAlgo)
+            val descrambled = descramble(bitmap, scrambleSeed xor scrambleHash, rawScrambleAlgo)
             bitmap.recycle()
 
             val output = Buffer()
@@ -140,6 +142,11 @@ object Descrambler {
         next = next xor (next shl 13)
         next = next xor (next ushr 17)
         return next xor (next shl 5)
+    }
+
+    private fun decodeScrambleHash(hash: String?): Int = when (hash) {
+        "03632" -> 58414
+        else -> 0
     }
 
     private fun ByteArray.hasImageSignature(): Boolean = size >= 12 && (


### PR DESCRIPTION
Fixed Comix’s current image descrambling by applying the reader’s X-Scramble-Hash mapping before building the tile order. I tested this mostly in Tachimanga because my Android Studio simulator decided to stop working a little bit into my testing, if someone could test it in Mihon just in case I would appreciate it.

If there's any issues please let me know, I haven't encountered any scrambled images in ~30mins of testing so I'm hoping that this fixes it.

Fixes #16850 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
