### PR TITLE
Zenko: update filters

### DIFF
--- a/src/uk/zenko/build.gradle.kts
+++ b/src/uk/zenko/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Zenko"
-    versionCode = 7
+    versionCode = 8
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 

--- a/src/uk/zenko/src/eu/kanade/tachiyomi/extension/uk/zenko/Filters.kt
+++ b/src/uk/zenko/src/eu/kanade/tachiyomi/extension/uk/zenko/Filters.kt
@@ -28,6 +28,19 @@ internal abstract class MultiValueFilter(
     val checked get() = selectedValues.takeIf { it.isNotEmpty() }
 }
 
+class TriStateFilter(name: String, val id: String) : Filter.TriState(name)
+
+abstract class TriStateGroup(
+    name: String,
+    val options: List<Pair<String, String>>,
+) : Filter.Group<TriStateFilter>(
+    name,
+    options.map { TriStateFilter(it.first, it.second) },
+) {
+    val included get() = state.filter { it.isIncluded() }.map { it.id }.takeUnless { it.isEmpty() }
+    val excluded get() = state.filter { it.isExcluded() }.map { it.id }.takeUnless { it.isEmpty() }
+}
+
 internal class MinFilter : Filter.Text("Від")
 internal class MaxFilter : Filter.Text("До")
 
@@ -107,7 +120,14 @@ internal class AgeFilter(blockedAge: Set<String>) : MultiValueFilter("Віков
     }
 }
 
