### PR TITLE
Mangakuri: Update baseUrl

### DIFF
--- a/src/id/mangakuri/build.gradle.kts
+++ b/src/id/mangakuri/build.gradle.kts
@@ -6,13 +6,13 @@ plugins {
 
 keiyoushi {
     name = "Mangakuri"
-    versionCode = 33
+    versionCode = 34
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
 
     source {
         lang = "id"
-        baseUrl = "https://lc1.mangakuri.online"
+        baseUrl = "https://lc2.mangakuri.online"
         versionId = 2
     }
 }


### PR DESCRIPTION
Closes #17774

Source Name:** Mangakuri
Language:** Indonesian (`id`)

 Updated baseUrl to `https://lc2.mangakuri.online/`.
 Increment versionCode in `build.gradle.kts`.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
