### PR TITLE
Comix, Descrambler, Filter, content and results fix

### DIFF
--- a/src/en/comix/build.gradle
+++ b/src/en/comix/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Comix'
     extClass = '.Comix'
-    extVersionCode = 30
+    extVersionCode = 31
     isNsfw = true
 }
 

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
@@ -40,6 +40,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Request
 import okhttp3.Response
 import okio.Buffer
+import org.json.JSONObject
 import org.jsoup.nodes.Document
 import rx.Observable
 import java.util.concurrent.Semaphore
@@ -137,7 +138,14 @@ class Comix :
         }
         val contentRating = request.url.queryParameter("content_rating")
             ?: preferences.contentRating()
-        val effectiveContentRating = contentRating.ifEmpty { "pornographic" }
+        val effectiveContentRating = contentRating
+            .split(',')
+            .lastOrNull { it.isNotBlank() }
+            .orEmpty()
+            .ifEmpty { "pornographic" }
+        val expectedKeyword = JSONObject.quote(
+            request.url.queryParameter("q") ?: request.url.queryParameter("keyword").orEmpty(),
+        )
         val searchResponse = document.extractBrowseResponse() ?: runInWebView(
             document = document,
             initializationScript = """
@@ -159,13 +167,17 @@ class Comix :
                 """
                     (function () {
                         const payloadKey = '__comixBrowsePayload';
-                        const capture = parsed => {
+                        const expectedKeyword = $expectedKeyword;
+                        const capture = (parsed, allowEmpty = false) => {
                             try {
+                                if (parsed && Array.isArray(parsed.items)) {
+                                    parsed = { result: parsed };
+                                }
                                 if (
                                     parsed &&
                                     parsed.result &&
                                     Array.isArray(parsed.result.items) &&
-                                    parsed.result.items.length > 0
+                                    (allowEmpty || parsed.result.items.length > 0)
                                 ) {
                                     window[payloadKey] = JSON.stringify(parsed);
                                     window.$interfaceName.passPayload(window[payloadKey]);
@@ -184,16 +196,66 @@ class Comix :
                         } catch (e) {}
 
                         if (window[payloadKey]) return window[payloadKey];
-                        if (JSON.parse.__comixBrowseCaptureInstalled) return null;
+                        if (window.__comixBrowseCaptureInstalled) return null;
+                        window.__comixBrowseCaptureInstalled = true;
+
+                        const captureText = text => {
+                            try {
+                                if (text) capture(JSON.parse(text), true);
+                            } catch (e) {}
+                        };
+
+                        const shouldCaptureUrl = rawUrl => {
+                            try {
+                                const url = new URL(rawUrl || '', window.location.origin);
+                                if (!url.pathname.includes('/api/v1/manga')) return false;
+                                if (!expectedKeyword) return true;
+                                return url.searchParams.get('keyword') === expectedKeyword;
+                            } catch (e) {
+                                return false;
+                            }
+                        };
+
+                        const originalFetch = window.fetch;
+                        if (typeof originalFetch === 'function') {
+                            window.fetch = function () {
+                                return originalFetch.apply(this, arguments).then(response => {
+                                    try {
+                                        const url = response && response.url || '';
+                                        if (shouldCaptureUrl(url)) {
+                                            response.clone().text().then(captureText).catch(() => {});
+                                        }
+                                    } catch (e) {}
+                                    return response;
+                                });
+                            };
+                        }
+
+                        const originalOpen = XMLHttpRequest.prototype.open;
+                        const originalSend = XMLHttpRequest.prototype.send;
+                        XMLHttpRequest.prototype.open = function (method, url) {
+                            this.__comixBrowseUrl = String(url || '');
+                            return originalOpen.apply(this, arguments);
+                        };
+                        XMLHttpRequest.prototype.send = function () {
+                            this.addEventListener('load', function () {
+                                try {
+                                    if (shouldCaptureUrl(this.__comixBrowseUrl)) {
+                                        captureText(this.responseText);
+                                    }
+                                } catch (e) {}
+                            });
+                            return originalSend.apply(this, arguments);
+                        };
+
                         const originalParse = JSON.parse;
                         const proxiedParse = new Proxy(originalParse, {
                             apply(target, thisArg, args) {
                                 const parsed = Reflect.apply(target, thisArg, args);
-                                capture(parsed);
+                                if (!expectedKeyword) capture(parsed);
                                 return parsed;
                             }
                         });
-                        proxiedParse.__comixBrowseCaptureInstalled = true;
                         JSON.parse = proxiedParse;
                         return window[payloadKey] || null;
                     })();
@@ -240,17 +302,6 @@ class Comix :
 
     // ============================== Search ===============================
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        if (query.isNotBlank()) {
-            val queryUrl = query.trim().toHttpUrlOrNull()
-            if (queryUrl != null) {
-                val host = queryUrl.host.removePrefix("www.")
-                if (host == baseUrl.toHttpUrl().host.removePrefix("www.") && queryUrl.pathSegments.size >= 2 && queryUrl.pathSegments[0] == "title") {
-                    val mangaId = queryUrl.pathSegments[1].substringBefore("-")
-                    return mangaDetailsRequest(SManga.create().apply { this.url = "/$mangaId" })
-                }
-            }
-        }
-
         val withFilters = baseUrl.toHttpUrl().newBuilder()
             .addPathSegment("browse")
             .apply {
@@ -300,11 +351,11 @@ class Comix :
             }
 
             if (query.isNotBlank()) {
-                addQueryParameter("keyword", query)
+                addQueryParameter("q", query)
                 build().queryParameterNames
                     .filter { it.startsWith("order[") }
                     .forEach(::removeAllQueryParameters)
-                addQueryParameter("order[relevance]", "desc")
+                addQueryParameter("sort", "relevance:desc")
             }
 
             addQueryParameter("page", page.toString())
@@ -315,7 +366,28 @@ class Comix :
 
     override fun searchMangaParse(response: Response) = throw UnsupportedOperationException()
 
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = fetchMangaListFromBrowse(searchMangaRequest(page, query, filters))
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        titlePathFromQuery(query)?.let { titlePath ->
+            return fetchMangaDetails(SManga.create().apply { url = titlePath })
+                .map { MangasPage(listOf(it), false) }
+        }
+
+        return fetchMangaListFromBrowse(searchMangaRequest(page, query, filters))
+    }
+
+    private fun titlePathFromQuery(query: String): String? {
+        val queryUrl = query.trim()
+            .takeIf { it.isNotEmpty() }
+            ?.toHttpUrlOrNull()
+            ?: return null
+
+        val host = queryUrl.host.removePrefix("www.")
+        if (host != baseUrl.toHttpUrl().host.removePrefix("www.")) return null
+        if (queryUrl.pathSegments.size < 2 || queryUrl.pathSegments[0] != "title") return null
+
+        val mangaId = queryUrl.pathSegments[1].substringBefore("-")
+        return mangaId.takeIf { it.isNotBlank() }?.let { "/$it" }
+    }
 
     /**
      * Apply every content-related source-level preference (rating, types,
@@ -332,8 +404,8 @@ class Comix :
     }
 
     private fun HttpUrl.Builder.applyContentRatingPreference() {
-        preferences.contentRating().takeIf { it.isNotEmpty() }?.let {
-            addQueryParameter("content_rating", it)
+        Filters.getContentRatingsUpTo(preferences.contentRating()).takeIf { it.isNotEmpty() }?.let {
+            addQueryParameter("content_rating", it.joinToString(","))
         }
     }
 

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Descrambler.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Descrambler.kt
@@ -30,12 +30,14 @@ object Descrambler {
         val rawScrambleSeed = response.header("x-scramble-seed")
         val rawScrambleGrid = response.header("x-scramble-grid")
         val rawScrambleAlgo = response.header("x-scramble-algo")
+        val rawScrambleHash = response.header("x-scramble-hash")
         val rawEncSeed = response.header("x-enc-seed")
         val rawEncAlgo = response.header("x-enc-algo")
 
         val encSeed = rawEncSeed?.toLongOrNull()?.toInt()
         val encLen = response.header("x-enc-len")?.toIntOrNull()
         val scrambleSeed = rawScrambleSeed?.toLongOrNull()?.toInt()
+        val scrambleHash = decodeScrambleHash(rawScrambleHash)
 
         val needsXor = encSeed != null && encSeed != 0 && encLen != null
         val shouldDescrambleGrid = rawScrambleGrid == "5x5" &&
@@ -62,7 +64,7 @@ object Descrambler {
                     .body("Failed to decode image".toResponseBody("text/plain".toMediaType()))
                     .build()
 
-            val descrambled = descramble(bitmap, scrambleSeed, rawScrambleAlgo)
+            val descrambled = descramble(bitmap, scrambleSeed xor scrambleHash, rawScrambleAlgo)
             bitmap.recycle()
 
             val output = Buffer()
@@ -140,6 +142,11 @@ object Descrambler {
         next = next xor (next shl 13)
         next = next xor (next ushr 17)
         return next xor (next shl 5)
+    }
+
+    private fun decodeScrambleHash(hash: String?): Int = when (hash?.trim()) {
+        "03632" -> 58414
+        else -> 0
     }
 
     private fun ByteArray.hasImageSignature(): Boolean = size >= 12 && (

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Filters.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Filters.kt
@@ -99,6 +99,13 @@ class Filters {
             Pair("Manhua", "manhua"),
             Pair("Other", "other"),
         )
+
+        fun getContentRatingsUpTo(maxRating: String): List<String> {
+            if (maxRating.isEmpty()) return emptyList()
+            val ratings = listOf("safe", "suggestive", "erotica", "pornographic")
+            val index = ratings.indexOf(maxRating)
+            return if (index == -1) emptyList() else ratings.take(index + 1)
+        }
     }
 
     fun getFilterList() = FilterList(
@@ -258,7 +265,7 @@ class Filters {
         override fun addToUri(builder: HttpUrl.Builder) {
             // The "Any" option intentionally keeps the parameter unset so the
             // site doesn't cap the results at a particular year.
-            if (state != 0) super.addToUri(builder)
+            if (state > 0) super.addToUri(builder)
         }
     }
 
@@ -283,8 +290,8 @@ class Filters {
             ),
         )
 
-    // The site filters by an inclusive cap: passing "suggestive" returns safe
-    // and suggestive titles, "erotica" adds those too, and so on.
+    // Keep the extension's old "up to" behavior even though the site now
+    // expects an explicit comma-separated list of selected content ratings.
     private class ContentRatingFilter :
         UriPartFilter(
             "Content rating",
@@ -300,7 +307,18 @@ class Filters {
         override fun addToUri(builder: HttpUrl.Builder) {
             // Index 0 is "Use preference" — let the source-level setting drive
             // the parameter instead of the manual filter.
-            if (state != 0) super.addToUri(builder)
+            if (state != 0) {
+                val selected = when (state) {
+                    1 -> "safe"
+                    2 -> "suggestive"
+                    3 -> "erotica"
+                    4 -> "pornographic"
+                    else -> ""
+                }
+                Filters.getContentRatingsUpTo(selected)
+                    .takeIf { it.isNotEmpty() }
+                    ?.let { builder.addQueryParameter("content_rating", it.joinToString(",")) }
+            }
         }
     }
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

Closes #16822 
Closes #16852 
Closes #16850 
Closes #16855
Closes #16856

They made changes to the descrambler, They also updated how the content rating and filters work. This also fixes the results view from my earlier PR. I have pulled it into this general fix #16829.

These changes take effect after a cache clear, and for suwa users, a cache clear in whatever browser they are using.