### PR TITLE
Bump dependencies and minsdk

### DIFF
--- a/common/proguard-rules.pro
+++ b/common/proguard-rules.pro
@@ -1,5 +1,5 @@
 #-dontobfuscate
--dontoptimize
+#-dontoptimize
 
 ## Partially based on https://android.googlesource.com/platform/tools/base/+/refs/heads/mirror-goog-studio-main/build-system/gradle-core/src/main/resources/com/android/build/gradle/proguard-common.txt
 

--- a/gradle/kei.versions.toml
+++ b/gradle/kei.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Used in [/gradle/build-logic/src/main/kotlin/AndroidBasePlugin.kt]
-android-sdk-min = "21"
+android-sdk-min = "26"
 android-sdk-compile = "37"
 android-sdk-target = "37"
 java = "11"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 android-gradle = "9.3.0"
-coroutines = "1.10.2"
-serialization = "1.7.3"
+coroutines = "1.11.0"
+serialization = "1.11.0"
 junit = "4.13.2"
-kotlin-gradle = "2.4.0"
+kotlin-gradle = "2.4.10"
 ksp = "2.3.9"
 kotlinpoet = "2.3.0"
 ktlint = "1.8.0"

--- a/lib/textinterceptor/src/keiyoushi/lib/textinterceptor/TextInterceptor.kt
+++ b/lib/textinterceptor/src/keiyoushi/lib/textinterceptor/TextInterceptor.kt
@@ -1,12 +1,10 @@
 package keiyoushi.lib.textinterceptor
 
-import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Typeface
 import android.net.Uri
-import android.os.Build
 import android.text.Html
 import android.text.Layout
 import android.text.StaticLayout
@@ -110,13 +108,7 @@ class TextInterceptor : Interceptor {
             .build()
     }
 
-    @SuppressLint("ObsoleteSdkInt")
-    private fun textFixer(htmlString: String): String = if (Build.VERSION.SDK_INT >= 24) {
-        Html.fromHtml(htmlString, Html.FROM_HTML_MODE_LEGACY).toString()
-    } else {
-        @Suppress("DEPRECATION")
-        Html.fromHtml(htmlString).toString()
-    }
+    private fun textFixer(htmlString: String): String = Html.fromHtml(htmlString, Html.FROM_HTML_MODE_LEGACY).toString()
 
     @Suppress("SameParameterValue")
     private fun StaticLayout.draw(canvas: Canvas, x: Float, y: Float) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,8 +33,9 @@ rootProject.name = "Keiyoushi"
 /**
  * Add or remove modules to load as needed for local development here.
  */
-loadAllIndividualExtensions()
-// loadIndividualExtension("all", "mangadex")
+// loadAllIndividualExtensions()
+loadIndividualExtension("all", "mangadex")
+loadIndividualExtension("en", "asurascans")
 
 /**
  * ===================================== COMMON CONFIGURATION ======================================

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,9 +33,8 @@ rootProject.name = "Keiyoushi"
 /**
  * Add or remove modules to load as needed for local development here.
  */
