### PR TITLE
MangaLivre: auto-discover the rotating client header

### DIFF
--- a/src/pt/mangalivre/build.gradle.kts
+++ b/src/pt/mangalivre/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 keiyoushi {
     name = "Manga Livre"
     className = "MangaLivre"
-    versionCode = 66
+    versionCode = 67
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 }

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
@@ -245,9 +245,9 @@ class MangaLivre :
     }
 
     /**
-     * O nome do header e o valor já rotacionaram (x-toonlivre-client -> x-tly-sec,
-     * web-x -> web-z99), então tentamos descobrir o par "x-...":"web-..." direto do
-     * bundle; se não der, mantemos o nome conhecido e procuramos só o valor.
+     * O nome do header rotaciona com frequência (x-toonlivre-client -> x-tly-sec ->
+     * x-app-key), o valor é sempre "web-...". Descobrimos o par "x-...":"web-..." direto
+     * do bundle para sobreviver às próximas rotações; se não der, usamos o último conhecido.
      */
     private fun extractToken(js: String): ClientToken? {
         PAIR_REGEX.find(js)?.let {
@@ -274,9 +274,9 @@ class MangaLivre :
         private const val MAX_PEEK = 1024L
         private const val NON_JSON_MESSAGE =
             "Resposta não-JSON (Cloudflare ou header desatualizado). Abra a fonte na WebView do app e tente de novo."
-        private val DEFAULT_TOKEN = ClientToken("x-tly-sec", "web-z99")
+        private val DEFAULT_TOKEN = ClientToken("x-app-key", "web-z99")
         private val ASSET_REGEX = Regex("/assets/index-[\\w-]+\\.js")
-        private val PAIR_REGEX = Regex("\"(x-t[a-z0-9-]+)\"\\s*[,:]\\s*\"(web-[a-z0-9]+)\"")
+        private val PAIR_REGEX = Regex("\"(x-[a-z0-9-]{2,})\"\\s*[,:]\\s*\"(web-[a-z0-9]+)\"")
         private val VALUE_REGEX = Regex("\"(web-[a-z0-9]+)\"")
     }
 }

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
@@ -201,6 +201,9 @@ class MangaLivre :
     @Volatile
     private var cachedToken: ClientToken? = null
 
+    @Volatile
+    private var cachedCandidates: List<ClientToken>? = null
+
     private fun clientHeaderInterceptor(chain: Interceptor.Chain): Response {
         val request = chain.request()
         if (request.url.host != baseUrlHost) {
@@ -208,57 +211,70 @@ class MangaLivre :
         }
 
         val token = currentToken()
-        val response = chain.proceed(
-            request.newBuilder().header(token.header, token.value).build(),
-        )
+        val response = chain.proceed(request.withClientHeader(token))
         if (response.code != 403 || !response.isOfficialAppError()) {
             return response
         }
 
+        // O header de cliente rotacionou. Redescobre os candidatos no bundle e testa
+        // cada um até a API parar de recusar, memorizando o que funcionar.
         response.close()
-        val refreshed = refreshToken()
-        return chain.proceed(
-            request.newBuilder().header(refreshed.header, refreshed.value).build(),
-        )
+        for (candidate in refreshCandidates()) {
+            if (candidate == token) continue
+            val retry = chain.proceed(request.withClientHeader(candidate))
+            if (retry.code != 403 || !retry.isOfficialAppError()) {
+                cachedToken = candidate
+                return retry
+            }
+            retry.close()
+        }
+        return chain.proceed(request.withClientHeader(token))
     }
+
+    private fun Request.withClientHeader(token: ClientToken): Request =
+        newBuilder().header(token.header, token.value).build()
 
     private fun currentToken(): ClientToken = cachedToken ?: synchronized(this) {
-        cachedToken ?: scrapeToken().also { cachedToken = it }
+        cachedToken ?: candidates().first().also { cachedToken = it }
     }
 
-    private fun refreshToken(): ClientToken = synchronized(this) {
-        scrapeToken().also { cachedToken = it }
-    }
+    private fun candidates(): List<ClientToken> = cachedCandidates ?: refreshCandidates()
 
-    private fun scrapeToken(): ClientToken {
-        return try {
-            val html = scrapeClient.newCall(GET("$baseUrl/index.html", headers)).execute()
-                .use { if (it.isSuccessful) it.body?.string().orEmpty() else "" }
-            val assetPath = ASSET_REGEX.find(html)?.value ?: return DEFAULT_TOKEN
-            val js = scrapeClient.newCall(GET("$baseUrl$assetPath", headers)).execute()
-                .use { if (it.isSuccessful) it.body?.string() else null }
-                ?: return DEFAULT_TOKEN
-            extractToken(js) ?: DEFAULT_TOKEN
-        } catch (_: Exception) {
-            DEFAULT_TOKEN
-        }
+    private fun refreshCandidates(): List<ClientToken> = synchronized(this) {
+        scrapeCandidates().also { cachedCandidates = it }
     }
 
     /**
-     * O nome do header rotaciona com frequência (x-toonlivre-client -> x-tly-sec ->
-     * x-app-key), o valor é sempre "web-...". Descobrimos o par "x-...":"web-..." direto
-     * do bundle para sobreviver às próximas rotações; se não der, usamos o último conhecido.
+     * O front-end manda um header de cliente cujo NOME rotaciona toda hora
+     * (x-toonlivre-client -> x-tly-sec -> x-app-key) e cujo valor costuma ser "web-...".
+     * Em vez de fixar um nome, varremos os bundles em /assets e coletamos todos os pares
+     * "x-...":"valor", priorizando os "web-..."; o interceptor testa cada um quando toma 403.
      */
-    private fun extractToken(js: String): ClientToken? {
-        PAIR_REGEX.find(js)?.let {
-            return ClientToken(it.groupValues[1], it.groupValues[2])
+    private fun scrapeCandidates(): List<ClientToken> {
+        return try {
+            val html = scrapeClient.newCall(GET("$baseUrl/", headers)).execute()
+                .use { if (it.isSuccessful) it.body?.string().orEmpty() else "" }
+            val assets = ASSET_REGEX.findAll(html).map { it.value }.distinct().toList()
+            val js = buildString {
+                assets.take(MAX_ASSETS).forEach { path ->
+                    scrapeClient.newCall(GET("$baseUrl$path", headers)).execute()
+                        .use { if (it.isSuccessful) append(it.body?.string().orEmpty()) }
+                }
+            }
+            extractCandidates(js)
+        } catch (_: Exception) {
+            listOf(DEFAULT_TOKEN)
         }
-        val value = VALUE_REGEX.findAll(js)
-            .map { it.groupValues[1] }
-            .toSet()
-            .singleOrNull()
-            ?: return null
-        return ClientToken(DEFAULT_TOKEN.header, value)
+    }
+
+    private fun extractCandidates(js: String): List<ClientToken> {
+        val pairs = PAIR_REGEX.findAll(js)
+            .map { ClientToken(it.groupValues[1], it.groupValues[2]) }
+            .distinct()
+            .toList()
+        val ranked = pairs.sortedByDescending { it.value.startsWith("web-") }
+            .take(MAX_CANDIDATES)
+        return (ranked + DEFAULT_TOKEN).distinct()
     }
 
     private fun Response.isOfficialAppError(): Boolean = try {
@@ -272,11 +288,12 @@ class MangaLivre :
     companion object {
         private const val ALTERNATIVE_TITLE_PREF = "alternativeTitlePref"
         private const val MAX_PEEK = 1024L
+        private const val MAX_ASSETS = 8
+        private const val MAX_CANDIDATES = 8
         private const val NON_JSON_MESSAGE =
             "Resposta não-JSON (Cloudflare ou header desatualizado). Abra a fonte na WebView do app e tente de novo."
         private val DEFAULT_TOKEN = ClientToken("x-app-key", "web-z99")
-        private val ASSET_REGEX = Regex("/assets/index-[\\w-]+\\.js")
-        private val PAIR_REGEX = Regex("\"(x-[a-z0-9-]{2,})\"\\s*[,:]\\s*\"(web-[a-z0-9]+)\"")
-        private val VALUE_REGEX = Regex("\"(web-[a-z0-9]+)\"")
+        private val ASSET_REGEX = Regex("/assets/[\\w-]+\\.js")
+        private val PAIR_REGEX = Regex("\"(x-[a-z0-9-]{2,})\"\\s*[,:]\\s*\"([a-z][a-z0-9-]{1,40})\"")
     }
 }

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
@@ -231,8 +231,7 @@ class MangaLivre :
         return chain.proceed(request.withClientHeader(token))
     }
 
-    private fun Request.withClientHeader(token: ClientToken): Request =
-        newBuilder().header(token.header, token.value).build()
+    private fun Request.withClientHeader(token: ClientToken): Request = newBuilder().header(token.header, token.value).build()
 
     private fun currentToken(): ClientToken = cachedToken ?: synchronized(this) {
         cachedToken ?: candidates().first().also { cachedToken = it }
@@ -250,21 +249,19 @@ class MangaLivre :
      * Em vez de fixar um nome, varremos os bundles em /assets e coletamos todos os pares
      * "x-...":"valor", priorizando os "web-..."; o interceptor testa cada um quando toma 403.
      */
-    private fun scrapeCandidates(): List<ClientToken> {
-        return try {
-            val html = scrapeClient.newCall(GET("$baseUrl/", headers)).execute()
-                .use { if (it.isSuccessful) it.body?.string().orEmpty() else "" }
-            val assets = ASSET_REGEX.findAll(html).map { it.value }.distinct().toList()
-            val js = buildString {
-                assets.take(MAX_ASSETS).forEach { path ->
-                    scrapeClient.newCall(GET("$baseUrl$path", headers)).execute()
-                        .use { if (it.isSuccessful) append(it.body?.string().orEmpty()) }
-                }
+    private fun scrapeCandidates(): List<ClientToken> = try {
+        val html = scrapeClient.newCall(GET("$baseUrl/", headers)).execute()
+            .use { if (it.isSuccessful) it.body?.string().orEmpty() else "" }
+        val assets = ASSET_REGEX.findAll(html).map { it.value }.distinct().toList()
+        val js = buildString {
+            assets.take(MAX_ASSETS).forEach { path ->
+                scrapeClient.newCall(GET("$baseUrl$path", headers)).execute()
+                    .use { if (it.isSuccessful) append(it.body?.string().orEmpty()) }
             }
-            extractCandidates(js)
-        } catch (_: Exception) {
-            listOf(DEFAULT_TOKEN)
         }
+        extractCandidates(js)
+    } catch (_: Exception) {
+        listOf(DEFAULT_TOKEN)
     }
 
     private fun extractCandidates(js: String): List<ClientToken> {


### PR DESCRIPTION
Follow-up to #17030. The site keeps rotating the **name** of the client header it requires on API calls: `x-toonlivre-client` → `x-tly-sec` → **`x-app-key`** (value stays `web-z99`). Each rotation makes every call return `403` ("aplicativo oficial") and the source stops loading. The narrow discovery shipped in #17030 (`x-t…` only) didn't catch `x-app-key`.

Instead of chasing each new name with a release, this makes the discovery self-healing:

- Scan **all** `/assets/*.js` chunks (not just `index-*.js`) and collect every `"x-…":"value"` pair, ranking `web-…` values first.
- On a `403` "aplicativo oficial", try the discovered candidates in order until the API accepts one, then cache the winner. This auto-recovers from future **name** (and **value**) rotations without a new release.
- Keep `x-app-key` / `web-z99` as the cold-start default.

Verified against the live bundle (real browser, Cloudflare cleared): the only `x-…` header paired with a `web-…` value is `x-app-key`, so the ranked discovery selects it unambiguously; the other `x-…` literals (`x-requested-with`, etc.) are only tried as low-priority fallbacks.

### Changes

- Auto-discover the client header (name + value) from the JS bundle; multi-candidate retry on `403`.
- Bump `versionCode` to 67.

No endpoint URLs or DTOs changed.

### Checklist

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code) — n/a
- [ ] Referenced all related issues in the PR body — follow-up to #17030
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately (unchanged: SAFE)
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed — n/a (unchanged)
- [ ] Have tested the modifications by compiling and running the extension through Android Studio — **I don't have an Android environment (iOS only).** I validated the header name/value and the discovery against the live site through a browser; relying on this PR's CI to compile, lint and build.
- [ ] Have removed `web_hi_res_512.png` when adding a new extension — n/a
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
