### PR TITLE
 Comikey (Multi): Fix 404 when logged-in

### DIFF
--- a/src/all/comikey/build.gradle.kts
+++ b/src/all/comikey/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 keiyoushi {
     name = "Comikey"
-    versionCode = 7
+    versionCode = 8
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/all/comikey/src/eu/kanade/tachiyomi/extension/all/comikey/Comikey.kt
+++ b/src/all/comikey/src/eu/kanade/tachiyomi/extension/all/comikey/Comikey.kt
@@ -320,7 +320,7 @@ abstract class Comikey :
                         response.headers["Content-Type"] ?: "application/divina+json+vnd.e4p.drm",
                         null,
                         response.code,
-                        response.message?.takeIf { it.isNotEmpty() } ?: "OK",
+                        response.message.takeIf { it.isNotEmpty() } ?: "OK",
                         response.headers.toMap(),
                         response.body.byteStream(),
                     )
@@ -472,6 +472,6 @@ abstract class Comikey :
     companion object {
         internal const val PREFIX_SLUG_SEARCH = "slug:"
         internal const val PREF_HIDE_LOCKED_CHAPTERS = "hide_locked_chapters"
-        private val RELAY_HOST_REGEX = Regex("""relay-\w+\.epub\.rocks""")
+        private val RELAY_HOST_REGEX = Regex("""relay-\w+\.(epub\.rocks|comikey\.com)""")
     }
 }


### PR DESCRIPTION
Closes #17195 

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
