### PR TITLE
Manga Demon: Handle 'updating' status as Unknown

### DIFF
--- a/src/en/mangademon/build.gradle.kts
+++ b/src/en/mangademon/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 keiyoushi {
     name = "Manga Demon"
-    versionCode = 19
+    versionCode = 20
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/en/mangademon/src/eu/kanade/tachiyomi/extension/en/mangademon/MangaDemon.kt
+++ b/src/en/mangademon/src/eu/kanade/tachiyomi/extension/en/mangademon/MangaDemon.kt
@@ -132,14 +132,19 @@ abstract class MangaDemon : HttpSource() {
                 thumbnail_url = selectFirst("div#manga-page img")!!.attr("abs:src")
                 genre = select("div.genres-list > li").joinToString { it.text() }
                 description = selectFirst("div#manga-info-rightColumn > div > div.white-font")!!.text()
-                author = select("div#manga-info-stats > div:has(> li:eq(0):contains(Author)) > li:eq(1)").text()
+                author = parseAuthor(select("div#manga-info-stats > div:has(> li:eq(0):contains(Author)) > li:eq(1)").text())
                 status = parseStatus(select("div#manga-info-stats > div:has(> li:eq(0):contains(Status)) > li:eq(1)").text())
             }
         }
     }
 
+    private fun parseAuthor(author: String?) = when {
+        author == null || author.contains("Updating", ignoreCase = true) -> null
+        else -> author
+    }
+
     private fun parseStatus(status: String?) = when {
-        status == null || status.contains("Updating", ignoreCase = true) -> SManga.UNKNOWN
+        status == null -> SManga.UNKNOWN
         status.contains("Ongoing", ignoreCase = true) -> SManga.ONGOING
         status.contains("Completed", ignoreCase = true) -> SManga.COMPLETED
         else -> SManga.UNKNOWN

--- a/src/en/mangademon/src/eu/kanade/tachiyomi/extension/en/mangademon/MangaDemon.kt
+++ b/src/en/mangademon/src/eu/kanade/tachiyomi/extension/en/mangademon/MangaDemon.kt
@@ -139,7 +139,7 @@ abstract class MangaDemon : HttpSource() {
     }
 
     private fun parseStatus(status: String?) = when {
-        status == null -> SManga.UNKNOWN
+        status == null || status.contains("Updating", ignoreCase = true) -> SManga.UNKNOWN
         status.contains("Ongoing", ignoreCase = true) -> SManga.ONGOING
         status.contains("Completed", ignoreCase = true) -> SManga.COMPLETED
         else -> SManga.UNKNOWN


### PR DESCRIPTION
Most manga on Manga Demon have "updating" or "Updating" in place of the author name.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