-// loadAllIndividualExtensions()
-loadIndividualExtension("all", "mangadex")
-loadIndividualExtension("en", "asurascans")
+loadAllIndividualExtensions()
+// loadIndividualExtension("all", "mangadex")
 
 /**
  * ===================================== COMMON CONFIGURATION ======================================

--- a/src/all/manhuarm/src/eu/kanade/tachiyomi/extension/all/manhuarm/Manhuarm.kt
+++ b/src/all/manhuarm/src/eu/kanade/tachiyomi/extension/all/manhuarm/Manhuarm.kt
@@ -1,9 +1,7 @@
 package eu.kanade.tachiyomi.extension.all.manhuarm
 
 import android.content.SharedPreferences
-import android.os.Build
 import android.widget.Toast
-import androidx.annotation.RequiresApi
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.Preference
@@ -46,7 +44,6 @@ import java.util.Date
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
-@RequiresApi(Build.VERSION_CODES.O)
 @Source
 abstract class Manhuarm :
     Madara(),

--- a/src/all/manhuarm/src/eu/kanade/tachiyomi/extension/all/manhuarm/interceptors/ComposedImageInterceptor.kt
+++ b/src/all/manhuarm/src/eu/kanade/tachiyomi/extension/all/manhuarm/interceptors/ComposedImageInterceptor.kt
@@ -11,7 +11,6 @@ import android.os.Build
 import android.text.Layout
 import android.text.StaticLayout
 import android.text.TextPaint
-import androidx.annotation.RequiresApi
 import eu.kanade.tachiyomi.extension.all.manhuarm.Dialog
 import eu.kanade.tachiyomi.extension.all.manhuarm.Language
 import eu.kanade.tachiyomi.extension.all.manhuarm.Manhuarm.Companion.PAGE_REGEX
@@ -27,7 +26,6 @@ import java.io.FileOutputStream
 import java.io.InputStream
 
 // The Interceptor joins the dialogues and pages of the manga.
-@RequiresApi(Build.VERSION_CODES.O)
 class ComposedImageInterceptor(
     val language: Language,
 ) : Interceptor {

--- a/src/all/manhuarm/src/eu/kanade/tachiyomi/extension/all/manhuarm/interceptors/TranslationInterceptor.kt
+++ b/src/all/manhuarm/src/eu/kanade/tachiyomi/extension/all/manhuarm/interceptors/TranslationInterceptor.kt
@@ -1,7 +1,5 @@
 package eu.kanade.tachiyomi.extension.all.manhuarm.interceptors
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import eu.kanade.tachiyomi.extension.all.manhuarm.Dialog
 import eu.kanade.tachiyomi.extension.all.manhuarm.Language
 import eu.kanade.tachiyomi.extension.all.manhuarm.Manhuarm.Companion.PAGE_REGEX
@@ -17,7 +15,6 @@ import okhttp3.Interceptor
 import okhttp3.Response
 import uy.kohesive.injekt.injectLazy
 
-@RequiresApi(Build.VERSION_CODES.O)
 class TranslationInterceptor(
     val language: Language,
     private val translator: TranslatorEngine,

--- a/src/all/projectsuki/src/eu/kanade/tachiyomi/extension/all/projectsuki/ProjectSuki.kt
+++ b/src/all/projectsuki/src/eu/kanade/tachiyomi/extension/all/projectsuki/ProjectSuki.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.extension.all.projectsuki
 
-import android.os.Build
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.asObservableSuccess
@@ -304,20 +303,6 @@ abstract class ProjectSuki :
             }
 
             searchMode == ProjectSukiFilters.SearchMode.SMART -> {
-                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-                    throw Exception(
-                        buildString {
-                            append("Please enable ")
-                            append(ProjectSukiFilters.SearchMode.SIMPLE)
-                            append(" Search Mode: ")
-                            append(ProjectSukiFilters.SearchMode.SMART)
-                            append(" mode requires Android API version >= 24, but ")
-                            append(Build.VERSION.SDK_INT)
-                            append(" was found!")
-                        },
-                    )
-                }
-
                 client.newCall(ProjectSukiAPI.bookSearchRequest(headers))
                     .asObservableSuccess()
                     .map { response -> ProjectSukiAPI.parseBookSearchResponse(response) }

--- a/src/all/projectsuki/src/eu/kanade/tachiyomi/extension/all/projectsuki/SmartBookSearchHandler.kt
+++ b/src/all/projectsuki/src/eu/kanade/tachiyomi/extension/all/projectsuki/SmartBookSearchHandler.kt
@@ -5,8 +5,6 @@ import android.icu.text.Collator
 import android.icu.text.Normalizer2
 import android.icu.text.RuleBasedCollator
 import android.icu.text.StringSearch
-import android.os.Build
-import androidx.annotation.RequiresApi
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.SManga
 import okhttp3.HttpUrl
@@ -19,7 +17,6 @@ private inline val INFO: Nothing get() = error("INFO")
 private typealias IsWord = Boolean
 
 @Suppress("MemberVisibilityCanBePrivate")
-@RequiresApi(Build.VERSION_CODES.N)
 class SmartBookSearchHandler(val rawQuery: String, val rawBooksData: Map<BookID, BookTitle>) {
 
     data class WordsData(val words: List<String>, val extra: List<String>, val wordRanges: List<IntRange>)

--- a/src/ar/mangatek/src/eu/kanade/tachiyomi/extension/ar/mangatek/MangaTek.kt
+++ b/src/ar/mangatek/src/eu/kanade/tachiyomi/extension/ar/mangatek/MangaTek.kt
@@ -1,9 +1,7 @@
 package eu.kanade.tachiyomi.extension.ar.mangatek
 
 import android.content.SharedPreferences
-import android.os.Build
 import android.widget.Toast
-import androidx.annotation.RequiresApi
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.network.GET
@@ -29,7 +27,6 @@ import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-@RequiresApi(Build.VERSION_CODES.O)
 @Source
 abstract class MangaTek :
     HttpSource(),

--- a/src/ar/mangatek/src/eu/kanade/tachiyomi/extension/ar/mangatek/SpeechBubblePainterInterceptor.kt
+++ b/src/ar/mangatek/src/eu/kanade/tachiyomi/extension/ar/mangatek/SpeechBubblePainterInterceptor.kt
@@ -10,7 +10,6 @@ import android.os.Build
 import android.text.Layout
 import android.text.StaticLayout
 import android.text.TextPaint
-import androidx.annotation.RequiresApi
 import eu.kanade.tachiyomi.extension.ar.mangatek.MangaTek.Companion.PAGE_REGEX
 import keiyoushi.utils.parseAs
 import okhttp3.Interceptor
@@ -20,7 +19,6 @@ import okhttp3.ResponseBody.Companion.toResponseBody
 import org.jsoup.Jsoup
 import java.io.ByteArrayOutputStream
 
-@RequiresApi(Build.VERSION_CODES.O)
 class SpeechBubblePainterInterceptor(val fontSize: Int) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {

--- a/src/ja/idolgravureprincessdate/src/eu/kanade/tachiyomi/extension/ja/idolgravureprincessdate/IdolGravureprincessDate.kt
+++ b/src/ja/idolgravureprincessdate/src/eu/kanade/tachiyomi/extension/ja/idolgravureprincessdate/IdolGravureprincessDate.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.extension.ja.idolgravureprincessdate
 
-import android.os.Build
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
@@ -41,11 +40,7 @@ abstract class IdolGravureprincessDate : HttpSource() {
     private val json: Json by injectLazy()
 
     private val dateFormat by lazy {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.getDefault())
-        } else {
-            SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
-        }
+        SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.getDefault())
     }
 
     override fun popularMangaRequest(page: Int) = GET(apiUrlBuilder(page).build(), headers)

--- a/src/ja/pixivcomic/src/eu/kanade/tachiyomi/extension/ja/pixivcomic/Utils.kt
+++ b/src/ja/pixivcomic/src/eu/kanade/tachiyomi/extension/ja/pixivcomic/Utils.kt
@@ -1,29 +1,14 @@
 package eu.kanade.tachiyomi.extension.ja.pixivcomic
 
-import android.os.Build
 import java.security.MessageDigest
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
-import java.util.TimeZone
-import kotlin.math.abs
 
 internal fun getTimeAndHash(salt: String): Pair<String, String> {
-    val now = Date()
-    val time = if (Build.VERSION.SDK_INT >= 24) {
-        SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.ROOT).format(now)
-    } else {
-        SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT).format(now) + now.zoneOffset()
-    }
+    val time = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.ROOT).format(Date())
 
     val hash = MessageDigest.getInstance("SHA-256").digest((time + salt).encodeToByteArray()).toHexString()
 
     return time to hash
-}
-
-private fun Date.zoneOffset(): String {
-    val offset = TimeZone.getDefault().getOffset(time)
-    val sign = if (offset >= 0) "+" else "-"
-    val minutes = abs(offset) / 60_000
-    return "%s%02d:%02d".format(Locale.ROOT, sign, minutes / 60, minutes % 60)
 }


### PR DESCRIPTION
:nyaboom:

- Bump dependencies
- Bump minSdk to 26 (Android 8.0)
  - Unlocks native `java.time` APIs.
  - Fixes a `kotlinx-serialization` default method crash on versions > 1.7.3.
    <details>
    <summary>Technical details</summary>
    <br>
    Bumping minSdk to 24 or higher fixes KT-84952 — a NoClassDefFoundError: GeneratedSerializer$-CC crash that started with kotlinx.serialization 1.8.0, which switched to compiling GeneratedSerializer with real Java 8 default interface methods instead of the old DefaultImpls shim. On Android versions below API 24, ART doesn't natively support default interface methods, so d8 has to desugar them: it rewrites calls to a default method into a call on a synthesized companion class (Interface$-CC), built by extracting the method body straight out of the interface's own class file at dex time. That's precisely what breaks for us — since kotlinx.serialization is a compileOnly dependency, its GeneratedSerializer interface is only visible to d8 for type-resolution, never handed over as program input to actually dex, so d8 rewrites the call site in our generated $serializer classes but has nothing to build the $-CC companion from, leaving a dangling reference that throws at runtime. Once minSdk >= 24 (Android 7.0 Nougat), ART natively supports default interface methods, so d8 skips desugaring entirely and leaves the call as a plain invokeinterface resolved directly against the interface's default implementation at runtime — no companion class needed, no dependency on the interface being bundled, and the crash never occurs.
    </details>
  - Note: This effectively requires all host apps to be minsdk 26+.
- Enable R8 optimizations

