### PR TITLE
Mediocretoons: URL modify back

### DIFF
--- a/src/pt/mediocretoons/build.gradle.kts
+++ b/src/pt/mediocretoons/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 keiyoushi {
     name = "Mediocre Toons"
-    versionCode = 19
+    versionCode = 20
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
 

--- a/src/pt/mediocretoons/src/eu/kanade/tachiyomi/extension/pt/mediocretoons/MediocreToons.kt
+++ b/src/pt/mediocretoons/src/eu/kanade/tachiyomi/extension/pt/mediocretoons/MediocreToons.kt
@@ -32,7 +32,7 @@ abstract class MediocreToons :
     HttpSource(),
     ConfigurableSource {
     override val supportsLatest = true
-    private val apiUrl = "https://back.mediocrescan.com"
+    private val apiUrl = "https://back2.mediocrescan.com"
 
     private val preferences: SharedPreferences by getPreferencesLazy()
 


### PR DESCRIPTION
closes: https://github.com/keiyoushi/extensions-source/issues/17281

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
