### PR TITLE
MangaLivre: decode alphabet-index reading-gate token

### DIFF
--- a/src/pt/mangalivre/build.gradle.kts
+++ b/src/pt/mangalivre/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Manga Livre"
-    versionCode = 75
+    versionCode = 76
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivre.kt
@@ -242,12 +242,11 @@ abstract class MangaLivre :
 
     private fun scrapeStaticCandidates(): List<ClientToken> = try {
         val js = fetchBundle()
-        val names = (decodeCharCodes(js) + decodeAtob(js))
-            .filter(::isHeaderCandidate)
-            .distinct()
-            .take(MAX_POOL)
+        val pool = (decodeAlphabet(js) + decodeCharCodes(js) + decodeAtob(js) + decodeLiterals(js)).distinct()
+        val names = pool.filter { NAME_REGEX.matches(it) && it.lowercase() !in STANDARD_HEADERS }.take(MAX_POOL)
+        val values = pool.filter { VALUE_REGEX.matches(it) && it.any(Char::isDigit) }.take(MAX_POOL)
         names
-            .flatMap { name -> names.mapNotNull { value -> if (name != value) ClientToken(name, value) else null } }
+            .flatMap { name -> values.mapNotNull { value -> if (name != value) ClientToken(name, value) else null } }
             .sortedByDescending { score(it.value) }
             .take(MAX_CANDIDATES)
     } catch (_: Exception) {
@@ -291,7 +290,23 @@ abstract class MangaLivre :
         .mapNotNull { it.groupValues[1].decodeBase64()?.utf8() }
         .toList()
 
-    private fun isHeaderCandidate(s: String): Boolean = s.matches(HEADER_NAME_REGEX) && '-' in s && s.lowercase() !in STANDARD_HEADERS
+    // Novo mecanismo do site: [indices].map(i => alfabeto[i]).join(""), com o alfabeto num literal.
+    private fun decodeAlphabet(js: String): List<String> {
+        val alphabets = ALPHABET_REGEX.findAll(js).map { it.groupValues[1] }.filter { '-' in it }.distinct().toList()
+        if (alphabets.isEmpty()) return emptyList()
+        return INDEX_REGEX.findAll(js).flatMap { match ->
+            val indices = match.groupValues[1].split(",").mapNotNull { it.toIntOrNull() }
+            alphabets.mapNotNull { alpha ->
+                if (indices.isNotEmpty() && indices.all { it < alpha.length }) {
+                    indices.map { alpha[it] }.joinToString("")
+                } else {
+                    null
+                }
+            }
+        }.toList()
+    }
+
+    private fun decodeLiterals(js: String): List<String> = LITERAL_REGEX.findAll(js).map { it.groupValues[1] }.toList()
 
     private fun score(value: String): Int = (if (value.any { it.isDigit() }) 200 else 0) + (MAX_VALUE_LEN - value.length).coerceAtLeast(0)
 
@@ -319,10 +334,14 @@ abstract class MangaLivre :
         private const val MAX_VALUE_LEN = 40
         private const val NON_JSON_MESSAGE =
             "Resposta não-JSON (Cloudflare ou header desatualizado). Abra a fonte na WebView do app e tente de novo."
-        private val DEFAULT_TOKEN = ClientToken("x-tly-nexus", "c77-block-q")
-        private val STANDARD_HEADERS = setOf("content-type", "accept", "accept-language", "authorization", "x-csrf-token")
-        private val HEADER_NAME_REGEX = Regex("[A-Za-z][\\w.-]{1,40}")
+        private val DEFAULT_TOKEN = ClientToken("x-tly-sigma", "w99-enigma-z")
+        private val STANDARD_HEADERS = setOf("x-csrf-token", "x-requested-with", "x-toonlivre-authenticated-user")
         private val ASSET_REGEX = Regex("/assets/[\\w-]+\\.js")
+        private val NAME_REGEX = Regex("(x|app)-[a-z]{2,}(-[a-z]{2,})*")
+        private val VALUE_REGEX = Regex("[a-z0-9]{2,5}-[a-z0-9]{2,14}(-[a-z])?")
+        private val ALPHABET_REGEX = Regex("\"([a-z0-9][a-z0-9-]{24,45})\"")
+        private val INDEX_REGEX = Regex("\\[(\\d{1,2}(?:,\\d{1,2}){3,60})\\]\\.map\\(\\w+=>[\\w\$]{1,3}\\[\\w+\\]\\)")
+        private val LITERAL_REGEX = Regex("\"([a-z0-9][a-z0-9-]{3,40})\"")
         private val CHARCODE_REGEX = Regex("\\[([\\d,]{5,240})\\][^\\[]{0,60}?fromCharCode\\([a-z]+(?:([-+*^])(\\d{1,4}))?\\)")
         private val ATOB_REGEX = Regex("atob\\(\"([A-Za-z0-9+/=]{1,80})\"\\)")
     }


### PR DESCRIPTION
Follow-up to #17521. The site swapped its char-code obfuscation for a **custom-alphabet index** scheme:

```js
$ = "abcdefghijklmnopqrstuvwxyz0123456789-",
me = [0,15,15,4,13,3].map(i => $[i]).join(""),               // "append"
ie = [23,36,19,11,24,36,18,8,6,12,0].map(i => $[i]).join("") // "x-tly-sigma"
```

So each header char is an index into an alphabet literal. The char-code decoder from #17521 no longer matches, and reading fell back to the stale default. Current header: `x-tly-sigma` / `w99-enigma-z` (with a decoy `v00-decoy-y`).

**Approach.** Since the obfuscation *class* keeps changing (literal → base64 → char-codes → char-codes+offset → alphabet-index), this decodes **all** of them into one pool and leans on two stable anchors: the header **name** always looks like `x-…`/`app-…`, and the value is always `<seg>-<word>-<letter>` (e.g. `w99-enigma-z`, `q88-matrix-o`, `c77-block-q`). Candidates are filtered by those strict shapes and validated by the `403 "aplicativo oficial"` oracle, so the decoy and CSS-class noise are skipped.

- `decodeAlphabet`: `[indices].map(i => ALPHA[i])` using alphabet literals from the bundle.
- kept `decodeCharCodes` (with offset) + `decodeAtob` + added `decodeLiterals`.
- strict `NAME_REGEX` / `VALUE_REGEX`; brute-force via the 403 oracle.
- Default → `x-tly-sigma` / `w99-enigma-z`. Bump `versionCode` to 76.

**Verified end-to-end against the live reading endpoint** (real browser, exact logic, real chapter): decodes `["x-tly-sigma", "w99-enigma-z", "v00-decoy-y"]`, and the oracle lands on `x-tly-sigma: w99-enigma-z` → `200` (decoy skipped).

### Checklist

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Set the `contentWarning` configuration appropriately (unchanged: SAFE)
- [x] Have not changed source names
- [ ] Have tested by compiling/running through Android Studio — iOS only; verified decode + gate + oracle end-to-end against the live endpoint, plus ktlint locally; relying on CI to build.
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop