### PR TITLE
MangaGeko, RageScans, Mangago, FlameComics: Split/add alt titles

### DIFF
--- a/src/en/flamecomics/build.gradle.kts
+++ b/src/en/flamecomics/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Flame Comics"
-    versionCode = 49
+    versionCode = 50
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComics.kt
+++ b/src/en/flamecomics/src/eu/kanade/tachiyomi/extension/en/flamecomics/FlameComics.kt
@@ -175,8 +175,22 @@ abstract class FlameComics : HttpSource() {
             json.decodeFromString<MangaDetailsResponseData>(response.body.string()).pageProps.series
         title = seriesData.title
         thumbnail_url = thumbnailUrl(seriesData)
-        description = seriesData.description
+
+        val synopsis = seriesData.description
             ?.let { Jsoup.parseBodyFragment(it).wholeText() }
+            .orEmpty()
+        val altNames = seriesData.altTitles.orEmpty()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+
+        description = buildString {
+            append(synopsis)
+            if (altNames.isNotEmpty()) {
+                if (isNotEmpty()) append("\n\n")
+                append(ALT_NAME)
+                altNames.forEach { name -> append("\n- $name") }
+            }
+        }.takeIf { it.isNotEmpty() }
 
         genre = seriesData.tags?.let { tags ->
             (listOf(seriesData.type) + tags).joinToString()
@@ -362,5 +376,6 @@ abstract class FlameComics : HttpSource() {
         private const val COMPOSED_SUFFIX = "?comp"
         private val MEDIA_TYPE = "image/png".toMediaType()
         private const val THUMBNAIL_FRAGMENT = "thumbnail"
+        private const val ALT_NAME = "Alternative Names:"
     }
 }

--- a/src/en/mangago/build.gradle.kts
+++ b/src/en/mangago/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Mangago"
-    versionCode = 36
+    versionCode = 37
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 

--- a/src/en/mangago/src/eu/kanade/tachiyomi/extension/en/mangago/Mangago.kt
+++ b/src/en/mangago/src/eu/kanade/tachiyomi/extension/en/mangago/Mangago.kt
@@ -186,10 +186,25 @@ abstract class Mangago :
                 description = info.selectFirst(".manga_summary")?.let { summary: Element ->
                     summary.selectFirst("font")?.remove()
                     summary.text()
-                }
+                }?.takeIf { !it.equals("not found...", ignoreCase = true) }
+
                 info.select(".manga_info li, .manga_right tr").forEach { el ->
                     when (el.selectFirst("b, label")?.text()?.lowercase()) {
-                        "alternative:" -> description = listOfNotNull(description, el.text()).joinToString("\n\n")
+                        "alternative:" -> {
+                            val labelText = el.selectFirst("b, label")?.text().orEmpty()
+                            val raw = el.text().removePrefix(labelText).trim()
+                            val altNames = parseAltNames(raw)
+
+                            if (altNames.isNotEmpty()) {
+                                description = buildString {
+                                    append(description.orEmpty())
+                                    if (isNotEmpty()) append("\n\n")
+                                    append(ALT_NAME_PREFIX)
+                                    append("\n")
+                                    altNames.joinTo(this, "\n") { "- $it" }
+                                }
+                            }
+                        }
 
                         "status:" -> status = when (el.selectFirst("span")?.text()?.lowercase()) {
                             "ongoing" -> SManga.ONGOING
@@ -204,6 +219,21 @@ abstract class Mangago :
                 }
             }
         }
+    }
+
+    private fun parseAltNames(raw: String): List<String> {
+        val separator = if (ALT_NAME_SLASH_SEMICOLON_REGEX.containsMatchIn(raw)) {
+            ALT_NAME_SLASH_SEMICOLON_REGEX
+        } else {
+            ALT_NAME_COMMA_REGEX
+        }
+
+        return raw.split(separator)
+            .map { it.trim() }
+            .filter {
+                it.isNotEmpty() &&
+                    !it.equals("None", ignoreCase = true)
+            }
     }
 
     private fun mangaFromElement(element: Element): SManga? = SManga.create().apply {
@@ -610,5 +640,8 @@ abstract class Mangago :
     companion object {
         private const val REMOVE_TITLE_VERSION_PREF = "REMOVE_TITLE_VERSION"
         private const val PREF_KEY_CUSTOM_UA = "pref_key_custom_ua_"
+        private const val ALT_NAME_PREFIX = "Alternative Names:"
+        private val ALT_NAME_SLASH_SEMICOLON_REGEX = Regex("[/;]")
+        private val ALT_NAME_COMMA_REGEX = Regex(",")
     }
 }

--- a/src/en/mangarawclub/build.gradle.kts
+++ b/src/en/mangarawclub/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "MangaGeko"
-    versionCode = 32
+    versionCode = 33
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 

--- a/src/en/mangarawclub/src/eu/kanade/tachiyomi/extension/en/mangarawclub/MangaRawClub.kt
+++ b/src/en/mangarawclub/src/eu/kanade/tachiyomi/extension/en/mangarawclub/MangaRawClub.kt
@@ -165,11 +165,11 @@ abstract class MangaRawClub :
             document.selectFirst(".description")?.text()?.substringAfter("Summary is")?.let {
                 append(it)
             }
-            document.selectFirst(".alternative-title")?.ownText()?.takeIf { it.isNotEmpty() }?.let {
-                append("\n\n$ALT_NAME")
-                it.split(",").filter { t -> t.isNotEmpty() && t.trim().lowercase() != "updating" }.forEach { name ->
-                    append("\n- ${name.trim()}")
-                }
+
+            parseAltNames(document.selectFirst(".alternative-title")?.ownText())?.let { altNames ->
+                if (isNotEmpty()) append("\n\n")
+                append(ALT_NAME)
+                altNames.forEach { name -> append("\n- $name") }
             }
         }
 
@@ -188,6 +188,21 @@ abstract class MangaRawClub :
         thumbnail_url = document.selectFirst(".cover img")?.let {
             it.absUrl("data-src").ifEmpty { it.absUrl("src") }
         }
+    }
+
+    private fun parseAltNames(raw: String?): List<String>? {
+        if (raw.isNullOrEmpty()) return null
+
+        val separator = if (ALT_NAME_BULLET_SEMICOLON_REGEX.containsMatchIn(raw)) {
+            ALT_NAME_BULLET_SEMICOLON_REGEX
+        } else {
+            ALT_NAME_COMMA_REGEX
+        }
+
+        return raw.split(separator)
+            .map { it.trim() }
+            .filter { it.isNotEmpty() && it.lowercase() != "updating" }
+            .takeIf { it.isNotEmpty() }
     }
 
     // ============================= Chapters ==============================
@@ -234,7 +249,9 @@ abstract class MangaRawClub :
     }
 
     companion object {
-        private const val ALT_NAME = "Alternative Name:"
+        private const val ALT_NAME = "Alternative Names:"
         private const val PREF_HIDE_NSFW = "pref_hide_nsfw"
+        private val ALT_NAME_BULLET_SEMICOLON_REGEX = Regex("[•;]")
+        private val ALT_NAME_COMMA_REGEX = Regex(",")
     }
 }

--- a/src/en/ragescans/build.gradle.kts
+++ b/src/en/ragescans/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Rage Scans"
-    versionCode = 1
+    versionCode = 2
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
     theme = "mangathemesia"

--- a/src/en/ragescans/src/eu/kanade/tachiyomi/extension/en/ragescans/RageScans.kt
+++ b/src/en/ragescans/src/eu/kanade/tachiyomi/extension/en/ragescans/RageScans.kt
@@ -1,9 +1,49 @@
 package eu.kanade.tachiyomi.extension.en.ragescans
 
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import eu.kanade.tachiyomi.source.model.SManga
 import keiyoushi.annotation.Source
+import org.jsoup.nodes.Document
 
 @Source
 abstract class RageScans : MangaThemesia() {
     override fun chapterListSelector() = "li:has(.chbox .eph-num):not(:has([data-bs-target='#lockedChapterModal']))"
+
+    override fun mangaDetailsParse(document: Document): SManga = super.mangaDetailsParse(document).apply {
+        val baseDescription = description
+            ?.substringBefore(altNamePrefix)
+            ?.trim()
+            .orEmpty()
+
+        val altNames = document.selectFirst(seriesAltNameSelector)?.ownText()
+            ?.let(::parseAltNames)
+            .orEmpty()
+
+        description = buildString {
+            append(baseDescription)
+            if (altNames.isNotEmpty()) {
+                if (isNotEmpty()) append("\n\n")
+                append(altNamePrefix.trim())
+                append("\n")
+                altNames.joinTo(this, "\n") { "- $it" }
+            }
+        }.takeIf { it.isNotEmpty() }
+    }
+
+    private fun parseAltNames(raw: String): List<String> {
+        val separator = if (ALT_NAME_SLASH_SEMICOLON_REGEX.containsMatchIn(raw)) {
+            ALT_NAME_SLASH_SEMICOLON_REGEX
+        } else {
+            ALT_NAME_COMMA_REGEX
+        }
+
+        return raw.split(separator)
+            .map { it.trim() }
+            .filter { it.isNotEmpty() && !it.equals("Unknown", ignoreCase = true) }
+    }
+
+    companion object {
+        private val ALT_NAME_SLASH_SEMICOLON_REGEX = Regex("[/;]")
+        private val ALT_NAME_COMMA_REGEX = Regex(",")
+    }
 }


### PR DESCRIPTION
Closes #7209

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by installing the extension
- [ ] Have removed `web_hi_res_512.png` when adding a new extensions
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
