### PR TITLE
Asura Scans: Fix Alt Titles splitting

### DIFF
--- a/src/en/asurascans/build.gradle.kts
+++ b/src/en/asurascans/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Asura Scans"
-    versionCode = 63
+    versionCode = 64
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/Dto.kt
+++ b/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/Dto.kt
@@ -64,20 +64,25 @@ class MangaDto(
         val plainDescription = description?.let { Jsoup.parseBodyFragment(it).text() }
         plainDescription?.let(::append)
 
-        rating?.let {
-            if (isNotEmpty()) append("\n\n")
-            append("Rating: %.2f".format(it))
-        }
-
         popularityRank?.let {
             if (isNotEmpty()) append("\n\n")
             append("Rank: #$it")
         }
 
-        if (!altTitles.isNullOrEmpty()) {
+        rating?.let {
+            if (isNotEmpty()) append("\n\n")
+            append("Rating: %.2f".format(it))
+        }
+
+        val cleanAltTitles = altTitles
+            ?.flatMap { it.split(" • ") }
+            ?.map { it.trim() }
+            ?.filter { it.isNotBlank() }
+
+        if (!cleanAltTitles.isNullOrEmpty()) {
             if (isNotEmpty()) append("\n\n")
             append("Alternative Titles:\n")
-            altTitles.joinTo(this, "\n") { "- $it" }
+            cleanAltTitles.joinTo(this, "\n") { "- $it" }
         }
     }
 


### PR DESCRIPTION
- Reorder Rank and rating
- Some series now returning alt_titles as a single string with title joined by " • " instead of separate array elements.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
