### PR TITLE
Grouple (RU) [ReadManga/SeiManga/MintManga/Usagi/AllHentai] - fix image loading

### DIFF
--- a/lib-multisrc/grouple/build.gradle.kts
+++ b/lib-multisrc/grouple/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 keiyoushi {
-    baseVersionCode = 40
+    baseVersionCode = 41
     libVersion = "1.4"
 
     deeplink {

--- a/lib-multisrc/grouple/src/eu/kanade/tachiyomi/multisrc/grouple/GroupLe.kt
+++ b/lib-multisrc/grouple/src/eu/kanade/tachiyomi/multisrc/grouple/GroupLe.kt
@@ -432,7 +432,7 @@ abstract class GroupLe :
                 }
             }
             if (!imageUrl.contains("://")) {
-                imageUrl = "https://$imageUrl"
+                imageUrl = "https:$imageUrl"
             }
             if (imageUrl.contains("one-way.work")) {
                 // domain that does not need a token

--- a/lib-multisrc/grouple/src/eu/kanade/tachiyomi/multisrc/grouple/GroupLe.kt
+++ b/lib-multisrc/grouple/src/eu/kanade/tachiyomi/multisrc/grouple/GroupLe.kt
@@ -412,31 +412,33 @@ abstract class GroupLe :
         val endIndex = html.indexOf(");", beginIndex)
         val trimmedHtml = html.substring(beginIndex, endIndex)
 
-        val p = Pattern.compile("'.*?','.*?',\".*?\"")
+        val p = Pattern.compile("""\[['"](.*?)['"],['"](.*?)['"],['"](.*?)['"].*?]""")
         val m = p.matcher(trimmedHtml)
 
         val pages = mutableListOf<Page>()
 
         var i = 0
         while (m.find()) {
-            val urlParts = m.group().replace("[\"\']+".toRegex(), "").split(',')
-            var url = if (urlParts[1].isEmpty() && urlParts[2].startsWith("/static/")) {
-                baseUrl + urlParts[2]
+            val host = m.group(1) ?: ""
+            val middle = m.group(2) ?: ""
+            val end = m.group(3) ?: ""
+            var imageUrl = if (middle.isBlank() && end.startsWith("/static/")) {
+                baseUrl + end
             } else {
-                if (urlParts[1].endsWith("/manga/")) {
-                    urlParts[0] + urlParts[2]
+                if (middle.endsWith("/manga/")) {
+                    host + end
                 } else {
-                    urlParts[1] + urlParts[0] + urlParts[2]
+                    middle + host + end
                 }
             }
-            if (!url.contains("://")) {
-                url = "https:$url"
+            if (!imageUrl.contains("://")) {
+                imageUrl = "https://$imageUrl"
             }
-            if (url.contains("one-way.work")) {
+            if (imageUrl.contains("one-way.work")) {
                 // domain that does not need a token
-                url = url.substringBefore("?")
+                imageUrl = imageUrl.substringBefore("?")
             }
-            pages.add(Page(i++, imageUrl = url.replace("//resh", "//h")))
+            pages.add(Page(i++, imageUrl = imageUrl.replace("//resh", "//h")))
         }
         return pages
     }


### PR DESCRIPTION
Checklist:

Quick fix for image loading. 
Site still needs rework and will throw 404 error (while opening chapters) for not authorized users if chapters are hidden, deleted by DMCA request or locked behind new subscription system [example](https://2.mintmanga.one/bank_krovi__A201cc7/vol3/61?d=MjE1Nzky).
A lot of fixes that might take a lot of time, and probably should be done alongside migration to 1.6, meanwhile quick fix for it to work.

Can't test RuMiX site - only licensed chapters that had to be bought are there, and i don't have anything bought there to test.

Upd. What caused error:
Extension uses regex to get url for images from string like that:

> rm_h.readerInit(chapterInfo, [['https://p15.rmr.rocks/','',"auto/123/57/65/op1189_00.png?t=1785032070&u=0&h=WOgfdmNZI-29l1TzZ7r7EQ",1300,850, ''],['https://p7.rmr.rocks/','',"auto/123/57/65/op1189_01_res.webp?t=1785032070&u=0&h=PDEex75md6ZcYl02XCjR1A",1644,2400, '']

Site added '' at the end, so regex started to match data like this:

> rm_h.readerInit(chapterInfo, [[`'https://p15.rmr.rocks/','',"auto/123/57/65/op1189_00.png?t=1785032070&u=0&h=WOgfdmNZI-29l1TzZ7r7EQ"`,1300,850, `''],['https://p7.rmr.rocks/','',"auto/123/57/65/op1189_01_res.webp?t=1785032070&u=0&h=PDEex75md6ZcYl02XCjR1A"`,1644,2400, '']

And failed to form correct url from both parts. Updated regex to match things inside [ ]

- [ ] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
