### PR TITLE
MangaOne: fix pages

### DIFF
--- a/src/ja/mangaone/build.gradle.kts
+++ b/src/ja/mangaone/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 keiyoushi {
     name = "Manga One"
-    versionCode = 2
+    versionCode = 3
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/ja/mangaone/src/eu/kanade/tachiyomi/extension/ja/mangaone/Dto.kt
+++ b/src/ja/mangaone/src/eu/kanade/tachiyomi/extension/ja/mangaone/Dto.kt
@@ -108,7 +108,7 @@ class Details(
     fun toSManga() = SManga.create().apply {
         title = name
         author = authors
-        description = infoText?.let { Jsoup.parse(it).text() }
+        description = infoText?.let { Jsoup.parseBodyFragment(it).text() }
         thumbnail_url = latestThumbnail?.thumbnail
     }
 }
@@ -166,7 +166,7 @@ class ViewerResponse(
 
 @Serializable
 class ViewerImages(
-    @ProtoNumber(1) val page: Images,
+    @ProtoNumber(1) val page: Images?,
 )
 
 @Serializable

--- a/src/ja/mangaone/src/eu/kanade/tachiyomi/extension/ja/mangaone/MangaOne.kt
+++ b/src/ja/mangaone/src/eu/kanade/tachiyomi/extension/ja/mangaone/MangaOne.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.extension.ja.mangaone
 
-import android.content.SharedPreferences
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.network.GET
@@ -16,11 +15,10 @@ import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.annotation.Source
 import keiyoushi.utils.firstInstanceOrNull
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAsProto
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.serialization.decodeFromByteArray
-import kotlinx.serialization.protobuf.ProtoBuf
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
@@ -35,7 +33,7 @@ abstract class MangaOne :
 
     private val apiUrl = "$baseUrl/api/client"
     private val jst = TimeZone.getTimeZone("Asia/Tokyo")
-    private val preferences: SharedPreferences by getPreferencesLazy()
+    private val preferences by getPreferencesLazy()
 
     private var tagList: List<Tags> = emptyList()
 
@@ -156,8 +154,8 @@ abstract class MangaOne :
         if (result.pages.isNullOrEmpty()) {
             throw Exception("Log in via WebView and rent or purchase this chapter to read.")
         }
-        return result.pages.mapIndexed { i, pages ->
-            Page(i, imageUrl = "${pages.page.url}#$key:$iv")
+        return result.pages.mapNotNull { it.page }.mapIndexed { i, page ->
+            Page(i, imageUrl = "${page.url}#$key:$iv")
         }
     }
 
@@ -188,8 +186,6 @@ abstract class MangaOne :
             }
         }
     }
-
-    private inline fun <reified T> Response.parseAsProto(): T = ProtoBuf.decodeFromByteArray(body.bytes())
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         SwitchPreferenceCompat(screen.context).apply {


### PR DESCRIPTION
Closes #17515

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
