### PR TITLE
MangaLivre: reading gate uses x-tly-token (via Headers.append)

### DIFF
--- a/src/pt/mangalivre/build.gradle.kts
+++ b/src/pt/mangalivre/build.gradle.kts
@@ -4,8 +4,13 @@ plugins {
 
 keiyoushi {
     name = "Manga Livre"
-    className = "MangaLivre"
     versionCode = 69
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
+
+    source {
+        baseUrl = "https://toonlivre.net"
+        lang = "pt-BR"
+        versionId = 2
+    }
 }

--- a/src/pt/mangalivre/build.gradle.kts
+++ b/src/pt/mangalivre/build.gradle.kts
@@ -4,13 +4,8 @@ plugins {
 
 keiyoushi {
     name = "Manga Livre"
-    versionCode = 68
+    className = "MangaLivre"
+    versionCode = 69
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
-
-    source {
-        baseUrl = "https://toonlivre.net"
-        lang = "pt-BR"
-        versionId = 2
-    }
 }

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
@@ -11,6 +11,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.annotation.Source
 import keiyoushi.network.rateLimit
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
@@ -23,20 +24,14 @@ import okhttp3.Response
 import java.io.IOException
 import kotlin.time.Duration.Companion.seconds
 
-class MangaLivre :
+@Source
+abstract class MangaLivre :
     HttpSource(),
     ConfigurableSource {
+
     private val baseUrlHost by lazy { baseUrl.toHttpUrl().host }
 
-    override val name: String = "Manga Livre"
-
-    override val baseUrl: String = "https://toonlivre.net"
-
-    override val lang: String = "pt-BR"
-
     override val supportsLatest: Boolean = true
-
-    override val versionId: Int = 2
 
     override val client: OkHttpClient = network.client.newBuilder()
         .addInterceptor(::clientHeaderInterceptor)
@@ -252,12 +247,12 @@ class MangaLivre :
      */
     private fun scrapeCandidates(): List<ClientToken> = try {
         val html = scrapeClient.newCall(GET("$baseUrl/", headers)).execute()
-            .use { if (it.isSuccessful) it.body?.string().orEmpty() else "" }
+            .use { if (it.isSuccessful) it.body.string() else "" }
         val assets = ASSET_REGEX.findAll(html).map { it.value }.distinct().toList()
         val js = buildString {
             assets.take(MAX_ASSETS).forEach { path ->
                 scrapeClient.newCall(GET("$baseUrl$path", headers)).execute()
-                    .use { if (it.isSuccessful) append(it.body?.string().orEmpty()) }
+                    .use { if (it.isSuccessful) append(it.body.string()) }
             }
         }
         extractCandidates(js)

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
@@ -11,7 +11,6 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
-import keiyoushi.annotation.Source
 import keiyoushi.network.rateLimit
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
@@ -24,14 +23,20 @@ import okhttp3.Response
 import java.io.IOException
 import kotlin.time.Duration.Companion.seconds
 
-@Source
-abstract class MangaLivre :
+class MangaLivre :
     HttpSource(),
     ConfigurableSource {
-
     private val baseUrlHost by lazy { baseUrl.toHttpUrl().host }
 
+    override val name: String = "Manga Livre"
+
+    override val baseUrl: String = "https://toonlivre.net"
+
+    override val lang: String = "pt-BR"
+
     override val supportsLatest: Boolean = true
+
+    override val versionId: Int = 2
 
     override val client: OkHttpClient = network.client.newBuilder()
         .addInterceptor(::clientHeaderInterceptor)
@@ -239,19 +244,20 @@ abstract class MangaLivre :
     }
 
     /**
-     * O front-end fixa o header de cliente via `Headers.set("nome", "valor")` no bundle,
-     * e nome/valor rotacionam toda hora (x-toonlivre-client/web-x -> app-token/tok-z99).
-     * Em vez de fixar isso, coletamos os pares de `.set(...)` dos /assets (ignorando headers
+     * O gate de "aplicativo oficial" (endpoints de leitura) exige um header de cliente que o
+     * front-end injeta no bundle via `Headers.append("x-tly-token", "v99-web-z")` — e há um
+     * decoy `set("app-token", ...)` que os endpoints abertos ignoram. Nome/valor rotacionam.
+     * Coletamos TODOS os pares literais de `.set(...)`/`.append(...)` dos /assets (fora headers
      * padrão) e o interceptor testa cada candidato quando a API recusa com 403.
      */
     private fun scrapeCandidates(): List<ClientToken> = try {
         val html = scrapeClient.newCall(GET("$baseUrl/", headers)).execute()
-            .use { if (it.isSuccessful) it.body.string() else "" }
+            .use { if (it.isSuccessful) it.body?.string().orEmpty() else "" }
         val assets = ASSET_REGEX.findAll(html).map { it.value }.distinct().toList()
         val js = buildString {
             assets.take(MAX_ASSETS).forEach { path ->
                 scrapeClient.newCall(GET("$baseUrl$path", headers)).execute()
-                    .use { if (it.isSuccessful) append(it.body.string()) }
+                    .use { if (it.isSuccessful) append(it.body?.string().orEmpty()) }
             }
         }
         extractCandidates(js)
@@ -285,9 +291,9 @@ abstract class MangaLivre :
         private const val MAX_CANDIDATES = 8
         private const val NON_JSON_MESSAGE =
             "Resposta não-JSON (Cloudflare ou header desatualizado). Abra a fonte na WebView do app e tente de novo."
-        private val DEFAULT_TOKEN = ClientToken("app-token", "tok-z99")
+        private val DEFAULT_TOKEN = ClientToken("x-tly-token", "v99-web-z")
         private val ASSET_REGEX = Regex("/assets/[\\w-]+\\.js")
-        private val SET_REGEX = Regex("\\.set\\(\\s*\"([A-Za-z][\\w.-]{1,40})\"\\s*,\\s*\"([^\"]{1,60})\"\\s*\\)")
+        private val SET_REGEX = Regex("\\.(?:set|append)\\(\\s*\"([A-Za-z][\\w.-]{1,40})\"\\s*,\\s*\"([^\"]{1,60})\"\\s*\\)")
         private val STANDARD_HEADERS = setOf("content-type", "accept", "authorization", "x-csrf-token")
     }
 }


### PR DESCRIPTION
Follow-up to #17030 / #17082 / #17104. Previous fixes chased the wrong header. Testing the live site revealed the real gate.

**Root cause.** The reading endpoints (`/api/mangas/{id}/chapters/{id}` and `/chapters-paginated`) reject requests with `403 {"error":"Acesso negado. Por favor, use o aplicativo oficial."}` unless a specific client header is present. The open endpoints (search / releases / manga-by-slug) do **not** gate, so browsing worked while reading failed.

In the bundle the request-header builder does:

```js
const S = new Headers(opts.headers || {})
S.append("x-tly-token", "v99-web-z")   // ← the real gate header (.append!)
S.set("app-token", "tok-z99")          // ← decoy the open endpoints ignore
if (method !== "GET"/"HEAD"/"OPTIONS") S.set("x-csrf-token", B)
```

The discovery added in #17104 only scanned `.set(...)`, so it picked the `app-token` **decoy** and the reading gate kept returning 403. The real header is `x-tly-token`, injected via `Headers.append(...)`.

**Fix.** Match both `.set(...)` and `.append(...)` literal pairs when scanning the bundle, and default to `x-tly-token` / `v99-web-z`. The existing multi-candidate `403` retry (which already keys on the "aplicativo oficial" body) then discovers/validates the right header and self-heals on future name/value rotations.

**Verified against the live API** (real browser past Cloudflare, replaying the exact interceptor logic):
- Cold start with the default `x-tly-token: v99-web-z` → `200` (pages load).
- Simulating a stale token (`app-token`) → `403` → the retry scans the bundle, extracts `x-tly-token/v99-web-z`, retries → `200`, and caches it.

### Changes

- Scan `.set(...)` **and** `.append(...)` literal header pairs in the bundle.
- Default client header → `x-tly-token` / `v99-web-z`.
- Bump `versionCode` to 69.

No endpoint URLs or DTOs changed.

### Checklist

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately (unchanged: SAFE)
- [x] Have not changed source names
- [ ] Have tested the modifications by compiling and running the extension through Android Studio — **iOS only, no Android.** I verified the header/gate against the live site and replayed the interceptor logic end-to-end (200 on the reading endpoint); checked formatting with ktlint locally; relying on CI to build.
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop