### PR TITLE
ZManga (mutli-src): Fix lazyloaded imgs

### DIFF
--- a/lib-multisrc/zmanga/build.gradle.kts
+++ b/lib-multisrc/zmanga/build.gradle.kts
@@ -3,6 +3,6 @@ plugins {
 }
 
 keiyoushi {
-    baseVersionCode = 2
+    baseVersionCode = 3
     libVersion = "1.4"
 }

--- a/lib-multisrc/zmanga/src/eu/kanade/tachiyomi/multisrc/zmanga/ZManga.kt
+++ b/lib-multisrc/zmanga/src/eu/kanade/tachiyomi/multisrc/zmanga/ZManga.kt
@@ -132,7 +132,9 @@ abstract class ZManga : HttpSource() {
     override fun mangaDetailsParse(response: Response): SManga = mangaDetailsParse(response.asJsoup())
 
     open fun mangaDetailsParse(document: Document): SManga = SManga.create().apply {
-        thumbnail_url = document.select("div.series-thumb img").attr("abs:src")
+        val thumb = document.select("div.series-thumb img")
+        thumbnail_url = thumb.attr("data-lazy-src").takeIf { it.isNotBlank() }
+            ?: thumb.attr("abs:src")
         author = document.select(".series-infolist li:contains(Author) span").text()
         artist = document.select(".series-infolist li:contains(Artist) span").text()
         status = parseStatus(document.select(".series-infoz .status").firstOrNull()?.ownText())
@@ -184,8 +186,10 @@ abstract class ZManga : HttpSource() {
 
     override fun pageListParse(response: Response): List<Page> = pageListParse(response.asJsoup())
 
-    open fun pageListParse(document: Document): List<Page> = document.select("div.reader-area img").mapIndexed { i, img ->
-        Page(i, imageUrl = img.attr("abs:src"))
+    open fun pageListParse(document: Document): List<Page> = document.select("div.reader-area img:not(noscript img)").mapIndexed { i, img ->
+        val imgUrl = img.attr("data-lazy-src").takeIf { it.isNotBlank() }
+            ?: img.attr("abs:src")
+        Page(i, imageUrl = imgUrl)
     }
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()


### PR DESCRIPTION
 Closes #17284

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
