### PR TITLE
tr/ragnarscans: fix chapter name parsing and update selectors

### DIFF
--- a/src/tr/ragnarscans/build.gradle.kts
+++ b/src/tr/ragnarscans/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 keiyoushi {
     name = "Ragnar Scans"
-    versionCode = 46
+    versionCode = 47
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
     theme = "initmanga"

--- a/src/tr/ragnarscans/src/eu/kanade/tachiyomi/extension/tr/ragnarscans/RagnarScans.kt
+++ b/src/tr/ragnarscans/src/eu/kanade/tachiyomi/extension/tr/ragnarscans/RagnarScans.kt
@@ -17,15 +17,16 @@ abstract class RagnarScans : InitManga() {
 
     private val ragnarDateFormat = SimpleDateFormat("d MMMM yyyy HH:mm", Locale("tr"))
 
-    override fun chapterListSelector() = "div.chapter-list > div.uk-position-relative"
+    override fun chapterListSelector() = "div.chapter-list > div.chapter-item"
 
     override fun chapterFromElement(element: Element) = SChapter.create().apply {
         setUrlWithoutDomain(element.selectFirst("a")!!.absUrl("href"))
 
-        name = element.selectFirst("div.uk-flex-none")?.text()
-            ?: element.select("a").text()
+        name = element.selectFirst("h3.uk-link-heading")!!.text()
+            .substringAfterLast("–")
+            .trim()
 
-        val dateStr = element.selectFirst("div.uk-text-meta")?.attr("uk-tooltip")
+        val dateStr = element.selectFirst("div.uk-article-meta span[uk-tooltip]")?.attr("uk-tooltip")
             ?.substringAfter("title: ")?.substringBefore(";")
         date_upload = ragnarDateFormat.tryParse(dateStr)
     }


### PR DESCRIPTION
Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop