### PR TITLE
3Hentai (Multi): Fix page filter and 1.6 migration

### DIFF
--- a/src/all/hentai3/build.gradle.kts
+++ b/src/all/hentai3/build.gradle.kts
@@ -6,9 +6,9 @@ plugins {
 
 keiyoushi {
     name = "3Hentai"
-    versionCode = 4
+    versionCode = 5
     contentWarning = ContentWarning.NSFW
-    libVersion = "1.4"
+    libVersion = "1.6"
 
     listOf(
         "all", "en", "ja", "ko", "zh", "mo", "es", "pt", "id", "jv",
@@ -21,5 +21,9 @@ keiyoushi {
             // lang changed from po to pl, id kept from before the rename
             if (it == "pl") id = 7940950215101782907L
         }
+    }
+
+    deeplink {
+        path("/d/..*")
     }
 }

--- a/src/all/hentai3/build.gradle.kts
+++ b/src/all/hentai3/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "3Hentai"
-    versionCode = 3
+    versionCode = 4
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
 

--- a/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
+++ b/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
@@ -128,13 +128,18 @@ abstract class Hentai3 :
                                 if (tag.startsWith("-")) append("-")
 
                                 append(filter.type)
-                                append(":'")
-                                append(tag.removePrefix("-"))
 
-                                if (filter.specific.isNotEmpty()) {
-                                    append(" (${filter.specific})")
+                                if (filter.type == "page") {
+                                    append(":$tag")
+                                } else {
+                                    append(":'")
+                                    append(tag.removePrefix("-"))
+
+                                    if (filter.specific.isNotEmpty()) {
+                                        append(" (${filter.specific})")
+                                    }
+                                    append("' ")
                                 }
-                                append("' ")
                             }
                     }
 

--- a/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
+++ b/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
@@ -222,11 +222,9 @@ abstract class Hentai3 :
         chapters: List<SChapter>,
         fetchDetails: Boolean,
         fetchChapters: Boolean,
-    ): SMangaUpdate = if (fetchDetails || fetchChapters) {
+    ): SMangaUpdate {
         val doc = client.get(getMangaUrl(manga)).asJsoup()
-        SMangaUpdate(parseMangaDetails(doc), parseChapterList(doc))
-    } else {
-        SMangaUpdate(manga, chapters)
+        return SMangaUpdate(parseMangaDetails(doc), parseChapterList(doc))
     }
 
     // Related manga

--- a/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
+++ b/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
@@ -1,32 +1,31 @@
 package eu.kanade.tachiyomi.extension.all.hentai3
 
-import android.content.SharedPreferences
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
-import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
-import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.annotation.Source
-import keiyoushi.utils.getPreferences
+import keiyoushi.network.get
+import keiyoushi.source.KeiSource
+import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.tryParse
+import kotlinx.serialization.json.JsonElement
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.Request
-import okhttp3.Response
-import org.jsoup.nodes.Element
-import java.text.ParseException
+import org.jsoup.nodes.Document
 import java.text.SimpleDateFormat
 import java.util.Locale
-import java.util.TimeZone
 
 @Source
 abstract class Hentai3 :
-    HttpSource(),
+    KeiSource(),
     ConfigurableSource {
 
     private val searchLang: String
@@ -63,53 +62,43 @@ abstract class Hentai3 :
             else -> ""
         }
 
-    override val supportsLatest = true
+    private val prefs by getPreferencesLazy()
 
-    override fun headersBuilder() = super.headersBuilder()
-        .set("referer", "$baseUrl/")
-        .set("origin", baseUrl)
-
-    private val prefs: SharedPreferences by lazy { getPreferences() }
-
-    private var displayFullTitle: Boolean = prefs.getBoolean("full_title", false)
-
-    override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        SwitchPreferenceCompat(screen.context).apply {
-            key = "full_title"
-            title = "Display full title"
-            setOnPreferenceChangeListener { _, newValue ->
-                displayFullTitle = newValue as Boolean
-                true
-            }
-        }.also(screen::addPreference)
+    // Popular + Latest
+    override suspend fun getPopularManga(page: Int): MangasPage {
+        val url = if (searchLang.isNotEmpty()) {
+            "$baseUrl/language/$searchLang/${if (page > 1) page else ""}?sort=popular"
+        } else {
+            "$baseUrl/search?q=pages%3A>0&page=$page&sort=popular"
+        }
+        val doc = client.get(url).asJsoup()
+        return parseMangasPage(doc)
     }
 
