### PR TITLE
Build: always delete signingkey.jks

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -97,6 +97,7 @@ jobs:
           retention-days: 1
 
       - name: Clean up CI files
+        if: always()
         run: rm signingkey.jks
 
   publish:


### PR DESCRIPTION
Makes sure that `signingkey.jks` is deleted even if build and upload steps fail.

Checklist:

- [ ] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
