### PR TITLE
Cosmicscanid: migrate to HttpSource

### DIFF
--- a/src/id/cosmicscansid/build.gradle.kts
+++ b/src/id/cosmicscansid/build.gradle.kts
@@ -5,11 +5,9 @@ plugins {
 keiyoushi {
     name = "CosmicScans.id"
     className = "CosmicScansID"
-    versionCode = 22
-    contentWarning = ContentWarning.SAFE
+    versionCode = 55
+    contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
-    theme = "mangathemesia"
-    baseUrl = "https://lc1.cosmicscans.to"
 }
 
 dependencies {

--- a/src/id/cosmicscansid/build.gradle.kts
+++ b/src/id/cosmicscansid/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 keiyoushi {
-    name = "CosmicScansID"
+    name = "CosmicScans"
     versionCode = 55
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"

--- a/src/id/cosmicscansid/build.gradle.kts
+++ b/src/id/cosmicscansid/build.gradle.kts
@@ -9,8 +9,3 @@ keiyoushi {
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 }
-
-dependencies {
-
-    implementation(project(":lib:randomua"))
-}

--- a/src/id/cosmicscansid/build.gradle.kts
+++ b/src/id/cosmicscansid/build.gradle.kts
@@ -11,6 +11,6 @@ keiyoushi {
     source {
         lang = "id"
         baseUrl = "https://01.cosmicscans.to"
-        versionId = 1
+        id = 6559481336553833282L
     }
 }

--- a/src/id/cosmicscansid/build.gradle.kts
+++ b/src/id/cosmicscansid/build.gradle.kts
@@ -3,9 +3,14 @@ plugins {
 }
 
 keiyoushi {
-    name = "CosmicScans.id"
-    className = "CosmicScansID"
+    name = "CosmicScansID"
     versionCode = 55
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
+
+    source {
+        lang = "id"
+        baseUrl = "https://01.cosmicscans.to"
+        versionId = 1
+    }
 }

--- a/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/CosmicScansID.kt
+++ b/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/CosmicScansID.kt
@@ -4,34 +4,44 @@ import android.content.SharedPreferences
 import android.widget.Toast
 import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.lib.randomua.addRandomUAPreference
 import keiyoushi.lib.randomua.setRandomUserAgent
 import keiyoushi.network.rateLimit
+import keiyoushi.utils.firstInstanceOrNull
 import keiyoushi.utils.getPreferences
+import keiyoushi.utils.parseAs
+import okhttp3.HttpUrl.Builder
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import org.jsoup.nodes.Element
-import org.jsoup.select.Elements
-import java.text.SimpleDateFormat
+import okhttp3.Response
+import rx.Observable
 import java.util.Locale
 import kotlin.time.Duration.Companion.seconds
 
 class CosmicScansID :
-    MangaThemesia(
-        "CosmicScans.id",
-        "https://lc1.cosmicscans.to",
-        "id",
-        dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("id")),
-    ),
+    HttpSource(),
     ConfigurableSource {
 
-    private val defaultBaseUrl: String = super.baseUrl
+    override val name = "CosmicScans.id"
+
+    private val defaultBaseUrl = "https://01.cosmicscans.to"
+
+    override val lang = "id"
+
+    override val supportsLatest = true
+
+    override val id = 6559481336553833282
+
+    private val apiUrl = "https://cdncid.csmcscns.id/v1/manga"
 
     private val preferences = getPreferences {
         getString(DEFAULT_BASE_URL_PREF, defaultBaseUrl).let { domain ->
@@ -44,23 +54,7 @@ class CosmicScansID :
         }
     }
 
-    override fun headersBuilder() = super.headersBuilder()
-        .setRandomUserAgent()
-
-    override fun getMangaUrl(manga: SManga) = "$baseUrl${manga.url}"
-
     private val isCi = System.getenv("CI") == "true"
-
-    override val baseUrl: String get() = when {
-        isCi -> defaultBaseUrl
-        else -> preferences.prefBaseUrl
-    }
-
-    override val client: OkHttpClient = super.client.newBuilder()
-        .rateLimit(20, 4.seconds)
-        .build()
-
-    override val hasProjectPage = true
 
     private var cachedBaseUrl: String? = null
     private var SharedPreferences.prefBaseUrl: String
@@ -75,37 +69,143 @@ class CosmicScansID :
             edit().putString(BASE_URL_PREF, value).apply()
         }
 
-    // search
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        if (query.isBlank()) {
-            return super.searchMangaRequest(page, query, filters)
-        }
-
-        val url = baseUrl.toHttpUrl().newBuilder()
-            .addPathSegments("page/$page/")
-            .addQueryParameter("s", query)
-
-        return GET(url.build())
+    override val baseUrl: String get() = when {
+        isCi -> defaultBaseUrl
+        else -> preferences.prefBaseUrl
     }
 
-    override fun searchMangaSelector() = ".bixbox:not(.hothome):has(.hpage) .utao .uta .imgu, .bixbox:not(.hothome) .listupd .bs .bsx"
+    private val cursorCache = mutableMapOf<String, String>()
 
-    // manga details
-    override val seriesDescriptionSelector = ".entry-content[itemprop=description] :not(a,p:has(a))"
+    private val lastPage = mutableMapOf<String, Int>()
 
-    override fun Element.imgAttr(): String = sequenceOf("data-lazy-src", "data-src", "data-cfsrc", "src")
-        .map { attr("abs:$it") }
-        .find { it.isNotEmpty() && !it.startsWith("data:") }
-        ?: ""
+    override val client: OkHttpClient = network.client.newBuilder()
+        .rateLimit(2, 1.seconds)
+        .build()
 
-    override fun Elements.imgAttr(): String = this.first()?.imgAttr() ?: ""
+    override fun headersBuilder() = super.headersBuilder()
+        .set("Origin", baseUrl)
+        .set("Referer", "$baseUrl/")
+        .setRandomUserAgent()
 
-    // pages
-    override val pageSelector = "div#readerarea img:not(noscript img):not([alt=''])"
+    // Popular
+    override fun popularMangaRequest(page: Int): Request {
+        val key = "popular"
+        lastPage[key] = page
+        val url = "$apiUrl/filter".toHttpUrl().newBuilder()
+            .addQueryParameter("limit", PAGE_SIZE.toString())
+            .addQueryParameter("order_by", "popular")
+            .addCursor(key, page)
+            .build()
+        return GET(url, headers)
+    }
 
+    override fun popularMangaParse(response: Response): MangasPage = parseMangaPage(response, "popular")
+
+    // Latest
+    override fun latestUpdatesRequest(page: Int): Request {
+        val key = "update"
+        lastPage[key] = page
+        val url = "$apiUrl/filter".toHttpUrl().newBuilder()
+            .addQueryParameter("limit", PAGE_SIZE.toString())
+            .addQueryParameter("order_by", "update")
+            .addCursor(key, page)
+            .build()
+        return GET(url, headers)
+    }
+
+    override fun latestUpdatesParse(response: Response): MangasPage = parseMangaPage(response, "update")
+
+    // Search
+    override fun fetchSearchManga(
+        page: Int,
+        query: String,
+        filters: FilterList,
+    ): Observable<MangasPage> {
+        if (query.isBlank() && !filters.hasActiveFilters() && page > 1) {
+            return Observable.just(MangasPage(emptyList(), false))
+        }
+        return super.fetchSearchManga(page, query, filters)
+            .map { mangasPage ->
+                val clientFilters = filters.buildClientFilters()
+                if (clientFilters.isEmpty()) {
+                    mangasPage
+                } else {
+                    val filtered = mangasPage.mangas.filter { manga ->
+                        clientFilters.all { predicate -> predicate(manga) }
+                    }
+                    MangasPage(filtered, mangasPage.hasNextPage)
+                }
+            }
+    }
+
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+        val endpoint = when {
+            query.isNotBlank() -> "search"
+            filters.firstInstanceOrNull<ProjectFilter>()?.state == 1 -> "latestProject"
+            else -> "filter"
+        }
+        val key = searchKey(query, filters, endpoint)
+        lastPage[key] = page
+        val url = "$apiUrl/$endpoint".toHttpUrl().newBuilder()
+            .addQueryParameter("limit", PAGE_SIZE.toString())
+            .apply {
+                if (query.isNotBlank()) addQueryParameter("q", query)
+                if (endpoint == "filter") addOrderFilter(filters)
+                if (endpoint != "search") addCursor(key, page)
+            }
+            .build()
+        return GET(url, headers)
+    }
+
+    override fun searchMangaParse(response: Response): MangasPage {
+        val query = response.request.url.queryParameter("q").orEmpty()
+        val path = response.request.url.encodedPath.substringAfterLast('/')
+        val key = when (path) {
+            "filter", "latestProject" -> searchKeyFromUrl(response, path)
+            else -> searchKey(query, FilterList(), "search")
+        }
+        return parseMangaPage(response, key)
+    }
+
+    // Details
+    override fun getMangaUrl(manga: SManga): String = "$baseUrl/series/${manga.url.substringAfterLast('/')}"
+
+    override fun mangaDetailsRequest(manga: SManga): Request {
+        val slug = manga.url.substringAfterLast('/')
+        return GET("$apiUrl/mangaDetail/$slug", headers)
+    }
+
+    override fun mangaDetailsParse(response: Response): SManga = response.parseAs<MangaDetailResponse>().data.toSMangaDetails()
+
+    // Chapters
+    override fun chapterListRequest(manga: SManga): Request = mangaDetailsRequest(manga)
+
+    override fun chapterListParse(response: Response): List<SChapter> = response.parseAs<MangaDetailResponse>().data.chapters.orEmpty()
+        .filter { it.slug?.isNotBlank() == true && it.redirectLink.isNullOrBlank() }
+        .map { it.toSChapter() }
+
+    override fun getChapterUrl(chapter: SChapter): String = "$baseUrl/chapter/${chapter.url.substringAfterLast('/')}"
+
+    // Pages
+    override fun pageListRequest(chapter: SChapter): Request {
+        val slug = chapter.url.substringAfterLast('/')
+        return GET("$apiUrl/readingPage/$slug", headers)
+    }
+
+    override fun pageListParse(response: Response): List<Page> {
+        val data = response.parseAs<ReadingPageResponse>().data
+        if (!data.redirectLink.isNullOrBlank()) return emptyList()
+        return data.toPageList()
+    }
+
+    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
+
+    // Filters
+    override fun getFilterList() = getCosmicScansIDFilterList()
+
+    // Preferences
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         screen.addRandomUAPreference()
-
         EditTextPreference(screen.context).apply {
             key = BASE_URL_PREF
             title = "Edit source URL"
@@ -120,7 +220,97 @@ class CosmicScansID :
         }.also { screen.addPreference(it) }
     }
 
