### PR TITLE
[RU]AllHentai add support of site mirror

### DIFF
--- a/src/ru/allhentai/build.gradle.kts
+++ b/src/ru/allhentai/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "AllHentai"
-    versionCode = 25
+    versionCode = 26
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
     theme = "grouple"

--- a/src/ru/allhentai/src/eu/kanade/tachiyomi/extension/ru/allhentai/AllHentai.kt
+++ b/src/ru/allhentai/src/eu/kanade/tachiyomi/extension/ru/allhentai/AllHentai.kt
@@ -7,7 +7,7 @@ import keiyoushi.annotation.Source
 @Source
 abstract class AllHentai : GroupLe() {
 
-    override val isNeedAuth = true
+    override val isNeedAuth = baseUrl != "https://x.ahen.me"
 
     override fun getFilterList() = FilterList(
         OrderBy(),

--- a/src/ru/allhentai/src/eu/kanade/tachiyomi/extension/ru/allhentai/AllHentai.kt
+++ b/src/ru/allhentai/src/eu/kanade/tachiyomi/extension/ru/allhentai/AllHentai.kt
@@ -7,7 +7,7 @@ import keiyoushi.annotation.Source
 @Source
 abstract class AllHentai : GroupLe() {
 
-    override val isNeedAuth = baseUrl != "https://x.ahen.me"
+    override val isNeedAuth get() = baseUrl != "https://x.ahen.me"
 
     override fun getFilterList() = FilterList(
         OrderBy(),


### PR DESCRIPTION
AllHentai has an official mirror (created by the owner of the main site) that does not support login/authorization. However, it displays certain titles that require a paid subscription on the main site and is accessible in Russia without using VPNs or bypass tools.

The current extension code requires authorization, so I added the mirror domain to the exception list for this check. Alternatively, it might be worth adding a toggle setting to allow switching this behavior if preferred.

For reference: The mirror does not load without a Referer header containing either the mirror's own URL or a search engine URL. This was implemented to make it harder to detect blocked content within Russia. If you want to test or open it in a browser, the easiest way is to follow [this](https://www.google.com/search?q=x.ahen.me) link and open the search result named Ahen (not "AllHentai").

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
