### PR TITLE
Update some domains

### DIFF
--- a/src/vi/cmanga/build.gradle.kts
+++ b/src/vi/cmanga/build.gradle.kts
@@ -6,14 +6,14 @@ plugins {
 
 keiyoushi {
     name = "CManga"
-    versionCode = 3
+    versionCode = 4
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 
     source {
         lang = "vi"
         baseUrl {
-            custom("https://cmangax17.com")
+            custom("https://cmangax18.com")
         }
     }
 }

--- a/src/vi/doctruyen3q/build.gradle.kts
+++ b/src/vi/doctruyen3q/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "DocTruyen3Q"
-    versionCode = 27
+    versionCode = 28
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
     theme = "wpcomics"
@@ -14,7 +14,7 @@ keiyoushi {
     source {
         lang = "vi"
         baseUrl {
-            custom("https://doctruyen3qhub2.com")
+            custom("https://doctruyen3qhub3.com")
         }
     }
 }

--- a/src/vi/luottruyen/build.gradle.kts
+++ b/src/vi/luottruyen/build.gradle.kts
@@ -6,14 +6,14 @@ plugins {
 
 keiyoushi {
     name = "LuotTruyen"
-    versionCode = 6
+    versionCode = 7
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 
     source {
         lang = "vi"
         baseUrl {
-            custom("https://luottruyen11.com")
+            custom("https://luottruyen12.com")
         }
     }
 }

--- a/src/vi/nhentaiclub/build.gradle.kts
+++ b/src/vi/nhentaiclub/build.gradle.kts
@@ -6,13 +6,13 @@ plugins {
 
 keiyoushi {
     name = "NhentaiClub"
-    versionCode = 2
+    versionCode = 3
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
 
     source {
         lang = "vi"
-        baseUrl = "https://nhentaiclub.space"
+        baseUrl = "https://nhentaiclub.online"
         id = 9124366814387777661L
     }
 }

--- a/src/vi/teamlanhlung/build.gradle.kts
+++ b/src/vi/teamlanhlung/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Team Lanh Lung"
-    versionCode = 33
+    versionCode = 34
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 

--- a/src/vi/teamlanhlung/build.gradle.kts
+++ b/src/vi/teamlanhlung/build.gradle.kts
@@ -14,7 +14,7 @@ keiyoushi {
         name = "Team Lạnh Lùng"
         lang = "vi"
         baseUrl {
-            custom("https://icecoldcore.com")
+            custom("https://lanhhome.casa")
         }
     }
 }

--- a/src/vi/toptruyen/build.gradle.kts
+++ b/src/vi/toptruyen/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Top Truyen"
-    versionCode = 31
+    versionCode = 32
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
     theme = "wpcomics"
@@ -14,7 +14,7 @@ keiyoushi {
     source {
         lang = "vi"
         baseUrl {
-            custom("https://www.toptruyenzone6.com")
+            custom("https://www.toptruyenzone7.com")
         }
     }
 }


### PR DESCRIPTION
Closed https://github.com/keiyoushi/extensions-source/issues/17419

## Changed Domains
- **cmanga**: `cmangax17.com` => `cmangax18.com`
- **doctruyen3q**: `doctruyen3qhub2.com` => `doctruyen3qhub3.com`
- **luottruyen**: `luottruyen11.com` => `luottruyen12.com`
- **nhentaiclub**: `nhentaiclub.space` => `nhentaiclub.online`
- **toptruyen**: `www.toptruyenzone6.com` => `www.toptruyenzone7.com`
- **teamlanhlung**: `icecoldcore.com` => `lanhhome.casa`

Checklist:
- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop