### PR TITLE
Update r8 rule

### DIFF
--- a/common/proguard-rules.pro
+++ b/common/proguard-rules.pro
@@ -24,7 +24,7 @@
 # resolved with reflection at runtime, so the Signature attribute is needed.
 # https://r8.googlesource.com/r8/+/refs/heads/master/compatibility-faq.md#troubleshooting-gson-gson
 -keepattributes Signature
--keep class * extends uy.kohesive.injekt.api.FullTypeReference
+-keep,allowshrinking,allowoptimization,allowobfuscation class * extends uy.kohesive.injekt.api.FullTypeReference
 
 # kotlinx-serialization — runtime keeps required for @Serializable types and their
 # generated $serializer companions.

--- a/core/src/main/kotlin/keiyoushi/utils/Context.kt
+++ b/core/src/main/kotlin/keiyoushi/utils/Context.kt
@@ -4,4 +4,4 @@ import android.app.Application
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
-val applicationContext: Application get() = Injekt.get()
+val applicationContext: Application = Injekt.get()


### PR DESCRIPTION
This allows r8 to correctly strip injekt's generated synthatic classes when the extension doesn't use the value. e.g `applicationContext`, `jsonInstance` etc
