### PR TITLE
fix(hentainexus): use image fallback

### DIFF
--- a/src/en/hentainexus/build.gradle
+++ b/src/en/hentainexus/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = "HentaiNexus"
     extClass = ".HentaiNexus"
-    extVersionCode = 17
+    extVersionCode = 18
     isNsfw = true
 }
 

--- a/src/en/hentainexus/src/eu/kanade/tachiyomi/extension/en/hentainexus/HentaiNexus.kt
+++ b/src/en/hentainexus/src/eu/kanade/tachiyomi/extension/en/hentainexus/HentaiNexus.kt
@@ -176,7 +176,7 @@ class HentaiNexus : HttpSource() {
 
         return json.parseToJsonElement(data).jsonArray
             .filter { it.jsonObject["type"]!!.jsonPrimitive.content == "image" }
-            .mapIndexed { i, it -> Page(i, imageUrl = it.jsonObject["image"]!!.jsonPrimitive.content) }
+            .mapIndexed { i, it -> Page(i, imageUrl = (it.jsonObject["image"] ?: it.jsonObject["image_fallback"])!!.jsonPrimitive.content) }
     }
 
     override fun imageUrlParse(response: Response) = throw UnsupportedOperationException()


### PR DESCRIPTION
Fixes #16947

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