-    // Popular
-    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/${if (searchLang.isNotEmpty()) "language/$searchLang/${if (page > 1) page else ""}?" else "search?q=pages%3A>0&page=$page&"}sort=popular", headers)
+    override suspend fun getLatestUpdates(page: Int): MangasPage {
+        val url = if (searchLang.isNotEmpty()) {
+            "$baseUrl/language/$searchLang/$page"
+        } else {
+            "$baseUrl/search?q=pages%3A>0&page=$page"
+        }
+        val doc = client.get(url).asJsoup()
+        return parseMangasPage(doc)
+    }
 
-    override fun popularMangaParse(response: Response): MangasPage {
-        val doc = response.asJsoup()
-
-        val mangas = doc.select("a[href*=/d/]").map(::popularMangaFromElement)
+    private fun parseMangasPage(doc: Document): MangasPage {
+        val mangas = doc.select("a[href*=/d/]").map { element ->
+            SManga.create().apply {
+                title = element.selectFirst("div.title")!!.ownText().shortenTitle()
+                setUrlWithoutDomain(element.absUrl("href"))
+                thumbnail_url = element.selectFirst("img:not([class])")!!.absUrl("src")
+            }
+        }
         val hasNextPage = doc.selectFirst("a[rel=next]") != null
-
         return MangasPage(mangas, hasNextPage)
     }
 
-    private fun popularMangaFromElement(element: Element): SManga = SManga.create().apply {
-        title = element.selectFirst("div.title")!!.ownText()
-        setUrlWithoutDomain(element.absUrl("href"))
-        thumbnail_url = element.selectFirst("img:not([class])")!!.absUrl("src")
-    }
-
-    // Latest
-    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/${if (searchLang.isNotEmpty()) "language/$searchLang/$page" else "search?q=pages%3A>0&page=$page"}", headers)
-
-    override fun latestUpdatesParse(response: Response): MangasPage = popularMangaParse(response)
-
     // Search
-
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
         var sort = ""
 
         val tags = buildString {
@@ -157,26 +146,35 @@ abstract class Hentai3 :
             addQueryParameter("sort", sort)
         }.build()
 
-        return GET(url, headers)
+        return parseMangasPage(client.get(url).asJsoup())
     }
-    override fun searchMangaParse(response: Response): MangasPage = popularMangaParse(response)
 
-    // Details
+    override fun getFilterList(data: JsonElement?): FilterList = getFilters()
 
-    override fun mangaDetailsParse(response: Response): SManga {
-        val document = response.asJsoup()
+    // Details + Chapters
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+        if (url.host != baseUrl.toHttpUrl().host) return null
+        if (url.pathSegments.getOrNull(0) != "d") return null
 
+        return url.pathSegments.getOrNull(1)?.let { id ->
+            parseMangaDetails(client.get("$baseUrl/d/$id").asJsoup())
+        }
+    }
+
+    private fun parseMangaDetails(document: Document): SManga {
         fun String.capitalizeEach() = this.split(" ").joinToString(" ") { s ->
             s.replaceFirstChar { sr ->
                 if (sr.isLowerCase()) sr.titlecase(Locale.getDefault()) else sr.toString()
             }
         }
         return SManga.create().apply {
+            setUrlWithoutDomain(document.location())
+
             val authors = document.select("a[href*=/groups/]").eachText().joinToString()
             val artists = document.select("a[href*=/artists/]").eachText().joinToString()
             initialized = true
 
-            title = document.select(if (displayFullTitle) "h1" else "h1 > span").text()
+            title = document.select("h1").text().shortenTitle()
             author = authors.ifEmpty { artists }
             artist = artists.ifEmpty { authors }
             genre = document.select("a[href*=/tags/]").eachText().joinToString {
@@ -201,46 +199,85 @@ abstract class Hentai3 :
                 document.select("a[href*=/language/]").eachText().joinToString().ifEmpty { null }?.let {
                     append("Languages: ", it.capitalizeEach(), "\n\n")
                 }
-
                 append(document.select("div.tag-container:contains(pages:)").text(), "\n")
             }
-            thumbnail_url = document.selectFirst("img[src*=thumbnail].w-96")?.absUrl("src")
+            thumbnail_url = document.selectFirst("img")!!.let { img ->
+                img.attr("data-src").ifEmpty { img.absUrl("src") }
+            }
             status = SManga.COMPLETED
             update_strategy = UpdateStrategy.ONLY_FETCH_ONCE
         }
     }
 
-    val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZZZZZ", Locale.ENGLISH).apply {
-        timeZone = TimeZone.getTimeZone("UTC")
-    }
+    private fun parseChapterList(doc: Document): List<SChapter> = listOf(
+        SChapter.create().apply {
+            name = "Chapter"
+            setUrlWithoutDomain(doc.location())
+            date_upload = dateFormat.tryParse(doc.select("time").attr("datetime"))
+        },
+    )
 
-    // Chapters
-
-    override fun chapterListParse(response: Response): List<SChapter> {
-        val doc = response.asJsoup()
-        return listOf(
-            SChapter.create().apply {
-                name = "Chapter"
-                setUrlWithoutDomain(response.request.url.toString())
-                date_upload = try {
-                    dateFormat.parse(doc.select("time").text())!!.time
-                } catch (_: ParseException) {
-                    0L
-                }
-            },
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        val doc = client.get(getMangaUrl(manga)).asJsoup()
+        return SMangaUpdate(
+            manga = if (fetchDetails) parseMangaDetails(doc) else manga,
+            chapters = if (fetchChapters) parseChapterList(doc) else chapters,
         )
     }
 
-    // Pages
+    override fun getMangaUrl(manga: SManga): String = baseUrl + manga.url
 
-    override fun pageListParse(response: Response): List<Page> {
-        val images = response.asJsoup().select("img:not([class], [src*=thumb], [src*=cover])")
-        return images.mapIndexed { index, image ->
-            val imageUrl = image.absUrl("src")
-            Page(index, imageUrl = imageUrl.replace(Regex("t(?=\\.)"), ""))
+    override fun getChapterUrl(chapter: SChapter): String = baseUrl + chapter.url
+
+    // Related manga
+    override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> {
+        val doc = client.get(getMangaUrl(manga)).asJsoup()
+        return doc.select("#similar-content .doujin-col .doujin a.cover").mapNotNull { link ->
+            SManga.create().apply {
+                title = link.selectFirst(".title")!!.text()
+                setUrlWithoutDomain(link.absUrl("href"))
+                thumbnail_url = link.selectFirst("img")!!.let { img ->
+                    img.attr("data-src").ifEmpty { img.absUrl("src") }
+                }
+            }
         }
     }
 
-    override fun getFilterList() = getFilters()
-    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
+    // Pages
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        val doc = client.get(getChapterUrl(chapter)).asJsoup()
+        return doc.select("img:not([class], [src*=thumb], [src*=cover])")
+            .mapIndexed { index, image ->
+                val imageUrl = image.absUrl("src")
+                Page(index, imageUrl = imageUrl.replace(REMOVE_THUMB_REGEX, ""))
+            }
+    }
+
+    // Preferences
+    private fun String.shortenTitle() = if (displayFullTitle) {
+        this
+    } else {
+        replace(SHORT_TITLE_REGEX, "").trim()
+    }
+
+    private val displayFullTitle
+        get() = prefs.getBoolean("full_title", false)
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        SwitchPreferenceCompat(screen.context).apply {
+            key = "full_title"
+            title = "Display full title"
+        }.also(screen::addPreference)
+    }
+
+    companion object {
+        private val SHORT_TITLE_REGEX = Regex("""(\[[^]]*]|[({][^)}]*[)}])""")
+        private val REMOVE_THUMB_REGEX = Regex("t(?=\\.)")
+        private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZZZZZ", Locale.ROOT)
+    }
 }

--- a/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
+++ b/src/all/hentai3/src/eu/kanade/tachiyomi/extension/all/hentai3/Hentai3.kt
@@ -222,19 +222,16 @@ abstract class Hentai3 :
         chapters: List<SChapter>,
         fetchDetails: Boolean,
         fetchChapters: Boolean,
-    ): SMangaUpdate {
+    ): SMangaUpdate = if (fetchDetails || fetchChapters) {
         val doc = client.get(getMangaUrl(manga)).asJsoup()
-        return SMangaUpdate(
-            manga = if (fetchDetails) parseMangaDetails(doc) else manga,
-            chapters = if (fetchChapters) parseChapterList(doc) else chapters,
-        )
+        SMangaUpdate(parseMangaDetails(doc), parseChapterList(doc))
+    } else {
+        SMangaUpdate(manga, chapters)
     }
 
-    override fun getMangaUrl(manga: SManga): String = baseUrl + manga.url
-
-    override fun getChapterUrl(chapter: SChapter): String = baseUrl + chapter.url
-
     // Related manga
+    override val supportsRelatedMangas = true
+
     override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> {
         val doc = client.get(getMangaUrl(manga)).asJsoup()
         return doc.select("#similar-content .doujin-col .doujin a.cover").mapNotNull { link ->


### PR DESCRIPTION
Closes #17660

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
