### PR TITLE
MangaLivre: match object-form reading-gate header in bundle

### DIFF
--- a/src/pt/mangalivre/build.gradle.kts
+++ b/src/pt/mangalivre/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 keiyoushi {
     name = "Manga Livre"
-    versionCode = 71
+    versionCode = 72
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
@@ -314,11 +314,14 @@ abstract class MangaLivre :
         private const val ENCODED_BONUS = 1000
         private const val NON_JSON_MESSAGE =
             "Resposta não-JSON (Cloudflare ou header desatualizado). Abra a fonte na WebView do app e tente de novo."
-        private val DEFAULT_TOKEN = ClientToken("x-gateway-key", "fw7-mob-q")
+        private val DEFAULT_TOKEN = ClientToken("x-tly-quantum", "j55-zero-o")
         private val STANDARD_HEADERS = setOf("content-type", "accept", "accept-language", "authorization", "x-csrf-token")
         private val HEADER_NAME_REGEX = Regex("[A-Za-z][\\w.-]{1,40}")
         private val ASSET_REGEX = Regex("/assets/[\\w-]+\\.js")
         private const val ARG = "(?:\"([^\"]{1,60})\"|atob\\(\"([A-Za-z0-9+/=]{1,80})\"\\))"
-        private val PAIR_REGEX = Regex("$ARG\\s*,\\s*$ARG")
+
+        // O par header/valor pode vir como argumentos adjacentes (`("k","v")`) ou como
+        // propriedades de objeto (`{k:atob(..),v:atob(..)}`); tolera uma chave opcional entre eles.
+        private val PAIR_REGEX = Regex("$ARG\\s*,\\s*(?:\\w+\\s*:\\s*)?$ARG")
     }
 }


### PR DESCRIPTION
Closes #17279

The reading-gate header on the page-list endpoint rotates daily and is scraped from
the bundle. It's now built as an object literal instead of adjacent args, so
`PAIR_REGEX` stopped matching it — discovery fell back to the stale default and page
requests 403'd (browse / latest / chapter list still worked).

```js
B = { k: atob("eC10bHktcXVhbnR1bQ=="), v: atob("ajU1LXplcm8tbw==") } // x-tly-quantum / j55-zero-o
S.append(B.k, B.v)
```

Fix: allow an optional object key between the two args in `PAIR_REGEX` (non-capturing,
so group indices are unchanged; old adjacent form still matches), refresh
`DEFAULT_TOKEN`, bump versionCode.

Verified against the live bundle and on-device: the old regex misses the `{k,v}` form,
the new one extracts the header, and chapters load/download again.

---

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
