### PR TITLE
RavenScans one line fix

### DIFF
--- a/src/en/ravenscans/build.gradle.kts
+++ b/src/en/ravenscans/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Raven Scans"
-    versionCode = 2
+    versionCode = 3
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
     theme = "mangathemesia"

--- a/src/en/ravenscans/src/eu/kanade/tachiyomi/extension/en/ravenscans/RavenScans.kt
+++ b/src/en/ravenscans/src/eu/kanade/tachiyomi/extension/en/ravenscans/RavenScans.kt
@@ -4,4 +4,6 @@ import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import keiyoushi.annotation.Source
 
 @Source
-abstract class RavenScans : MangaThemesia()
+abstract class RavenScans : MangaThemesia() {
+    override val mangaUrlDirectory = "/series"
+}


### PR DESCRIPTION
Closes #17658

Raven Scans moved listings from `/manga` to `/series` (`/manga` returns 404; `/series` works).

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

