### PR TITLE
zh/manhuaren: Replace DateFormat with SimpleDateFormat

### DIFF
--- a/src/zh/manhuaren/build.gradle.kts
+++ b/src/zh/manhuaren/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Manhuaren"
-    versionCode = 18
+    versionCode = 19
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/zh/manhuaren/src/eu/kanade/tachiyomi/extension/zh/manhuaren/Manhuaren.kt
+++ b/src/zh/manhuaren/src/eu/kanade/tachiyomi/extension/zh/manhuaren/Manhuaren.kt
@@ -2,7 +2,6 @@ package eu.kanade.tachiyomi.extension.zh.manhuaren
 
 import android.content.SharedPreferences
 import android.os.Build
-import android.text.format.DateFormat
 import android.util.Base64
 import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen
@@ -246,7 +245,7 @@ abstract class Manhuaren :
     }
 
     private fun myRequest(url: HttpUrl, method: String, body: RequestBody?): Request {
-        val now = DateFormat.format("yyyy-MM-dd+HH:mm:ss", Date()).toString()
+        val now = SimpleDateFormat("yyyy-MM-dd+HH:mm:ss", Locale.US).format(Date())
         val userId = preferences.getString(USER_ID_PREF, "-1")!!
         val newUrl = url.newBuilder()
             .setQueryParameter("gsm", "md5")


### PR DESCRIPTION
## Summary

Replace `android.text.format.DateFormat` with `java.text.SimpleDateFormat`
when generating the `gts` request parameter.

`android.text.format.DateFormat.format()` is unavailable in Suwayomi Server,
causing the Manhuaren extension to fail before sending requests.

This change preserves the same timestamp format and was tested successfully
on a local Suwayomi Docker instance.

Related to Suwayomi/Suwayomi-Server#2185
https://github.com/Suwayomi/Suwayomi-Server/issues/2185

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
