### PR TITLE
DuaLeoTruyen (VI): update domain

### DIFF
--- a/src/vi/dualeotruyen/build.gradle.kts
+++ b/src/vi/dualeotruyen/build.gradle.kts
@@ -4,14 +4,14 @@ plugins {
 
 keiyoushi {
     name = "Dua Leo Truyen"
-    versionCode = 23
+    versionCode = 24
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
 
     source {
         name = "Dưa Leo Truyện"
         lang = "vi"
-        baseUrl("https://dualeotruyendc.com") {
+        baseUrl("https://dualeotruyenhn.com") {
             withCustom = true
         }
     }


### PR DESCRIPTION
closes #17332 

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
