### PR TITLE
feat(vi/toptruyen): add static genre filters

### DIFF
--- a/src/vi/toptruyen/build.gradle.kts
+++ b/src/vi/toptruyen/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Top Truyen"
-    versionCode = 32
+    versionCode = 33
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
     theme = "wpcomics"

--- a/src/vi/toptruyen/src/eu/kanade/tachiyomi/extension/vi/toptruyen/TopTruyen.kt
+++ b/src/vi/toptruyen/src/eu/kanade/tachiyomi/extension/vi/toptruyen/TopTruyen.kt
@@ -87,6 +87,66 @@ abstract class TopTruyen :
 
     override val genresSelector = ".categories-detail ul.nav li:not(.active) a"
 
+    override fun getFilterList(): FilterList {
+        if (genreList.isEmpty()) {
+            genreList = listOf(
+                Pair(null, "Tất cả"),
+                Pair("action", "Action"),
+                Pair("truong-thanh", "Adult"),
+                Pair("phieu-luu", "Adventure"),
+                Pair("anime", "Anime"),
+                Pair("chuyen-sinh", "Chuyển Sinh"),
+                Pair("comedy", "Comedy"),
+                Pair("nau-an", "Cooking"),
+                Pair("comic", "Comic"),
+                Pair("co-dai", "Cổ Đại"),
+                Pair("drama", "Drama"),
+                Pair("dam-my", "Đam Mỹ"),
+                Pair("ecchi", "Ecchi"),
+                Pair("fantasy", "Fantasy"),
+                Pair("harem", "Harem"),
+                Pair("historical", "Historical"),
+                Pair("horror", "Horror"),
+                Pair("live-action", "Live action"),
+                Pair("manga", "Manga"),
+                Pair("manhua", "Manhua"),
+                Pair("manhwa", "Manhwa"),
+                Pair("martial-arts", "Martial Arts"),
+                Pair("mature", "Mature"),
+                Pair("mystery", "Mystery"),
+                Pair("mecha", "Mecha"),
+                Pair("ngon-tinh", "Ngôn Tình"),
+                Pair("one-shot", "One shot"),
+                Pair("psychological", "Psychological"),
+                Pair("romance", "Romance"),
+                Pair("school-life", "School Life"),
+                Pair("shoujo", "Shoujo"),
+                Pair("shoujo-ai", "Shoujo Ai"),
+                Pair("shounen", "Shounen"),
+                Pair("slice-of-life", "Slice of Life"),
+                Pair("seinen", "Seinen"),
+                Pair("smut", "Smut"),
+                Pair("sci-fi", "Sci-fi"),
+                Pair("soft-yaoi", "Soft Yaoi"),
+                Pair("soft-yuri", "Soft Yuri"),
+                Pair("sports", "Sports"),
+                Pair("supernatural", "Supernatural"),
+                Pair("josei", "Josei"),
+                Pair("thieu-nhi", "Thiếu Nhi"),
+                Pair("trinh-tham", "Trinh Thám"),
+                Pair("truyen-mau", "Truyện Màu"),
+                Pair("tragedy", "Tragedy"),
+                Pair("webtoon", "Webtoon"),
+                Pair("xuyen-khong", "Xuyên Không"),
+                Pair("gender-bender", "Gender Bender"),
+                Pair("yuri", "Yuri"),
+                Pair("he-thong", "Hệ Thống"),
+                Pair("yaoi", "Yaoi"),
+            )
+        }
+        return super.getFilterList()
+    }
+
     // Configurable, automatic change domain
     private val preferences: SharedPreferences = getPreferences()
     private var hasCheckedRedirect = false


### PR DESCRIPTION
Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
