### PR TITLE
fix(es): Update LeerMangaEsp domain, API paths, and UI selectors

### DIFF
--- a/src/es/leermangaesp/build.gradle.kts
+++ b/src/es/leermangaesp/build.gradle.kts
@@ -6,17 +6,17 @@ plugins {
 
 keiyoushi {
     name = "LeerMangaEsp"
-    versionCode = 1
+    versionCode = 3
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 
     source {
         lang = "es"
-        baseUrl = "https://leermangaesp.net"
+        baseUrl = "https://mangalect.org"
     }
 
     deeplink {
-        host("leermangaesp.net")
+        host("mangalect.org")
         path("/manga/..*")
         path("/leer-m/..*")
     }

--- a/src/es/leermangaesp/src/eu/kanade/tachiyomi/extension/es/leermangaesp/LeerMangaEsp.kt
+++ b/src/es/leermangaesp/src/eu/kanade/tachiyomi/extension/es/leermangaesp/LeerMangaEsp.kt
@@ -39,7 +39,7 @@ abstract class LeerMangaEsp : HttpSource() {
     override fun popularMangaParse(response: Response): MangasPage {
         val allMangas = response.parseAs<List<HomeGridMangaDto>> { body: String ->
             val document = Jsoup.parse(body)
-            val popularScript = document.selectFirst("script#populares-ssr")
+            val popularScript = document.selectFirst("script#ssr-trends-data")
             popularScript?.data().orEmpty()
         }
 
@@ -203,7 +203,7 @@ abstract class LeerMangaEsp : HttpSource() {
         .build()
 
     private fun mangaUrlFromSlug(slug: String): HttpUrl {
-        val normalizedSlug = slug.trim().removePrefix("/manga/").trim('/').substringBefore('/')
+        val normalizedSlug = slug.trim().removePrefix("/info/").trim('/').substringBefore('/')
 
         return baseUrl.toHttpUrl().newBuilder()
             .encodedPath("$MANGA_PATH_PREFIX$normalizedSlug/")
@@ -211,11 +211,11 @@ abstract class LeerMangaEsp : HttpSource() {
     }
 
     private fun isSupportedDeeplink(url: HttpUrl): Boolean {
-        if (!url.host.contains("leermangaesp")) return false
+        if (!url.host.contains("mangalect")) return false
 
         val pathSegments = url.pathSegments
         return when (pathSegments.getOrNull(0)?.lowercase(Locale.ROOT)) {
-            "manga", "leer-m" -> !pathSegments.getOrNull(1).isNullOrBlank()
+            "info", "manga", "leer-m" -> !pathSegments.getOrNull(1).isNullOrBlank()
             else -> false
         }
     }
@@ -297,6 +297,6 @@ abstract class LeerMangaEsp : HttpSource() {
 
     companion object {
         const val PAGE_SIZE = 20
-        const val MANGA_PATH_PREFIX = "/manga/"
+        const val MANGA_PATH_PREFIX = "/info/"
     }
 }


### PR DESCRIPTION
LeerMangaEsp rebranded to MangaLect and completely migrated to `mangalect.org`. This broke the extension (returning EOF on the home page and 404 errors on chapter lists).

Changes proposed in this pull request:
- Updated `baseUrl` to `https://mangalect.org`.
- Updated the popular manga selector to `script#ssr-trends-data` as the old HTML ID was removed.
- Updated `MANGA_PATH_PREFIX` from `/manga/` to `/info/` to fix HTTP 404 errors when loading chapters.
- Updated deeplink logic to support the new `mangalect` host and `info` segments.
- Kept `imageBaseUrl` pointing to the `/file/leermangaesp` folder, as the server still uses the old directory name for covers.
