### PR TITLE
Update contentWarning on some extensions

### DIFF
--- a/src/all/mangaball/build.gradle.kts
+++ b/src/all/mangaball/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 keiyoushi {
     name = "Manga Ball"
     versionCode = 3
-    contentWarning = ContentWarning.NSFW
+    contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 
     listOf(

--- a/src/all/mangataro/build.gradle.kts
+++ b/src/all/mangataro/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 keiyoushi {
     name = "MangaTaro"
     versionCode = 10
-    contentWarning = ContentWarning.SAFE
+    contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
     theme = "mangataro"
 

--- a/src/en/arenascans/build.gradle.kts
+++ b/src/en/arenascans/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 keiyoushi {
     name = "Arena Scans"
     versionCode = 0
-    contentWarning = ContentWarning.SAFE
+    contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
     theme = "mangathemesia"
 

--- a/src/en/artlapsa/build.gradle.kts
+++ b/src/en/artlapsa/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 keiyoushi {
     name = "Art Lapsa"
     versionCode = 5
-    contentWarning = ContentWarning.SAFE
+    contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
     theme = "keyoapp"
 

--- a/src/en/comickfan/build.gradle.kts
+++ b/src/en/comickfan/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 keiyoushi {
     name = "ComicK Fanmade"
     versionCode = 3
-    contentWarning = ContentWarning.NSFW
+    contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 
     source {

--- a/src/en/mangafox/build.gradle.kts
+++ b/src/en/mangafox/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 keiyoushi {
     name = "MangaFox"
     versionCode = 9
-    contentWarning = ContentWarning.NSFW
+    contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 
     source {

--- a/src/en/mangatown/build.gradle.kts
+++ b/src/en/mangatown/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 keiyoushi {
     name = "Mangatown"
     versionCode = 10
-    contentWarning = ContentWarning.NSFW
+    contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 
     source {

--- a/src/en/manhuatop/build.gradle.kts
+++ b/src/en/manhuatop/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 keiyoushi {
     name = "ManhuaTop"
     versionCode = 1
-    contentWarning = ContentWarning.NSFW
+    contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
     theme = "madara"
 

--- a/src/en/onemangaco/build.gradle.kts
+++ b/src/en/onemangaco/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 keiyoushi {
     name = "1Manga.co"
     versionCode = 0
-    contentWarning = ContentWarning.NSFW
+    contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
     theme = "mangahub"
 


### PR DESCRIPTION
Checklist:

- [ ] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
