### PR TITLE
Update some domains, ContentWarning

### DIFF
--- a/src/vi/kirakira/build.gradle.kts
+++ b/src/vi/kirakira/build.gradle.kts
@@ -4,12 +4,12 @@ plugins {
 
 keiyoushi {
     name = "KiraKira"
-    versionCode = 2
+    versionCode = 3
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 
     source {
         lang = "vi"
-        baseUrl = "https://truyenkira.com"
+        baseUrl = "https://truyenkira.net"
     }
 }

--- a/src/vi/luottruyen/build.gradle.kts
+++ b/src/vi/luottruyen/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 keiyoushi {
     name = "LuotTruyen"
     versionCode = 6
-    contentWarning = ContentWarning.NSFW
+    contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 
     source {

--- a/src/vi/luottruyen/build.gradle.kts
+++ b/src/vi/luottruyen/build.gradle.kts
@@ -4,13 +4,13 @@ plugins {
 
 keiyoushi {
     name = "LuotTruyen"
-    versionCode = 5
+    versionCode = 6
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
 
     source {
         lang = "vi"
-        baseUrl("https://luottruyen10.com") {
+        baseUrl("https://luottruyen11.com") {
             withCustom = true
         }
     }

--- a/src/vi/muntruyen/build.gradle.kts
+++ b/src/vi/muntruyen/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 keiyoushi {
     name = "MunTruyen"
     versionCode = 3
-    contentWarning = ContentWarning.NSFW
+    contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 
     source {

--- a/src/vi/muntruyen/build.gradle.kts
+++ b/src/vi/muntruyen/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 keiyoushi {
     name = "MunTruyen"
-    versionCode = 3
+    versionCode = 4
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 

--- a/src/vi/muntruyen/build.gradle.kts
+++ b/src/vi/muntruyen/build.gradle.kts
@@ -10,7 +10,7 @@ keiyoushi {
 
     source {
         lang = "vi"
-        baseUrl("https://moonnovel.store") {
+        baseUrl("https://munedge.com") {
             withCustom = true
         }
     }

--- a/src/vi/toptruyen/build.gradle.kts
+++ b/src/vi/toptruyen/build.gradle.kts
@@ -4,14 +4,14 @@ plugins {
 
 keiyoushi {
     name = "Top Truyen"
-    versionCode = 30
+    versionCode = 31
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
     theme = "wpcomics"
 
     source {
         lang = "vi"
-        baseUrl("https://www.toptruyenzone5.com") {
+        baseUrl("https://www.toptruyenzone6.com") {
             withCustom = true
         }
     }

--- a/src/vi/toptruyen/build.gradle.kts
+++ b/src/vi/toptruyen/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 keiyoushi {
     name = "Top Truyen"
     versionCode = 31
-    contentWarning = ContentWarning.NSFW
+    contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
     theme = "wpcomics"
 

--- a/src/vi/truyenhentaivn/build.gradle.kts
+++ b/src/vi/truyenhentaivn/build.gradle.kts
@@ -4,12 +4,12 @@ plugins {
 
 keiyoushi {
     name = "TruyenHentaivn"
-    versionCode = 4
+    versionCode = 5
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
 
     source {
         lang = "vi"
-        baseUrl = "https://truyenhentaivn.space"
+        baseUrl = "https://truyenhentaivn.store"
     }
 }


### PR DESCRIPTION
Closed https://github.com/keiyoushi/extensions-source/issues/17351
Closed https://github.com/keiyoushi/extensions-source/issues/17335

## Changed Domains
- **kirakira**: `truyenkira.com` => `truyenkira.net`
- **luottruyen**: `luottruyen10.com` => `luottruyen11.com`
- **muntruyen**: `moonnovel.store` => `munedge.com`
- **toptruyen**: `www.toptruyenzone5.com` => `www.toptruyenzone6.com`
- **truyenhentaivn**: `truyenhentaivn.space` => `truyenhentaivn.store`

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
