### PR TITLE
fix(madara): properly parse srcset with image descriptors (w/x suffixes)

### DIFF
--- a/lib-multisrc/madara/build.gradle.kts
+++ b/lib-multisrc/madara/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
 }
 
 keiyoushi {
-    baseVersionCode = 51
+    baseVersionCode = 52
     libVersion = "1.4"
 
     deeplink {

--- a/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
+++ b/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
@@ -824,9 +824,27 @@ abstract class Madara : HttpSource() {
     /**
      *  Get the best image quality available from srcset
      */
-    protected open fun String.getSrcSetImage(): String? = this.split(" ")
-        .filter(URL_REGEX::matches)
-        .maxOfOrNull(String::toString)
+    protected open fun String.getSrcSetImage(): String? {
+        val images = this.split(",")
+            .map { it.trim().split("\\s+".toRegex()) }
+            .filter { it.isNotEmpty() && URL_REGEX.matches(it[0]) }
+
+        val imagesWithDescriptor = images
+            .filter { it.size == 2 }
+            .mapNotNull { candidate ->
+                IMAGE_DESCRIPTOR_REGEX.find(candidate[1])?.let { match ->
+                    Pair(candidate[0], match.groupValues[1].toFloat())
+                }
+            }
+
+        // Prefer images with descriptors as to get the highest resolution
+        if (imagesWithDescriptor.isNotEmpty()) {
+            return imagesWithDescriptor.maxByOrNull { it.second }?.first
+        }
+
+        // Fallback to lexicographical comparison of image URLs
+        return images.maxOfOrNull { it.first() }
+    }
 
     /**
      *  Apply any additional processing to the thumbnail URL if needed.
@@ -1170,6 +1188,7 @@ abstract class Madara : HttpSource() {
     companion object {
         const val URL_SEARCH_PREFIX = "slug:"
         val URL_REGEX = """^(https?://[^\s/$.?#].[^\s]*)${'$'}""".toRegex()
+        val IMAGE_DESCRIPTOR_REGEX = """^(\d+|\d+\.\d+)([wx])$""".toRegex()
     }
 }
 

--- a/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
+++ b/lib-multisrc/madara/src/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
@@ -826,7 +826,7 @@ abstract class Madara : HttpSource() {
      */
     protected open fun String.getSrcSetImage(): String? {
         val images = this.split(",")
-            .map { it.trim().split("\\s+".toRegex()) }
+            .map { it.trim().split(WHITESPACE_REGEX, limit = 2) }
             .filter { it.isNotEmpty() && URL_REGEX.matches(it[0]) }
 
         val imagesWithDescriptor = images
@@ -1188,6 +1188,7 @@ abstract class Madara : HttpSource() {
     companion object {
         const val URL_SEARCH_PREFIX = "slug:"
         val URL_REGEX = """^(https?://[^\s/$.?#].[^\s]*)${'$'}""".toRegex()
+        val WHITESPACE_REGEX = """\s+""".toRegex()
         val IMAGE_DESCRIPTOR_REGEX = """^(\d+|\d+\.\d+)([wx])$""".toRegex()
     }
 }


### PR DESCRIPTION
Refactored getSrcSetImage() to correctly handle comma-separated srcset entries with width (w) and pixel-density (x) descriptors. Previously the method used to compare URLs lexicographically, which breaks on srcset="link-34x68.jpg 34w, link-330x700.jpg 330w" and chooses link-34x68.jpg.

Adds IMAGE_DESCRIPTOR_REGEX companion constant and prefers highest-resolution images by descriptor value, falling back to lexicographical URL comparison when no descriptors are present.

Checklist:

- [ ] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