+    // Utilities
+    private fun parseMangaPage(response: Response, key: String): MangasPage {
+        val result = response.parseAs<MangaListResponse>()
+        val page = lastPage[key] ?: 1
+        if (!result.cursor?.nextCursor.isNullOrBlank()) {
+            cursorCache["$key:${page + 1}"] = result.cursor.nextCursor.orEmpty()
+        }
+        return MangasPage(result.data.map { it.toSManga() }, result.cursor?.hasNext == true)
+    }
+
+    private fun Builder.addCursor(key: String, page: Int): Builder = apply {
+        if (page > 1) {
+            cursorCache["$key:$page"]?.takeIf { it.isNotBlank() }
+                ?.let { addQueryParameter("after", it) }
+        }
+    }
+
+    private fun Builder.addOrderFilter(filters: FilterList): Builder = apply {
+        filters.firstInstanceOrNull<OrderFilter>()?.value
+            ?.takeIf { it.isNotBlank() }
+            ?.let { addQueryParameter("order_by", it) }
+    }
+
+    private fun FilterList.buildClientFilters(): List<(SManga) -> Boolean> {
+        val predicates = mutableListOf<(SManga) -> Boolean>()
+
+        firstInstanceOrNull<StatusFilter>()?.value?.takeIf { it.isNotBlank() }?.let { status ->
+            predicates += { manga ->
+                manga.status == when (status.lowercase(Locale.ROOT)) {
+                    "ongoing" -> SManga.ONGOING
+                    "completed", "complete" -> SManga.COMPLETED
+                    "hiatus" -> SManga.ON_HIATUS
+                    else -> SManga.UNKNOWN
+                }
+            }
+        }
+
+        firstInstanceOrNull<TypeFilter>()?.value?.takeIf { it.isNotBlank() }?.let { type ->
+            predicates += { manga ->
+                manga.description?.contains("Type: $type", ignoreCase = true) == true
+            }
+        }
+
+        val selectedGenres = firstInstanceOrNull<GenreFilter>()?.state
+            ?.filter { it.state }
+            ?.map { it.genre }
+            ?: emptyList()
+        if (selectedGenres.isNotEmpty()) {
+            predicates += { manga ->
+                val mangaGenres = manga.genre.orEmpty()
+                selectedGenres.all { selected ->
+                    mangaGenres.contains(selected, ignoreCase = true)
+                }
+            }
+        }
+
+        return predicates
+    }
+
+    private fun FilterList.hasActiveFilters(): Boolean = firstInstanceOrNull<OrderFilter>()?.state != 0 ||
+        firstInstanceOrNull<StatusFilter>()?.state != 0 ||
+        firstInstanceOrNull<TypeFilter>()?.state != 0 ||
+        firstInstanceOrNull<ProjectFilter>()?.state == 1 ||
+        firstInstanceOrNull<GenreFilter>()?.state.orEmpty().any { it.state }
+
+    private fun searchKey(query: String, filters: FilterList, endpoint: String): String = listOf(
+        endpoint,
+        query,
+        filters.firstInstanceOrNull<OrderFilter>()?.value.orEmpty(),
+        filters.firstInstanceOrNull<StatusFilter>()?.value.orEmpty(),
+        filters.firstInstanceOrNull<TypeFilter>()?.value.orEmpty(),
+        filters.firstInstanceOrNull<ProjectFilter>()?.state?.toString().orEmpty(),
+        filters.firstInstanceOrNull<GenreFilter>()?.state.orEmpty()
+            .filter { it.state }.joinToString(",") { it.genre },
+    ).joinToString(":")
+
+    private fun searchKeyFromUrl(response: Response, endpoint: String): String {
+        val url = response.request.url
+        return listOf(
+            endpoint,
+            "",
+            url.queryParameter("order_by").orEmpty(),
+            "",
+            "",
+            if (endpoint == "latestProject") "1" else "0",
+            "",
+        ).joinToString(":")
+    }
+
     companion object {
+        private const val PAGE_SIZE = 24
         private const val BASE_URL_PREF = "overrideBaseUrl"
         private const val DEFAULT_BASE_URL_PREF = "defaultBaseUrl"
     }

