### PR TITLE
Fixed cosmicscans url

### DIFF
--- a/src/id/cosmicscansid/build.gradle.kts
+++ b/src/id/cosmicscansid/build.gradle.kts
@@ -6,13 +6,13 @@ plugins {
 
 keiyoushi {
     name = "CosmicScans"
-    versionCode = 55
+    versionCode = 56
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 
     source {
         lang = "id"
-        baseUrl = "https://01.cosmicscans.to"
+        baseUrl = "https://02.cosmicscans.to"
         id = 6559481336553833282L
     }
 }


### PR DESCRIPTION
Closes #17830

changed baseUrl to "https://02.cosmicscans.to"

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
