### PR TITLE
Zaimanhua: Fix crash when reading chapters due to JWT decoding error

### DIFF
--- a/src/zh/zaimanhua/build.gradle.kts
+++ b/src/zh/zaimanhua/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Zaimanhua"
-    versionCode = 18
+    versionCode = 19
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/zh/zaimanhua/src/eu/kanade/tachiyomi/extension/zh/zaimanhua/Zaimanhua.kt
+++ b/src/zh/zaimanhua/src/eu/kanade/tachiyomi/extension/zh/zaimanhua/Zaimanhua.kt
@@ -134,7 +134,7 @@ abstract class Zaimanhua :
         if (token.isBlank()) return false
         val parts = token.split(".")
         if (parts.size != 3) throw Exception("token格式错误，不符合JWT规范")
-        val payload = Base64.decode(parts[1], Base64.DEFAULT).toString(Charsets.UTF_8).parseAs<JwtPayload>()
+        val payload = Base64.decode(parts[1], Base64.URL_SAFE or Base64.NO_WRAP).toString(Charsets.UTF_8).parseAs<JwtPayload>()
         if (payload.expirationTime * 1000 < System.currentTimeMillis()) return false
 
         val response = client.newCall(


### PR DESCRIPTION
Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

---

### Issue
Crash when opening a chapter for reading. Log:
```
java.io.IOException: kotlinx.serialization.json.JsonDecodingException:
Unexpected JSON token at offset 98: Expected quotation mark '"', but had ' '
instead at path: $.exp
```

### Root Cause
`Zaimanhua.isValid()` decodes the JWT payload using standard Base64 (`Base64.DEFAULT`), but the JWT specification (RFC 7515) mandates **Base64url** encoding for the payload (charset `-_`, no padding).

When a token's payload, after Base64url encoding, contains `-` or `_` characters, `Base64.DEFAULT` discards these non-standard characters as illegal, causing byte misalignment in the decoded stream. The UTF-8 restoration produces garbled text (e.g., the `sub` value `散装苊 e��ZY...` in the log). Subsequently, `parseAs<JwtPayload>()` throws a `JsonDecodingException` while skipping unknown fields, causing `fetchPageList` to fail and `ReaderActivity` to crash.

Tokens with longer subjects containing Chinese usernames (e.g., "散装苊") will inevitably trigger this issue.

### Fix
Switch the payload decoding to Base64url mode:
`Base64.URL_SAFE or Base64.NO_WRAP`.

`android.util.Base64` is inherently tolerant of unpadded input, avoiding the pitfall of JDK's `java.util.Base64`, which strictly requires padding. This approach is also consistent with how JWTs are handled in other extensions within the repository (e.g., `src/fr/ono`).

### Changes
- `Zaimanhua.kt`: JWT payload decoding `Base64.DEFAULT` → `Base64.URL_SAFE or Base64.NO_WRAP`
- `build.gradle.kts`: `versionCode` 18 → 19