### PR TITLE
Shinigami: Use dynamic CDN base URL from API

### DIFF
--- a/src/id/shinigami/build.gradle.kts
+++ b/src/id/shinigami/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Shinigami"
-    versionCode = 79
+    versionCode = 80
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/id/shinigami/src/eu/kanade/tachiyomi/extension/id/shinigami/Shinigami.kt
+++ b/src/id/shinigami/src/eu/kanade/tachiyomi/extension/id/shinigami/Shinigami.kt
@@ -22,8 +22,6 @@ import java.util.Locale
 abstract class Shinigami : HttpSource() {
     private val apiUrl = "https://api.shngm.io"
 
-    private val cdnUrl = "https://storage.shngm.id"
-
     override val supportsLatest = true
 
     private val apiHeaders: Headers by lazy { apiHeadersBuilder().build() }
@@ -231,7 +229,7 @@ abstract class Shinigami : HttpSource() {
         val result = response.parseAs<ShinigamiPageListDto>()
 
         return result.pageList.chapterPage.pages.mapIndexed { index, imageName ->
-            Page(index = index, imageUrl = "$cdnUrl${result.pageList.chapterPage.path}$imageName")
+            Page(index = index, imageUrl = "${result.pageList.baseUrl}${result.pageList.chapterPage.path}$imageName")
         }
     }
 

--- a/src/id/shinigami/src/eu/kanade/tachiyomi/extension/id/shinigami/ShinigamiDto.kt
+++ b/src/id/shinigami/src/eu/kanade/tachiyomi/extension/id/shinigami/ShinigamiDto.kt
@@ -59,6 +59,7 @@ class ShinigamiPageListDto(
 
 @Serializable
 class ShinigamiPagesDataDto(
+    @SerialName("base_url") val baseUrl: String,
     @SerialName("chapter") val chapterPage: ShinigamiPagesData2Dto,
 )
 


### PR DESCRIPTION
Closes #12650 

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
