### PR TITLE
AryaScans: Null author and Alt name

### DIFF
--- a/src/en/aryascans/build.gradle.kts
+++ b/src/en/aryascans/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Arya Scans"
-    versionCode = 1
+    versionCode = 2
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
     theme = "madara"

--- a/src/en/aryascans/src/eu/kanade/tachiyomi/extension/en/aryascans/AryaScans.kt
+++ b/src/en/aryascans/src/eu/kanade/tachiyomi/extension/en/aryascans/AryaScans.kt
@@ -11,7 +11,7 @@ abstract class AryaScans : Madara() {
 
     override val popularMangaUrlSelector = "${super.popularMangaUrlSelector}:not([href=New]):not([target=_self])"
 
-    override val altNameSelector = ""
+    override val altNameSelector = "noSelector"
 
     override fun mangaDetailsParse(document: Document): SManga = super.mangaDetailsParse(document).apply {
         author = null

--- a/src/en/aryascans/src/eu/kanade/tachiyomi/extension/en/aryascans/AryaScans.kt
+++ b/src/en/aryascans/src/eu/kanade/tachiyomi/extension/en/aryascans/AryaScans.kt
@@ -15,5 +15,6 @@ abstract class AryaScans : Madara() {
 
     override fun mangaDetailsParse(document: Document): SManga = super.mangaDetailsParse(document).apply {
         author = null
+        artist = null
     }
 }

--- a/src/en/aryascans/src/eu/kanade/tachiyomi/extension/en/aryascans/AryaScans.kt
+++ b/src/en/aryascans/src/eu/kanade/tachiyomi/extension/en/aryascans/AryaScans.kt
@@ -1,11 +1,19 @@
 package eu.kanade.tachiyomi.extension.en.aryascans
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.source.model.SManga
 import keiyoushi.annotation.Source
+import org.jsoup.nodes.Document
 
 @Source
 abstract class AryaScans : Madara() {
     override val useNewChapterEndpoint = true
 
     override val popularMangaUrlSelector = "${super.popularMangaUrlSelector}:not([href=New]):not([target=_self])"
+
+    override val altNameSelector = ""
+
+    override fun mangaDetailsParse(document: Document): SManga = super.mangaDetailsParse(document).apply {
+        author = null
+    }
 }


### PR DESCRIPTION
Author and alt name fields on this source never contain real data. Removing both instead of displaying meaningless values.
- Always null out author (site never returns a real author — only "KKMH", "acqq", or blank)
- Disable alt name parsing (values are junk: "KKMH", "KUAIKANMANHUA", "ACQQ")


Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by installing the extension
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
