### PR TITLE
Zenon: fix browsing

### DIFF
--- a/src/ja/zenon/build.gradle.kts
+++ b/src/ja/zenon/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Zenon"
-    versionCode = 0
+    versionCode = 1
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
     theme = "gigaviewer"

--- a/src/ja/zenon/src/eu/kanade/tachiyomi/extension/ja/zenon/Zenon.kt
+++ b/src/ja/zenon/src/eu/kanade/tachiyomi/extension/ja/zenon/Zenon.kt
@@ -1,10 +1,8 @@
 package eu.kanade.tachiyomi.extension.ja.zenon
 
 import eu.kanade.tachiyomi.multisrc.gigaviewer.GigaViewer
-import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.SManga
 import keiyoushi.annotation.Source
-import okhttp3.Request
 import org.jsoup.nodes.Element
 
 @Source

--- a/src/ja/zenon/src/eu/kanade/tachiyomi/extension/ja/zenon/Zenon.kt
+++ b/src/ja/zenon/src/eu/kanade/tachiyomi/extension/ja/zenon/Zenon.kt
@@ -11,8 +11,6 @@ import org.jsoup.nodes.Element
 abstract class Zenon : GigaViewer() {
     override val supportsLatest: Boolean = false
 
-    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/series", headers)
-
     override val popularMangaSelector: String = ".series-item"
 
     override fun popularMangaFromElement(element: Element): SManga = SManga.create().apply {

--- a/src/ja/zenon/src/eu/kanade/tachiyomi/extension/ja/zenon/Zenon.kt
+++ b/src/ja/zenon/src/eu/kanade/tachiyomi/extension/ja/zenon/Zenon.kt
@@ -23,6 +23,8 @@ abstract class Zenon : GigaViewer() {
         setUrlWithoutDomain(element.selectFirst("a")!!.absUrl("href"))
     }
 
+    override val searchMangaNextPageSelector = "a.pager-next"
+
     override fun getCollections(): List<Collection> = listOf(
         Collection("読切作品", "oneshot"),
         Collection("漫画賞", "newcomer"),

--- a/src/ja/zenon/src/eu/kanade/tachiyomi/extension/ja/zenon/Zenon.kt
+++ b/src/ja/zenon/src/eu/kanade/tachiyomi/extension/ja/zenon/Zenon.kt
@@ -23,14 +23,6 @@ abstract class Zenon : GigaViewer() {
         setUrlWithoutDomain(element.selectFirst("a")!!.absUrl("href"))
     }
 
-    override val searchMangaSelector: String = "ul.search-series-list > li"
-
-    override fun searchMangaFromElement(element: Element): SManga = SManga.create().apply {
-        title = element.selectFirst(".series-title")!!.text()
-        thumbnail_url = element.selectFirst("img")?.absUrl("src")
-        setUrlWithoutDomain(element.selectFirst("a")!!.absUrl("href"))
-    }
-
     override fun getCollections(): List<Collection> = listOf(
         Collection("読切作品", "oneshot"),
         Collection("漫画賞", "newcomer"),

--- a/src/ja/zenon/src/eu/kanade/tachiyomi/extension/ja/zenon/Zenon.kt
+++ b/src/ja/zenon/src/eu/kanade/tachiyomi/extension/ja/zenon/Zenon.kt
@@ -11,7 +11,7 @@ import org.jsoup.nodes.Element
 abstract class Zenon : GigaViewer() {
     override val supportsLatest: Boolean = false
 
-    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/series/zenyon", headers)
+    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/series", headers)
 
     override val popularMangaSelector: String = ".series-item"
 
@@ -23,7 +23,7 @@ abstract class Zenon : GigaViewer() {
         setUrlWithoutDomain(element.selectFirst("a")!!.absUrl("href"))
     }
 
-    override val searchMangaSelector: String = "ul.series-list > li"
+    override val searchMangaSelector: String = "ul.search-series-list > li"
 
     override fun searchMangaFromElement(element: Element): SManga = SManga.create().apply {
         title = element.selectFirst(".series-title")!!.text()
@@ -32,9 +32,6 @@ abstract class Zenon : GigaViewer() {
     }
 
     override fun getCollections(): List<Collection> = listOf(
-        Collection("コミックぜにょん", "zenyon"),
-        Collection("月刊コミックゼノン", "zenon"),
-        Collection("コミックタタン", "tatan"),
         Collection("読切作品", "oneshot"),
         Collection("漫画賞", "newcomer"),
     )


### PR DESCRIPTION
Closes #17585 

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
