### PR TITLE
Noyacg: update to extlib 1.6

### DIFF
--- a/src/zh/noyacg/build.gradle.kts
+++ b/src/zh/noyacg/build.gradle.kts
@@ -6,12 +6,17 @@ plugins {
 
 keiyoushi {
     name = "NoyAcg"
-    versionCode = 4
-    contentWarning = ContentWarning.NSFW // or MIXED, please confirm
-    libVersion = "1.4"
+    versionCode = 5
+    contentWarning = ContentWarning.MIXED
+    libVersion = "1.6"
 
     source {
         lang = "zh"
         baseUrl = "https://beta.noyteam.online"
+    }
+
+    deeplink {
+        host("beta.noyteam.online")
+        path("/manga/..*")
     }
 }

--- a/src/zh/noyacg/build.gradle.kts
+++ b/src/zh/noyacg/build.gradle.kts
@@ -11,8 +11,14 @@ keiyoushi {
     libVersion = "1.6"
 
     source {
-        lang = "zh"
-        baseUrl = "https://beta.noyteam.online"
+        lang = "zh-Hant"
+        baseUrl {
+            mirrors(
+                "https://api.noyteam.online",
+                "https://api.noymanga.com",
+                "https://api.noy.asia",
+            )
+        }
     }
 
     deeplink {

--- a/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/Dto.kt
+++ b/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/Dto.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.extension.zh.noyacg
 import eu.kanade.tachiyomi.source.model.SManga
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -13,20 +14,11 @@ fun String.formatAuthors() = split(" ").joinToString { name ->
     name.split("-").joinToString(" ") { word -> word.replaceFirstChar { it.uppercaseChar() } }
 }
 
-fun String.formatNames() = split(" ").joinToString()
-
 @Serializable
 class ListingPageDto(
-    val info: List<MangaDto>?,
-    val len: Int?,
     val status: String,
-)
-
-@Serializable
-class SearchPageDto(
-    val count: Int?,
-    val data: List<SearchMangaDto>?,
-    val status: String,
+    @JsonNames("info", "data") val data: List<MangaDto>?,
+    @JsonNames("len", "count") val count: Int?,
 )
 
 class MangaDetailDto(
@@ -49,33 +41,40 @@ class ChapterDto(
 
 @Serializable
 class MangaDto(
-    @SerialName("Bid") val id: Int,
-    @SerialName("Mode") val mode: Int,
-    @SerialName("Bookname") val name: String,
-    @SerialName("Description") val description: String,
-    @SerialName("Author") val author: String,
-    @SerialName("Pname") val pname: String,
-    @SerialName("Ptag") val tags: String,
-    @SerialName("Otag") val otag: String,
-    @SerialName("Time") val time: Long,
-    @SerialName("Len") val len: Int,
-    @SerialName("Status") val status: Int,
-    @SerialName("RatingSUM") val rating: Float,
+    @JsonNames("Bid", "id") val id: Int,
+    @JsonNames("Mode", "mode") val mode: Int,
+    @JsonNames("Bookname", "name") val name: String,
+    @JsonNames("Description", "description") val description: String,
+    @JsonNames("Author", "author") val author: String,
+    @JsonNames("Time", "time") val time: Long,
+    @JsonNames("Status", "status") val status: Int,
+    @JsonNames("RatingSUM", "rating_sum") val rating: Float,
+    @SerialName("Len") val len: Int?,
+    @SerialName("Pname") val pName: String?,
+    @SerialName("Ptag") val pTag: String?,
+    @SerialName("Otag") val oTag: String?,
+    val pname: List<String>?,
+    val tags: List<String>?,
+    val otag: List<String>?,
 ) {
     fun toSManga(imgBaseUrl: String) = SManga.create().also { m ->
         m.url = id.toString()
         m.title = name
         m.author = author.formatAuthors()
         m.description = formatDescription()
-        m.genre = tags.replace(" ", ", ")
+        m.genre = pTag?.replace(" ", ", ") ?: tags?.joinToString()
         m.status = if (mode == 0 || status == 1) SManga.COMPLETED else SManga.ONGOING
         m.thumbnail_url = "$imgBaseUrl/$id/m1.webp"
         m.initialized = mode == 0 || description.isNotEmpty()
     }
 
     fun formatDescription() = description.ifBlank {
-        "時間：${DATE_FORMAT.format(time * 1000)}\n评分：$rating\n原作：${otag.formatNames()}\n角色：${pname.formatNames()}"
+        "時間：${DATE_FORMAT.format(time * 1000)}\n评分：$rating\n" +
+            "原作：${oTag?.formatNames() ?: otag?.joinToString()}\n" +
+            "角色：${pName?.formatNames() ?: pname?.joinToString()}"
     }
+
+    fun String.formatNames() = split(" ").joinToString()
 }
 
 @Serializable
@@ -87,42 +86,13 @@ class RecommendMangaDto(
     @SerialName("tags") val tags: String,
     @SerialName("status") val status: Boolean,
 ) {
-    fun toSManga() = SManga.create().also { m ->
+    fun toSManga(imgBaseUrl: String) = SManga.create().also { m ->
         m.url = id.toString()
         m.title = name
         m.author = author.formatAuthors()
         m.genre = tags.replace(" ", ", ")
         m.status = if (!mode || status) SManga.COMPLETED else SManga.ONGOING
-        m.thumbnail_url = "https://img.noymanga.com/$id/m1.webp"
+        m.thumbnail_url = "$imgBaseUrl/$id/m1.webp"
         m.initialized = !mode
-    }
-}
-
-@Serializable
-class SearchMangaDto(
-    private val id: Int,
-    private val mode: Int,
-    private val name: String,
-    private val description: String,
-    private val author: String,
-    private val pname: List<String>,
-    private val tags: List<String>,
-    private val otag: List<String>,
-    private val time: Long,
-    private val status: Int,
-    @SerialName("rating_sum") private val rating: Float,
-) {
-    fun toSManga() = SManga.create().also { m ->
-        m.url = id.toString()
-        m.title = name
-        m.author = author.formatAuthors()
-        m.description = "時間：${DATE_FORMAT.format(time * 1000)}\n" +
-            "评分：$rating\n" +
-            "原作：${otag.joinToString()}\n" +
-            "角色：${pname.joinToString()}" + (description.takeIf(CharSequence::isNotEmpty)?.let { "\n---\n$it" } ?: "")
-        m.genre = tags.joinToString()
-        m.status = if (mode == 0 || status == 1) SManga.COMPLETED else SManga.ONGOING
-        m.thumbnail_url = "https://img.noymanga.com/$id/m1.webp"
-        m.initialized = mode == 0 || description.isNotEmpty()
     }
 }

--- a/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/Dto.kt
+++ b/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/Dto.kt
@@ -9,9 +9,11 @@ import java.util.Locale
 const val LISTING_PAGE_SIZE = 20
 val DATE_FORMAT = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH)
 
-fun String.formatNames() = split(" ").joinToString { name ->
+fun String.formatAuthors() = split(" ").joinToString { name ->
     name.split("-").joinToString(" ") { word -> word.replaceFirstChar { it.uppercaseChar() } }
 }
+
+fun String.formatNames() = split(" ").joinToString()
 
 @Serializable
 class ListingPageDto(
@@ -30,7 +32,8 @@ class SearchPageDto(
 class MangaDetailDto(
     val status: String,
     val book: MangaDto?,
-    val chapters: List<Pair<String, List<ChapterDto>>>?,
+    val recommend: List<RecommendMangaDto>?,
+    val chapters: Map<String, List<ChapterDto>>?,
 )
 
 @Serializable
@@ -59,41 +62,60 @@ class MangaDto(
     @SerialName("Status") val status: Int,
     @SerialName("RatingSUM") val rating: Float,
 ) {
-    fun toSManga() = SManga.create().also { m ->
+    fun toSManga(imgBaseUrl: String) = SManga.create().also { m ->
         m.url = id.toString()
         m.title = name
-        m.author = author.formatNames()
+        m.author = author.formatAuthors()
         m.description = formatDescription()
         m.genre = tags.replace(" ", ", ")
         m.status = if (mode == 0 || status == 1) SManga.COMPLETED else SManga.ONGOING
-        m.thumbnail_url = "https://img.noymanga.com/$id/m1.webp"
+        m.thumbnail_url = "$imgBaseUrl/$id/m1.webp"
         m.initialized = mode == 0 || description.isNotEmpty()
     }
 
-    fun formatDescription() = "時間：${DATE_FORMAT.format(time * 1000)}\n" +
-        "评分：$rating\n" +
-        "原作：${otag.formatNames()}\n" +
-        "角色：${pname.formatNames()}" + (description.takeIf(CharSequence::isNotEmpty)?.let { "\n---\n$it" } ?: "")
+    fun formatDescription() = description.ifBlank {
+        "時間：${DATE_FORMAT.format(time * 1000)}\n评分：$rating\n原作：${otag.formatNames()}\n角色：${pname.formatNames()}"
+    }
+}
+
+@Serializable
+class RecommendMangaDto(
+    @SerialName("bid") val id: Int,
+    @SerialName("mode") val mode: Boolean,
+    @SerialName("bookname") val name: String,
+    @SerialName("author") val author: String,
+    @SerialName("tags") val tags: String,
+    @SerialName("status") val status: Boolean,
+) {
+    fun toSManga() = SManga.create().also { m ->
+        m.url = id.toString()
+        m.title = name
+        m.author = author.formatAuthors()
+        m.genre = tags.replace(" ", ", ")
+        m.status = if (!mode || status) SManga.COMPLETED else SManga.ONGOING
+        m.thumbnail_url = "https://img.noymanga.com/$id/m1.webp"
+        m.initialized = !mode
+    }
 }
 
 @Serializable
 class SearchMangaDto(
     private val id: Int,
+    private val mode: Int,
     private val name: String,
     private val description: String,
     private val author: String,
-    private val tags: List<String>,
     private val pname: List<String>,
+    private val tags: List<String>,
     private val otag: List<String>,
     private val time: Long,
-    private val mode: Int,
     private val status: Int,
     @SerialName("rating_sum") private val rating: Float,
 ) {
     fun toSManga() = SManga.create().also { m ->
         m.url = id.toString()
         m.title = name
-        m.author = author.formatNames()
+        m.author = author.formatAuthors()
         m.description = "時間：${DATE_FORMAT.format(time * 1000)}\n" +
             "评分：$rating\n" +
             "原作：${otag.joinToString()}\n" +

--- a/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/Dto.kt
+++ b/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/Dto.kt
@@ -17,15 +17,15 @@ fun String.formatAuthors() = split(" ").joinToString { name ->
 @Serializable
 class ListingPageDto(
     val status: String,
-    @JsonNames("info", "data") val data: List<MangaDto>?,
-    @JsonNames("len", "count") val count: Int?,
+    @JsonNames("info", "data") val data: List<MangaDto>,
+    @JsonNames("len", "count") val count: Int,
 )
 
 class MangaDetailDto(
     val status: String,
-    val book: MangaDto?,
-    val recommend: List<RecommendMangaDto>?,
-    val chapters: Map<String, List<ChapterDto>>?,
+    val book: MangaDto,
+    val recommend: List<RecommendMangaDto>,
+    val chapters: Map<String, List<ChapterDto>>,
 )
 
 @Serializable

--- a/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/Filters.kt
+++ b/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/Filters.kt
@@ -4,11 +4,7 @@ import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import okhttp3.FormBody
 
-fun getFilterListInternal() = FilterList(
-    SearchTypeFilter(),
-    SortFilter(),
-    StatusFilter(),
-)
+fun buildFilterList() = FilterList(SearchTypeFilter(), SortFilter(), StatusFilter())
 
 interface SearchFilter {
     fun addTo(builder: FormBody.Builder)

--- a/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/Filters.kt
+++ b/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/Filters.kt
@@ -19,7 +19,7 @@ class SearchTypeFilter :
 }
 
 class SortFilter :
-    Filter.Select<String>("排序方式", arrayOf("預設", "觀看次數", "收藏", "評分")),
+    Filter.Select<String>("排序方式", arrayOf("時間", "閲讀", "收藏", "評分")),
     SearchFilter {
     override fun addTo(builder: FormBody.Builder) {
         builder.addEncoded("sort", arrayOf("", "views", "favorites", "rating")[state])

--- a/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/NoyAcg.kt
+++ b/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/NoyAcg.kt
@@ -65,8 +65,8 @@ abstract class NoyAcg :
     private fun mangaPageParse(response: Response, page: Int): MangasPage {
         val result = response.parseAs<ListingPageDto>()
         if (result.status != "ok") throw Exception("請在 WebView 中登入")
-        val mangas = result.info!!.map { it.toSManga(imgBaseUrl) }
-        return MangasPage(mangas, page * LISTING_PAGE_SIZE < result.len!!)
+        val mangas = result.data!!.map { it.toSManga(imgBaseUrl) }
+        return MangasPage(mangas, page * LISTING_PAGE_SIZE < result.count!!)
     }
 
     // Popular
@@ -94,10 +94,7 @@ abstract class NoyAcg :
         val body = FormBody.Builder().addEncoded("value", query).addEncoded("page", page.toString()).addEncoded("type", "book")
         filters.filterIsInstance<SearchFilter>().forEach { it.addTo(body) }
         val response = client.post("$baseUrl/api/v4/search/fetch", body.build())
-        val result = response.parseAs<SearchPageDto>()
-        if (result.status != "ok") throw Exception("請在 WebView 中登入")
-        val mangas = result.data!!.map(SearchMangaDto::toSManga)
-        return MangasPage(mangas, page * LISTING_PAGE_SIZE < result.count!!)
+        return mangaPageParse(response, page)
     }
 
     // Manga & Chapters
@@ -106,8 +103,12 @@ abstract class NoyAcg :
 
     override fun getChapterUrl(chapter: SChapter) = "$baseUrl/reader/${chapter.url}"
 
-    override suspend fun getMangaByUrl(url: HttpUrl) = url.pathSegments.last().toIntOrNull()?.let {
-        client.get("$baseUrl/api/v4/book/$it?comment=false").parseManga().book!!.toSManga(imgBaseUrl)
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+        return url.pathSegments.last().toIntOrNull()?.let {
+            val comic = client.get("$baseUrl/api/v4/book/$it?comment=false").parseManga()
+            if (comic.status != "ok") throw Exception("請在 WebView 中登入")
+            comic.book!!.toSManga(imgBaseUrl)
+        }
     }
 
     override suspend fun fetchMangaUpdate(
@@ -142,6 +143,7 @@ abstract class NoyAcg :
                         date_upload = it.createdAt * 1000
                         // chapter_number = it.sort.toFloat()
                         scanlator = category.key
+                        memo = buildJsonObject { put("size", it.count) }
                     }
                 }.reversed()
             }
@@ -152,7 +154,7 @@ abstract class NoyAcg :
 
     override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> {
         val comic = client.get("$baseUrl/api/v4/book/${manga.url}?comment=false").parseManga()
-        return comic.recommend?.map(RecommendMangaDto::toSManga) ?: emptyList()
+        return comic.recommend?.map { it.toSManga(imgBaseUrl) } ?: emptyList()
     }
 
     // Pages

--- a/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/NoyAcg.kt
+++ b/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/NoyAcg.kt
@@ -2,170 +2,167 @@ package eu.kanade.tachiyomi.extension.zh.noyacg
 
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import keiyoushi.annotation.Source
+import keiyoushi.network.get
+import keiyoushi.network.post
+import keiyoushi.source.KeiSource
+import keiyoushi.utils.array
+import keiyoushi.utils.getObjectOrNull
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.getStringOrNull
+import keiyoushi.utils.int
+import keiyoushi.utils.obj
 import keiyoushi.utils.parseAs
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import okhttp3.FormBody
+import okhttp3.Headers
+import okhttp3.HttpUrl
 import okhttp3.Request
 import okhttp3.Response
-import rx.Observable
 
 @Source
 abstract class NoyAcg :
-    HttpSource(),
+    KeiSource(),
     ConfigurableSource {
 
-    override val supportsLatest = true
+    private val pref by getPreferencesLazy()
+    private val imgBaseUrl get() = pref.getString(IMG_HOSTING_PREF, "https://img.noymanga.com")!!
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         getPreferencesInternal(screen.context).forEach(screen::addPreference)
     }
 
-    private val pref by getPreferencesLazy()
+    override fun Headers.Builder.configureHeaders() = apply {
+        set("User-Agent", "NoyAcg/3.0")
+        add("allow-adult", pref.getString(ADULT_PREF, "both")!!)
+    }
 
-    override fun headersBuilder() = super.headersBuilder().add("referer", "$baseUrl/")
-        .add("allow-adult", pref.getString(ADULT_PREF, "both")!!)
-
-    private fun Response.parseMangaDetail(): MangaDetailDto {
+    private fun Response.parseManga(): MangaDetailDto {
         val jsonObject = parseAs<JsonObject>()
-        val status = jsonObject["status"]?.jsonPrimitive?.contentOrNull ?: "error"
-        val book = jsonObject["book"]?.jsonObject?.get("info")?.parseAs<MangaDto>()
-        val categories = jsonObject["chapters"]?.jsonObject?.get("categories")?.jsonArray?.map { it.parseAs<CategoryDto>() } ?: emptyList()
+        val status = jsonObject.getStringOrNull("status") ?: "error"
+        val book = jsonObject.getObjectOrNull("book")
+        val info = book?.get("info")?.parseAs<MangaDto>()
+        val recommend = book?.get("recommend")?.parseAs<List<RecommendMangaDto>>()
+        val categories = jsonObject["chapters"]?.obj?.get("categories")?.array?.map { it.parseAs<CategoryDto>() } ?: emptyList()
         val chaptersMap = mutableMapOf<Int, List<ChapterDto>>()
-        jsonObject["chapters"]?.jsonObject?.get("data")?.jsonObject?.forEach { (key, value) ->
-            key.toIntOrNull()?.let { categoryId ->
-                chaptersMap[categoryId] = value.jsonArray.map { it.parseAs<ChapterDto>() }
-            }
+        jsonObject["chapters"]?.obj?.get("data")?.obj?.forEach { (key, value) ->
+            key.toIntOrNull()?.let { categoryId -> chaptersMap[categoryId] = value.array.map { it.parseAs<ChapterDto>() } }
         }
-        val chapters = categories.map { category ->
-            category.name to (chaptersMap[category.id] ?: emptyList())
-        }
-        return MangaDetailDto(status, book, chapters)
+        val chapters = categories.associate { category -> category.name to (chaptersMap[category.id] ?: emptyList()) }
+        return MangaDetailDto(status, info, recommend, chapters)
+    }
+
+    private fun mangaPageParse(response: Response, page: Int): MangasPage {
+        val result = response.parseAs<ListingPageDto>()
+        if (result.status != "ok") throw Exception("請在 WebView 中登入")
+        val mangas = result.info!!.map { it.toSManga(imgBaseUrl) }
+        return MangasPage(mangas, page * LISTING_PAGE_SIZE < result.len!!)
     }
 
     // Popular
 
-    override fun popularMangaRequest(page: Int): Request {
+    override suspend fun getPopularManga(page: Int): MangasPage {
         val type = pref.getString(POPULAR_MANGAS_PREF, "day")!!
         val body = FormBody.Builder().addEncoded("type", type).addEncoded("page", page.toString())
-        return POST("$baseUrl/api/readLeaderboard#$page", headers, body.build())
+        val response = client.post("$baseUrl/api/readLeaderboard", body.build())
+        return mangaPageParse(response, page)
     }
 
-    override fun popularMangaParse(response: Response): MangasPage {
-        val result = response.parseAs<ListingPageDto>()
-        check(result.status == "ok") { throw Exception("請在 WebView 中登入") }
-        val page = response.request.url.fragment!!.toInt()
-        val mangas = result.info!!.map(MangaDto::toSManga)
-        return MangasPage(mangas, page * LISTING_PAGE_SIZE < result.len!!)
-    }
+    // Updates
 
-    // Latest Updates
-
-    override fun latestUpdatesRequest(page: Int): Request {
+    override suspend fun getLatestUpdates(page: Int): MangasPage {
         val body = FormBody.Builder().addEncoded("page", page.toString()).addEncoded("sort", "new")
-        return POST("$baseUrl/api/b1/booklist#$page", headers, body.build())
+        val response = client.post("$baseUrl/api/b1/booklist", body.build())
+        return mangaPageParse(response, page)
     }
-
-    override fun latestUpdatesParse(response: Response) = popularMangaParse(response)
 
     // Search
 
-    override fun getFilterList() = getFilterListInternal()
+    override fun getFilterList(data: JsonElement?) = buildFilterList()
 
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        val body = FormBody.Builder().addEncoded("value", query)
-            .addEncoded("page", page.toString())
-            .addEncoded("type", "book")
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
+        val body = FormBody.Builder().addEncoded("value", query).addEncoded("page", page.toString()).addEncoded("type", "book")
         filters.filterIsInstance<SearchFilter>().forEach { it.addTo(body) }
-        return POST("$baseUrl/api/v4/search/fetch#$page", headers, body.build())
-    }
-
-    override fun searchMangaParse(response: Response): MangasPage {
+        val response = client.post("$baseUrl/api/v4/search/fetch", body.build())
         val result = response.parseAs<SearchPageDto>()
-        check(result.status == "ok") { throw Exception("請在 WebView 中登入") }
-        val page = response.request.url.fragment!!.toInt()
+        if (result.status != "ok") throw Exception("請在 WebView 中登入")
         val mangas = result.data!!.map(SearchMangaDto::toSManga)
         return MangasPage(mangas, page * LISTING_PAGE_SIZE < result.count!!)
     }
 
-    // Manga
+    // Manga & Chapters
 
     override fun getMangaUrl(manga: SManga) = "$baseUrl/manga/${manga.url}"
 
-    override fun mangaDetailsRequest(manga: SManga) = GET("$baseUrl/api/v4/book/${manga.url}", headers)
-
-    override fun mangaDetailsParse(response: Response): SManga {
-        val manga = response.parseMangaDetail()
-        check(manga.status == "ok") { throw Exception("請在 WebView 中登入") }
-        return SManga.create().apply {
-            url = manga.book!!.id.toString()
-            title = manga.book.name
-            author = manga.book.author
-            description = manga.book.formatDescription()
-            genre = manga.book.tags.replace(" ", ", ")
-            status = if (manga.book.mode == 0 || manga.book.status == 1) SManga.COMPLETED else SManga.ONGOING
-        }
-    }
-
-    // Chapter
-
     override fun getChapterUrl(chapter: SChapter) = "$baseUrl/reader/${chapter.url}"
 
-    override fun chapterListRequest(manga: SManga) = mangaDetailsRequest(manga)
+    override suspend fun getMangaByUrl(url: HttpUrl) = url.pathSegments.last().toIntOrNull()?.let {
+        client.get("$baseUrl/api/v4/book/$it?comment=false").parseManga().book!!.toSManga(imgBaseUrl)
+    }
 
-    override fun chapterListParse(response: Response): List<SChapter> {
-        val manga = response.parseMangaDetail()
-        check(manga.status == "ok") { throw Exception("請在 WebView 中登入") }
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        val response = client.get("$baseUrl/api/v4/book/${manga.url}?comment=false")
+        val comic = response.parseManga()
+        if (comic.status != "ok") throw Exception("請在 WebView 中登入")
+
+        val sManga = comic.book!!.toSManga(imgBaseUrl)
+
         val mangaId = response.request.url.pathSegments.last()
-        return if (manga.chapters!!.isEmpty()) {
+        val sChapters = if (comic.chapters!!.isEmpty()) {
             listOf(
                 SChapter.create().apply {
                     url = mangaId
-                    name = "單章節（${manga.book!!.len}P）"
-                    date_upload = manga.book.time * 1000
+                    name = "單章節（${comic.book.len}P）"
+                    date_upload = comic.book.time * 1000
                     chapter_number = 0F
+                    memo = buildJsonObject { put("size", comic.book.len) }
                 },
             )
         } else {
-            manga.chapters.reversed().flatMap { category ->
-                category.second.map {
+            comic.chapters.flatMap { category ->
+                category.value.map {
                     SChapter.create().apply {
                         url = "$mangaId/${it.id}"
                         name = "${it.name}（${it.count}P）"
                         date_upload = it.createdAt * 1000
                         // chapter_number = it.sort.toFloat()
-                        scanlator = category.first
+                        scanlator = category.key
                     }
                 }.reversed()
             }
         }
+
+        return SMangaUpdate(sManga, sChapters)
+    }
+
+    override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> {
+        val comic = client.get("$baseUrl/api/v4/book/${manga.url}?comment=false").parseManga()
+        return comic.recommend?.map(RecommendMangaDto::toSManga) ?: emptyList()
     }
 
     // Pages
 
-    override fun pageListParse(response: Response) = throw UnsupportedOperationException()
-
-    override fun fetchPageList(chapter: SChapter): Observable<List<Page>> {
-        val size = chapter.name.substringAfterLast('（').substringBefore('P').toInt()
-        return Observable.just(
-            List(size) { Page(it, imageUrl = "https://img.noymanga.com/${chapter.url}/${it + 1}.webp") },
-        )
+    override suspend fun getPageList(chapter: SChapter) = List(chapter.memo["size"]!!.int) {
+        Page(it, imageUrl = "/${chapter.url}/${it + 1}.webp")
     }
 
-    // Image
-
-    override fun imageUrlParse(response: Response) = throw UnsupportedOperationException()
+    override fun imageRequest(page: Page): Request {
+        val imgBaseUrl = pref.getString(IMG_HOSTING_PREF, "https://img.noymanga.com")!!
+        return GET(imgBaseUrl + page.imageUrl, headers)
+    }
 }

--- a/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/NoyAcg.kt
+++ b/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/NoyAcg.kt
@@ -27,8 +27,8 @@ import kotlinx.serialization.json.put
 import okhttp3.FormBody
 import okhttp3.Headers
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
-import okhttp3.Request
 import okhttp3.Response
 import java.io.IOException
 
@@ -38,7 +38,9 @@ abstract class NoyAcg :
     ConfigurableSource {
 
     private val pref by getPreferencesLazy()
-    private val imgBaseUrl get() = pref.getString(IMG_HOSTING_PREF, "https://img.noymanga.com")!!
+    private val imgBaseUrl get() = baseUrl.replace("api", "img")
+
+    override fun getHomeUrl() = "https://beta.noyteam.online"
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         getPreferencesInternal(screen.context).forEach(screen::addPreference)
@@ -50,6 +52,7 @@ abstract class NoyAcg :
     }
 
     override fun OkHttpClient.Builder.configureClient() = apply {
+        cookieJar(SessionCookieJar(getHomeUrl().toHttpUrl(), network.client.cookieJar))
         addNetworkInterceptor { chain ->
             val resp = chain.proceed(chain.request())
             resp.takeUnless {
@@ -110,9 +113,9 @@ abstract class NoyAcg :
 
     // Manga & Chapters
 
-    override fun getMangaUrl(manga: SManga) = "$baseUrl/manga/${manga.url}"
+    override fun getMangaUrl(manga: SManga) = "${getHomeUrl()}/manga/${manga.url}"
 
-    override fun getChapterUrl(chapter: SChapter) = "$baseUrl/reader/${chapter.url}"
+    override fun getChapterUrl(chapter: SChapter) = "${getHomeUrl()}/reader/${chapter.url}"
 
     override suspend fun getMangaByUrl(url: HttpUrl): SManga? = url.pathSegments.last().toIntOrNull()?.let {
         val comic = client.get("$baseUrl/api/v4/book/$it?comment=false").parseManga()
@@ -159,6 +162,8 @@ abstract class NoyAcg :
         return SMangaUpdate(sManga, sChapters)
     }
 
+    override val supportsRelatedMangas = true
+
     override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> {
         val comic = client.get("$baseUrl/api/v4/book/${manga.url}?comment=false").parseManga()
         return comic.recommend.map { it.toSManga(imgBaseUrl) }
@@ -170,8 +175,5 @@ abstract class NoyAcg :
         Page(it, imageUrl = "/${chapter.url}/${it + 1}.webp")
     }
 
-    override fun imageRequest(page: Page): Request {
-        val imgBaseUrl = pref.getString(IMG_HOSTING_PREF, "https://img.noymanga.com")!!
-        return GET(imgBaseUrl + page.imageUrl, headers)
-    }
+    override fun imageRequest(page: Page) = GET(imgBaseUrl + page.imageUrl, headers)
 }

--- a/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/NoyAcg.kt
+++ b/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/NoyAcg.kt
@@ -14,7 +14,7 @@ import keiyoushi.network.get
 import keiyoushi.network.post
 import keiyoushi.source.KeiSource
 import keiyoushi.utils.array
-import keiyoushi.utils.getObjectOrNull
+import keiyoushi.utils.getObject
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.getStringOrNull
 import keiyoushi.utils.int
@@ -27,8 +27,10 @@ import kotlinx.serialization.json.put
 import okhttp3.FormBody
 import okhttp3.Headers
 import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
+import java.io.IOException
 
 @Source
 abstract class NoyAcg :
@@ -47,12 +49,22 @@ abstract class NoyAcg :
         add("allow-adult", pref.getString(ADULT_PREF, "both")!!)
     }
 
+    override fun OkHttpClient.Builder.configureClient() = apply {
+        addNetworkInterceptor { chain ->
+            val resp = chain.proceed(chain.request())
+            resp.takeUnless {
+                it.header("Content-Type")?.contains("application/json") == true &&
+                    (it.header("Content-Encoding") == null || it.header("Content-Length") == "18")
+            } ?: resp.use { throw IOException("請在 WebView 中登入") }
+        }
+    }
+
     private fun Response.parseManga(): MangaDetailDto {
         val jsonObject = parseAs<JsonObject>()
         val status = jsonObject.getStringOrNull("status") ?: "error"
-        val book = jsonObject.getObjectOrNull("book")
-        val info = book?.get("info")?.parseAs<MangaDto>()
-        val recommend = book?.get("recommend")?.parseAs<List<RecommendMangaDto>>()
+        val book = jsonObject.getObject("book")
+        val info = book["info"]!!.parseAs<MangaDto>()
+        val recommend = book["recommend"]!!.parseAs<List<RecommendMangaDto>>()
         val categories = jsonObject["chapters"]?.obj?.get("categories")?.array?.map { it.parseAs<CategoryDto>() } ?: emptyList()
         val chaptersMap = mutableMapOf<Int, List<ChapterDto>>()
         jsonObject["chapters"]?.obj?.get("data")?.obj?.forEach { (key, value) ->
@@ -64,9 +76,8 @@ abstract class NoyAcg :
 
     private fun mangaPageParse(response: Response, page: Int): MangasPage {
         val result = response.parseAs<ListingPageDto>()
-        if (result.status != "ok") throw Exception("請在 WebView 中登入")
-        val mangas = result.data!!.map { it.toSManga(imgBaseUrl) }
-        return MangasPage(mangas, page * LISTING_PAGE_SIZE < result.count!!)
+        val mangas = result.data.map { it.toSManga(imgBaseUrl) }
+        return MangasPage(mangas, page * LISTING_PAGE_SIZE < result.count)
     }
 
     // Popular
@@ -103,12 +114,9 @@ abstract class NoyAcg :
 
     override fun getChapterUrl(chapter: SChapter) = "$baseUrl/reader/${chapter.url}"
 
-    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
-        return url.pathSegments.last().toIntOrNull()?.let {
-            val comic = client.get("$baseUrl/api/v4/book/$it?comment=false").parseManga()
-            if (comic.status != "ok") throw Exception("請在 WebView 中登入")
-            comic.book!!.toSManga(imgBaseUrl)
-        }
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? = url.pathSegments.last().toIntOrNull()?.let {
+        val comic = client.get("$baseUrl/api/v4/book/$it?comment=false").parseManga()
+        comic.book.toSManga(imgBaseUrl)
     }
 
     override suspend fun fetchMangaUpdate(
@@ -119,12 +127,11 @@ abstract class NoyAcg :
     ): SMangaUpdate {
         val response = client.get("$baseUrl/api/v4/book/${manga.url}?comment=false")
         val comic = response.parseManga()
-        if (comic.status != "ok") throw Exception("請在 WebView 中登入")
 
-        val sManga = comic.book!!.toSManga(imgBaseUrl)
+        val sManga = comic.book.toSManga(imgBaseUrl)
 
         val mangaId = response.request.url.pathSegments.last()
-        val sChapters = if (comic.chapters!!.isEmpty()) {
+        val sChapters = if (comic.chapters.isEmpty()) {
             listOf(
                 SChapter.create().apply {
                     url = mangaId
@@ -154,7 +161,7 @@ abstract class NoyAcg :
 
     override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> {
         val comic = client.get("$baseUrl/api/v4/book/${manga.url}?comment=false").parseManga()
-        return comic.recommend?.map { it.toSManga(imgBaseUrl) } ?: emptyList()
+        return comic.recommend.map { it.toSManga(imgBaseUrl) }
     }
 
     // Pages

--- a/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/Preferences.kt
+++ b/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/Preferences.kt
@@ -6,6 +6,9 @@ import androidx.preference.ListPreference
 
 const val POPULAR_MANGAS_PREF = "POPULAR_MANGAS"
 const val ADULT_PREF = "ADULT"
+const val IMG_HOSTING_PREF = "IMG_HOSTING"
+
+val imgBaseUrls = arrayOf("https://img.noymanga.com", "https://img.noyteam.online", "https://img.noy.asia")
 
 fun getPreferencesInternal(context: Context) = arrayOf(
     ListPreference(context).apply {
@@ -27,5 +30,13 @@ fun getPreferencesInternal(context: Context) = arrayOf(
             Toast.makeText(context, "重啟應用後生效", Toast.LENGTH_SHORT).show()
             true
         }
+    },
+    ListPreference(context).apply {
+        key = IMG_HOSTING_PREF
+        title = "切換伺服器分流（圖床）"
+        summary = "%s"
+        setDefaultValue("https://img.noymanga.com")
+        entries = imgBaseUrls.map { it.removePrefix("https://") }.toTypedArray()
+        entryValues = imgBaseUrls
     },
 )

--- a/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/Preferences.kt
+++ b/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/Preferences.kt
@@ -1,14 +1,10 @@
 package eu.kanade.tachiyomi.extension.zh.noyacg
 
 import android.content.Context
-import android.widget.Toast
 import androidx.preference.ListPreference
 
 const val POPULAR_MANGAS_PREF = "POPULAR_MANGAS"
 const val ADULT_PREF = "ADULT"
-const val IMG_HOSTING_PREF = "IMG_HOSTING"
-
-val imgBaseUrls = arrayOf("https://img.noymanga.com", "https://img.noyteam.online", "https://img.noy.asia")
 
 fun getPreferencesInternal(context: Context) = arrayOf(
     ListPreference(context).apply {
@@ -26,17 +22,5 @@ fun getPreferencesInternal(context: Context) = arrayOf(
         setDefaultValue("both")
         entries = arrayOf("僅顯示全年齡內容", "僅顯示成人内容", "顯示所有内容")
         entryValues = arrayOf("false", "true", "both")
-        setOnPreferenceChangeListener { _, _ ->
-            Toast.makeText(context, "重啟應用後生效", Toast.LENGTH_SHORT).show()
-            true
-        }
-    },
-    ListPreference(context).apply {
-        key = IMG_HOSTING_PREF
-        title = "切換伺服器分流（圖床）"
-        summary = "%s"
-        setDefaultValue("https://img.noymanga.com")
-        entries = imgBaseUrls.map { it.removePrefix("https://") }.toTypedArray()
-        entryValues = imgBaseUrls
     },
 )

--- a/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/SessionCookieJar.kt
+++ b/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/SessionCookieJar.kt
@@ -9,5 +9,4 @@ class SessionCookieJar(private val homeUrl: HttpUrl, private val cookieJar: Cook
     override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) = cookieJar.saveFromResponse(url, cookies)
 
     override fun loadForRequest(url: HttpUrl) = cookieJar.loadForRequest(if (url.host.startsWith("api")) homeUrl else url)
-
 }

--- a/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/SessionCookieJar.kt
+++ b/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/SessionCookieJar.kt
@@ -1,0 +1,13 @@
+package eu.kanade.tachiyomi.extension.zh.noyacg
+
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.HttpUrl
+
+class SessionCookieJar(private val homeUrl: HttpUrl, private val cookieJar: CookieJar) : CookieJar {
+
+    override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) = cookieJar.saveFromResponse(url, cookies)
+
+    override fun loadForRequest(url: HttpUrl) = cookieJar.loadForRequest(if (url.host.startsWith("api")) homeUrl else url)
+
+}


### PR DESCRIPTION
I think the current auto-generated mirror url configuration can't migrate login status (cookies) when users switch, which is a bit of a pain point. Could `KeiSource` use `CookieJar` to allow all hosts to share cookies? Just like I've implemented it on [NoyAcg](https://github.com/keiyoushi/extensions-source/pull/17938/changes#diff-d90f97ed1152963135d25e2a326e3889c93c2fbdafbc3ed7601346cba5107e70) right now.

I haven't considered the situation of other sources, so this is just a small suggestion.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
