### PR TITLE
West Manga: update domain

### DIFF
--- a/src/id/westmanga/build.gradle.kts
+++ b/src/id/westmanga/build.gradle.kts
@@ -6,13 +6,13 @@ plugins {
 
 keiyoushi {
     name = "West Manga"
-    versionCode = 43
+    versionCode = 44
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 
     source {
         lang = "id"
-        baseUrl = "https://v1.westmanga.cc"
+        baseUrl = "https://v1.westmanga.my"
         id = 8883916630998758688L
     }
 }


### PR DESCRIPTION
Closes #17809

Updates West Manga's base URL from `https://v1.westmanga.cc` to `https://v1.westmanga.my`.

The main site at `https://westmanga.site` lists the new domain, the new host serves the current application, and the existing API accepts requests with the new Referer. The source ID is preserved.

Validation:
- `./gradlew :src:id:westmanga:spotlessCheck :src:id:westmanga:assembleDebug :src:id:westmanga:assembleRelease`

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (not applicable)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling the extension
- [x] Have removed `web_hi_res_512.png` when adding a new extension (not applicable)
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop