### PR TITLE
Leitura Manga (pt-BR): Fix details

### DIFF
--- a/src/pt/leituramanga/build.gradle.kts
+++ b/src/pt/leituramanga/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 keiyoushi {
     name = "Leitura Manga"
-    versionCode = 5
+    versionCode = 6
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
 

--- a/src/pt/leituramanga/src/eu/kanade/tachiyomi/extension/pt/leituramanga/Dto.kt
+++ b/src/pt/leituramanga/src/eu/kanade/tachiyomi/extension/pt/leituramanga/Dto.kt
@@ -32,7 +32,7 @@ class MangaDto(
     val slug: String,
     val author: String? = null,
     val description: String? = null,
-    val status: String? = null,
+    val status: Int? = null,
     val genres: List<GenreDto>? = emptyList(),
     val alternativeTitles: List<String>? = emptyList(),
 ) {
@@ -49,8 +49,10 @@ class MangaDto(
             }
         }
         status = when (this@MangaDto.status) {
-            "Ongoing" -> SManga.ONGOING
-            "Completed" -> SManga.COMPLETED
+            0, 1 -> SManga.ONGOING
+            2 -> SManga.COMPLETED
+            3 -> SManga.CANCELLED
+            4 -> SManga.ON_HIATUS
             else -> SManga.UNKNOWN
         }
         genre = this@MangaDto.genres?.joinToString { it.name }

--- a/src/pt/leituramanga/src/eu/kanade/tachiyomi/extension/pt/leituramanga/LeituraManga.kt
+++ b/src/pt/leituramanga/src/eu/kanade/tachiyomi/extension/pt/leituramanga/LeituraManga.kt
@@ -122,8 +122,10 @@ abstract class LeituraManga : HttpSource() {
         genre = document.select("h2 + div > a[href*=genre]").joinToString { it.text() }
 
         status = when (document.selectFirst("h2:contains(Informações) +div p:contains(Status)")?.text()?.substringAfter(":")?.trim()?.lowercase()) {
-            "ongoing" -> SManga.ONGOING
-            "completed" -> SManga.COMPLETED
+            "Em breve", "Em andamento" -> SManga.ONGOING
+            "Completo" -> SManga.COMPLETED
+            "Cancelado" -> SManga.CANCELLED
+            "Em pausa" -> SManga.ON_HIATUS
             else -> SManga.UNKNOWN
         }
 


### PR DESCRIPTION
Closes #17302 

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
