### PR TITLE
Naver Webtoon (ko): Skip age-rating banner

### DIFF
--- a/src/ko/navercomic/build.gradle.kts
+++ b/src/ko/navercomic/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Naver Comic"
-    versionCode = 8
+    versionCode = 9
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/ko/navercomic/src/eu/kanade/tachiyomi/extension/ko/navercomic/NaverComic.kt
+++ b/src/ko/navercomic/src/eu/kanade/tachiyomi/extension/ko/navercomic/NaverComic.kt
@@ -148,7 +148,9 @@ abstract class NaverComic : HttpSource() {
 
         var urls = document.select(".wt_viewer img").map { it.attr("abs:src").ifEmpty { it.attr("src") } }
         if (urls.isEmpty()) {
-            urls = document.select(".toon_view_lst img").map { it.attr("abs:data-src").ifEmpty { it.attr("data-src") } }
+            urls = document.select(".toon_view_lst img.toon_image").map {
+                it.attr("abs:data-src").ifEmpty { it.attr("abs:src") }
+            }
         }
 
         return urls.mapIndexed { index, url -> Page(index, imageUrl = url) }


### PR DESCRIPTION
Closes #17609 

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by installing the extension
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
