### PR TITLE
Asura Scans: Format comma separated alt titles

### DIFF
--- a/src/en/asurascans/build.gradle.kts
+++ b/src/en/asurascans/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Asura Scans"
-    versionCode = 65
+    versionCode = 66
     contentWarning = ContentWarning.SAFE
     libVersion = "1.6"
 

--- a/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/Dto.kt
+++ b/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/Dto.kt
@@ -50,8 +50,8 @@ class MangaDetailsDto(
     private val description: String? = null,
     private val rating: Double? = null,
     private val popularityRank: Int? = null,
-    @SerialName("alternativeTitles")
-    private val altTitles: String? = null,
+    @SerialName("alt_titles")
+    private val altTitles: List<String>? = null,
     private val genres: List<GenreDto>? = null,
     private val status: String? = null,
 ) {
@@ -81,9 +81,9 @@ class MangaDetailsDto(
         }
 
         val cleanAltTitles = altTitles
-            ?.split(" • ")
+            ?.flatMap { it.split("•") }
             ?.map { it.trim() }
-            ?.filter { it.isNotBlank() }
+            ?.filter { it.isNotEmpty() }
 
         if (!cleanAltTitles.isNullOrEmpty()) {
             if (isNotEmpty()) append("\n\n")

--- a/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/Dto.kt
+++ b/src/en/asurascans/src/eu/kanade/tachiyomi/extension/en/asurascans/Dto.kt
@@ -50,8 +50,7 @@ class MangaDetailsDto(
     private val description: String? = null,
     private val rating: Double? = null,
     private val popularityRank: Int? = null,
-    @SerialName("alt_titles")
-    private val altTitles: List<String>? = null,
+    private val alternativeTitles: String? = null,
     private val genres: List<GenreDto>? = null,
     private val status: String? = null,
 ) {
@@ -80,8 +79,8 @@ class MangaDetailsDto(
             append("Rating: %.2f".format(it))
         }
 
-        val cleanAltTitles = altTitles
-            ?.flatMap { it.split("•") }
+        val cleanAltTitles = alternativeTitles
+            ?.let { if (it.contains("•")) it.split("•") else it.split(",") }
             ?.map { it.trim() }
             ?.filter { it.isNotEmpty() }
 


### PR DESCRIPTION
~~Regression: reverted from `alternativeTitles` back to `alt_titles` (Related #17626 )~~
~~1. alternativeTitles is blank for some series, unlike alt_titles — e.g. "A Painter Who Draws Dungeons" or "Got Dropped into a Ghost Story, Still Gotta Work".~~
~~2. alternativeTitles uses comma as separator for some series — e.g. "Sword of the Undying", "The Forgotten Field" or "Only I Have an EX-Grade Summon" and many more. Comma can be part of a title, whereas alt_titles uses newline or • only.~~

Nvm, just noticed switched from REST API to Astro props 

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by running the extension
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
