### PR TITLE
Liliana: filter placeholder SVG pages

### DIFF
--- a/lib-multisrc/liliana/build.gradle.kts
+++ b/lib-multisrc/liliana/build.gradle.kts
@@ -4,4 +4,4 @@ plugins {
     alias(kei.plugins.multisrc)
 }
 
-baseVersionCode = 4
+baseVersionCode = 5

--- a/lib-multisrc/liliana/src/eu/kanade/tachiyomi/multisrc/liliana/Liliana.kt
+++ b/lib-multisrc/liliana/src/eu/kanade/tachiyomi/multisrc/liliana/Liliana.kt
@@ -288,16 +288,24 @@ abstract class Liliana(
     }
 
     protected open fun pageListParse(document: Document): List<Page> = if (document.selectFirst("div.separator[data-index]") == null) {
-        document.select("div.separator").mapIndexed { i, page ->
-            val url = page.selectFirst("a")!!.attr("abs:href")
-            Page(i, imageUrl = url)
-        }
+        document.select("div.separator")
+            .mapNotNull { page -> page.selectFirst("a")?.attr("abs:href") }
+            .filter(::isPageImageUrl)
+            .mapIndexed { i, url -> Page(i, imageUrl = url) }
     } else {
-        document.select("div.separator[data-index]").map { page ->
-            val index = page.attr("data-index").toInt()
-            val url = page.selectFirst("a")!!.attr("abs:href")
-            Page(index, imageUrl = url)
-        }.sortedBy { it.index }
+        document.select("div.separator[data-index]")
+            .mapNotNull { page ->
+                val url = page.selectFirst("a")?.attr("abs:href") ?: return@mapNotNull null
+                if (!isPageImageUrl(url)) return@mapNotNull null
+                Page(page.attr("data-index").toInt(), imageUrl = url)
+            }
+            .sortedBy { it.index }
+    }
+
+    private fun isPageImageUrl(url: String): Boolean {
+        val lowerUrl = url.lowercase()
+        val path = lowerUrl.substringBefore('?').substringBefore('#')
+        return !path.endsWith(".svg") && !lowerUrl.contains("loading_comments")
     }
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()


### PR DESCRIPTION
## What changed

- Filter Liliana page URLs before creating `Page` entries.
- Ignore placeholder SVG/comment loader URLs such as `loading_comments.svg` so they are not downloaded as manga pages.
- Bump the Liliana `baseVersionCode` so affected extensions receive an update.

## Why

ManhuaPlusOrg can include a non-page placeholder in the chapter image AJAX response:

```text
https://cdn.mangageko.com/mg1/loading_comments.svg
```

That URL is emitted as the final `div.separator[data-index]` entry for some chapters. The downloader then treats it as a manga page and fails while fetching the image because the remote host terminates the TLS handshake.

Filtering the placeholder keeps the page list to actual manga images and avoids failing an otherwise valid chapter download.

## Validation

Ran locally in an Android SDK container:

```text
./gradlew src:en:manhuaplusorg:assembleRelease
./gradlew lib-multisrc:liliana:spotlessCheck src:en:manhuaplusorg:spotlessCheck
```
