### PR TITLE
RF Dragon Scan (pt-BR): Fix next-action ids

### DIFF
--- a/src/pt/rfdragonscan/build.gradle.kts
+++ b/src/pt/rfdragonscan/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "RF Dragon Scan"
-    versionCode = 12
+    versionCode = 13
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/pt/rfdragonscan/src/eu/kanade/tachiyomi/extension/pt/rfdragonscan/RFDragonScan.kt
+++ b/src/pt/rfdragonscan/src/eu/kanade/tachiyomi/extension/pt/rfdragonscan/RFDragonScan.kt
@@ -109,7 +109,7 @@ abstract class RFDragonScan :
 
         return POST(
             baseUrl + manga.url,
-            actionHeaders("60bd903bddc3d9d07f2b58fe32f0238afd74e492d6", baseUrl + manga.url, stateTree),
+            actionHeaders("60d532a2a6a7a0ff42de5f69dcdf2db5860a2f76b0", baseUrl + manga.url, stateTree),
             requestBody,
         )
     }
@@ -141,7 +141,7 @@ abstract class RFDragonScan :
 
         return POST(
             baseUrl + manga.url,
-            actionHeaders("6075c7373783e0d2488372dc7fcb9ffe1470bc41d2", baseUrl + manga.url, stateTree),
+            actionHeaders("607bcd9f90d5db5edaa2cf1aff7a002b5b14ead30a", baseUrl + manga.url, stateTree),
             requestBody,
         )
     }
@@ -186,7 +186,7 @@ abstract class RFDragonScan :
 
         return POST(
             baseUrl + chapter.url,
-            actionHeaders("605aecabcce97cec193f09ebe5fe3a9ae46e432ea2", baseUrl + chapter.url, stateTree),
+            actionHeaders("60390ae612bb67d3d0614b47c7fa396fa4201aa323", baseUrl + chapter.url, stateTree),
             requestBody,
         )
     }
@@ -360,9 +360,9 @@ abstract class RFDragonScan :
             val mangaSlug = pathSegments[1]
 
             val actionId = if (firstSegment == "migrate") {
-                "60bd903bddc3d9d07f2b58fe32f0238afd74e492d6"
+                "60d532a2a6a7a0ff42de5f69dcdf2db5860a2f76b0"
             } else {
-                "6075c7373783e0d2488372dc7fcb9ffe1470bc41d2"
+                "607bcd9f90d5db5edaa2cf1aff7a002b5b14ead30a"
             }
 
             val payload = "[\"$mangaId\",\"$mangaSlug\"]"


### PR DESCRIPTION
Closes #17510

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
