### PR TITLE
DragonTranslationOrg: Update selectors

### DIFF
--- a/src/es/dragontranslationorg/build.gradle.kts
+++ b/src/es/dragontranslationorg/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 keiyoushi {
     name = "DragonTranslation.org"
-    versionCode = 1
+    versionCode = 2
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
     theme = "madara"

--- a/src/es/dragontranslationorg/src/eu/kanade/tachiyomi/extension/es/dragontranslationorg/DragonTranslationOrg.kt
+++ b/src/es/dragontranslationorg/src/eu/kanade/tachiyomi/extension/es/dragontranslationorg/DragonTranslationOrg.kt
@@ -1,18 +1,56 @@
 package eu.kanade.tachiyomi.extension.es.dragontranslationorg
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.annotation.Source
 import keiyoushi.network.rateLimit
+import keiyoushi.utils.parseAs
 import okhttp3.OkHttpClient
+import okhttp3.Response
+import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
 
 @Source
 abstract class DragonTranslationOrg : Madara() {
     override val dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("es"))
-    override val useLoadMoreRequest = LoadMoreStrategy.Always
+    override val useLoadMoreRequest = LoadMoreStrategy.Never
 
     override val client: OkHttpClient = super.client.newBuilder()
         .rateLimit(3)
         .build()
+
+    override fun popularMangaSelector() = "div#mkAgrid > a.acard"
+
+    override fun popularMangaNextPageSelector() = "div.wp-pagenavi > a.nextpostslink"
+
+    override fun popularMangaFromElement(element: Element) = SManga.create().apply {
+        setUrlWithoutDomain(element.attr("abs:href"))
+        title = element.selectFirst("div.ac-t")!!.ownText()
+        element.selectFirst(popularMangaUrlSelectorImg)?.let {
+            thumbnail_url = processThumbnail(imageFromElement(it), true)
+        }
+    }
+
+    override fun searchMangaParse(response: Response) = popularMangaParse(response)
+
+    override val mangaDetailsSelectorTitle = "div.hcol > .htitle"
+    override val mangaDetailsSelectorStatus = "div.hcol > .htags > .htag--status"
+    override val mangaDetailsSelectorDescription = "div#syn > p"
+    override val mangaDetailsSelectorThumbnail = "div.hposter__card > img"
+    override val mangaDetailsSelectorGenre = "div.hcol > .hchips--genres > a.chip"
+
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val scriptData = response.asJsoup().selectFirst("script#mk-chapters-data")!!.data()
+        val dto = scriptData.parseAs<ChapterListDto>()
+        return dto.items.map { chapterDto ->
+            SChapter.create().apply {
+                setUrlWithoutDomain(chapterDto.url)
+                name = chapterDto.name
+                date_upload = parseChapterDate(chapterDto.ago)
+            }
+        }
+    }
 }

--- a/src/es/dragontranslationorg/src/eu/kanade/tachiyomi/extension/es/dragontranslationorg/Dto.kt
+++ b/src/es/dragontranslationorg/src/eu/kanade/tachiyomi/extension/es/dragontranslationorg/Dto.kt
@@ -1,0 +1,15 @@
+package eu.kanade.tachiyomi.extension.es.dragontranslationorg
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+class ChapterListDto(
+    val items: List<ChapterDto>,
+)
+
+@Serializable
+class ChapterDto(
+    val name: String,
+    val url: String,
+    val ago: String,
+)


### PR DESCRIPTION
Closes #17329 

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
