### PR TITLE
fix theme config timing

### DIFF
--- a/gradle/build-logic/src/main/kotlin/PluginExtension.kt
+++ b/gradle/build-logic/src/main/kotlin/PluginExtension.kt
@@ -106,7 +106,7 @@ class PluginExtension : Plugin<Project> {
         }
 
         val themeExtension = keiyoushi.theme.map { themeName ->
-            project(":lib-multisrc:$themeName").extensions.findByType(KeiyoushiMultisrcExtension::class.java)
+            evaluationDependsOn(":lib-multisrc:$themeName").extensions.findByType(KeiyoushiMultisrcExtension::class.java)
                 ?: throw AssertionError("Theme project :lib-multisrc:$themeName must apply kei.plugins.multisrc")
         }
 


### PR DESCRIPTION
force the theme project to be configured before reading its extension.
With gradle configure-on-demand the dependency on it is added through a lazy provider, so gradle may not have applied its plugin yet by the time we read it