### PR TITLE
Kagane [Multi]: Update API URL

### DIFF
--- a/src/all/kagane/build.gradle.kts
+++ b/src/all/kagane/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Kagane"
-    versionCode = 27
+    versionCode = 28
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 

--- a/src/all/kagane/src/eu/kanade/tachiyomi/extension/all/kagane/Kagane.kt
+++ b/src/all/kagane/src/eu/kanade/tachiyomi/extension/all/kagane/Kagane.kt
@@ -46,7 +46,7 @@ abstract class Kagane :
         get() = if (lang == "zh") listOf("zh-Hans", "zh-Hant") else listOf(lang)
 
     private val domain get() = baseUrl.removePrefix("https://")
-    private val apiUrl get() = "https://yuzuki.$domain"
+    private val apiUrl get() = "https://$domain"
 
     override val supportsLatest = true
 


### PR DESCRIPTION
Closes #17726.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
