### PR TITLE
MangaBox: Exclude ads from manga selector

### DIFF
--- a/lib-multisrc/mangabox/build.gradle.kts
+++ b/lib-multisrc/mangabox/build.gradle.kts
@@ -3,6 +3,6 @@ plugins {
 }
 
 keiyoushi {
-    baseVersionCode = 13
+    baseVersionCode = 14
     libVersion = "1.4"
 }

--- a/lib-multisrc/mangabox/src/eu/kanade/tachiyomi/multisrc/mangabox/MangaBox.kt
+++ b/lib-multisrc/mangabox/src/eu/kanade/tachiyomi/multisrc/mangabox/MangaBox.kt
@@ -510,7 +510,7 @@ abstract class MangaBox :
                 val prev = imageList.lastOrNull()
                 val prevSize = prev?.size
                 if (
-                // size is known
+                    // size is known
                     size != null &&
 
                     // previous size is known

--- a/lib-multisrc/mangabox/src/eu/kanade/tachiyomi/multisrc/mangabox/MangaBox.kt
+++ b/lib-multisrc/mangabox/src/eu/kanade/tachiyomi/multisrc/mangabox/MangaBox.kt
@@ -217,7 +217,7 @@ abstract class MangaBox :
 
     // ============================== Popular ==============================
 
-    open fun popularMangaSelector() = "div.truyen-list > div.list-truyen-item-wrap, div.comic-list > .list-comic-item-wrap"
+    open fun popularMangaSelector() = ":is(div.truyen-list > div.list-truyen-item-wrap, div.comic-list > .list-comic-item-wrap):has(a[data-id])"
 
     override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/$popularUrlPath$page", headers)
 
@@ -510,7 +510,7 @@ abstract class MangaBox :
                 val prev = imageList.lastOrNull()
                 val prevSize = prev?.size
                 if (
-                    // size is known
+                // size is known
                     size != null &&
 
                     // previous size is known


### PR DESCRIPTION
MangaBox sources have been including ads in the manga lists. This change updates the manga selector to exclude any entries missing the `data-id` attribute (i.e. ads).

Example of an ad in the manga list:

![image](https://github.com/user-attachments/assets/bd524be1-daf4-4e77-80be-97938e512dbf)

Checklist:

- [ ] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
