### PR TITLE
RagnarScans (tr): Fix domain and chapter list parsing

### DIFF
--- a/src/tr/ragnarscans/build.gradle.kts
+++ b/src/tr/ragnarscans/build.gradle.kts
@@ -4,14 +4,14 @@ plugins {
 
 keiyoushi {
     name = "Ragnar Scans"
-    versionCode = 45
+    versionCode = 46
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
     theme = "initmanga"
 
     source {
         lang = "tr"
-        baseUrl = "https://ragnarscans.com"
+        baseUrl = "https://ragnarscans.net"
         versionId = 2
     }
 }

--- a/src/tr/ragnarscans/src/eu/kanade/tachiyomi/extension/tr/ragnarscans/RagnarScans.kt
+++ b/src/tr/ragnarscans/src/eu/kanade/tachiyomi/extension/tr/ragnarscans/RagnarScans.kt
@@ -1,7 +1,12 @@
 package eu.kanade.tachiyomi.extension.tr.ragnarscans
 
 import eu.kanade.tachiyomi.multisrc.initmanga.InitManga
+import eu.kanade.tachiyomi.source.model.SChapter
 import keiyoushi.annotation.Source
+import keiyoushi.utils.tryParse
+import org.jsoup.nodes.Element
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 @Source
 abstract class RagnarScans : InitManga() {
@@ -9,4 +14,19 @@ abstract class RagnarScans : InitManga() {
     override val mangaUrlDirectory = "manga"
 
     override val popularUrlSlug = "en-cok-takip-edilenler"
+
+    private val ragnarDateFormat = SimpleDateFormat("d MMMM yyyy HH:mm", Locale("tr"))
+
+    override fun chapterListSelector() = "div.chapter-list > div.uk-position-relative"
+
+    override fun chapterFromElement(element: Element) = SChapter.create().apply {
+        setUrlWithoutDomain(element.selectFirst("a")!!.absUrl("href"))
+
+        name = element.selectFirst("div.uk-flex-none")?.text()
+            ?: element.select("a").text()
+
+        val dateStr = element.selectFirst("div.uk-text-meta")?.attr("uk-tooltip")
+            ?.substringAfter("title: ")?.substringBefore(";")
+        date_upload = ragnarDateFormat.tryParse(dateStr)
+    }
 }


### PR DESCRIPTION
Closes #[16879](https://github.com/keiyoushi/extensions-source/issues/16879)

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
