### PR TITLE
core: Add OkHttp and JsonElement helpers

### DIFF
--- a/core/src/main/kotlin/keiyoushi/network/OkHttp.kt
+++ b/core/src/main/kotlin/keiyoushi/network/OkHttp.kt
@@ -1,0 +1,288 @@
+package keiyoushi.network
+
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.await
+import eu.kanade.tachiyomi.network.awaitSuccess
+import eu.kanade.tachiyomi.source.online.HttpSource
+import okhttp3.CacheControl
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.Response
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * Default cache control.
+ */
+private val DEFAULT_CACHE_CONTROL = CacheControl.Builder().maxAge(10.minutes).build()
+
+/**
+ * Executes a GET request asynchronously and returns the response.
+ *
+ * @param url The [HttpUrl] to request.
+ * @param headers The headers to include in the request.
+ * @param cacheControl The cache control settings for the request.
+ * @param ensureSuccess If true, throws an exception if the response code is not 2xx.
+ * @return The HTTP [Response].
+ */
+suspend fun OkHttpClient.get(
+    url: HttpUrl,
+    headers: Headers,
+    cacheControl: CacheControl = DEFAULT_CACHE_CONTROL,
+    ensureSuccess: Boolean = true,
+): Response {
+    val call = newCall(GET(url, headers, cacheControl))
+
+    return if (ensureSuccess) {
+        call.awaitSuccess()
+    } else {
+        call.await()
+    }
+}
+
+/**
+ * Executes a GET request asynchronously using a URL string and returns the response.
+ *
+ * @param url The URL string to request.
+ * @param headers The headers to include in the request.
+ * @param cacheControl The cache control settings for the request.
+ * @param ensureSuccess If true, throws an exception if the response code is not 2xx.
+ * @return The HTTP [Response].
+ */
+suspend fun OkHttpClient.get(
+    url: String,
+    headers: Headers,
+    cacheControl: CacheControl = DEFAULT_CACHE_CONTROL,
+    ensureSuccess: Boolean = true,
+): Response = get(url.toHttpUrl(), headers, cacheControl, ensureSuccess)
+
+/**
+ * Executes a GET request asynchronously, automatically retrieving the headers from the
+ * current [HttpSource] context receiver.
+ *
+ * @param url The [HttpUrl] to request.
+ * @param cacheControl The cache control settings for the request.
+ * @param ensureSuccess If true, throws an exception if the response code is not 2xx.
+ * @return The HTTP [Response].
+ */
+context(source: HttpSource)
+suspend fun OkHttpClient.get(
+    url: HttpUrl,
+    cacheControl: CacheControl = DEFAULT_CACHE_CONTROL,
+    ensureSuccess: Boolean = true,
+): Response = get(url, source.headers, cacheControl, ensureSuccess)
+
+/**
+ * Executes a GET request asynchronously using a URL string, automatically retrieving the
+ * headers from the current [HttpSource] context receiver.
+ *
+ * @param url The URL string to request.
+ * @param cacheControl The cache control settings for the request.
+ * @param ensureSuccess If true, throws an exception if the response code is not 2xx.
+ * @return The HTTP [Response].
+ */
+context(source: HttpSource)
+suspend fun OkHttpClient.get(
+    url: String,
+    cacheControl: CacheControl = DEFAULT_CACHE_CONTROL,
+    ensureSuccess: Boolean = true,
+): Response = get(url, source.headers, cacheControl, ensureSuccess)
+
+/**
+ * Executes a POST request asynchronously and returns the response.
+ *
+ * @param url The URL string to request.
+ * @param headers The headers to include in the request.
+ * @param body The request body payload.
+ * @param ensureSuccess If true, throws an exception if the response code is not 2xx.
+ * @return The HTTP [Response].
+ */
+suspend fun OkHttpClient.post(
+    url: String,
+    headers: Headers,
+    body: RequestBody,
+    ensureSuccess: Boolean = true,
+): Response {
+    val call = newCall(POST(url, headers, body))
+
+    return if (ensureSuccess) {
+        call.awaitSuccess()
+    } else {
+        call.await()
+    }
+}
+
+/**
+ * Executes a POST request asynchronously, automatically retrieving the headers from the
+ * current [HttpSource] context receiver.
+ *
+ * @param url The URL string to request.
+ * @param body The request body payload.
+ * @param ensureSuccess If true, throws an exception if the response code is not 2xx.
+ * @return The HTTP [Response].
+ */
+context(source: HttpSource)
+suspend fun OkHttpClient.post(
+    url: String,
+    body: RequestBody,
+    ensureSuccess: Boolean = true,
+): Response = post(url, source.headers, body, ensureSuccess)
+
+/**
+ * Executes a PUT request asynchronously using an [HttpUrl] and returns the response.
+ *
+ * @param url The [HttpUrl] to request.
+ * @param headers The headers to include in the request.
+ * @param body The request body payload.
+ * @param ensureSuccess If true, throws an exception if the response code is not 2xx.
+ * @return The HTTP [Response].
+ */
+suspend fun OkHttpClient.put(
+    url: HttpUrl,
+    headers: Headers,
+    body: RequestBody,
+    ensureSuccess: Boolean = true,
+): Response {
+    val request = Request.Builder()
+        .url(url)
+        .headers(headers)
+        .put(body)
+        .build()
+    val call = newCall(request)
+
+    return if (ensureSuccess) {
+        call.awaitSuccess()
+    } else {
+        call.await()
+    }
+}
+
+/**
+ * Executes a PUT request asynchronously and returns the response.
+ *
+ * @param url The URL string to request.
+ * @param headers The headers to include in the request.
+ * @param body The request body payload.
+ * @param ensureSuccess If true, throws an exception if the response code is not 2xx.
+ * @return The HTTP [Response].
+ */
+suspend fun OkHttpClient.put(
+    url: String,
+    headers: Headers,
+    body: RequestBody,
+    ensureSuccess: Boolean = true,
+): Response = put(url.toHttpUrl(), headers, body, ensureSuccess)
+
+/**
+ * Executes a PUT request asynchronously, automatically retrieving the headers from the
+ * current [HttpSource] context receiver.
+ *
+ * @param url The URL string to request.
+ * @param body The request body payload.
+ * @param ensureSuccess If true, throws an exception if the response code is not 2xx.
+ * @return The HTTP [Response].
+ */
+context(source: HttpSource)
+suspend fun OkHttpClient.put(
+    url: String,
+    body: RequestBody,
+    ensureSuccess: Boolean = true,
+): Response = put(url, source.headers, body, ensureSuccess)
+
+/**
+ * Executes a PUT request asynchronously using an [HttpUrl], automatically retrieving the
+ * headers from the current [HttpSource] context receiver.
+ *
+ * @param url The [HttpUrl] to request.
+ * @param body The request body payload.
+ * @param ensureSuccess If true, throws an exception if the response code is not 2xx.
+ * @return The HTTP [Response].
+ */
+context(source: HttpSource)
+suspend fun OkHttpClient.put(
+    url: HttpUrl,
+    body: RequestBody,
+    ensureSuccess: Boolean = true,
+): Response = put(url, source.headers, body, ensureSuccess)
+
+/**
+ * Executes a HEAD request asynchronously using an [HttpUrl] and returns the response.
+ *
+ * @param url The [HttpUrl] to request.
+ * @param headers The headers to include in the request.
+ * @param cacheControl The cache control settings for the request.
+ * @param ensureSuccess If true, throws an exception if the response code is not 2xx.
+ * @return The HTTP [Response].
+ */
+suspend fun OkHttpClient.head(
+    url: HttpUrl,
+    headers: Headers,
+    cacheControl: CacheControl = DEFAULT_CACHE_CONTROL,
+    ensureSuccess: Boolean = true,
+): Response {
+    val request = Request.Builder()
+        .url(url)
+        .headers(headers)
+        .cacheControl(cacheControl)
+        .head()
+        .build()
+    val call = newCall(request)
+
+    return if (ensureSuccess) {
+        call.awaitSuccess()
+    } else {
+        call.await()
+    }
+}
+
+/**
+ * Executes a HEAD request asynchronously and returns the response.
+ *
+ * @param url The URL string to request.
+ * @param headers The headers to include in the request.
+ * @param cacheControl The cache control settings for the request.
+ * @param ensureSuccess If true, throws an exception if the response code is not 2xx.
+ * @return The HTTP [Response].
+ */
+suspend fun OkHttpClient.head(
+    url: String,
+    headers: Headers,
+    cacheControl: CacheControl = DEFAULT_CACHE_CONTROL,
+    ensureSuccess: Boolean = true,
+): Response = head(url.toHttpUrl(), headers, cacheControl, ensureSuccess)
+
+/**
+ * Executes a HEAD request asynchronously using a URL string, automatically retrieving the
+ * headers from the current [HttpSource] context receiver.
+ *
+ * @param url The URL string to request.
+ * @param cacheControl The cache control settings for the request.
+ * @param ensureSuccess If true, throws an exception if the response code is not 2xx.
+ * @return The HTTP [Response].
+ */
+context(source: HttpSource)
+suspend fun OkHttpClient.head(
+    url: String,
+    cacheControl: CacheControl = DEFAULT_CACHE_CONTROL,
+    ensureSuccess: Boolean = true,
+): Response = head(url, source.headers, cacheControl, ensureSuccess)
+
+/**
+ * Executes a HEAD request asynchronously using an [HttpUrl], automatically retrieving the
+ * headers from the current [HttpSource] context receiver.
+ *
+ * @param url The [HttpUrl] to request.
+ * @param cacheControl The cache control settings for the request.
+ * @param ensureSuccess If true, throws an exception if the response code is not 2xx.
+ * @return The HTTP [Response].
+ */
+context(source: HttpSource)
+suspend fun OkHttpClient.head(
+    url: HttpUrl,
+    cacheControl: CacheControl = DEFAULT_CACHE_CONTROL,
+    ensureSuccess: Boolean = true,
+): Response = head(url, source.headers, cacheControl, ensureSuccess)

