### PR TITLE
Fix Roliascan (Mangataro)

### DIFF
--- a/lib-multisrc/mangataro/build.gradle.kts
+++ b/lib-multisrc/mangataro/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 keiyoushi {
-    baseVersionCode = 1
+    baseVersionCode = 2
     libVersion = "1.4"
 
     deeplink {

--- a/lib-multisrc/mangataro/build.gradle.kts
+++ b/lib-multisrc/mangataro/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 keiyoushi {
-    baseVersionCode = 2
+    baseVersionCode = 1
     libVersion = "1.4"
 
     deeplink {

--- a/lib-multisrc/mangataro/src/eu/kanade/tachiyomi/multisrc/mangataro/MangaTaro.kt
+++ b/lib-multisrc/mangataro/src/eu/kanade/tachiyomi/multisrc/mangataro/MangaTaro.kt
@@ -281,7 +281,7 @@ abstract class MangaTaro : HttpSource() {
             it.language.equals(lang, ignoreCase = true)
         }.map {
             SChapter.create().apply {
-                setUrlWithoutDomain(it.url)
+                setUrlWithoutDomain(it.url.removeSuffix("/"))
                 name = buildString {
                     append("Chapter ")
                     append(it.chapter)

--- a/lib-multisrc/mangataro/src/eu/kanade/tachiyomi/multisrc/mangataro/MangaTaro.kt
+++ b/lib-multisrc/mangataro/src/eu/kanade/tachiyomi/multisrc/mangataro/MangaTaro.kt
@@ -310,7 +310,7 @@ abstract class MangaTaro : HttpSource() {
 
     // ========================== Pages ==========================
     override fun pageListRequest(chapter: SChapter): Request {
-        val chapterId = getChapterUrl(chapter).toHttpUrl()
+        val chapterId = getChapterUrl(chapter).removeSuffix("/").toHttpUrl()
             .pathSegments.last()
             .substringAfterLast("-")
 

--- a/src/en/roliascan/build.gradle.kts
+++ b/src/en/roliascan/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 keiyoushi {
     name = "Rolia Scan"
-    versionCode = 7
+    versionCode = 8
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
     theme = "mangataro"

--- a/src/en/roliascan/src/eu/kanade/tachiyomi/extension/en/roliascan/RoliaScan.kt
+++ b/src/en/roliascan/src/eu/kanade/tachiyomi/extension/en/roliascan/RoliaScan.kt
@@ -9,7 +9,6 @@ import eu.kanade.tachiyomi.multisrc.mangataro.TagFilter
 import eu.kanade.tachiyomi.multisrc.mangataro.TagFilterMatch
 import eu.kanade.tachiyomi.multisrc.mangataro.TypeFilter
 import eu.kanade.tachiyomi.multisrc.mangataro.YearFilter
-import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
@@ -17,7 +16,6 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import keiyoushi.annotation.Source
 import keiyoushi.utils.parseAs
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import rx.Observable
 
@@ -41,7 +39,7 @@ abstract class RoliaScan : MangaTaro() {
 
     // ========================== Pages ==========================
     override fun pageListRequest(chapter: SChapter): Request {
-        if(!chapter.url.endsWith("/")) throw Exception("Refresh Manga to update information about chapters")
+        if (!chapter.url.endsWith("/")) throw Exception("Refresh Manga to update information about chapters")
         return super.pageListRequest(chapter)
     }
 

--- a/src/en/roliascan/src/eu/kanade/tachiyomi/extension/en/roliascan/RoliaScan.kt
+++ b/src/en/roliascan/src/eu/kanade/tachiyomi/extension/en/roliascan/RoliaScan.kt
@@ -9,12 +9,16 @@ import eu.kanade.tachiyomi.multisrc.mangataro.TagFilter
 import eu.kanade.tachiyomi.multisrc.mangataro.TagFilterMatch
 import eu.kanade.tachiyomi.multisrc.mangataro.TypeFilter
 import eu.kanade.tachiyomi.multisrc.mangataro.YearFilter
+import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import keiyoushi.annotation.Source
 import keiyoushi.utils.parseAs
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Request
 import rx.Observable
 
 @Source
@@ -34,6 +38,12 @@ abstract class RoliaScan : MangaTaro() {
     // Aggregate results from multiple API pages so
     // the user always gets a full page of results.
     override fun fetchLatestUpdates(page: Int): Observable<MangasPage> = fetchMultiplePages(page) { searchMangaRequest(it, "", SortFilter.latest) }
+
+    // ========================== Pages ==========================
+    override fun pageListRequest(chapter: SChapter): Request {
+        if(!chapter.url.endsWith("/")) throw Exception("Refresh Manga to update information about chapters")
+        return super.pageListRequest(chapter)
+    }
 
     // ========================= Filters =========================
     override fun getFilterList() = FilterList(

--- a/src/en/roliascan/src/eu/kanade/tachiyomi/extension/en/roliascan/RoliaScan.kt
+++ b/src/en/roliascan/src/eu/kanade/tachiyomi/extension/en/roliascan/RoliaScan.kt
@@ -39,7 +39,7 @@ abstract class RoliaScan : MangaTaro() {
 
     // ========================== Pages ==========================
     override fun pageListRequest(chapter: SChapter): Request {
-        if (!chapter.url.endsWith("/")) throw Exception("Refresh Manga to update information about chapters")
+        if (chapter.url.endsWith("/")) throw Exception("Refresh Manga to update information about chapters")
         return super.pageListRequest(chapter)
     }
 


### PR DESCRIPTION
Checklist:

Closes #17321

I guess RoliaScans changed url structure forcing "/" at the end of url's.
And, while trying to get `chapterId` in `pageListRequest` from new url:
```
val chapterId = "$baseUrl${chapter.url}".toHttpUrl()
            .pathSegments.last()
            .substringAfterLast("-")
```
path segments from it would be (as example): `["read", "the-regressed-mercenary-has-a-plan", "ch94-263357", ""]`, which caused an error in the request later, since it didn't have proper Id in it.

`url` in `SManga` are saved as combination of id and slug, taken from API, so change in site url doesn't affect it, and migrating manga are not necessary. But `SChapter` set's `url` with `setUrlWithoutDomain`, so `url` will be different.

Goal for the fix: restore previous `url` structure. Hoarders won't be forced to re-download, if they didn't refresh manga. Those who got new chapters, with new `url` - should be fine after refresh. Add a check for them, forcing refresh.

P.S. Google search with few test url's returns url without / at the end as result, otherwise url are the same. 

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
