### PR TITLE
MangaLivre: decode base64/atob-obfuscated reading-gate header

### DIFF
--- a/src/pt/mangalivre/build.gradle.kts
+++ b/src/pt/mangalivre/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 keiyoushi {
     name = "Manga Livre"
-    versionCode = 69
+    versionCode = 70
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
@@ -21,6 +21,7 @@ import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
+import okio.ByteString.Companion.decodeBase64
 import java.io.IOException
 import kotlin.time.Duration.Companion.seconds
 
@@ -240,10 +241,9 @@ abstract class MangaLivre :
 
     /**
      * O gate de "aplicativo oficial" (endpoints de leitura) exige um header de cliente que o
-     * front-end injeta no bundle via `Headers.append("x-tly-token", "v99-web-z")` — e há um
-     * decoy `set("app-token", ...)` que os endpoints abertos ignoram. Nome/valor rotacionam.
-     * Coletamos TODOS os pares literais de `.set(...)`/`.append(...)` dos /assets (fora headers
-     * padrão) e o interceptor testa cada candidato quando a API recusa com 403.
+     * front-end injeta via `Headers.append(...)` no bundle — hoje ofuscado com base64/`atob(...)`
+     * (ex.: app-sec-token/z11-web-y). Coletamos os pares de `.set`/`.append` (literais e atob) dos
+     * /assets, fora headers padrão, e o interceptor testa cada candidato quando a API recusa 403.
      */
     private fun scrapeCandidates(): List<ClientToken> = try {
         val html = scrapeClient.newCall(GET("$baseUrl/", headers)).execute()
@@ -261,8 +261,16 @@ abstract class MangaLivre :
     }
 
     private fun extractCandidates(js: String): List<ClientToken> {
-        val pairs = SET_REGEX.findAll(js)
+        val literals = LITERAL_REGEX.findAll(js)
             .map { ClientToken(it.groupValues[1], it.groupValues[2]) }
+        val encoded = ATOB_REGEX.findAll(js)
+            .mapNotNull {
+                val header = it.groupValues[1].decodeBase64()?.utf8() ?: return@mapNotNull null
+                val value = it.groupValues[2].decodeBase64()?.utf8() ?: return@mapNotNull null
+                ClientToken(header, value)
+            }
+        val pairs = (encoded + literals)
+            .filter { it.header.matches(HEADER_NAME_REGEX) }
             .filterNot { it.header.lowercase() in STANDARD_HEADERS }
             .distinct()
             .toList()
@@ -286,9 +294,12 @@ abstract class MangaLivre :
         private const val MAX_CANDIDATES = 8
         private const val NON_JSON_MESSAGE =
             "Resposta não-JSON (Cloudflare ou header desatualizado). Abra a fonte na WebView do app e tente de novo."
-        private val DEFAULT_TOKEN = ClientToken("x-tly-token", "v99-web-z")
-        private val ASSET_REGEX = Regex("/assets/[\\w-]+\\.js")
-        private val SET_REGEX = Regex("\\.(?:set|append)\\(\\s*\"([A-Za-z][\\w.-]{1,40})\"\\s*,\\s*\"([^\"]{1,60})\"\\s*\\)")
+        private val DEFAULT_TOKEN = ClientToken("app-sec-token", "z11-web-y")
         private val STANDARD_HEADERS = setOf("content-type", "accept", "authorization", "x-csrf-token")
+        private val HEADER_NAME_REGEX = Regex("[A-Za-z][\\w.-]{1,40}")
+        private val ASSET_REGEX = Regex("/assets/[\\w-]+\\.js")
+        private const val B64 = "atob\\(\"([A-Za-z0-9+/=]{1,80})\"\\)"
+        private val LITERAL_REGEX = Regex("\\.(?:set|append)\\(\\s*\"([A-Za-z][\\w.-]{1,40})\"\\s*,\\s*\"([^\"]{1,60})\"\\s*\\)")
+        private val ATOB_REGEX = Regex("\\.(?:set|append)\\(\\s*$B64\\s*,\\s*$B64\\s*\\)")
     }
 }


### PR DESCRIPTION
Follow-up to #17225. The reading gate escalated its obfuscation again, which is why the header discovery kept missing it.

**What changed.** The client header the reading endpoints require is no longer a string literal in the bundle — it is now built with `atob()` (base64):

```js
S.append(atob("YXBwLXNlYy10b2tlbg=="), atob("ejExLXdlYi15"))
//        └ "app-sec-token"             └ "z11-web-y"
```

So `#17225`'s literal `.set/.append("name","value")` scan found only decoys, and reading kept returning `403 {"error":"Acesso negado. Por favor, use o aplicativo oficial."}`.

**Fix.** Also match `.set/.append(atob("…"), atob("…"))` and base64-decode both parts (via okio `decodeBase64().utf8()`), alongside the plain-literal form. Decoded names are sanity-checked against a header-name shape and the standard-header denylist; the existing multi-candidate `403` retry then validates and caches the right one, self-healing across name/value rotations. Default → `app-sec-token` / `z11-web-y`.

**Verified end-to-end against the live API** (real browser, replaying the exact interceptor logic on a reading endpoint):
- Candidates extracted with the new regexes → `[app-sec-token/z11-web-y, lite/1]` (the atob pair is correctly decoded).
- Cold start with the default → `200` (pages load).
- Simulating a stale token → `403` → scans the bundle, decodes `app-sec-token`, retries → `200`, caches it.

### Changes

- Decode base64/`atob(...)` header pairs from the bundle (not just string literals).
- Default client header → `app-sec-token` / `z11-web-y`.
- Bump `versionCode` to 70.

No endpoint URLs or DTOs changed.

### Checklist

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately (unchanged: SAFE)
- [x] Have not changed source names
- [ ] Have tested the modifications by compiling and running the extension through Android Studio — **iOS only, no Android.** Verified the header/gate and replayed the interceptor logic end-to-end against the live reading endpoint (200); checked formatting with ktlint locally; relying on CI to build.
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop