### PR TITLE
MangaLivre: recover obfuscated Rabbit constants

### DIFF
--- a/src/pt/mangalivre/build.gradle.kts
+++ b/src/pt/mangalivre/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Manga Livre"
-    versionCode = 85
+    versionCode = 86
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivreDecryptor.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/MangaLivreDecryptor.kt
@@ -9,7 +9,11 @@ import keiyoushi.utils.readIntBigEndian
 import keiyoushi.utils.readIntLittleEndian
 import keiyoushi.utils.stringOrNull
 import kotlinx.serialization.json.JsonElement
+import okhttp3.CacheControl
 import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import java.security.MessageDigest
 import java.time.LocalDate
@@ -21,91 +25,243 @@ class MangaLivreDecryptor(
     private val headers: Headers,
 ) {
 
-    @Volatile private var constants = Constants(DEFAULT_HOSTNAME_PART, DEFAULT_ANTIBOT_PART, DEFAULT_ENC_KEY)
+    private val baseUrlHost = baseUrl.toHttpUrl().host
+
+    @Volatile private var constants = Constants(DEFAULT_HASH_INPUT_SUFFIX, DEFAULT_ENC_KEY)
 
     private var lastReloadAt = 0L
 
-    private data class Constants(val hostPart: String, val antibotPart: String, val encKey: String)
+    private data class Constants(val hashInputSuffix: String, val encKey: String)
 
-    fun decrypt(cipherWrapperBody: String, dataKey: String): String? = runCatching {
-        val ciphertext = cipherWrapperBody.parseAs<JsonElement>()[dataKey]?.stringOrNull
-            ?: return@runCatching null
-        decryptRabbit(ciphertext, derivePassword()).takeIf { it.isValidJson() }
+    private class Payload(val salt: ByteArray, val ciphertext: ByteArray)
+
+    fun decrypt(cipherWrapperBody: String, dataKey: String): String? = cipherWrapperBody.toPayload(dataKey)?.decrypt(constants)
+
+    fun reloadConstantsAndDecrypt(readerPath: String, cipherWrapperBody: String, dataKey: String): String? {
+        val payload = cipherWrapperBody.toPayload(dataKey) ?: return null
+        synchronized(this) {
+            payload.decrypt(constants)?.let { return it }
+
+            val now = System.currentTimeMillis()
+            if (now - lastReloadAt < RELOAD_COOLDOWN_MS) return null
+            lastReloadAt = now
+
+            for (scriptUrl in fetchScriptUrls(readerPath)) {
+                val reloaded = fetchScript(scriptUrl)?.extractConstants(payload) ?: continue
+                constants = reloaded
+                return payload.decrypt(reloaded)
+            }
+        }
+        return null
+    }
+
+    private fun fetchScriptUrls(readerPath: String): List<HttpUrl> = runCatching {
+        val request = GET(baseUrl + readerPath, headers).newBuilder()
+            .cacheControl(CacheControl.FORCE_NETWORK)
+            .build()
+        client.newCall(request).execute().use { it.asJsoup() }
+            .select("script[src]")
+            .mapNotNull { it.absUrl("src").toHttpUrlOrNull() }
+            .filter { it.host == baseUrlHost }
+            .distinct()
+            .sortedBy { if (it.pathSegments.last().startsWith(BUNDLE_NAME_PREFIX)) 0 else 1 }
+            .take(MAX_BUNDLE_CANDIDATES)
+    }.getOrDefault(emptyList())
+
+    private fun fetchScript(scriptUrl: HttpUrl): String? = runCatching {
+        client.newCall(GET(scriptUrl, headers)).execute().use { response ->
+            response.takeIf { it.isSuccessful }?.body?.string()
+        }
     }.getOrNull()
 
-    fun reloadConstants(readerPath: String) {
-        synchronized(this) {
-            val now = System.currentTimeMillis()
-            if (now - lastReloadAt < RELOAD_COOLDOWN_MS) return
-            val reloaded = runCatching {
-                val indexJsUrl = client.newCall(GET(baseUrl + readerPath, headers)).execute()
-                    .asJsoup()
-                    .selectFirst("script[src*=index]")
-                    ?.absUrl("src")
-                    ?: return@runCatching null
-                client.newCall(GET(indexJsUrl, headers)).execute().use { it.body.string() }
-                    .extractConstants()
-            }.getOrNull() ?: return
-
-            constants = reloaded
-            lastReloadAt = now
+    private fun String.extractConstants(payload: Payload): Constants? {
+        for (values in constantValueVariants()) {
+            values.asConstantCandidates()
+                .firstOrNull { payload.looksDecryptable(it) && payload.decrypt(it) != null }
+                ?.let { return it }
         }
+        return legacyConstants()?.takeIf { payload.decrypt(it) != null }
     }
 
-    private fun String.extractConstants(): Constants? {
-        extractDirectConstants()?.let { return it }
+    /**
+     * Ordered value lists to build candidate constants from, cheapest first.
+     *
+     * The scopes around the hash call cover constants kept as plain literals. Obfuscated ones do
+     * not need an anchor at all: values that decode to printable ASCII are rare enough to be
+     * collected from the whole script, so the recovery survives the call site being rewritten.
+     */
+    private fun String.constantValueVariants(): Sequence<List<String>> = sequence {
+        for (call in SHA256_CALL_REGEX.findAll(this@constantValueVariants).take(MAX_SHA256_CALL_SITES)) {
+            yieldAll(scopeValues(call.range.first))
+        }
+        yield(decodedValues())
+    }
+
+    private fun String.legacyConstants(): Constants? {
         val legacy = EV_CONSTANTS_REGEX.find(this)
-        val hostPart = ENV_HOST_REGEX.find(this)?.groupValues?.get(1) ?: legacy?.groupValues?.get(1)
-        val antibotPart = ENV_ANTIBOT_REGEX.find(this)?.groupValues?.get(1) ?: legacy?.groupValues?.get(2)
-        val encKey = ENV_ENCRYPTION_REGEX.find(this)?.groupValues?.get(1) ?: legacy?.groupValues?.get(3)
-        return if (hostPart != null && antibotPart != null && encKey != null) {
-            Constants(hostPart, antibotPart, encKey)
-        } else {
-            null
+        val hostPart = ENV_HOST_REGEX.find(this)?.groupValues?.get(1)
+            ?: legacy?.groupValues?.get(1)
+            ?: return null
+        val antibotPart = ENV_ANTIBOT_REGEX.find(this)?.groupValues?.get(1)
+            ?: legacy?.groupValues?.get(2)
+            ?: return null
+        val encKey = ENV_ENCRYPTION_REGEX.find(this)?.groupValues?.get(1)
+            ?: legacy?.groupValues?.get(3)
+            ?: return null
+        return Constants(hostPart + antibotPart, encKey)
+    }
+
+    private fun String.scopeValues(hashIndex: Int): List<List<String>> {
+        val searchStart = maxOf(0, hashIndex - FUNCTION_SEARCH_WINDOW)
+        val arrowBlock = ARROW_BLOCK_REGEX.findAll(substring(searchStart, hashIndex)).lastOrNull()
+        val openingBrace = arrowBlock?.range?.last?.plus(searchStart)
+        val scopeStart = openingBrace?.plus(1) ?: searchStart
+        val scopeEnd = openingBrace?.let { findMatchingBrace(it) }
+            ?: minOf(length, hashIndex + FUNCTION_TAIL_WINDOW)
+        val scope = substring(scopeStart, scopeEnd)
+
+        val values = buildList {
+            STRING_LITERAL_REGEX.findAll(scope).forEach { match ->
+                add(match.range.first to match.groupValues[1].ifEmpty { match.groupValues[2] })
+            }
+            BYTE_SEQUENCE_REGEX.findAll(scope).forEach { match ->
+                match.decodeByteSequence()?.let { add(match.range.first to it) }
+            }
+        }.inSourceOrder()
+
+        // Candidates are built from contiguous runs, so a decoded value cannot simply be appended
+        // next to its encoded form. Each decoding is a separate ordered variant.
+        return listOf(values, values.map { it.decodeHexAscii() ?: it })
+            .map { it.asConstantValues() }
+            .filter { it.isNotEmpty() }
+            .distinct()
+    }
+
+    private fun String.decodedValues(): List<String> = buildList {
+        HEX_LITERAL_REGEX.findAll(this@decodedValues).forEach { match ->
+            match.groupValues[1].ifEmpty { match.groupValues[2] }
+                .decodeHexAscii()
+                ?.let { add(match.range.first to it) }
+        }
+        BYTE_SEQUENCE_REGEX.findAll(this@decodedValues).forEach { match ->
+            match.decodeByteSequence()?.let { add(match.range.first to it) }
+        }
+    }.inSourceOrder().asConstantValues()
+
+    private fun List<Pair<Int, String>>.inSourceOrder(): List<String> = sortedBy { it.first }.map { it.second }
+
+    private fun List<String>.asConstantValues(): List<String> = filter { it.isConstantCandidate() }.distinct().take(MAX_CONSTANT_VALUES)
+
+    private fun String.findMatchingBrace(openingBrace: Int): Int? {
+        var depth = 0
+        var quote: Char? = null
+        var escaped = false
+
+        for (index in openingBrace until length) {
+            val char = this[index]
+            if (quote != null) {
+                when {
+                    escaped -> escaped = false
+                    char == '\\' -> escaped = true
+                    char == quote -> quote = null
+                }
+                continue
+            }
+
+            when (char) {
+                '\'', '"', '`' -> quote = char
+                '{' -> depth++
+                '}' -> if (--depth == 0) return index
+            }
+        }
+        return null
+    }
+
+    private fun MatchResult.decodeByteSequence(): String? {
+        val tokens = groupValues[1].split(',')
+        val codes = tokens.mapNotNull { token ->
+            val trimmed = token.trim()
+            val code = if (trimmed.startsWith("0x", ignoreCase = true)) {
+                trimmed.drop(2).toIntOrNull(16)
+            } else {
+                trimmed.toIntOrNull()
+            }
+            code?.takeIf { it in PRINTABLE_ASCII_RANGE }
+        }
+        return codes.takeIf { it.size == tokens.size }
+            ?.map(Int::toChar)
+            ?.joinToString("")
+    }
+
+    private fun String.isConstantCandidate(): Boolean = length in MIN_CONSTANT_LENGTH..MAX_CONSTANT_LENGTH && all { it.code in PRINTABLE_ASCII_RANGE }
+
+    private fun String.decodeHexAscii(): String? {
+        if (length < MIN_HEX_LENGTH || length % 2 != 0) return null
+        val codes = chunked(2).map { it.toIntOrNull(16) ?: return null }
+        return codes.takeIf { it.all { code -> code in PRINTABLE_ASCII_RANGE } }
+            ?.map(Int::toChar)
+            ?.joinToString("")
+    }
+
+    private fun List<String>.asConstantCandidates(): Sequence<Constants> = sequence {
+        for (start in indices) {
+            for (end in start until size) {
+                val hashInputSuffix = subList(start, end + 1).joinToString("")
+                for (keyIndex in indices) {
+                    if (keyIndex in start..end) continue
+                    yield(Constants(hashInputSuffix, this@asConstantCandidates[keyIndex]))
+                }
+            }
         }
     }
 
-    private fun String.extractDirectConstants(): Constants? {
-        val hashIndex = indexOf(SHA256_MARKER).takeIf { it >= 0 } ?: return null
-        val functionStart = lastIndexOf("=>{", hashIndex).takeIf { it >= 0 }
-            ?: maxOf(0, hashIndex - PASSWORD_FUNCTION_WINDOW)
-        val returnIndex = lastIndexOf("return", hashIndex).takeIf { it > functionStart } ?: return null
-        val hashInputSuffix = STRING_LITERAL_REGEX.findAll(substring(functionStart, returnIndex))
-            .map { it.groupValues[1] }
-            .filter { it.length > 2 }
-            .joinToString("")
-        val encryptionKey = STRING_LITERAL_REGEX.find(substring(returnIndex, hashIndex))
-            ?.groupValues?.get(1)
-            .orEmpty()
-        return if (hashInputSuffix.isNotEmpty() && encryptionKey.isNotEmpty()) {
-            Constants(hashInputSuffix, "", encryptionKey)
-        } else {
-            null
+    private fun String.toPayload(dataKey: String): Payload? = runCatching {
+        val ciphertextB64 = parseAs<JsonElement>()[dataKey]?.stringOrNull ?: return null
+        val encrypted = Base64.decode(ciphertextB64, Base64.DEFAULT)
+        Payload(encrypted.copyOfRange(8, 16), encrypted.copyOfRange(16, encrypted.size))
+    }.getOrNull()
+
+    private fun Payload.decrypt(constants: Constants): String? {
+        val today = LocalDate.now(ZoneOffset.UTC)
+        for (offset in DATE_OFFSETS) {
+            val plaintext = String(decryptRabbit(derivePassword(today.plusDays(offset), constants)), Charsets.UTF_8)
+            if (plaintext.isValidJson()) return plaintext
+        }
+        return null
+    }
+
+    private fun Payload.looksDecryptable(constants: Constants): Boolean {
+        val today = LocalDate.now(ZoneOffset.UTC)
+        return DATE_OFFSETS.any { offset ->
+            decryptRabbit(derivePassword(today.plusDays(offset), constants), PREVIEW_LENGTH).looksLikeJson()
         }
     }
+
+    private fun Payload.decryptRabbit(password: String, maxBytes: Int = Int.MAX_VALUE): ByteArray {
+        val (key, iv) = evpBytesToKey(password.toByteArray(), salt)
+        val plaintext = ciphertext.copyOf(minOf(maxBytes, ciphertext.size))
+        Rabbit().apply { setup(key, iv) }.crypt(plaintext)
+        return plaintext
+    }
+
+    private fun ByteArray.looksLikeJson(): Boolean {
+        val start = indexOfFirst { !it.isJsonWhitespace() }.takeIf { it >= 0 } ?: return false
+        return (this[start] == '{'.code.toByte() || this[start] == '['.code.toByte()) && all { it.isJsonText() }
+    }
+
+    private fun Byte.isJsonWhitespace(): Boolean = toInt() in JSON_WHITESPACE
+
+    private fun Byte.isJsonText(): Boolean = (toInt() and 0xFF) >= 0x20 || isJsonWhitespace()
 
     private fun String.isValidJson(): Boolean = runCatching { parseAs<JsonElement>() }.isSuccess
 
-    private fun decryptRabbit(ciphertextB64: String, password: String): String {
-        val encrypted = Base64.decode(ciphertextB64, Base64.DEFAULT)
-        val salt = encrypted.copyOfRange(8, 16)
-        val ciphertext = encrypted.copyOfRange(16, encrypted.size)
-
-        val (key, iv) = evpBytesToKey(password.toByteArray(), salt)
-        val plaintext = ciphertext.copyOf()
-        Rabbit().apply { setup(key, iv) }.crypt(plaintext)
-
-        return String(plaintext, Charsets.UTF_8)
-    }
-
-    private fun derivePassword(date: String = LocalDate.now(ZoneOffset.UTC).toString()): String {
-        val c = constants
-        val toHash = "$date${c.hostPart}${c.antibotPart}"
+    private fun derivePassword(date: LocalDate, constants: Constants): String {
+        val toHash = "$date${constants.hashInputSuffix}"
         val hashPart = MessageDigest.getInstance("SHA-256")
             .digest(toHash.toByteArray())
             .joinToString("") { "%02x".format(it) }
             .substring(0, 8)
-        return c.encKey + hashPart
+        return constants.encKey + hashPart
     }
 
     private fun evpBytesToKey(password: ByteArray, salt: ByteArray, keyLen: Int = 16, ivLen: Int = 8): Pair<ByteArray, ByteArray> {
@@ -127,14 +283,30 @@ class MangaLivreDecryptor(
     }
 
     companion object {
-        private const val DEFAULT_HOSTNAME_PART = "toonlivre.net::w3"
-        private const val DEFAULT_ANTIBOT_PART = "r7_5m2_k"
-        private const val DEFAULT_ENC_KEY = "Phantom-Tide-Harvest8"
+        private const val DEFAULT_HASH_INPUT_SUFFIX = "toonlivre.net::y8q2_4k9_w"
+        private const val DEFAULT_ENC_KEY = "Vortex-Blade-Nexus4"
 
         private const val RELOAD_COOLDOWN_MS = 30_000L
-        private const val PASSWORD_FUNCTION_WINDOW = 2_000
-        private const val SHA256_MARKER = ".SHA256("
-        private val STRING_LITERAL_REGEX = Regex("""["']([^"']*)["']""")
+        private const val FUNCTION_SEARCH_WINDOW = 4_000
+        private const val FUNCTION_TAIL_WINDOW = 1_000
+        private const val MAX_BUNDLE_CANDIDATES = 8
+        private const val MAX_SHA256_CALL_SITES = 8
+        private const val MAX_CONSTANT_VALUES = 12
+        private const val MIN_CONSTANT_LENGTH = 3
+        private const val MAX_CONSTANT_LENGTH = 128
+        private const val MIN_HEX_LENGTH = 6
+        private const val PREVIEW_LENGTH = 64
+        private const val BUNDLE_NAME_PREFIX = "index-"
+        private val PRINTABLE_ASCII_RANGE = 0x20..0x7E
+        private val JSON_WHITESPACE = listOf(0x09, 0x0A, 0x0D, 0x20)
+        private val DATE_OFFSETS = longArrayOf(0, -1, 1)
+        private val ARROW_BLOCK_REGEX = Regex("""=>\s*\{""")
+        private val SHA256_CALL_REGEX = Regex("""(?:\.|\[\s*["'])SHA256""")
+        private val STRING_LITERAL_REGEX = Regex(""""([^"\\]*)"|'([^'\\]*)'""")
+        private val HEX_LITERAL_REGEX = Regex(""""([\da-fA-F]{$MIN_HEX_LENGTH,})"|'([\da-fA-F]{$MIN_HEX_LENGTH,})'""")
+        private val BYTE_SEQUENCE_REGEX = Regex(
+            """(?:\[\s*|\(\s*)((?:(?:0[xX][\da-fA-F]+|\d{1,3})\s*,\s*){2,}(?:0[xX][\da-fA-F]+|\d{1,3}))\s*[\])]""",
+        )
 
         private val EV_CONSTANTS_REGEX = Regex(
             """toISOString\(\)\.split\("T"\)\[0]\s*,\s*\w+\s*=\s*"([^"]+)"\s*,\s*\w+\s*=\s*"([^"]+)"\s*,\s*\w+\s*=\s*"([^"]+)""",

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/ReadingGateInterceptor.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/ReadingGateInterceptor.kt
@@ -26,38 +26,33 @@ class ReadingGateInterceptor(
         if (request.url.host != baseUrlHost) {
             return chain.proceed(request)
         }
-        return proceedDecrypted(chain, request, seedRetried = false, decryptReloaded = false)
+        return proceedDecrypted(chain, request, seedRetried = false)
     }
 
     private fun proceedDecrypted(
         chain: Interceptor.Chain,
         request: Request,
         seedRetried: Boolean,
-        decryptReloaded: Boolean,
     ): Response {
         val response = chain.proceed(request.withSignature(forceRefresh = seedRetried))
 
-        if (response.code == 403) {
-            if (seedRetried) return response
+        if (response.code == 403 && !seedRetried) {
             response.close()
-            return proceedDecrypted(chain, request, seedRetried = true, decryptReloaded)
+            return proceedDecrypted(chain, request, seedRetried = true)
         }
 
         val dataKey = response.headers["x-toon-datakey"] ?: return response
 
         val contentType = response.body.contentType()
-        val decrypted = decryptor.decrypt(response.body.string(), dataKey)
-        if (decrypted != null) {
-            return response.newBuilder()
-                .body(decrypted.toResponseBody(contentType))
-                .build()
-        }
-
-        response.close()
-        if (decryptReloaded) throw IOException(NON_JSON_MESSAGE)
+        val cipherWrapperBody = response.body.string()
         val readerPath = request.tag(ReaderPath::class.java)?.path ?: "/"
-        decryptor.reloadConstants(readerPath)
-        return proceedDecrypted(chain, request, seedRetried, decryptReloaded = true)
+        val decrypted = decryptor.decrypt(cipherWrapperBody, dataKey)
+            ?: decryptor.reloadConstantsAndDecrypt(readerPath, cipherWrapperBody, dataKey)
+            ?: throw IOException(NON_JSON_MESSAGE)
+
+        return response.newBuilder()
+            .body(decrypted.toResponseBody(contentType))
+            .build()
     }
 
     private fun Request.withSignature(forceRefresh: Boolean): Request = newBuilder()


### PR DESCRIPTION
Closes #17874

## Root cause

The site moved the Rabbit password constants into numeric arrays decoded at runtime via `String.fromCharCode`:

```js
o=Z0([116,111,111,110,...]),i=Z0([109,51,...]),l=Z0([83,111,108,...]),u=[n,o,i].join(""),f=Gi.SHA256(u)...
```

The extractor added in #17846 only looked at string literals, so it recovered nothing and every chapter failed with `Não foi possível decifrar a resposta`.

## Changes

- Collect both string literals and numeric/hex byte sequences from the scope around the `.SHA256(` call, build candidate passwords from contiguous runs, and accept only the candidate that actually decrypts the response. Guessing is bounded by the payload itself, so a new obfuscation shape does not need a new regex.
- Screen candidates against a 64-byte prefix before decrypting in full. The exhaustive worst case is ~180 ms regardless of chapter size; previously every candidate decrypted the whole payload.
- Decrypt the response already in hand after a reload instead of re-issuing the request, which also removes a retry parameter from the interceptor.
- Apply the reload cooldown per attempt so a site-side breakage cannot trigger a full asset scan on every chapter.
- Fetch the reader HTML with `FORCE_NETWORK` and the bundles through the normal cache, since bundle URLs are content-hashed. This halves the requests a reload needs.
- Tolerate a one-day UTC difference, so responses served from the OkHttp cache across a date boundary still decrypt.
- Update the fallback constants to the ones currently served.

The existing `VITE_*` and legacy extractors are kept as fallbacks.

## Validation

- `:src:pt:mangalivre:clean :spotlessCheck :assembleDebug :assembleRelease`
- Live on-device run after clearing all Mihon data: catalog, details, and *O Começo Depois do Fim* chapter 245 rendered (`1 / 14`), with no error in logcat.
- Also exercised the real classes against a local server with generated `crypto-js` payloads, covering recovery from the byte-array, string-literal, and `VITE_*` formats, a 400-page payload, the cooldown, the 403 seed refresh, and the date tolerance.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code) — not a theme change
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed — neither changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension — not a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop