### PR TITLE
Add AI translation wait constant

### DIFF
--- a/src/ar/mangatek/src/eu/kanade/tachiyomi/extension/ar/mangatek/SpeechBubblePainterInterceptor.kt
+++ b/src/ar/mangatek/src/eu/kanade/tachiyomi/extension/ar/mangatek/SpeechBubblePainterInterceptor.kt
@@ -175,5 +175,8 @@ class SpeechBubblePainterInterceptor(val fontSize: Int) : Interceptor {
     companion object {
         const val SCALED_DENSITY = 0.75f // 1px = 0.75pt
         val mediaType = "image/png".toMediaType()
+        
+        // ثابت الانتظار على ترجمات AI (10 ثواني)
+        const val AI_TRANSLATION_WAIT_MS = 10000L
     }
 }


### PR DESCRIPTION
Added a constant for AI translation wait time.

Checklist:

- [ ] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
