### PR TITLE
fix(toonily): add mangaDetailsSelectorDescription override

### DIFF
--- a/src/en/toonily/build.gradle.kts
+++ b/src/en/toonily/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 keiyoushi {
     name = "Toonily"
-    versionCode = 14
+    versionCode = 15
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
     theme = "madara"

--- a/src/en/toonily/src/eu/kanade/tachiyomi/extension/en/toonily/Toonily.kt
+++ b/src/en/toonily/src/eu/kanade/tachiyomi/extension/en/toonily/Toonily.kt
@@ -27,6 +27,8 @@ abstract class Toonily : Madara() {
     override val sendViewCount = false
     override val useLoadMoreRequest = LoadMoreStrategy.Always
 
+    override val mangaDetailsSelectorDescription: String = "div.content-area div.summary__content"
+
     override fun searchMangaSelector() = "div.page-item-detail.manga"
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request = super.searchMangaRequest(


### PR DESCRIPTION
The manga summary description was not loading because Toonily page structure uses a different selector than Madara default.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