-internal class GenresFilter : MultiValueFilter("Жанри", genres) {
+internal class GenresFilter(blockedGenres: Set<String>) : TriStateGroup("Жанри", genres) {
+    init {
+        state.forEach { filter ->
+            if (blockedGenres.contains(filter.id)) {
+                filter.state = 2
+            }
+        }
+    }
     companion object {
         val genres = listOf(
             "Апокаліпсис" to "Апокаліпсис",
@@ -162,7 +182,7 @@ internal class GenresFilter : MultiValueFilter("Жанри", genres) {
     }
 }
 
-internal class TagsFilter : MultiValueFilter("Теги", tags) {
+internal class TagsFilter : TriStateGroup("Теги", tags) {
     companion object {
         val tags = listOf(
             "Авторський роман" to "Авторський роман",

--- a/src/uk/zenko/src/eu/kanade/tachiyomi/extension/uk/zenko/Zenko.kt
+++ b/src/uk/zenko/src/eu/kanade/tachiyomi/extension/uk/zenko/Zenko.kt
@@ -26,17 +26,20 @@ import java.util.Calendar
 abstract class Zenko :
     HttpSource(),
     ConfigurableSource {
-    private val apiurlHost by lazy { API_URL.toHttpUrl().host }
+    private val domain by lazy { baseUrl.toHttpUrl().host }
+    private val apiUrl by lazy { "https://api.$domain" }
+    private val imgUrl by lazy { "https://storage.$domain" }
+    private val apiUrlHost by lazy { "api.$domain" }
 
     override val supportsLatest = true
     private val preferences by getPreferencesLazy()
 
     override fun headersBuilder() = super.headersBuilder()
-        .add("Origin", "$baseUrl/")
+        .add("Origin", baseUrl)
         .add("Referer", "$baseUrl/")
 
     override val client = network.client.newBuilder()
-        .rateLimit(10) { it.host == apiurlHost }
+        .rateLimit(10) { it.host == apiUrlHost }
         .build()
 
     // ============================== Popular ===============================
@@ -63,7 +66,7 @@ abstract class Zenko :
     private fun makeCatalogRequest(page: Int, sortBy: String, query: String? = null, filters: FilterList? = null): Request {
         val offset = offsetCounter(page)
         val currentYear = Calendar.getInstance().get(Calendar.YEAR)
-        val url = "$API_URL/titles".toHttpUrl().newBuilder()
+        val url = "$apiUrl/titles".toHttpUrl().newBuilder()
             .addQueryParameter("limit", "15")
             .addQueryParameter("offset", offset)
 
@@ -75,8 +78,14 @@ abstract class Zenko :
                 }
                 is CategoryFilter -> filter.checked?.let { url.addQueryParameter("categories", it.joinToString(",")) }
                 is TranslationStatusFilter -> filter.checked?.let { url.addQueryParameter("translationStatus", it.joinToString(",")) }
-                is GenresFilter -> filter.checked?.let { url.addQueryParameter("genres", it.joinToString(",")) }
-                is TagsFilter -> filter.checked?.let { url.addQueryParameter("tags", it.joinToString(",")) }
+                is GenresFilter -> {
+                    filter.included?.let { url.addQueryParameter("genres", it.joinToString(",")) }
+                    filter.excluded?.let { url.addQueryParameter("excludeGenres", it.joinToString(",")) }
+                }
+                is TagsFilter -> {
+                    filter.included?.let { url.addQueryParameter("tags", it.joinToString(",")) }
+                    filter.excluded?.let { url.addQueryParameter("excludeTags", it.joinToString(",")) }
+                }
                 is AgeFilter -> filter.checked?.let { url.addQueryParameter("ageLimit", it.joinToString(",")) }
                 is YearRangeFilter -> {
                     filter.minValue?.let { url.addQueryParameter("releaseYearFrom", checkMinRange(it, 1980, currentYear)) }
@@ -89,6 +98,7 @@ abstract class Zenko :
         if (filters == null) {
             val hiddenCat = hiddenCategories()
             val ageCat = ageLimit()
+            val hiddenGenres = blockGenres()
             url.addQueryParameter("sortBy", sortBy)
             url.addQueryParameter("order", "DESC")
 
@@ -99,6 +109,10 @@ abstract class Zenko :
             if (ageCat.isNotEmpty()) {
                 val ageLimitSetting = ageCat.joinToString(",")
                 url.addQueryParameter("ageLimit", ageLimitSetting)
+            }
+            if (hiddenGenres.isNotEmpty()) {
+                val hiddenGenresSetting = hiddenGenres.joinToString(",")
+                url.addQueryParameter("excludeGenres", hiddenGenresSetting)
             }
         }
 
@@ -126,7 +140,7 @@ abstract class Zenko :
 
     override fun mangaDetailsRequest(manga: SManga): Request {
         val mangaId = manga.url.substringAfter("titles/")
-        val url = "$API_URL/titles/$mangaId"
+        val url = "$apiUrl/titles/$mangaId"
         return GET(url, headers)
     }
 
@@ -162,7 +176,7 @@ abstract class Zenko :
 
     override fun chapterListRequest(manga: SManga): Request {
         val mangaId = manga.url.substringAfter("titles/")
-        val url = "$API_URL/titles/$mangaId/chapters"
+        val url = "$apiUrl/titles/$mangaId/chapters"
         return GET(url, headers)
     }
 
@@ -185,14 +199,14 @@ abstract class Zenko :
     // =============================== Pages ================================
     override fun pageListRequest(chapter: SChapter): Request {
         val (titleId, chapterId) = chapter.url.substringAfter("titles/").split("/", limit = 2)
-        val url = "$API_URL/chapters/$chapterId"
+        val url = "$apiUrl/chapters/$chapterId"
         return GET(url, headers)
     }
 
     override fun pageListParse(response: Response): List<Page> {
         val data = response.parseAs<ChapterResponseItem>()
         return data.pages!!.map { page ->
-            Page(page.id, imageUrl = "$IMAGE_STORAGE_URL/${page.content}")
+            Page(page.id, imageUrl = "$imgUrl/${page.content}")
         }
     }
 
@@ -208,7 +222,7 @@ abstract class Zenko :
         Filter.Separator(),
         AgeFilter(ageLimit()),
         Filter.Separator(),
-        GenresFilter(),
+        GenresFilter(blockGenres()),
         Filter.Separator(),
         TagsFilter(),
         Filter.Separator(),
@@ -219,6 +233,7 @@ abstract class Zenko :
     private fun isEng(): String = preferences.getString(LANGUAGE_PREF, "ua")!!
     private fun ageLimit(): Set<String> = preferences.getStringSet(SITE_AGE_PREF, emptySet<String>())!!
     private fun hiddenCategories(): Set<String> = preferences.getStringSet(SITE_CATEGORIES_PREF, setOf(SITE_CATEGORIES_DEFAULT))!!
+    private fun blockGenres(): Set<String> = preferences.getStringSet(GENRES_PREF, emptySet<String>())!!
 
     private fun getSelectedLanguage(isEng: String, engName: String?, name: String): String = when {
         isEng == "eng" && !engName.isNullOrEmpty() -> engName
@@ -262,6 +277,23 @@ abstract class Zenko :
         }.let(screen::addPreference)
 
         MultiSelectListPreference(screen.context).apply {
+            val tags = GenresFilter.genres
+            key = GENRES_PREF
+            title = GENRES_PREF_TITLE
+            entries = tags.map { it.first }.toTypedArray()
+            entryValues = tags.map { it.second }.toTypedArray()
+            summary = blockGenres().joinToString()
+            dialogTitle = GENRES_PREF_DIALOG
+            setDefaultValue(emptySet<String>())
+
+            setOnPreferenceChangeListener { _, values ->
+                val selected = values as Set<*>
+                this.summary = selected.joinToString()
+                true
+            }
+        }.let(screen::addPreference)
+
+        MultiSelectListPreference(screen.context).apply {
             key = SITE_CATEGORIES_PREF
             title = SITE_CATEGORIES_PREF_TITLE
             val tags = CategoryFilter.categories
@@ -299,7 +331,7 @@ abstract class Zenko :
 
     private fun Long.secToMs(): Long = this * 1000
 
-    private fun buildImageUrl(imageId: String): String = "$IMAGE_STORAGE_URL/$imageId?optimizer=image&width=560&quality=70&height=auto"
+    private fun buildImageUrl(imageId: String): String = "$imgUrl/$imageId?optimizer=image&width=560&quality=70&height=auto"
 
     private fun checkMinRange(input: String?, min: Int, max: Int): String {
         val value = input?.trim()?.takeIf(String::isNotEmpty)?.toIntOrNull() ?: return min.toString()
@@ -313,10 +345,11 @@ abstract class Zenko :
     }
 
     companion object {
-        private const val API_URL = "https://api.zenko.online"
-        private const val IMAGE_STORAGE_URL = "https://storage.zenko.online"
         private const val LANGUAGE_PREF = "TitleLanguagePref"
         private const val LANGUAGE_PREF_TITLE = "Вибір мови на обкладинці"
+        private const val GENRES_PREF = "pref_genres_exclude"
+        private const val GENRES_PREF_TITLE = "Приховані жанри"
+        private const val GENRES_PREF_DIALOG = "Виберіть жанри які потрібно сховати"
         private const val SITE_AGE_PREF = "site_age_categories"
         private const val SITE_AGE_PREF_TITLE = "Вікові обмеження"
         private const val SITE_AGE_PREF_DIALOG = "Контент з обраними віковими обмеженнями буде відображатися"


### PR DESCRIPTION
Checklist:

The site added functionality to exclude manga from search results by genre and tag.
- Updated filters to include this functionality.
- Added preferences to automatically hide selected genres.
- Converted api and image storage url from static to dynamic, based on the `baseUrl`.

.

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
