### PR TITLE
MangaDistrict: Option to not clean title during browsing/search

### DIFF
--- a/src/en/mangadistrict/build.gradle.kts
+++ b/src/en/mangadistrict/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 keiyoushi {
     name = "Manga District"
-    versionCode = 16
+    versionCode = 17
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
     theme = "madara"

--- a/src/en/mangadistrict/src/eu/kanade/tachiyomi/extension/en/mangadistrict/MangaDistrict.kt
+++ b/src/en/mangadistrict/src/eu/kanade/tachiyomi/extension/en/mangadistrict/MangaDistrict.kt
@@ -49,11 +49,17 @@ abstract class MangaDistrict :
         } catch (_: Exception) {}
     }
 
-    override fun popularMangaFromElement(element: Element): SManga = super.popularMangaFromElement(element).cleanTitleIfNeeded()
+    override fun popularMangaFromElement(element: Element): SManga = super.popularMangaFromElement(element).let {
+        it.takeIf { noCleanTitlesWhileBrowsing() }
+            ?: it.cleanTitleIfNeeded()
+    }
 
     override fun popularMangaNextPageSelector() = "div[role=navigation] span.current + a.page"
 
-    override fun latestUpdatesFromElement(element: Element): SManga = super.latestUpdatesFromElement(element).cleanTitleIfNeeded()
+    override fun latestUpdatesFromElement(element: Element): SManga = super.latestUpdatesFromElement(element).let {
+        it.takeIf { noCleanTitlesWhileBrowsing() }
+            ?: it.cleanTitleIfNeeded()
+    }
 
     override fun searchMangaSelector() = popularMangaSelector()
     override fun searchMangaNextPageSelector() = popularMangaNextPageSelector()
@@ -286,6 +292,7 @@ abstract class MangaDistrict :
 
     private fun isRemoveTitleVersion() = preferences.getBoolean(REMOVE_TITLE_VERSION_PREF, false)
     private fun customRemoveTitle(): String = preferences.getString("${REMOVE_TITLE_CUSTOM_PREF}_$lang", "")!!
+    private fun noCleanTitlesWhileBrowsing(): Boolean = preferences.getBoolean(NO_REMOVE_TITLE_BROWSING_PREF, false)
     private fun getImgRes() = preferences.getString(IMG_RES_PREF, IMG_RES_DEFAULT)!!
 
     private var SharedPreferences.dates: MutableMap<String, Long>
@@ -301,6 +308,14 @@ abstract class MangaDistrict :
         }
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        val noRemoveTitleBrowsingPref = CheckBoxPreference(screen.context).apply {
+            key = NO_REMOVE_TITLE_BROWSING_PREF
+            title = "Don't apply title cleaning in browsing/search results"
+            summary = "Don't apply the 2 options above when browsing or searching for manga, but still apply them in manga details."
+            setVisible(isRemoveTitleVersion() || customRemoveTitle().isNotEmpty())
+            setDefaultValue(false)
+        }
+
         CheckBoxPreference(screen.context).apply {
             key = REMOVE_TITLE_VERSION_PREF
             title = "Remove version information from entry titles"
@@ -309,6 +324,11 @@ abstract class MangaDistrict :
                 "To update existing entries, remove them from your library (unfavorite) and refresh manually. " +
                 "You might also want to clear the database in advanced settings."
             setDefaultValue(false)
+            setOnPreferenceChangeListener { _, newValue ->
+                val enabled = newValue as Boolean
+                noRemoveTitleBrowsingPref.setVisible(enabled || customRemoveTitle().isNotEmpty())
+                true
+            }
         }.let(screen::addPreference)
 
         EditTextPreference(screen.context).apply {
@@ -344,12 +364,15 @@ abstract class MangaDistrict :
                 val (isValid, message) = validate(newValue as String)
                 if (isValid) {
                     summary = newValue
+                    noRemoveTitleBrowsingPref.setVisible(isRemoveTitleVersion() || newValue.isNotEmpty())
                 } else {
                     Toast.makeText(screen.context, message, Toast.LENGTH_LONG).show()
                 }
                 isValid
             }
         }.let(screen::addPreference)
+
+        screen.addPreference(noRemoveTitleBrowsingPref)
 
         ListPreference(screen.context).apply {
             key = IMG_RES_PREF
@@ -376,6 +399,7 @@ abstract class MangaDistrict :
 
         private const val REMOVE_TITLE_VERSION_PREF = "REMOVE_TITLE_VERSION"
         private const val REMOVE_TITLE_CUSTOM_PREF = "REMOVE_TITLE_CUSTOM"
+        private const val NO_REMOVE_TITLE_BROWSING_PREF = "NO_REMOVE_TITLE_BROWSING"
         private const val TAG_LIST_PREF = "TAG_LIST"
 
         private const val IMG_RES_PREF = "IMG_RES"


### PR DESCRIPTION
**Reason:** This source often has 2 versions of a same manhwa, the normal one and the "(Uncensored)" one, showing together. For the purpose of normalizing title and duplicate matching, the pref to `Clean title` need to be turned on. But when it's turned on, both versions appear to have the same name while browsing and are indistinguishable.

This PR adds a pref that won't apply cleaning title while browsing. So that:
- When browsing/searching, the 2 versions are distinguishable.
- When opening the detail screen, the title is still cleaned so I can add it to library normalized.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
