### PR TITLE
MangaLivre: decode offset char-codes + generic WebView header capture

### DIFF
--- a/src/pt/mangalivre/build.gradle.kts
+++ b/src/pt/mangalivre/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 keiyoushi {
     name = "Manga Livre"
-    versionCode = 74
+    versionCode = 75
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
@@ -268,7 +268,17 @@ abstract class MangaLivre :
 
     private fun decodeCharCodes(js: String): List<String> = CHARCODE_REGEX.findAll(js)
         .mapNotNull { match ->
-            val codes = match.groupValues[1].split(",").mapNotNull { it.toIntOrNull() }
+            val op = match.groupValues[2]
+            val k = match.groupValues[3].toIntOrNull() ?: 0
+            val codes = match.groupValues[1].split(",").mapNotNull { it.toIntOrNull() }.map { n ->
+                when (op) {
+                    "-" -> n - k
+                    "+" -> n + k
+                    "*" -> n * k
+                    "^" -> n xor k
+                    else -> n
+                }
+            }
             if (codes.isNotEmpty() && codes.all { it in 32..126 }) {
                 codes.map { it.toChar() }.joinToString("")
             } else {
@@ -313,7 +323,7 @@ abstract class MangaLivre :
         private val STANDARD_HEADERS = setOf("content-type", "accept", "accept-language", "authorization", "x-csrf-token")
         private val HEADER_NAME_REGEX = Regex("[A-Za-z][\\w.-]{1,40}")
         private val ASSET_REGEX = Regex("/assets/[\\w-]+\\.js")
-        private val CHARCODE_REGEX = Regex("\\[(\\d{1,3}(?:,\\d{1,3}){2,60})\\]")
+        private val CHARCODE_REGEX = Regex("\\[([\\d,]{5,240})\\][^\\[]{0,60}?fromCharCode\\([a-z]+(?:([-+*^])(\\d{1,4}))?\\)")
         private val ATOB_REGEX = Regex("atob\\(\"([A-Za-z0-9+/=]{1,80})\"\\)")
     }
 }

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/TokenExtractor.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/TokenExtractor.kt
@@ -68,24 +68,31 @@ object TokenExtractor {
                     view.evaluateJavascript(
                         """
                         (function() {
+                            const _std = new Set([
+                                'accept', 'accept-language', 'accept-encoding', 'content-type',
+                                'content-length', 'authorization', 'user-agent', 'referer', 'origin',
+                                'cookie', 'cache-control', 'pragma', 'connection', 'host', 'dnt',
+                                'x-csrf-token', 'x-requested-with', 'priority', 'sec-fetch-dest',
+                                'sec-fetch-mode', 'sec-fetch-site', 'sec-ch-ua', 'sec-ch-ua-mobile',
+                                'sec-ch-ua-platform',
+                            ]);
+                            const _report = function(k, v) {
+                                if (k && v && !_std.has(String(k).toLowerCase()) && String(v).length < 60) {
+                                    TokenBridge.onToken(k, v);
+                                }
+                            };
                             const _fetch = window.fetch;
                             window.fetch = function(input, init) {
                                 const headers = (init && init.headers) ? init.headers : {};
                                 const entries = headers instanceof Headers
                                     ? [...headers.entries()]
                                     : Object.entries(headers);
-                                for (const [k, v] of entries) {
-                                    if (k.toLowerCase().startsWith('x-tly') || k.toLowerCase().startsWith('x-toon')) {
-                                        TokenBridge.onToken(k, v);
-                                    }
-                                }
+                                for (const [k, v] of entries) { _report(k, v); }
                                 return _fetch.apply(this, arguments);
                             };
                             const _xhr = XMLHttpRequest.prototype.setRequestHeader;
                             XMLHttpRequest.prototype.setRequestHeader = function(k, v) {
-                                if (k.toLowerCase().startsWith('x-tly') || k.toLowerCase().startsWith('x-toon')) {
-                                    TokenBridge.onToken(k, v);
-                                }
+                                _report(k, v);
                                 return _xhr.apply(this, arguments);
                             };
                         })();


### PR DESCRIPTION
Follow-up to #17384. The site escalated the char-code obfuscation again: the arrays now carry an **arithmetic offset** — `[...].map(ue => String.fromCharCode(ue - 50))` — so the previous decoder (which assumed `fromCharCode(n)`) produced garbage and, because the raw numbers are >126, filtered everything out. It also started shipping a **decoy** pair in the bundle. Current live header: `x-tly-cipher` / `q88-matrix-o`.

**Changes**

1. `decodeCharCodes` now parses the map operation and constant (`fromCharCode(n - 50)`, `+`, `*`, `^`) and applies it, so char-code arrays with an offset (or none) decode correctly. The `403 "aplicativo oficial"` oracle still validates, so the decoy is simply skipped.
2. `TokenExtractor` (WebView) now reports **any** non-standard request header (short value) instead of only `x-tly*`/`x-toon*`, so the WebView path keeps working when the name rotates (it has been `x-app-key`, `app-sec-token`, `x-gateway-key`, `x-tly-cipher`, …).
3. Bump `versionCode` to 75.

**Verified end-to-end against the live reading endpoint** (real browser, exact decode + candidate/oracle logic, real chapter): the offset-aware decoder recovers the pool `["x-tly-cipher", "q88-matrix-o", "p00-decoy-x"]`, and the 403 oracle lands on `x-tly-cipher: q88-matrix-o` (skipping the decoy) → `200`.

### Checklist

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Set the `contentWarning` configuration appropriately (unchanged: SAFE)
- [x] Have not changed source names
- [ ] Have tested by compiling/running through Android Studio — iOS only; verified the decode + gate + oracle end-to-end against the live reading endpoint, plus ktlint locally; relying on CI to build.
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop