### PR TITLE
AllManga (EN): Fix mangaUrl reset

### DIFF
--- a/src/en/allanime/build.gradle.kts
+++ b/src/en/allanime/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "AllManga"
-    versionCode = 20
+    versionCode = 21
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 

--- a/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/AllManga.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/AllManga.kt
@@ -42,9 +42,10 @@ import java.util.concurrent.TimeUnit
 abstract class AllManga :
     HttpSource(),
     ConfigurableSource {
-    private val apiUrlHost by lazy { apiUrl.toHttpUrl().host }
 
     private val apiUrl = "https://api.allanime.day/api"
+
+    private val apiUrlHost by lazy { apiUrl.toHttpUrl().host }
 
     override val supportsLatest = true
 
@@ -52,8 +53,34 @@ abstract class AllManga :
 
     private val preferences by getPreferencesLazy()
 
+    private val retryRegex = Regex("""in (\d+) second""", RegexOption.IGNORE_CASE)
+
     override val client = network.client.newBuilder()
         .apply { interceptors().removeAll { it.javaClass.simpleName == "CloudflareInterceptor" } }
+        .addInterceptor { chain ->
+            val request = chain.request()
+
+            if (request.url.host != apiUrlHost) return@addInterceptor chain.proceed(request)
+
+            var lastResponse: Response? = null
+
+            for (attempt in 0..5) {
+                val response = chain.proceed(request)
+                lastResponse = response
+
+                val retryAfter = retryRegex.find(response.peekBody(1024).string())
+                    ?.groupValues?.get(1)?.toLongOrNull()
+
+                if (retryAfter == null) return@addInterceptor response
+
+                if (attempt < 5) {
+                    response.close()
+                    Thread.sleep(retryAfter * 1000)
+                }
+            }
+
+            return@addInterceptor lastResponse!!
+        }
         .rateLimit(1) { it.host == apiUrlHost }
         .build()
 

--- a/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/AllManga.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/AllManga.kt
@@ -181,9 +181,7 @@ abstract class AllManga :
     override fun getMangaUrl(manga: SManga): String {
         // to solve interactive CF manually for the chapter
         if (mangaUrl != null) {
-            val chapterUrl = mangaUrl!!
-            mangaUrl = null
-            return chapterUrl
+            return mangaUrl!!
         }
         val mangaId = manga.url.split("/")[2]
         return "$baseUrl/manga/$mangaId"
@@ -232,8 +230,9 @@ abstract class AllManga :
         client.newCall(GET(chapterUrl, headers)).execute().use { response ->
             if (response.code == 403 || response.code == 503) {
                 mangaUrl = chapterUrl
-                throw IOException("Solve Captcha in Webview and Retry")
+                throw IOException("Solve captcha in WebView and retry")
             }
+            mangaUrl = null
             pageListFromWebView(response.asJsoup())
         }
     }


### PR DESCRIPTION
Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop


