### PR TITLE
Hiper (multi-src): Fix migration and use Instant

### DIFF
--- a/lib-multisrc/hiper/build.gradle.kts
+++ b/lib-multisrc/hiper/build.gradle.kts
@@ -7,6 +7,6 @@ dependencies {
 }
 
 keiyoushi {
-    baseVersionCode = 5
+    baseVersionCode = 6
     libVersion = "1.6"
 }

--- a/lib-multisrc/hiper/src/eu/kanade/tachiyomi/multisrc/hiper/Dto.kt
+++ b/lib-multisrc/hiper/src/eu/kanade/tachiyomi/multisrc/hiper/Dto.kt
@@ -3,12 +3,10 @@ package eu.kanade.tachiyomi.multisrc.hiper
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import keiyoushi.utils.tryParse
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
-import java.text.SimpleDateFormat
-import java.util.Locale
+import kotlin.time.Instant
 
 @Serializable
 class WrapperContent(
@@ -60,7 +58,7 @@ class ChapterDto(
     fun toSChapter(mangaPath: String) = SChapter.create().apply {
         name = buildChapterName()
         chapter_number = number
-        date_upload = dateFormat.tryParse(createdAt)
+        date_upload = Instant.parseOrNull(createdAt)?.toEpochMilliseconds() ?: 0L
         url = "$mangaPath/$number"
     }
 
@@ -74,7 +72,6 @@ class ChapterDto(
     private val labelNumber: String get() = "Chapter ${number.toString().replace(".0", "")}"
 
     companion object {
-        private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT)
         private val NUMBER_REGEX = """\d+""".toRegex()
     }
 }

--- a/lib-multisrc/hiper/src/eu/kanade/tachiyomi/multisrc/hiper/Hiper.kt
+++ b/lib-multisrc/hiper/src/eu/kanade/tachiyomi/multisrc/hiper/Hiper.kt
@@ -208,10 +208,10 @@ abstract class Hiper :
         return "$baseUrl/$mangaPath/$slug/${chapter.getNumber()}".removeSuffix(".0")
     }
 
-    protected open suspend fun getChapterList(manga: SManga): List<SChapter> {
+    protected open suspend fun getChapterList(manga: SManga): List<SChapter>? {
         val mangaId = manga.memo.getLongOrNull("mangaId")
             ?: manga.url.substringAfterLast("#").toLongOrNull() // Fallback for old manga URLs
-            ?: throw IOException("Refresh chapter list")
+            ?: return null
 
         val input = buildJsonObject {
             putJsonObject("0") {
@@ -263,10 +263,18 @@ abstract class Hiper :
         fetchDetails: Boolean,
         fetchChapters: Boolean,
     ): SMangaUpdate {
-        val updatedManga = if (fetchDetails) getMangaDetails(manga) else null
-        val updatedChapters = if (fetchChapters) getChapterList(manga) else null
+        var updatedManga = if (fetchDetails) getMangaDetails(manga)!! else manga
+        val updatedChapters = if (fetchChapters) {
+            getChapterList(updatedManga) ?: run {
+                // Auto migrate
+                updatedManga = getMangaDetails(manga)!!
+                getChapterList(updatedManga)
+            }!!
+        } else {
+            chapters
+        }
 
-        return SMangaUpdate(updatedManga ?: manga, updatedChapters ?: chapters)
+        return SMangaUpdate(updatedManga, updatedChapters)
     }
 
     // ============================ Related manga ==============================
@@ -478,7 +486,7 @@ abstract class Hiper :
         .substringBefore("/")
         .substringBefore("#")
         .takeIf(String::isNotBlank)
-        ?: throw IOException("Refresh chapter list")
+        ?: throw IOException("Migrate from $name to $name")
 
     fun SChapter.getNumber() = if (chapter_number > 0) {
         chapter_number


### PR DESCRIPTION
Related to #17652 

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
