### PR TITLE
ZetTruyen (VI): update domain

### DIFF
--- a/src/vi/zettruyen/build.gradle.kts
+++ b/src/vi/zettruyen/build.gradle.kts
@@ -4,12 +4,12 @@ plugins {
 
 keiyoushi {
     name = "ZetTruyen"
-    versionCode = 10
-    contentWarning = ContentWarning.SAFE
+    versionCode = 11
+    contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 
     source {
         lang = "vi"
-        baseUrl = "https://www.zettruyen.fit"
+        baseUrl = "https://www.zettruyen.ink"
     }
 }


### PR DESCRIPTION
closes #17307 

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
