### PR TITLE
MangaLivre: discover client header from bundle Headers.set() calls

### DIFF
--- a/src/pt/mangalivre/build.gradle.kts
+++ b/src/pt/mangalivre/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 keiyoushi {
     name = "Manga Livre"
     className = "MangaLivre"
-    versionCode = 67
+    versionCode = 68
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 }

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
@@ -244,10 +244,10 @@ class MangaLivre :
     }
 
     /**
-     * O front-end manda um header de cliente cujo NOME rotaciona toda hora
-     * (x-toonlivre-client -> x-tly-sec -> x-app-key) e cujo valor costuma ser "web-...".
-     * Em vez de fixar um nome, varremos os bundles em /assets e coletamos todos os pares
-     * "x-...":"valor", priorizando os "web-..."; o interceptor testa cada um quando toma 403.
+     * O front-end fixa o header de cliente via `Headers.set("nome", "valor")` no bundle,
+     * e nome/valor rotacionam toda hora (x-toonlivre-client/web-x -> app-token/tok-z99).
+     * Em vez de fixar isso, coletamos os pares de `.set(...)` dos /assets (ignorando headers
+     * padrão) e o interceptor testa cada candidato quando a API recusa com 403.
      */
     private fun scrapeCandidates(): List<ClientToken> = try {
         val html = scrapeClient.newCall(GET("$baseUrl/", headers)).execute()
@@ -265,11 +265,12 @@ class MangaLivre :
     }
 
     private fun extractCandidates(js: String): List<ClientToken> {
-        val pairs = PAIR_REGEX.findAll(js)
+        val pairs = SET_REGEX.findAll(js)
             .map { ClientToken(it.groupValues[1], it.groupValues[2]) }
+            .filterNot { it.header.lowercase() in STANDARD_HEADERS }
             .distinct()
             .toList()
-        val ranked = pairs.sortedByDescending { it.value.startsWith("web-") }
+        val ranked = pairs.sortedByDescending { it.value.length + if ('-' in it.value) 100 else 0 }
             .take(MAX_CANDIDATES)
         return (ranked + DEFAULT_TOKEN).distinct()
     }
@@ -289,8 +290,9 @@ class MangaLivre :
         private const val MAX_CANDIDATES = 8
         private const val NON_JSON_MESSAGE =
             "Resposta não-JSON (Cloudflare ou header desatualizado). Abra a fonte na WebView do app e tente de novo."
-        private val DEFAULT_TOKEN = ClientToken("x-app-key", "web-z99")
+        private val DEFAULT_TOKEN = ClientToken("app-token", "tok-z99")
         private val ASSET_REGEX = Regex("/assets/[\\w-]+\\.js")
-        private val PAIR_REGEX = Regex("\"(x-[a-z0-9-]{2,})\"\\s*[,:]\\s*\"([a-z][a-z0-9-]{1,40})\"")
+        private val SET_REGEX = Regex("\\.set\\(\\s*\"([A-Za-z][\\w.-]{1,40})\"\\s*,\\s*\"([^\"]{1,60})\"\\s*\\)")
+        private val STANDARD_HEADERS = setOf("content-type", "accept", "authorization", "x-csrf-token")
     }
 }


### PR DESCRIPTION
Follow-up to #17030 / #17082. The site keeps rotating the client header it requires on API calls. This time it changed **both the name and the value, and dropped the `x-` prefix**: `x-app-key` / `web-z99` → **`app-token` / `tok-z99`**. The discovery in #17082 assumed an `x-…` name with a `web-…` value, so it missed it and every call went back to `403` ("aplicativo oficial").

Instead of chasing the naming, this anchors on the actual mechanism. In the bundle the header is set with literals:

```js
const S = new Headers(opts.headers || {})
S.set("app-token", "tok-z99")                 // ← the secret header (both literals)
if (method !== "GET" && …) S.set("x-csrf-token", B)   // csrf, dynamic value
```

So the discovery now collects every `Headers.set("name", "value")` pair with **literal** name and value from the `/assets` chunks (the csrf one has a dynamic value, so it's naturally excluded), drops a small denylist of standard headers, and the interceptor tries each candidate on a `403` until the API accepts one, caching the winner. This self-heals across **name, value and prefix** rotations without a new release.

Verified against the live bundle (real browser, Cloudflare cleared): there are only two literal `.set(...)` pairs — `app-token`/`tok-z99` (selected) and a `lite`/`1` flag (tried and rejected on `403` if ever needed).

### Changes

- Discover the client header from `Headers.set("name", "value")` literals in the bundle instead of an `x-…`/`web-…` pattern; multi-candidate retry on `403` (unchanged).
- Default to `app-token` / `tok-z99` for cold start.
- Bump `versionCode` to 68.

No endpoint URLs or DTOs changed.

### Checklist

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code) — n/a
- [ ] Referenced all related issues in the PR body — follow-up to #17030 / #17082
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately (unchanged: SAFE)
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed — n/a (unchanged)
- [ ] Have tested the modifications by compiling and running the extension through Android Studio — **I don't have an Android environment (iOS only).** I validated the new header mechanism against the live site through a browser and checked formatting with ktlint locally; relying on this PR's CI to compile, lint and build.
- [ ] Have removed `web_hi_res_512.png` when adding a new extension — n/a
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop