### PR TITLE
GoDa: fix HTTP 410 by using v2 chapter API

### DIFF
--- a/src/zh/baozimhorg/build.gradle
+++ b/src/zh/baozimhorg/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'GoDa'
     extClass = '.GoDaManhua'
     themePkg = 'goda'
-    overrideVersionCode = 32
+    overrideVersionCode = 33
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/zh/baozimhorg/src/eu/kanade/tachiyomi/extension/zh/baozimhorg/Dto.kt
+++ b/src/zh/baozimhorg/src/eu/kanade/tachiyomi/extension/zh/baozimhorg/Dto.kt
@@ -69,9 +69,80 @@ class PageListDto(val info: PageListInfoDto)
 class PageListInfoDto(val images: PageListInfoImagesDto)
 
 @Serializable
-class PageListInfoImagesDto(val images: List<ImageDto>)
+class PageListInfoImagesDto(val images: String)
 
 @Serializable
 class ImageDto(private val url: String, private val order: Int) {
     fun toPage() = Page(order, imageUrl = "https://f40-1-4.g-mh.online$url")
+}
+
+/**
+ * The /api/v2/chapter/getinfo endpoint returns the image list as an obfuscated
+ * string instead of a plain array. This reverses the site's client-side decoder
+ * (assets/runtime/chapter-decoder.js) into the original JSON array of images.
+ *
+ * Pipeline: strip "J7r" prefix / "nQ" suffix -> split into 3 parts around the
+ * "kD" and "W4s" markers -> reorder to part3+part1+part2 -> reverse every 2nd
+ * 7-char block -> map the custom alphabet back to standard base64url -> base64
+ * decode -> UTF-8 JSON.
+ */
+object ChapterImageDecoder {
+    private const val STD = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+    private const val CUSTOM = "_-9876543210abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    private const val PREFIX = "J7r"
+    private const val MARKER1 = "kD"
+    private const val MARKER2 = "W4s"
+    private const val SUFFIX = "nQ"
+    private const val GROUP = 7
+
+    fun decode(input: String): String {
+        require(input.startsWith(PREFIX) && input.endsWith(SUFFIX)) { "未知的章节数据格式" }
+        val body = input.substring(PREFIX.length, input.length - SUFFIX.length)
+        val payloadLen = body.length - MARKER1.length - MARKER2.length
+        require(payloadLen > 0) { "未知的章节数据格式" }
+
+        val aLen = payloadLen / 3
+        val bLen = (payloadLen - aLen) / 2
+        val cLen = payloadLen - aLen - bLen
+
+        val part1 = body.substring(0, bLen)
+        val marker1 = body.substring(bLen, bLen + MARKER1.length)
+        val part2 = body.substring(bLen + MARKER1.length, bLen + MARKER1.length + cLen)
+        val marker2 = body.substring(bLen + MARKER1.length + cLen, bLen + MARKER1.length + cLen + MARKER2.length)
+        val part3 = body.substring(bLen + MARKER1.length + cLen + MARKER2.length)
+        require(marker1 == MARKER1 && marker2 == MARKER2 && part3.length == aLen) { "未知的章节数据格式" }
+
+        val reordered = part3 + part1 + part2
+        val standard = mapAlphabet(unzigzag(reordered))
+        return String(base64UrlDecode(standard), Charsets.UTF_8)
+    }
+
+    private fun unzigzag(s: String): String {
+        val sb = StringBuilder(s.length)
+        var i = 0
+        var block = 0
+        while (i < s.length) {
+            val chunk = s.substring(i, minOf(i + GROUP, s.length))
+            sb.append(if (block % 2 == 1) chunk.reversed() else chunk)
+            i += GROUP
+            block++
+        }
+        return sb.toString()
+    }
+
+    private fun mapAlphabet(s: String): String {
+        val sb = StringBuilder(s.length)
+        for (ch in s) {
+            val idx = CUSTOM.indexOf(ch)
+            require(idx >= 0) { "无效的章节数据字符" }
+            sb.append(STD[idx])
+        }
+        return sb.toString()
+    }
+
+    private fun base64UrlDecode(s: String): ByteArray {
+        val pad = (4 - s.length % 4) % 4
+        val padded = s + "=".repeat(pad)
+        return android.util.Base64.decode(padded, android.util.Base64.URL_SAFE or android.util.Base64.NO_WRAP)
+    }
 }