--- a/core/src/main/kotlin/keiyoushi/network/OkHttp.kt
+++ b/core/src/main/kotlin/keiyoushi/network/OkHttp.kt
@@ -96,7 +96,7 @@ suspend fun OkHttpClient.get(
 ): Response = get(url, source.headers, cacheControl, ensureSuccess)
 
 /**
- * Executes a POST request asynchronously using an [HttpUrl] and returns the response.
+ * Executes a POST request asynchronously and returns the response.
  *
  * @param url The [HttpUrl] to request.
  * @param headers The headers to include in the request.
@@ -125,7 +125,7 @@ suspend fun OkHttpClient.post(
 }
 
 /**
- * Executes a POST request asynchronously and returns the response.
+ * Executes a POST request asynchronously using a URL string and returns the response.
  *
  * @param url The URL string to request.
  * @param headers The headers to include in the request.
@@ -141,7 +141,7 @@ suspend fun OkHttpClient.post(
 ): Response = post(url.toHttpUrl(), headers, body, ensureSuccess)
 
 /**
- * Executes a POST request asynchronously using an [HttpUrl], automatically retrieving the
+ * Executes a POST request asynchronously, automatically retrieving the
  * headers from the current [HttpSource] context receiver.
  *
  * @param url The [HttpUrl] to request.
@@ -157,8 +157,8 @@ suspend fun OkHttpClient.post(
 ): Response = post(url, source.headers, body, ensureSuccess)
 
 /**
- * Executes a POST request asynchronously, automatically retrieving the headers from the
- * current [HttpSource] context receiver.
+ * Executes a POST request asynchronously using a URL string, automatically retrieving the
+ * headers from the current [HttpSource] context receiver.
  *
  * @param url The URL string to request.
  * @param body The request body payload.
@@ -173,7 +173,7 @@ suspend fun OkHttpClient.post(
 ): Response = post(url, source.headers, body, ensureSuccess)
 
 /**
- * Executes a PUT request asynchronously using an [HttpUrl] and returns the response.
+ * Executes a PUT request asynchronously and returns the response.
  *
  * @param url The [HttpUrl] to request.
  * @param headers The headers to include in the request.
@@ -202,7 +202,7 @@ suspend fun OkHttpClient.put(
 }
 
 /**
- * Executes a PUT request asynchronously and returns the response.
+ * Executes a PUT request asynchronously using a URL string and returns the response.
  *
  * @param url The URL string to request.
  * @param headers The headers to include in the request.
@@ -218,8 +218,8 @@ suspend fun OkHttpClient.put(
 ): Response = put(url.toHttpUrl(), headers, body, ensureSuccess)
 
 /**
- * Executes a PUT request asynchronously, automatically retrieving the headers from the
- * current [HttpSource] context receiver.
+ * Executes a PUT request asynchronously using a URL string, automatically retrieving the
+ * headers from the current [HttpSource] context receiver.
  *
  * @param url The URL string to request.
  * @param body The request body payload.
@@ -234,7 +234,7 @@ suspend fun OkHttpClient.put(
 ): Response = put(url, source.headers, body, ensureSuccess)
 
 /**
- * Executes a PUT request asynchronously using an [HttpUrl], automatically retrieving the
+ * Executes a PUT request asynchronously, automatically retrieving the
  * headers from the current [HttpSource] context receiver.
  *
  * @param url The [HttpUrl] to request.
@@ -250,7 +250,7 @@ suspend fun OkHttpClient.put(
 ): Response = put(url, source.headers, body, ensureSuccess)
 
 /**
- * Executes a HEAD request asynchronously using an [HttpUrl] and returns the response.
+ * Executes a HEAD request asynchronously and returns the response.
  *
  * @param url The [HttpUrl] to request.
  * @param headers The headers to include in the request.
@@ -280,7 +280,7 @@ suspend fun OkHttpClient.head(
 }
 
 /**
- * Executes a HEAD request asynchronously and returns the response.
+ * Executes a HEAD request asynchronously using a URL string and returns the response.
  *
  * @param url The URL string to request.
  * @param headers The headers to include in the request.
@@ -312,7 +312,7 @@ suspend fun OkHttpClient.head(
 ): Response = head(url, source.headers, cacheControl, ensureSuccess)
 
 /**
- * Executes a HEAD request asynchronously using an [HttpUrl], automatically retrieving the
+ * Executes a HEAD request asynchronously, automatically retrieving the
  * headers from the current [HttpSource] context receiver.
  *
  * @param url The [HttpUrl] to request.

--- a/core/src/main/kotlin/keiyoushi/network/OkHttp.kt
+++ b/core/src/main/kotlin/keiyoushi/network/OkHttp.kt
@@ -1,7 +1,5 @@
 package keiyoushi.network
 
-import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.source.online.HttpSource
@@ -35,7 +33,12 @@ suspend fun OkHttpClient.get(
     cacheControl: CacheControl = DEFAULT_CACHE_CONTROL,
     ensureSuccess: Boolean = true,
 ): Response {
-    val call = newCall(GET(url, headers, cacheControl))
+    val request = Request.Builder()
+        .url(url)
+        .headers(headers)
+        .cacheControl(cacheControl)
+        .build()
+    val call = newCall(request)
 
     return if (ensureSuccess) {
         call.awaitSuccess()
@@ -93,6 +96,35 @@ suspend fun OkHttpClient.get(
 ): Response = get(url, source.headers, cacheControl, ensureSuccess)
 
 /**
+ * Executes a POST request asynchronously using an [HttpUrl] and returns the response.
+ *
+ * @param url The [HttpUrl] to request.
+ * @param headers The headers to include in the request.
+ * @param body The request body payload.
+ * @param ensureSuccess If true, throws an exception if the response code is not 2xx.
+ * @return The HTTP [Response].
+ */
+suspend fun OkHttpClient.post(
+    url: HttpUrl,
+    headers: Headers,
+    body: RequestBody,
+    ensureSuccess: Boolean = true,
+): Response {
+    val request = Request.Builder()
+        .url(url)
+        .headers(headers)
+        .post(body)
+        .build()
+    val call = newCall(request)
+
+    return if (ensureSuccess) {
+        call.awaitSuccess()
+    } else {
+        call.await()
+    }
+}
+
+/**
  * Executes a POST request asynchronously and returns the response.
  *
  * @param url The URL string to request.
@@ -106,15 +138,23 @@ suspend fun OkHttpClient.post(
     headers: Headers,
     body: RequestBody,
     ensureSuccess: Boolean = true,
-): Response {
-    val call = newCall(POST(url, headers, body))
+): Response = post(url.toHttpUrl(), headers, body, ensureSuccess)
 
-    return if (ensureSuccess) {
-        call.awaitSuccess()
-    } else {
-        call.await()
-    }
-}
+/**
+ * Executes a POST request asynchronously using an [HttpUrl], automatically retrieving the
+ * headers from the current [HttpSource] context receiver.
+ *
+ * @param url The [HttpUrl] to request.
+ * @param body The request body payload.
+ * @param ensureSuccess If true, throws an exception if the response code is not 2xx.
+ * @return The HTTP [Response].
+ */
+context(source: HttpSource)
+suspend fun OkHttpClient.post(
+    url: HttpUrl,
+    body: RequestBody,
+    ensureSuccess: Boolean = true,
+): Response = post(url, source.headers, body, ensureSuccess)
 
 /**
  * Executes a POST request asynchronously, automatically retrieving the headers from the

--- a/core/src/main/kotlin/keiyoushi/utils/JsonElement.kt
+++ b/core/src/main/kotlin/keiyoushi/utils/JsonElement.kt
@@ -1,0 +1,54 @@
+package keiyoushi.utils
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import kotlinx.serialization.json.longOrNull
+
+operator fun JsonElement?.get(key: String): JsonElement? = this?.jsonObject?.get(key)
+
+operator fun JsonElement?.get(index: Int): JsonElement? = this?.jsonArray?.get(index)
+
+val JsonElement.obj: JsonObject get() = jsonObject
+val JsonElement.array: JsonArray get() = jsonArray
+val JsonElement.string: String get() = jsonPrimitive.content
+val JsonElement.stringOrNull: String? get() = jsonPrimitive.contentOrNull
+val JsonElement.int: Int get() = jsonPrimitive.int
+val JsonElement.intOrNull: Int? get() = jsonPrimitive.intOrNull
+val JsonElement.long: Long get() = jsonPrimitive.long
+val JsonElement.longOrNull: Long? get() = jsonPrimitive.longOrNull
+val JsonElement.boolean: Boolean get() = jsonPrimitive.boolean
+val JsonElement.booleanOrNull: Boolean? get() = jsonPrimitive.booleanOrNull
+
+fun JsonObject.getString(key: String): String = getValue(key).jsonPrimitive.content
+
+fun JsonObject.getStringOrNull(key: String): String? = get(key)?.jsonPrimitive?.contentOrNull
+
+fun JsonObject.getInt(key: String): Int = getValue(key).jsonPrimitive.int
+
+fun JsonObject.getIntOrNull(key: String): Int? = get(key)?.jsonPrimitive?.intOrNull
+
+fun JsonObject.getLong(key: String): Long = getValue(key).jsonPrimitive.long
+
+fun JsonObject.getLongOrNull(key: String): Long? = get(key)?.jsonPrimitive?.longOrNull
+
+fun JsonObject.getBoolean(key: String): Boolean = getValue(key).jsonPrimitive.boolean
+
+fun JsonObject.getBooleanOrNull(key: String): Boolean? = get(key)?.jsonPrimitive?.booleanOrNull
+
+fun JsonObject.getArray(key: String): JsonArray = getValue(key).jsonArray
+
+fun JsonObject.getArrayOrNull(key: String): JsonArray? = get(key)?.jsonArray
+
+fun JsonObject.getObject(key: String): JsonObject = getValue(key).jsonObject
+
+fun JsonObject.getObjectOrNull(key: String): JsonObject? = get(key)?.jsonObject


### PR DESCRIPTION
`OkHttp` extensions split from https://github.com/keiyoushi/extensions-source/pull/16874
suspend api, will be useful in new 1.6 extensions

`JsonElement` extensions useful for the new `memo` field in `SManga`/`SChapter`

allows: 
        `memo["key1"]["key2"][0]!!.string`

as opposed to:
        `memo["key1"]!!.jsonObject["key2"]!!.jsonArray[0].jsonPrimitive.content`