### PR TITLE
Twi4 (JA): migrate to new dsl and fixes

### DIFF
--- a/src/ja/twi4/build.gradle.kts
+++ b/src/ja/twi4/build.gradle.kts
@@ -4,13 +4,17 @@ plugins {
 
 keiyoushi {
     name = "Twi4"
-    className = "Twi4"
-    versionCode = 6
+    versionCode = 7
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 
+    source {
+        lang = "ja"
+        // The domain sai-zen-sen.jp directs to their main site rather than Twi4. It has to be /comics/twi4
+        baseUrl = "https://sai-zen-sen.jp/comics/twi4"
+    }
+
     deeplink {
-        host("sai-zen-sen.jp")
         path("/comics/twi4/..*/.*")
     }
 }

--- a/src/ja/twi4/src/eu/kanade/tachiyomi/extension/ja/twi4/Twi4.kt
+++ b/src/ja/twi4/src/eu/kanade/tachiyomi/extension/ja/twi4/Twi4.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.extension.ja.twi4
 
-import android.app.Application
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.asObservableSuccess
 import eu.kanade.tachiyomi.source.model.FilterList
@@ -10,217 +9,56 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
-import okhttp3.Headers
+import keiyoushi.annotation.Source
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Request
 import okhttp3.Response
 import rx.Observable
-import uy.kohesive.injekt.injectLazy
 
-class Twi4 : HttpSource() {
-    // The domain sai-zen-sen.jp directs to their main site rather than Twi4. It has to be /comics/twi4
-    override val baseUrl: String = "https://sai-zen-sen.jp/comics/twi4/"
-    override val lang: String = "ja"
-    override val name: String = "Twi4"
+@Source
+abstract class Twi4 : HttpSource() {
     override val supportsLatest: Boolean = false
-    private val application: Application by injectLazy()
-    private val validPageTest: Regex =
-        Regex("/comics/twi4/\\w+/works/\\d{4}\\.[0-9a-zA-Z]{32}\\.jpg")
 
-    companion object Constants {
+    companion object {
         const val SEARCH_PREFIX_SLUG = "SLUG:"
+        private val TITLE_REGEX = Regex("『(.+)』.+ \\| ツイ４ \\| 最前線")
+        private val CHAPTER_REGEX = Regex(".+『(.+)』 #(\\d+)")
     }
 
-    private fun getUrlDomain(): String = baseUrl.substring(0, 22)
-
-    private fun getChromeHeaders(): Headers = headersBuilder().add(
-        "User-Agent",
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Safari/537.36",
-    ).build()
+    private val hostRoot by lazy { baseUrl.toHttpUrl().let { "${it.scheme}://${it.host}" } }
 
     // Both latest and popular only lists 4 manga in total
     // As the full catalog is consists of less than 50 manga, it is not worth implementing
     // We'll just list all manga in the catalog instead
+    override fun popularMangaRequest(page: Int): Request = GET(baseUrl, headers)
+
     override fun popularMangaParse(response: Response): MangasPage {
         val doc = response.asJsoup()
-        val ret = mutableListOf<SManga>()
         // Manga that are recently updated don't show up on the full catalog
         // So we'll need to parse the recent updates section as well
-        val listings = arrayOf(
-            "#lineup_recent > div> section",
-            "#lineup > div > section:not(.zadankai):not([id])",
-        )
-        for (listing in listings) {
-            val mangas = doc.select(listing)
-            for (manga in mangas) {
-                ret.add(
-                    SManga.create().apply {
-                        thumbnail_url =
-                            getUrlDomain() + manga.select("div.figgroup > figure > a > img")
-                                .attr("src")
-                        setUrlWithoutDomain(
-                            getUrlDomain() + manga.select("div.hgroup > h3 > a").attr("href"),
-                        )
-                        title = manga.select("div.hgroup > h3 > a").text()
-                        author = manga.select("div.hgroup > p").text()
-                        status =
-                            if (manga.select("ul:first-child > li:last-child > em.is-completed")
-                                    .isEmpty()
-                            ) {
-                                SManga.ONGOING
-                            } else {
-                                SManga.COMPLETED
-                            }
-                    },
-                )
+        val mangas = doc.select("#lineup_recent > div > section, #lineup > div > section:not(.zadankai):not([id])")
+
+        val ret = mangas.mapNotNull { manga ->
+            val a = manga.selectFirst("div.hgroup > h3 > a") ?: return@mapNotNull null
+            SManga.create().apply {
+                thumbnail_url = manga.selectFirst("div.figgroup > figure > a > img")?.attr("abs:src")
+                setUrlWithoutDomain(a.attr("abs:href"))
+                title = a.text()
+                author = manga.selectFirst("div.hgroup > p")?.text()
+                status = if (manga.selectFirst("ul > li:last-child > em.is-completed") == null) {
+                    SManga.ONGOING
+                } else {
+                    SManga.COMPLETED
+                }
             }
         }
         return MangasPage(ret, false)
     }
 
-    override fun popularMangaRequest(page: Int): Request = GET(baseUrl, getChromeHeaders())
+    override fun latestUpdatesRequest(page: Int): Request = throw UnsupportedOperationException()
 
-    override fun mangaDetailsRequest(manga: SManga): Request = GET(getUrlDomain() + manga.url, getChromeHeaders())
-
-    override fun mangaDetailsParse(response: Response): SManga {
-        val document = response.asJsoup()
-        return SManga.create().apply {
-            // We need to get the title and thumbnail again.
-            // This is only needed if you search by slug, as we have no information about the them.
-            // Interestingly the page body has no mention of the title at all. It only exists in <title>
-            val titleRegex = Regex("『(.+)』.+ \\| ツイ４ \\| 最前線")
-            val match = titleRegex.matchEntire(document.title())
-            title = match?.groups?.get(1)?.value.toString()
-            // Twi4 uses the exact same thumbnail at both the main page and manga details
-            thumbnail_url =
-                getUrlDomain() + document.select("#introduction > header > div > h2 > img")
-                    .attr("src")
-            description =
-                document.select("#introduction > div > div > p").text()
-            // Determine who are the authors and artists
-            // 作者, 原作 -> Author (Also the artist) / Original author (Such as light novel adaptation)
-            // 漫画 -> Artist only
-            // 提供, etc, etc -> Sponsors, irrelevant stuff
-            val staffs = document.select("#introduction > div > section > header > div > h3")
-            for (staff in staffs) {
-                val role = staff.select("small")
-                if (role.isEmpty()) {
-                    continue
-                }
-                when (role.text().replace("：", "").trim()) {
-                    "作者" -> {
-                        author = staff.select("span").text()
-                        artist = staff.select("span").text()
-                    }
-
-                    // If 作者 and 原作 appear at the same time, 原作 will overwrite the author field
-                    "原作" -> {
-                        author = staff.select("span").text()
-                    }
-
-                    "漫画" -> {
-                        artist = staff.select("span").text()
-                    }
-                }
-            }
-            // While the status can be obtained at the home page, there is no such info at the details page
-        }
-    }
-
-    override fun chapterListRequest(manga: SManga): Request = GET(getUrlDomain() + manga.url, getChromeHeaders())
-
-    // They have a <noscript> layout! This is surprising
-    // Though their manga pages fails to load as it relies on JS
-    override fun chapterListParse(response: Response): List<SChapter> {
-        val doc = response.asJsoup()
-        val chapterRegex = Regex(".+『(.+)』 #(\\d+)")
-        val allChapters = doc.select("#backnumbers > div > ul > li")
-        val ret = mutableListOf<SChapter>()
-        // Returns the shortened series name from the request URL. Should be good enough for an identifier
-        val series = response.request.url.toUrl().toString().dropLast(1).substringAfterLast("/")
-        val sharedPref = application.getSharedPreferences("source_${id}_time_found:$series", 0)
-        val editor = sharedPref.edit()
-        for (chapter in allChapters) {
-            val match = chapterRegex.matchEntire(chapter.select("a").text())
-            val chapNumber = match?.groups?.get(2)?.value
-            ret.add(
-                SChapter.create().apply {
-                    if (chapNumber != null) {
-                        this.chapter_number = chapNumber.toFloat()
-                        this.name = chapNumber.toInt().toString() + " - " + match.groups[1]?.value
-                    }
-                    setUrlWithoutDomain(chapter.select("a").attr("href"))
-                    // We can't determine the upload date from the website
-                    // Store date_upload when a chapter is found for the first time
-                    // *Borrowed from CatManga
-                    val dateFound = System.currentTimeMillis()
-                    if (!sharedPref.contains(chapNumber)) {
-                        editor.putLong(chapNumber, dateFound)
-                    }
-                    this.date_upload = sharedPref.getLong(chapNumber, dateFound)
-                },
-            )
-        }
-        editor.apply()
-        ret.sortByDescending { chapter -> chapter.chapter_number }
-        return ret
-    }
-
-    override fun pageListRequest(chapter: SChapter): Request = GET(getUrlDomain() + chapter.url, getChromeHeaders())
-
-    override fun pageListParse(response: Response): List<Page> {
-        val doc = response.asJsoup()
-        // The site interprets 1 page == 1 chapter
-        // There should only be 1 article in the document
-        val page = doc.select("article.comic:first-child")
-        val ret = mutableListOf<Page>()
-        // The image url *in most cases* supposed to look like this /comic/twi4/comicName/works/pageNumber.suffix.jpg
-        // The noscript page broke the image links in a few mangas and they don't come with the suffix
-        // In this case we need to request an index file and obtain the file suffix
-        var imageUrl: String = getUrlDomain() + page.select("div > div > p > img").attr("src")
-        if (!validPageTest.matches(page.select("div > div > p > img").attr("src"))) {
-            val requestUrl = response.request.url.toUrl().toString()
-            val chapterNum = requestUrl.substringAfterLast("/").take(4).toInt()
-            // The index file contains everything about each image. Usually we can find the file name directly from the document
-            // This is a failsafe
-            val indexResponse = client.newCall(
-                GET(
-                    requestUrl.substringBeforeLast("/") + "/index.js",
-                    getChromeHeaders(),
-                ),
-            ).execute()
-            if (!indexResponse.isSuccessful) {
-                throw Exception("Failed to find pages!")
-            }
-            // We got a JS file that looks very much like a JSON object
-            // A few string manipulation and we can parse the whole thing as JSON!
-            val re = Regex("([A-z]+):")
-            val index = indexResponse.body.string().substringAfter("=").dropLast(1)
-                .let { re.replace(it, "\"$1\":") }
-            indexResponse.close()
-            val indexElement = index.let { Json.parseToJsonElement(it) }
-            val suffix =
-                indexElement.jsonObject["Items"]?.jsonArray?.get(chapterNum - 1)?.jsonObject?.get("Suffix")?.jsonPrimitive?.content
-            // Twi4's image links are a bit of a mess
-            // Because in very rare cases, the image filename *doesn't* come with a suffix
-            // So only attach the suffix if there is one
-            if (suffix != null) {
-                imageUrl = getUrlDomain() + page.select("div > div > p > img").attr("src")
-                    .dropLast(4) + suffix + ".jpg"
-            }
-        }
-        ret.add(
-            Page(
-                index = page.select("header > div > h3 > span.number").text().toInt(),
-                imageUrl = imageUrl,
-            ),
-        )
-        return ret
-    }
+    override fun latestUpdatesParse(response: Response): MangasPage = throw UnsupportedOperationException()
 
     // There is no search functionality in the site
     // It is possible to implement something rudimentary for search to function
@@ -230,11 +68,11 @@ class Twi4 : HttpSource() {
         filters: FilterList,
     ): Observable<MangasPage> {
         if (query.startsWith("https://")) {
-            val url = query.toHttpUrl()
+            val url = query.toHttpUrlOrNull() ?: throw Exception("Invalid URL")
             if (url.host != baseUrl.toHttpUrl().host) {
                 throw Exception("Unsupported url")
             }
-            val slug = url.pathSegments[2]
+            val slug = url.pathSegments.getOrNull(2) ?: throw Exception("Unsupported url structure")
             return fetchSearchManga(page, "$SEARCH_PREFIX_SLUG$slug", filters)
         }
 
@@ -247,35 +85,130 @@ class Twi4 : HttpSource() {
             // There will still be some urls that would accidentally activate the intent (like the news page),
             // but there's no way to avoid it.
             if (slug.endsWith("html") || slug.startsWith("zadankai") || slug.startsWith("others")) {
-                return Observable.just(MangasPage(listOf(), false))
+                return Observable.just(MangasPage(emptyList(), false))
             }
-            return client.newCall(GET(baseUrl + slug))
+
+            val searchUrl = if (baseUrl.endsWith("/")) baseUrl + slug else "$baseUrl/$slug/"
+            return client.newCall(GET(searchUrl, headers))
                 .asObservableSuccess()
-                .map { response -> searchMangaSlug(response, slug) }
+                .map { response -> searchMangaSlug(response, searchUrl) }
         }
+
         return fetchPopularManga(page).map { mp ->
             mp.copy(
-                mp.mangas.filter {
+                mangas = mp.mangas.filter {
                     it.title.contains(query, true)
                 },
             )
         }
     }
 
-    private fun searchMangaSlug(response: Response, slug: String): MangasPage {
-        val details = mangaDetailsParse(response)
-        details.setUrlWithoutDomain(baseUrl + slug)
-        return MangasPage(listOf(details), false)
-    }
-
-    // All these functions are unused
-    override fun latestUpdatesParse(response: Response): MangasPage = throw UnsupportedOperationException()
-
-    override fun latestUpdatesRequest(page: Int): Request = throw UnsupportedOperationException()
-
-    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request = throw UnsupportedOperationException()
 
     override fun searchMangaParse(response: Response): MangasPage = throw UnsupportedOperationException()
 
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request = throw UnsupportedOperationException()
+    private fun searchMangaSlug(response: Response, searchUrl: String): MangasPage {
+        val details = mangaDetailsParse(response)
+        details.setUrlWithoutDomain(searchUrl)
+        return MangasPage(listOf(details), false)
+    }
+
+    override fun mangaDetailsRequest(manga: SManga): Request = GET(hostRoot + manga.url, headers)
+
+    override fun fetchMangaDetails(manga: SManga): Observable<SManga> {
+        val details = client.newCall(mangaDetailsRequest(manga)).asObservableSuccess().map { mangaDetailsParse(it) }
+        val statusObservable = client.newCall(GET(baseUrl, headers)).asObservableSuccess().map { parseStatus(it, manga.url) }
+
+        return Observable.zip(details, statusObservable) { d, s -> d.apply { status = s } }
+    }
+
+    private fun parseStatus(response: Response, mangaUrl: String): Int {
+        val doc = response.asJsoup()
+        val mangas = doc.select("#lineup_recent > div > section, #lineup > div > section:not(.zadankai):not([id])")
+        val entry = mangas.firstOrNull { it.selectFirst("div.hgroup > h3 > a")?.attr("href") == mangaUrl }
+
+        return if (entry?.selectFirst("ul > li:last-child > em.is-completed") == null) {
+            SManga.ONGOING
+        } else {
+            SManga.COMPLETED
+        }
+    }
+
+    override fun mangaDetailsParse(response: Response): SManga {
+        val document = response.asJsoup()
+        return SManga.create().apply {
+            // We need to get the title and thumbnail again.
+            // This is only needed if you search by slug, as we have no information about the them.
+            // Interestingly the page body has no mention of the title at all. It only exists in <title>
+            val match = TITLE_REGEX.matchEntire(document.title())
+            title = match?.groups?.get(1)?.value ?: document.title()
+            // Twi4 uses the exact same thumbnail at both the main page and manga details
+            thumbnail_url = document.selectFirst("#introduction > header > div > h2 > img")?.attr("abs:src")
+            description = document.selectFirst("#introduction > div > div > p")?.text()
+
+            // Determine who are the authors and artists
+            // 作者, 原作 -> Author (Also the artist) / Original author (Such as light novel adaptation)
+            // 漫画 -> Artist only
+            // 提供, etc, etc -> Sponsors, irrelevant stuff
+            val staffs = document.select("#introduction > div > section > header > div > h3")
+            for (staff in staffs) {
+                val role = staff.selectFirst("small")?.text()?.replace("：", "")?.trim() ?: continue
+                val name = staff.selectFirst("span")?.text() ?: continue
+
+                when (role) {
+                    "作者" -> {
+                        author = name
+                        artist = name
+                    }
+                    // If 作者 and 原作 appear at the same time, 原作 will overwrite the author field
+                    "原作" -> author = name
+                    "漫画" -> artist = name
+                }
+            }
+            // While the status can be obtained at the home page, there is no such info at the details page
+        }
+    }
+
+    override fun chapterListRequest(manga: SManga): Request = GET(hostRoot + manga.url, headers)
+
+    // They have a <noscript> layout! This is surprising
+    // Though their manga pages fails to load as it relies on JS
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val doc = response.asJsoup()
+        val allChapters = doc.select("#backnumbers > div > ul > li")
+
+        val ret = allChapters.mapNotNull { chapter ->
+            val a = chapter.selectFirst("a") ?: return@mapNotNull null
+            val match = CHAPTER_REGEX.matchEntire(a.text())
+            val chapNumber = match?.groups?.get(2)?.value
+
+            SChapter.create().apply {
+                if (chapNumber != null) {
+                    this.chapter_number = chapNumber.toFloat()
+                    this.name = "${chapNumber.toInt()} - ${match.groups[1]?.value}"
+                    // We can't determine the upload date from the website
+                    // Leaving date_upload unset
+                } else {
+                    this.name = a.text()
+                }
+                setUrlWithoutDomain(a.attr("abs:href"))
+            }
+        }
+
+        return ret.sortedByDescending { it.chapter_number }
+    }
+
+    override fun pageListRequest(chapter: SChapter): Request = GET(hostRoot + chapter.url, headers)
+
+    override fun pageListParse(response: Response): List<Page> {
+        val doc = response.asJsoup()
+        // The site interprets 1 page == 1 chapter
+        // There should only be 1 article in the document
+        val page = doc.selectFirst("article.comic") ?: return emptyList()
+        val img = page.selectFirst("div > div > p > img") ?: return emptyList()
+
+        return listOf(Page(0, imageUrl = img.attr("abs:src")))
+    }
+
+    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
 }


### PR DESCRIPTION
Checklist:

- [X] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [X] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

Changes
- Fix status parsing
- Fix 404 error on some pages
- Remove the now unnecessary hardcoded header
- Remove the outdated `index.js` logic
- Migrate to new dsl
- Cleanup

I left the pre-existing comments that seemed consistent