### PR TITLE
fix(en/mangablaze): adapt to new site theme

### DIFF
--- a/src/en/mangablaze/build.gradle
+++ b/src/en/mangablaze/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.MangaBlaze'
     themePkg = 'madara'
     baseUrl = 'https://mangablaze.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = false
 }
 

--- a/src/en/mangablaze/src/eu/kanade/tachiyomi/extension/en/mangablaze/MangaBlaze.kt
+++ b/src/en/mangablaze/src/eu/kanade/tachiyomi/extension/en/mangablaze/MangaBlaze.kt
@@ -1,7 +1,14 @@
 package eu.kanade.tachiyomi.extension.en.mangablaze
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.util.asJsoup
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.Request
+import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 
@@ -14,26 +21,64 @@ class MangaBlaze :
     override val useLoadMoreRequest = LoadMoreStrategy.Never
     override val useNewChapterEndpoint = true
 
-    override fun popularMangaSelector() = "article.x72-col"
-    override val popularMangaUrlSelector = "h3.x72-title a"
+    override fun popularMangaRequest(page: Int) = GET("$baseUrl/$mangaSubString/${searchPage(page)}?orderby=popular", headers)
 
-    override fun searchMangaSelector() = "article.z8x-card"
-    override val searchMangaUrlSelector = "h2.z8x-card__title a"
+    override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/$mangaSubString/${searchPage(page)}?orderby=new", headers)
 
-    override fun parseGenres(document: Document): List<Genre> = document.select("label.r9-chip:has(input[type=checkbox][name='genre[]'])").map {
-        Genre(
-            it.selectFirst("span")!!.text(),
-            it.selectFirst("input")!!.`val`(),
-        )
+    override fun popularMangaSelector() = "a.acard"
+    override fun searchMangaSelector() = popularMangaSelector()
+
+    override fun popularMangaFromElement(element: Element) = mangaFromElement(element)
+    override fun searchMangaFromElement(element: Element) = mangaFromElement(element)
+
+    private fun mangaFromElement(element: Element) = SManga.create().apply {
+        setUrlWithoutDomain(element.absUrl("href"))
+        title = element.selectFirst(".ac-t")!!.text()
+        element.selectFirst(".ac-img img")?.let {
+            thumbnail_url = processThumbnail(imageFromElement(it), true)
+        }
     }
 
-    override val mangaDetailsSelectorTitle = "h1.nbu-hero__title, h1#nbu-hero-title"
-    override val mangaDetailsSelectorThumbnail = "img.nbu-hero__img"
-    override val mangaDetailsSelectorDescription = ".nbu-summary__body"
+    override fun popularMangaNextPageSelector() = ".pager span.on + a"
 
-    override fun chapterListSelector() = "a.nxv3-card:not(.zax-chapter-premium)"
-    override fun chapterFromElement(element: Element): SChapter = SChapter.create().apply {
-        setUrlWithoutDomain(element.absUrl("href"))
-        name = element.selectFirst(".zax-chapter-title")!!.text()
+    // The site filters by a single genre through the manga archive (?genre=slug)
+    // instead of Madara's default genre[] parameter on the search endpoint.
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+        if (query.isBlank()) {
+            val genre = filters.filterIsInstance<GenreList>()
+                .firstOrNull()
+                ?.state?.firstOrNull { it.state }?.id
+            if (!genre.isNullOrEmpty()) {
+                return GET("$baseUrl/$mangaSubString/${searchPage(page)}?genre=$genre", headers)
+            }
+        }
+        return super.searchMangaRequest(page, query, filters)
+    }
+
+    override fun genresRequest() = GET("$baseUrl/$mangaSubString/", headers)
+
+    override fun parseGenres(document: Document): List<Genre> = document.select(".chips a.chip[href*=genre=]").mapNotNull { a ->
+        val slug = a.absUrl("href").toHttpUrlOrNull()?.queryParameter("genre") ?: return@mapNotNull null
+        Genre(a.text(), slug)
+    }
+
+    override val mangaDetailsSelectorTitle = "h1.htitle"
+    override val mangaDetailsSelectorThumbnail = ".poster img"
+    override val mangaDetailsSelectorDescription = ".syn"
+    override val mangaDetailsSelectorStatus = ".hinfo .hi.ok"
+    override val mangaDetailsSelectorGenre = ".genres a.genre"
+
+    // The detail page no longer embeds the chapter list nor the
+    // manga-chapters-holder wrapper that Madara relies on to trigger the
+    // AJAX fetch, so always request the chapters endpoint directly.
+    // It returns classic Madara markup; premium chapters are locked
+    // (href="#") so they are excluded.
+    override fun chapterListSelector() = "li.wp-manga-chapter:not(.premium-block)"
+
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val mangaUrl = response.asJsoup().location().removeSuffix("/")
+        return client.newCall(xhrChaptersRequest(mangaUrl)).execute().use { xhr ->
+            xhr.asJsoup().select(chapterListSelector()).map(::chapterFromElement)
+        }
     }
 }

--- a/src/en/mangablaze/src/eu/kanade/tachiyomi/extension/en/mangablaze/MangaBlaze.kt
+++ b/src/en/mangablaze/src/eu/kanade/tachiyomi/extension/en/mangablaze/MangaBlaze.kt
@@ -70,15 +70,12 @@ class MangaBlaze :
 
     // The detail page no longer embeds the chapter list nor the
     // manga-chapters-holder wrapper that Madara relies on to trigger the
-    // AJAX fetch, so always request the chapters endpoint directly.
-    // It returns classic Madara markup; premium chapters are locked
-    // (href="#") so they are excluded.
+    // AJAX fetch, so request the chapters endpoint directly.
+    override fun chapterListRequest(manga: SManga) = xhrChaptersRequest(baseUrl + manga.url.removeSuffix("/"))
+
+    // The endpoint returns classic Madara markup; premium chapters are
+    // locked (href="#") so they are excluded.
     override fun chapterListSelector() = "li.wp-manga-chapter:not(.premium-block)"
 
-    override fun chapterListParse(response: Response): List<SChapter> {
-        val mangaUrl = response.asJsoup().location().removeSuffix("/")
-        return client.newCall(xhrChaptersRequest(mangaUrl)).execute().use { xhr ->
-            xhr.asJsoup().select(chapterListSelector()).map(::chapterFromElement)
-        }
-    }
+    override fun chapterListParse(response: Response): List<SChapter> = response.asJsoup().select(chapterListSelector()).map(::chapterFromElement)
 }


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
