### PR TITLE
Senkuro/Senkognito: fix pagination

### DIFF
--- a/lib-multisrc/senkuro/build.gradle.kts
+++ b/lib-multisrc/senkuro/build.gradle.kts
@@ -4,4 +4,4 @@ plugins {
     alias(kei.plugins.multisrc)
 }
 
-baseVersionCode = 12
+baseVersionCode = 13

--- a/lib-multisrc/senkuro/src/eu/kanade/tachiyomi/multisrc/senkuro/Senkuro.kt
+++ b/lib-multisrc/senkuro/src/eu/kanade/tachiyomi/multisrc/senkuro/Senkuro.kt
@@ -58,7 +58,7 @@ abstract class Senkuro(
     override fun popularMangaRequest(page: Int): Request {
         fetchTachiyomiSearchFilters(page)
 
-        val offset = (page - 1) * 20
+        val offset = (page - 1) * OFFSET_COUNT
         val request = graphQLPost(
             url = apiUrl,
             headers = headers,
@@ -76,7 +76,7 @@ abstract class Senkuro(
     override fun popularMangaParse(response: Response): MangasPage {
         val data = response.parseGraphQLAs<TachiyomiSearchResponseDto>()
         val mangasList = data.mangaTachiyomiSearch.mangas.map { it.toSManga() }
-        return MangasPage(mangasList, mangasList.size >= 20)
+        return MangasPage(mangasList, mangasList.size >= OFFSET_COUNT)
     }
 
     // ============================== Latest ===============================
@@ -165,7 +165,7 @@ abstract class Senkuro(
             }
         }
 
-        val offset = (page - 1) * 20
+        val offset = (page - 1) * OFFSET_COUNT
 
         val request = graphQLPost(
             url = apiUrl,
@@ -413,5 +413,6 @@ abstract class Senkuro(
         private const val API_DOMAIN_PREF = "MangaApiDomain"
         private const val API_DOMAIN_TITLE = "Домен"
         private const val API_DOMAIN_DEFAULT = "https://api.senkuro.com"
+        private const val OFFSET_COUNT = 10
     }
 }


### PR DESCRIPTION
Checklist:

**Issue:** Popular and Filter tab returns only 10 results, and stops without loading second page.

Until #16620 check in code to load next page of results in Popular/Filter tabs were:
`return MangasPage(mangasList, mangasList.isNotEmpty())`
and extension worked with any offset, since it didn't check the number of results.

Extension uses dedicated API, so it's hard to say why site gets 20 results, but extension gets only 10 manga in response. Maybe it was 20, but were changed at some point, and because of the `mangasList.isNotEmpty()` check it worked anyway, with any number of results.
I didn't find anything in [Senkuro demands](https://github.com/keiyoushi/extensions-source/pull/16620#issuecomment-4682150973) about `limit` or any other parameter to set number of returned results. Or requirements for the offset.

**Changes:**
1. Changing offset to 10 in all requests, assuming that it's now a default server pagination size for the extension.
2. Changing check for loading next page to fix pagination.

.

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