--- a/src/zh/baozimhorg/src/eu/kanade/tachiyomi/extension/zh/baozimhorg/Dto.kt
+++ b/src/zh/baozimhorg/src/eu/kanade/tachiyomi/extension/zh/baozimhorg/Dto.kt
@@ -95,6 +95,11 @@ object ChapterImageDecoder {
     private const val SUFFIX = "nQ"
     private const val GROUP = 7
 
+    // Precomputed lookup: custom-alphabet char code -> standard base64url char (-1 = invalid)
+    private val DECODE_TABLE = IntArray(128) { -1 }.apply {
+        for (i in CUSTOM.indices) this[CUSTOM[i].code] = STD[i].code
+    }
+
     fun decode(input: String): String {
         require(input.startsWith(PREFIX) && input.endsWith(SUFFIX)) { "未知的章节数据格式" }
         val body = input.substring(PREFIX.length, input.length - SUFFIX.length)
@@ -133,9 +138,9 @@ object ChapterImageDecoder {
     private fun mapAlphabet(s: String): String {
         val sb = StringBuilder(s.length)
         for (ch in s) {
-            val idx = CUSTOM.indexOf(ch)
-            require(idx >= 0) { "无效的章节数据字符" }
-            sb.append(STD[idx])
+            val mapped = if (ch.code < DECODE_TABLE.size) DECODE_TABLE[ch.code] else -1
+            require(mapped >= 0) { "无效的章节数据字符" }
+            sb.append(mapped.toChar())
         }
         return sb.toString()
     }

--- a/src/zh/baozimhorg/src/eu/kanade/tachiyomi/extension/zh/baozimhorg/GoDaManhua.kt
+++ b/src/zh/baozimhorg/src/eu/kanade/tachiyomi/extension/zh/baozimhorg/GoDaManhua.kt
@@ -8,14 +8,11 @@ import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import keiyoushi.utils.getPreferences
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.json.Json
+import keiyoushi.utils.parseAs
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
 import okio.IOException
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
 
 class GoDaManhua :
     GoDa("GoDa漫画", "", "zh"),
@@ -40,11 +37,9 @@ class GoDaManhua :
 
     override val client = super.client.newBuilder().addInterceptor(NotFoundInterceptor()).build()
 
-    private val json: Json = Injekt.get()
-
     override fun fetchChapterList(mangaId: String): List<SChapter> {
         val response = client.newCall(GET("https://api-get-v3.mgsearcher.com/api/manga/get?mid=$mangaId&mode=all", headers)).execute()
-        return json.decodeFromString<ResponseDto<ChapterListDto>>(response.body.string()).data.toChapterList()
+        return response.parseAs<ResponseDto<ChapterListDto>>().data.toChapterList()
     }
 
     override fun pageListRequest(mangaId: String, chapterId: String): Request {
@@ -53,9 +48,9 @@ class GoDaManhua :
     }
 
     override fun pageListParse(response: Response): List<Page> {
-        val info = json.decodeFromString<ResponseDto<PageListDto>>(response.body.string()).data.info
+        val info = response.parseAs<ResponseDto<PageListDto>>().data.info
         val decoded = ChapterImageDecoder.decode(info.images.images)
-        return json.decodeFromString<List<ImageDto>>(decoded).map { it.toPage() }
+        return decoded.parseAs<List<ImageDto>>().map { it.toPage() }
     }
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {

--- a/src/zh/baozimhorg/src/eu/kanade/tachiyomi/extension/zh/baozimhorg/GoDaManhua.kt
+++ b/src/zh/baozimhorg/src/eu/kanade/tachiyomi/extension/zh/baozimhorg/GoDaManhua.kt
@@ -49,10 +49,14 @@ class GoDaManhua :
 
     override fun pageListRequest(mangaId: String, chapterId: String): Request {
         if (mangaId.isEmpty() || chapterId.isEmpty()) throw Exception("请刷新漫画")
-        return GET("https://api-get-v3.mgsearcher.com/api/chapter/getinfo?m=$mangaId&c=$chapterId", headers)
+        return GET("https://api-get-v3.mgsearcher.com/api/v2/chapter/getinfo?m=$mangaId&c=$chapterId", headers)
     }
 
-    override fun pageListParse(response: Response): List<Page> = json.decodeFromString<ResponseDto<PageListDto>>(response.body.string()).data.info.images.images.map { it.toPage() }
+    override fun pageListParse(response: Response): List<Page> {
+        val info = json.decodeFromString<ResponseDto<PageListDto>>(response.body.string()).data.info
+        val decoded = ChapterImageDecoder.decode(info.images.images)
+        return json.decodeFromString<List<ImageDto>>(decoded).map { it.toPage() }
+    }
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         ListPreference(screen.context).apply {


### PR DESCRIPTION
### Problem

`zh.baozimhorg` (GoDa) fails with **HTTP 410** when opening a chapter. The legacy chapter endpoint has been disabled server-side:

```
GET https://api-get-v3.mgsearcher.com/api/chapter/getinfo
{"code":410,"msg":"Legacy chapter API is disabled. Please use /api/v2/chapter/getinfo","status":false}
```

### Fix

- Switch the page list request to `/api/v2/chapter/getinfo`.
- The v2 response returns the image list as an obfuscated string (`info.images.images`) instead of a plain array. Added `ChapterImageDecoder` that reverses the site's client-side decoder back into the original JSON array.

The decode is a deterministic, keyless string transform (strip prefix/suffix markers → reorder segments → reverse every 7-char block → map a custom alphabet back to standard base64url → base64 decode → JSON). The image CDN host is unchanged.

### Testing

Built with `./gradlew src:zh:baozimhorg:assembleDebug` and verified on a real device: chapters that previously returned 410 now load correctly. Decoder output was cross-checked against the site's own decoder on multiple chapters of different lengths.

Closes #16818

---

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