--- a/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/CosmicScansID.kt
+++ b/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/CosmicScansID.kt
@@ -7,6 +7,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.annotation.Source
 import keiyoushi.network.rateLimit
 import keiyoushi.utils.firstInstanceOrNull
 import keiyoushi.utils.parseAs
@@ -19,17 +20,10 @@ import rx.Observable
 import java.util.Locale
 import kotlin.time.Duration.Companion.seconds
 
-class CosmicScansID : HttpSource() {
-
-    override val name = "CosmicScans.id"
-
-    override val baseUrl = "https://01.cosmicscans.to"
-
-    override val lang = "id"
+@Source
+abstract class CosmicScansID : HttpSource() {
 
     override val supportsLatest = true
-
-    override val id = 6559481336553833282
 
     private val apiUrl = "https://cdncid.csmcscns.id/v1/manga"
 
@@ -38,7 +32,7 @@ class CosmicScansID : HttpSource() {
     private val lastPage = mutableMapOf<String, Int>()
 
     override val client: OkHttpClient = network.client.newBuilder()
-        .rateLimit(2, 1.seconds)
+        .rateLimit(3, 1.seconds)
         .build()
 
     override fun headersBuilder() = super.headersBuilder()

--- a/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/CosmicScansID.kt
+++ b/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/CosmicScansID.kt
@@ -39,6 +39,12 @@ abstract class CosmicScansID : HttpSource() {
         .set("Origin", baseUrl)
         .set("Referer", "$baseUrl/")
 
+    // URL compat: handle old "/manga/slug" and new "/series/slug"
+    private fun SManga.slug(): String = url
+        .removePrefix("/manga/")
+        .removePrefix("/series/")
+        .trimEnd('/')
+
     // Popular
     override fun popularMangaRequest(page: Int): Request {
         val key = "popular"
@@ -120,10 +126,10 @@ abstract class CosmicScansID : HttpSource() {
     }
 
     // Details
-    override fun getMangaUrl(manga: SManga): String = "$baseUrl/series/${manga.url.substringAfterLast('/')}"
+    override fun getMangaUrl(manga: SManga): String = "$baseUrl/series/${manga.slug()}"
 
     override fun mangaDetailsRequest(manga: SManga): Request {
-        val slug = manga.url.substringAfterLast('/')
+        val slug = manga.slug()
         return GET("$apiUrl/mangaDetail/$slug", headers)
     }
 

--- a/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/CosmicScansID.kt
+++ b/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/CosmicScansID.kt
@@ -1,22 +1,14 @@
 package eu.kanade.tachiyomi.extension.id.cosmicscansid
 
-import android.content.SharedPreferences
-import android.widget.Toast
-import androidx.preference.EditTextPreference
-import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
-import keiyoushi.lib.randomua.addRandomUAPreference
-import keiyoushi.lib.randomua.setRandomUserAgent
 import keiyoushi.network.rateLimit
 import keiyoushi.utils.firstInstanceOrNull
-import keiyoushi.utils.getPreferences
 import keiyoushi.utils.parseAs
 import okhttp3.HttpUrl.Builder
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -27,13 +19,11 @@ import rx.Observable
 import java.util.Locale
 import kotlin.time.Duration.Companion.seconds
 
-class CosmicScansID :
-    HttpSource(),
-    ConfigurableSource {
+class CosmicScansID : HttpSource() {
 
     override val name = "CosmicScans.id"
 
-    private val defaultBaseUrl = "https://01.cosmicscans.to"
+    override val baseUrl = "https://01.cosmicscans.to"
 
     override val lang = "id"
 
@@ -42,37 +32,6 @@ class CosmicScansID :
     override val id = 6559481336553833282
 
     private val apiUrl = "https://cdncid.csmcscns.id/v1/manga"
-
-    private val preferences = getPreferences {
-        getString(DEFAULT_BASE_URL_PREF, defaultBaseUrl).let { domain ->
-            if (domain != defaultBaseUrl) {
-                edit()
-                    .putString(BASE_URL_PREF, defaultBaseUrl)
-                    .putString(DEFAULT_BASE_URL_PREF, defaultBaseUrl)
-                    .apply()
-            }
-        }
-    }
-
-    private val isCi = System.getenv("CI") == "true"
-
-    private var cachedBaseUrl: String? = null
-    private var SharedPreferences.prefBaseUrl: String
-        get() {
-            if (cachedBaseUrl == null) {
-                cachedBaseUrl = getString(BASE_URL_PREF, defaultBaseUrl)!!
-            }
-            return cachedBaseUrl!!
-        }
-        set(value) {
-            cachedBaseUrl = value
-            edit().putString(BASE_URL_PREF, value).apply()
-        }
-
-    override val baseUrl: String get() = when {
-        isCi -> defaultBaseUrl
-        else -> preferences.prefBaseUrl
-    }
 
     private val cursorCache = mutableMapOf<String, String>()
 
@@ -85,7 +44,6 @@ class CosmicScansID :
     override fun headersBuilder() = super.headersBuilder()
         .set("Origin", baseUrl)
         .set("Referer", "$baseUrl/")
-        .setRandomUserAgent()
 
     // Popular
     override fun popularMangaRequest(page: Int): Request {
@@ -203,23 +161,6 @@ class CosmicScansID :
     // Filters
     override fun getFilterList() = getCosmicScansIDFilterList()
 
-    // Preferences
-    override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        screen.addRandomUAPreference()
-        EditTextPreference(screen.context).apply {
-            key = BASE_URL_PREF
-            title = "Edit source URL"
-            summary = "For temporary use, if the extension is updated the change will be lost."
-            dialogTitle = title
-            dialogMessage = "Default URL:\n$defaultBaseUrl"
-            setDefaultValue(defaultBaseUrl)
-            setOnPreferenceChangeListener { _, _ ->
-                Toast.makeText(screen.context, "Restart the application to apply the changes", Toast.LENGTH_LONG).show()
-                true
-            }
-        }.also { screen.addPreference(it) }
-    }
-
     // Utilities
     private fun parseMangaPage(response: Response, key: String): MangasPage {
         val result = response.parseAs<MangaListResponse>()
@@ -311,7 +252,5 @@ class CosmicScansID :
 
     companion object {
         private const val PAGE_SIZE = 24
-        private const val BASE_URL_PREF = "overrideBaseUrl"
-        private const val DEFAULT_BASE_URL_PREF = "defaultBaseUrl"
     }
 }

--- a/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/Dto.kt
+++ b/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/Dto.kt
@@ -1,0 +1,123 @@
+package eu.kanade.tachiyomi.extension.id.cosmicscansid
+
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.jsoup.Jsoup
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+
+private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ROOT)
+    .apply { timeZone = TimeZone.getTimeZone("UTC") }
+
+@Serializable
+class MangaListResponse(
+    val data: List<MangaDto> = emptyList(),
+    val cursor: CursorDto? = null,
+)
+
+@Serializable
+class CursorDto(
+    val hasNext: Boolean = false,
+    val nextCursor: String? = null,
+)
+
+@Serializable
+class MangaDetailResponse(
+    val data: MangaDetailDto = MangaDetailDto(),
+)
+
+@Serializable
+class ReadingPageResponse(
+    val data: ReadingPageDto = ReadingPageDto(),
+)
+
+@Serializable
+class MangaDto(
+    private val title: String? = null,
+    private val slug: String? = null,
+    private val cover: String? = null,
+    private val status: String? = null,
+    private val type: String? = null,
+    private val genres: List<String>? = null,
+) {
+    fun toSManga(): SManga = SManga.create().apply {
+        title = this@MangaDto.title.orEmpty()
+        url = "/series/${this@MangaDto.slug.orEmpty()}"
+        thumbnail_url = this@MangaDto.cover
+        genre = this@MangaDto.genres?.joinToString()
+        status = when (this@MangaDto.status?.lowercase(Locale.ROOT)) {
+            "ongoing" -> SManga.ONGOING
+            "completed", "complete" -> SManga.COMPLETED
+            "hiatus", "on hiatus", "on-hold", "on hold" -> SManga.ON_HIATUS
+            else -> SManga.UNKNOWN
+        }
+        description = this@MangaDto.type?.let { "Type: $it" }
+        initialized = false
+    }
+}
+
+@Serializable
+class MangaDetailDto(
+    private val title: String? = null,
+    private val slug: String? = null,
+    private val cover: String? = null,
+    private val sinopsis: String? = null,
+    private val type: String? = null,
+    private val author: String? = null,
+    private val genre: List<String>? = null,
+    private val genres: List<String>? = null,
+    private val status: String? = null,
+    val chapters: List<ChapterDto>? = null,
+) {
+    fun toSMangaDetails(): SManga = SManga.create().apply {
+        title = this@MangaDetailDto.title.orEmpty()
+        url = "/series/${this@MangaDetailDto.slug.orEmpty()}"
+        thumbnail_url = this@MangaDetailDto.cover
+        description = listOfNotNull(
+            this@MangaDetailDto.sinopsis,
+            this@MangaDetailDto.type?.let { "Type: $it" },
+            this@MangaDetailDto.author?.let { "Author: $it" },
+        ).joinToString("\n\n")
+        genre = (this@MangaDetailDto.genre ?: this@MangaDetailDto.genres)?.joinToString()
+        author = this@MangaDetailDto.author
+        status = when (this@MangaDetailDto.status?.lowercase(Locale.ROOT)) {
+            "ongoing" -> SManga.ONGOING
+            "completed", "complete" -> SManga.COMPLETED
+            "hiatus", "on hiatus", "on-hold", "on hold" -> SManga.ON_HIATUS
+            else -> SManga.UNKNOWN
+        }
+        initialized = true
+    }
+}
+
+@Serializable
+class ChapterDto(
+    val slug: String? = null,
+    private val chapterNum: String? = null,
+    private val time: String? = null,
+    @SerialName("redirect_link") val redirectLink: String? = null,
+) {
+    fun toSChapter(): SChapter = SChapter.create().apply {
+        name = "Chapter ${this@ChapterDto.chapterNum.orEmpty()}".trim()
+        url = "/chapter/${this@ChapterDto.slug.orEmpty()}"
+        chapter_number = this@ChapterDto.chapterNum?.toFloatOrNull() ?: -1f
+        date_upload = runCatching { dateFormat.parse(this@ChapterDto.time ?: "")?.time }.getOrNull() ?: 0L
+    }
+}
+
+@Serializable
+class ReadingPageDto(
+    private val chapters: List<String>? = null,
+    @SerialName("redirect_link") val redirectLink: String? = null,
+) {
+    fun toPageList(): List<Page> = chapters.orEmpty()
+        .mapNotNull { html ->
+            Jsoup.parse(html).selectFirst("img")?.attr("src")
+                ?.takeIf { it.isNotBlank() }
+        }
+        .mapIndexed { index, imageUrl -> Page(index, imageUrl = imageUrl) }
+}

--- a/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/Filters.kt
+++ b/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/Filters.kt
@@ -1,0 +1,71 @@
+package eu.kanade.tachiyomi.extension.id.cosmicscansid
+
+import eu.kanade.tachiyomi.source.model.Filter
+import eu.kanade.tachiyomi.source.model.FilterList
+
+internal fun getCosmicScansIDFilterList() = FilterList(
+    OrderFilter(),
+    StatusFilter(),
+    TypeFilter(),
+    ProjectFilter(),
+    GenreFilter(GENRES),
+)
+
+internal open class SelectFilter(
+    name: String,
+    private val options: Array<Pair<String, String>>,
+) : Filter.Select<String>(name, options.map { it.first }.toTypedArray()) {
+    val value: String get() = options[state].second
+}
+
+internal class OrderFilter :
+    SelectFilter(
+        "Urutkan",
+        arrayOf(
+            "Update" to "update",
+            "Popular" to "popular",
+            "A-Z" to "az",
+            "Z-A" to "za",
+            "Baru Ditambahkan" to "added",
+        ),
+    )
+
+internal class StatusFilter :
+    SelectFilter(
+        "Status",
+        arrayOf(
+            "Semua" to "",
+            "Ongoing" to "Ongoing",
+            "Completed" to "Completed",
+            "Hiatus" to "Hiatus",
+        ),
+    )
+
+internal class TypeFilter :
+    SelectFilter(
+        "Tipe",
+        arrayOf(
+            "Semua" to "",
+            "Manga" to "Manga",
+            "Manhwa" to "Manhwa",
+            "Manhua" to "Manhua",
+        ),
+    )
+
+internal class ProjectFilter :
+    Filter.Select<String>(
+        "Project",
+        arrayOf(
+            "Semua",
+            "Project",
+        ),
+    )
+
+internal class Genre(val genre: String) : Filter.CheckBox(genre)
+
+internal class GenreFilter(genres: List<Genre>) : Filter.Group<Genre>("Genre", genres)
+
+internal val GENRES = listOf(
+    "Action", "Adventure", "Comedy", "Drama", "Fantasy", "Martial Arts", "Romance",
+    "School Life", "Shounen", "Supernatural", "System", "Thriller", "Murim",
+).map { Genre(it) }


### PR DESCRIPTION
The site has migrated from WordPress/MangaThemesia to SvelteKit with a custom REST API (cdncid.csmcscns.id).

Changes:

- Migrate source from MangaThemesia to HttpSource
- Replace HTML scraping with JSON API parsing
- Fix popularMangaRequest: /popular (404) → /filter?orderBy=popular
- Fix latestUpdatesRequest: /update (404) → /filter?orderBy=update
- Add cursor-based pagination for all list endpoints
- dd filter support: order, status, type, genre, project

Closed #17092
Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [ ] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
