### PR TITLE
MangaLivre: static self-heal via 403 oracle (works without WebView)

### DIFF
--- a/src/pt/mangalivre/build.gradle.kts
+++ b/src/pt/mangalivre/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 keiyoushi {
     name = "Manga Livre"
-    versionCode = 73
+    versionCode = 74
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
@@ -21,6 +21,7 @@ import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
+import okio.ByteString.Companion.decodeBase64
 import java.io.IOException
 import kotlin.time.Duration.Companion.seconds
 
@@ -37,6 +38,12 @@ abstract class MangaLivre :
         .addInterceptor(::clientHeaderInterceptor)
         .rateLimit(2, 1.seconds) { it.host == baseUrlHost }
         .build()
+
+    private val scrapeClient: OkHttpClient by lazy {
+        network.client.newBuilder()
+            .followRedirects(false)
+            .build()
+    }
 
     private val apiUrl: String = "$baseUrl/api"
 
@@ -186,6 +193,14 @@ abstract class MangaLivre :
     @Volatile
     private var cachedToken: ClientToken? = null
 
+    /**
+     * O gate de "aplicativo oficial" (endpoints de leitura) exige um header de cliente que o
+     * front-end injeta no bundle, rotacionado e reofuscado todo dia (literal -> atob -> char codes
+     * `[..].map(String.fromCharCode)`). Em vez de perseguir cada encoding, decodificamos os
+     * strings do bundle (char codes + base64), montamos pares "nome/valor" com forma de header e
+     * deixamos o 403 "aplicativo oficial" ser o oráculo: testamos os candidatos até um dar 200.
+     * O WebView (TokenExtractor) fica como último recurso, pois pode não existir no port iOS.
+     */
     private fun clientHeaderInterceptor(chain: Interceptor.Chain): Response {
         val request = chain.request()
         if (request.url.host != baseUrlHost) {
@@ -199,16 +214,76 @@ abstract class MangaLivre :
         }
 
         response.close()
-        val newToken = extractTokenViaWebView() ?: return chain.proceed(request.withClientHeader(token))
-        cachedToken = newToken
-        return chain.proceed(request.withClientHeader(newToken))
+        for (candidate in scrapeStaticCandidates()) {
+            if (candidate == token) continue
+            val retry = chain.proceed(request.withClientHeader(candidate))
+            if (retry.code != 403 || !retry.isOfficialAppError()) {
+                cachedToken = candidate
+                return retry
+            }
+            retry.close()
+        }
+        extractTokenViaWebView()?.let { webViewToken ->
+            val retry = chain.proceed(request.withClientHeader(webViewToken))
+            if (retry.code != 403 || !retry.isOfficialAppError()) {
+                cachedToken = webViewToken
+                return retry
+            }
+            retry.close()
+        }
+        return chain.proceed(request.withClientHeader(token))
     }
 
     private fun Request.withClientHeader(token: ClientToken): Request = newBuilder().header(token.header, token.value).build()
 
     private fun currentToken(): ClientToken = cachedToken ?: synchronized(this) {
-        cachedToken ?: (extractTokenViaWebView() ?: DEFAULT_TOKEN).also { cachedToken = it }
+        cachedToken ?: (scrapeStaticCandidates().firstOrNull() ?: DEFAULT_TOKEN).also { cachedToken = it }
     }
+
+    private fun scrapeStaticCandidates(): List<ClientToken> = try {
+        val js = fetchBundle()
+        val names = (decodeCharCodes(js) + decodeAtob(js))
+            .filter(::isHeaderCandidate)
+            .distinct()
+            .take(MAX_POOL)
+        names
+            .flatMap { name -> names.mapNotNull { value -> if (name != value) ClientToken(name, value) else null } }
+            .sortedByDescending { score(it.value) }
+            .take(MAX_CANDIDATES)
+    } catch (_: Exception) {
+        emptyList()
+    }
+
+    private fun fetchBundle(): String {
+        val html = scrapeClient.newCall(GET("$baseUrl/", headers)).execute()
+            .use { if (it.isSuccessful) it.body.string() else "" }
+        val assets = ASSET_REGEX.findAll(html).map { it.value }.distinct().toList()
+        return buildString {
+            assets.take(MAX_ASSETS).forEach { path ->
+                scrapeClient.newCall(GET("$baseUrl$path", headers)).execute()
+                    .use { if (it.isSuccessful) append(it.body.string()) }
+            }
+        }
+    }
+
+    private fun decodeCharCodes(js: String): List<String> = CHARCODE_REGEX.findAll(js)
+        .mapNotNull { match ->
+            val codes = match.groupValues[1].split(",").mapNotNull { it.toIntOrNull() }
+            if (codes.isNotEmpty() && codes.all { it in 32..126 }) {
+                codes.map { it.toChar() }.joinToString("")
+            } else {
+                null
+            }
+        }
+        .toList()
+
+    private fun decodeAtob(js: String): List<String> = ATOB_REGEX.findAll(js)
+        .mapNotNull { it.groupValues[1].decodeBase64()?.utf8() }
+        .toList()
+
+    private fun isHeaderCandidate(s: String): Boolean = s.matches(HEADER_NAME_REGEX) && '-' in s && s.lowercase() !in STANDARD_HEADERS
+
+    private fun score(value: String): Int = (if (value.any { it.isDigit() }) 200 else 0) + (MAX_VALUE_LEN - value.length).coerceAtLeast(0)
 
     private fun extractTokenViaWebView(): ClientToken? = try {
         TokenExtractor.extract(baseUrl, headers["User-Agent"])
@@ -228,8 +303,17 @@ abstract class MangaLivre :
     companion object {
         private const val ALTERNATIVE_TITLE_PREF = "alternativeTitlePref"
         private const val MAX_PEEK = 1024L
+        private const val MAX_ASSETS = 8
+        private const val MAX_POOL = 12
+        private const val MAX_CANDIDATES = 16
+        private const val MAX_VALUE_LEN = 40
         private const val NON_JSON_MESSAGE =
             "Resposta não-JSON (Cloudflare ou header desatualizado). Abra a fonte na WebView do app e tente de novo."
-        private val DEFAULT_TOKEN = ClientToken("X-Tly-Nexus", "c77-block-q")
+        private val DEFAULT_TOKEN = ClientToken("x-tly-nexus", "c77-block-q")
+        private val STANDARD_HEADERS = setOf("content-type", "accept", "accept-language", "authorization", "x-csrf-token")
+        private val HEADER_NAME_REGEX = Regex("[A-Za-z][\\w.-]{1,40}")
+        private val ASSET_REGEX = Regex("/assets/[\\w-]+\\.js")
+        private val CHARCODE_REGEX = Regex("\\[(\\d{1,3}(?:,\\d{1,3}){2,60})\\]")
+        private val ATOB_REGEX = Regex("atob\\(\"([A-Za-z0-9+/=]{1,80})\"\\)")
     }
 }


### PR DESCRIPTION
Follow-up to #17380 (WebView token extraction). On the iOS port (Tachimanga) the WebView is unreliable, and the current flow blocks on it (up to 30s) with only a hardcoded default as fallback — so it breaks as soon as the token rotates. Its hook also only captures `x-tly`/`x-toon` headers, which misses the names the site has used (`x-app-key`, `app-sec-token`, `x-gateway-key`, …).

This adds a **fast static self-heal that does not need a WebView**, keeping the WebView as a last resort.

**How.** The gate header is still a static string in the bundle, just re-obfuscated over time: literal → `atob(base64)` → now `String.fromCharCode([...])` (current live header: `x-tly-nexus` / `c77-block-q`). Instead of chasing each encoding at the call site, decode the bundle's char-code arrays and base64 strings into a pool, keep the header-shaped ones (hyphenated, non-standard), form `name/value` pairs, and let the `403 "aplicativo oficial"` response be the oracle — try candidates until one returns `200`, cache it. WebView (`TokenExtractor`) is only invoked if every static candidate fails.

**Verified end-to-end against the live reading endpoint** (real browser, exact logic, real chapter):
- Bundle decode (char-codes + base64) → clean pool `["x-tly-nexus", "c77-block-q"]` (no CSS noise).
- Brute-force via the 403 oracle finds `x-tly-nexus: c77-block-q` on the **first** try → `200`.
- Cold start uses the top static candidate (no blocking WebView call on the common path).

Also confirmed the origin is case-insensitive on the header name, and that a plain OkHttp client can fetch the bundle (so the static path works without a browser).

### Changes

- Add `scrapeStaticCandidates()`: decode char-code arrays + base64 from `/assets`, build header candidates, brute-force against the 403 oracle; runs before the WebView.
- Re-add a non-redirecting `scrapeClient` for bundle fetching.
- Default header → `x-tly-nexus` / `c77-block-q`.
- Bump `versionCode` to 74.

### Checklist

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Set the `contentWarning` configuration appropriately (unchanged: SAFE)
- [x] Have not changed source names
- [ ] Have tested by compiling/running through Android Studio — iOS only; verified the decode + gate + full candidate/oracle logic end-to-end against the live reading endpoint (200 on first try), plus ktlint locally; relying on CI to build.
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop