### PR TITLE
MangaKawaii (FR): Fix language

### DIFF
--- a/src/fr/mangakawaii/build.gradle
+++ b/src/fr/mangakawaii/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Mangakawaii'
     extClass = '.MangaKawaii'
-    extVersionCode = 38
+    extVersionCode = 39
     isNsfw = false
 }
 

--- a/src/fr/mangakawaii/src/eu/kanade/tachiyomi/extension/fr/mangakawaii/MangaKawaii.kt
+++ b/src/fr/mangakawaii/src/eu/kanade/tachiyomi/extension/fr/mangakawaii/MangaKawaii.kt
@@ -53,7 +53,7 @@ class MangaKawaii :
         .addInterceptor { chain ->
             // fetch lang path to get encrypted cookie that server uses for lang check
             if (currentLang != language) {
-                network.client.newCall(GET("$baseUrl/lang/$language", headers)).execute()
+                network.client.newCall(GET("$baseUrl/lang/$language", headers)).execute().close()
                 currentLang = language
             }
             chain.proceed(chain.request())

--- a/src/fr/mangakawaii/src/eu/kanade/tachiyomi/extension/fr/mangakawaii/MangaKawaii.kt
+++ b/src/fr/mangakawaii/src/eu/kanade/tachiyomi/extension/fr/mangakawaii/MangaKawaii.kt
@@ -1,6 +1,10 @@
 package eu.kanade.tachiyomi.extension.fr.mangakawaii
 
+import android.webkit.WebSettings
+import androidx.preference.ListPreference
+import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
@@ -8,6 +12,8 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.applicationContext
+import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.tryParse
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -16,7 +22,9 @@ import okhttp3.Response
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class MangaKawaii : HttpSource() {
+class MangaKawaii :
+    HttpSource(),
+    ConfigurableSource {
 
     override val name = "Mangakawaii"
     override val baseUrl = "https://www.mangakawaii.io"
@@ -25,6 +33,31 @@ class MangaKawaii : HttpSource() {
     override val supportsLatest = true
 
     private val dateFormat = SimpleDateFormat("dd.MM.yyyy", Locale.US)
+
+    private val preferences by getPreferencesLazy()
+
+    private var currentLang = ""
+
+    private val webViewUA: String? by lazy {
+        runCatching { WebSettings.getDefaultUserAgent(applicationContext) }
+            .getOrNull()
+    }
+
+    // CF challange doesn't auto-solve due to needed interaction
+    // So equal UA of manual webview solve with OkHttp
+    override fun headersBuilder() = super.headersBuilder().apply {
+        webViewUA?.takeIf { it.isNotBlank() }?.let { set("User-Agent", it) }
+    }
+
+    override val client = network.client.newBuilder()
+        .addInterceptor { chain ->
+            // fetch lang path to get encrypted cookie that server uses for lang check
+            if (currentLang != language) {
+                network.client.newCall(GET("$baseUrl/lang/$language", headers)).execute()
+                currentLang = language
+            }
+            chain.proceed(chain.request())
+        }.build()
 
     // Popular
     override fun popularMangaRequest(page: Int) = GET(baseUrl, headers)
@@ -183,7 +216,22 @@ class MangaKawaii : HttpSource() {
         return GET(page.imageUrl!!, imgHeaders)
     }
 
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        ListPreference(screen.context).apply {
+            key = PREF_LANGUAGE
+            summary = "%s"
+            title = "Language"
+            entries = arrayOf("🇫🇷 Français", "🇬🇧 English")
+            entryValues = arrayOf("fr", "en")
+            setDefaultValue("fr")
+        }.let(screen::addPreference)
+    }
+
+    private val language: String
+        get() = preferences.getString(PREF_LANGUAGE, lang)!!
+
     companion object {
+        private const val PREF_LANGUAGE = "pref_lang"
         private val CHAPTER_SLUG_REGEX = Regex("""var chapter_slug = "([^"]*)";""")
         private val MANGA_SLUG_REGEX = Regex("""var oeuvre_slug = "([^"]*)";""")
         private val APP_LOCALE_REGEX = Regex("""var applocale = "([^"]*)";""")


### PR DESCRIPTION
A factory would be messy because of the site's cookie design and reader apps singleton caching, the English is just put in there, main fix is for French-only results by default

Closes #16827 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop 
