### PR TITLE
ComicK Fanmade: fix date parsing again

### DIFF
--- a/src/en/comickfan/build.gradle
+++ b/src/en/comickfan/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'ComicK Fanmade'
     extClass = '.ComicKFan'
     baseUrl = 'https://comickfan.com'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/en/comickfan/src/eu/kanade/tachiyomi/extension/en/comickfan/ComicKFan.kt
+++ b/src/en/comickfan/src/eu/kanade/tachiyomi/extension/en/comickfan/ComicKFan.kt
@@ -27,7 +27,7 @@ class ComicKFan : HttpSource() {
     override val lang = "en"
     override val supportsLatest = true
 
-    private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssSSSSSS'Z'", Locale.ROOT).apply {
+    private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'", Locale.ROOT).apply {
         timeZone = TimeZone.getTimeZone("UTC")
     }
 
@@ -172,6 +172,6 @@ class ComicKFan : HttpSource() {
         name = "Chapter $chapter"
         scanlator = groupNames.joinToString()
         chapter.toFloatOrNull()?.also { chapter_number = it }
-        date_upload = dateFormat.tryParse(publishedAt ?: createdAt)
+        date_upload = dateFormat.tryParse(createdAt ?: publishedAt)
     }
 }


### PR DESCRIPTION
Fixes comick fan chapter timestamp parsing by adding the missing dot in the date format.
Also prioritizes `createdAt` over `publishedAt` as the former is what's displayed in the website.

Previously, all date parsing failed and returned 0L. This follows up PR #16109, and I've tested the changes.

Checklist:
- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] ~Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions~
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] ~Added the `isNsfw = true` flag in `build.gradle` when appropriate~
- [x] Have not changed source names
- [x] ~Have explicitly kept the `id` if a source's name or language were changed~
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] ~Have removed `web_hi_res_512.png` when adding a new extension~
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
