### PR TITLE
Mangadotnet [EN]: Update Search

### DIFF
--- a/src/en/mangadotnet/src/eu/kanade/tachiyomi/extension/en/mangadotnet/Dto.kt
+++ b/src/en/mangadotnet/src/eu/kanade/tachiyomi/extension/en/mangadotnet/Dto.kt
@@ -8,7 +8,10 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNames
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.JsonTransformingSerializer
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.serializer
 import kotlin.collections.emptyMap
 import kotlin.math.roundToInt
@@ -53,7 +56,15 @@ class BrowseManga(
     private val id: Int,
     private val title: String,
     private val photo: String? = null,
+    @SerialName("is_blurworthy")
+    private val isBlurworthy: JsonElement? = null,
 ) {
+    val isAdult: Boolean
+        get() = when (isBlurworthy) {
+            is JsonPrimitive -> isBlurworthy.intOrNull == 1 || isBlurworthy.booleanOrNull == true
+            else -> false
+        }
+
     fun toSManga(baseUrl: String) = SManga.create().apply {
         url = id.toString()
         title = this@BrowseManga.title

--- a/src/en/mangadotnet/src/eu/kanade/tachiyomi/extension/en/mangadotnet/Mangadotnet.kt
+++ b/src/en/mangadotnet/src/eu/kanade/tachiyomi/extension/en/mangadotnet/Mangadotnet.kt
@@ -61,7 +61,7 @@ class Mangadotnet :
     override val baseUrl = "https://mangadot.net"
     override val supportsLatest = true
 
-    override val client = network.cloudflareClient
+    override val client = network.client
 
     // ============================== Setup ===============================
     private val preferences = getPreferences {

--- a/src/en/mangadotnet/src/eu/kanade/tachiyomi/extension/en/mangadotnet/Mangadotnet.kt
+++ b/src/en/mangadotnet/src/eu/kanade/tachiyomi/extension/en/mangadotnet/Mangadotnet.kt
@@ -61,7 +61,7 @@ class Mangadotnet :
     override val baseUrl = "https://mangadot.net"
     override val supportsLatest = true
 
-    override val client = network.client
+    override val client = network.cloudflareClient
 
     // ============================== Setup ===============================
     private val preferences = getPreferences {
@@ -335,7 +335,16 @@ class Mangadotnet :
         val data = response.decodeRscAs<Data<MangaList>>().data
         updateGenres(data.allGenres)
 
-        return MangasPage(data.mangaList.orEmpty().map { it.toSManga(baseUrl) }, data.hasNextPage())
+        val mode = adultModePref()
+        val filteredManga = data.mangaList.orEmpty().filter { manga ->
+            when (mode) {
+                "none" -> !manga.isAdult
+                "1" -> manga.isAdult
+                else -> true
+            }
+        }
+
+        return MangasPage(filteredManga.map { it.toSManga(baseUrl) }, data.hasNextPage())
     }
 
     // ============================== Details ==============================


### PR DESCRIPTION
Site changed how search shows results, and blur 18+ entries. Logic is:
- Not blurworthy -> No 18+
- Blurworthy -> 18+ Only

The preference for both (No 18+ & 18+ Only) joins the results to match current website behavior now.

No bump as this should be merged with #16748.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
