### PR TITLE
RizzComic: Filter out discord advertisement images

### DIFF
--- a/src/en/rizzcomic/build.gradle.kts
+++ b/src/en/rizzcomic/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Rizz Comic"
-    versionCode = 13
+    versionCode = 14
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
     theme = "mangathemesia"

--- a/src/en/rizzcomic/src/eu/kanade/tachiyomi/extension/en/rizzcomic/RizzComic.kt
+++ b/src/en/rizzcomic/src/eu/kanade/tachiyomi/extension/en/rizzcomic/RizzComic.kt
@@ -27,6 +27,7 @@ import kotlin.time.Duration.Companion.seconds
 abstract class RizzComic : MangaThemesiaAlt() {
     override val mangaUrlDirectory = "/series"
     override val dateFormat = SimpleDateFormat("dd MMM yyyy", Locale.ENGLISH)
+    override val pageSelector = "div#readerarea img:not(a[href*='discord'] img)"
 
     override val client = super.client.newBuilder()
         .addInterceptor { chain ->

--- a/src/en/rizzcomic/src/eu/kanade/tachiyomi/extension/en/rizzcomic/RizzComic.kt
+++ b/src/en/rizzcomic/src/eu/kanade/tachiyomi/extension/en/rizzcomic/RizzComic.kt
@@ -27,7 +27,7 @@ import kotlin.time.Duration.Companion.seconds
 abstract class RizzComic : MangaThemesiaAlt() {
     override val mangaUrlDirectory = "/series"
     override val dateFormat = SimpleDateFormat("dd MMM yyyy", Locale.ENGLISH)
-    override val pageSelector = "div#readerarea img:not(a[href*='discord'] img)"
+    override val pageSelector = "div#readerarea > img"
 
     override val client = super.client.newBuilder()
         .addInterceptor { chain ->


### PR DESCRIPTION
While reading All Hail the Sect Leader via RizzComic extension I noticed the final page of every chapter was failing to load every time.
I checked the website and found out it's just an ad for their discord:
```
<div id="readerarea" class="rdminimal" data-size="14" style="font-size:14px !important">
  <img src="https://cdn.55779955.xyz/file/roraor/wp-content/uploads/2023/ahsl/113/01.webp">
  <img src="https://cdn.55779955.xyz/file/roraor/wp-content/uploads/2023/ahsl/113/02.webp">
  <img src="https://cdn.55779955.xyz/file/roraor/wp-content/uploads/2023/ahsl/113/03.webp">
  <img src="https://cdn.55779955.xyz/file/roraor/wp-content/uploads/2023/ahsl/113/04.webp">
  <img src="https://cdn.55779955.xyz/file/roraor/wp-content/uploads/2023/ahsl/113/05.webp">
  <img src="https://cdn.55779955.xyz/file/roraor/wp-content/uploads/2023/ahsl/113/06.webp">
  <img src="https://cdn.55779955.xyz/file/roraor/wp-content/uploads/2023/ahsl/113/07.webp">
  <a href="https://discord.com/invite/Yxhj5FbATU">
    <img src="https://cdn.rizzfables.com/wp-content/uploads/2024/08/20/66c47bc2c15dd.webp" loading="lazy">
  </a>
</div>
```

Their Discord ad image fetch is failing with HTTP status 526. Regardless of whether it loads successfully, it is not part of the chapter, so it should be no issue to exclude it from the reader.

Proposed solution:
Rather than fetching all <img> descendants under #readerarea, fetch only immediately children.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] **[N/A]** Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] **[N/A]** Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] **[N/A]** Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] **[N/A]** Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
