### PR TITLE
Comix Yet Another Descramble 

### DIFF
--- a/src/en/comix/build.gradle.kts
+++ b/src/en/comix/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 keiyoushi {
     name = "Comix"
     className = "Comix"
-    versionCode = 31
+    versionCode = 32
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
 

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Comix.kt
@@ -71,7 +71,7 @@ class Comix :
             if (response.code != 404) return@addInterceptor response
 
             val url = request.url.toString()
-            val fallbacks = listOf("/si/", "/i/", "/sii/", "/ii/")
+            val fallbacks = listOf("/i5/", "/si/", "/i/", "/sii/", "/ii/")
                 .map { url.replaceFirst(SCRAMBLE_PATH_FALLBACK_REGEX, it) }
                 .filter { it != url }
 
@@ -1093,7 +1093,7 @@ class Comix :
         private const val SCRIPT_RETRY_INTERVAL_MS = 100L
         private const val WEBVIEW_WIDTH = 1080
         private const val WEBVIEW_HEIGHT = 1920
-        private val SCRAMBLE_PATH_FALLBACK_REGEX = Regex("/s?i+/")
+        private val SCRAMBLE_PATH_FALLBACK_REGEX = Regex("/(?:i5|s?i+)/")
         private val CHAPTER_NUM_REGEX = Regex("""Ch\.([\d.]+)""")
         private val GROUP_ID_REGEX = Regex("""/groups/(\d+)""")
         private val CHAPTER_ID_REGEX = Regex("""/(\d+)-""")

--- a/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Descrambler.kt
+++ b/src/en/comix/src/eu/kanade/tachiyomi/extension/en/comix/Descrambler.kt
@@ -146,6 +146,7 @@ object Descrambler {
 
     private fun decodeScrambleHash(hash: String?): Int = when (hash?.trim()) {
         "03632" -> 58414
+        "02900" -> 117532
         else -> 0
     }
 


### PR DESCRIPTION
Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

Closes #17028

They added another descramble hash whilst keeping the old ones. 

Tested and works

There could be more hashes that change the scramble values, but ive not seen them yet on the pages i have tested

They also added a new image fallback which i have added
