### PR TITLE
HoraHentai: parse galleries as separate chapters

### DIFF
--- a/src/pt/horahentai/build.gradle.kts
+++ b/src/pt/horahentai/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Hora Hentai"
-    versionCode = 1
+    versionCode = 2
     contentWarning = ContentWarning.NSFW
     libVersion = "1.6"
 

--- a/src/pt/horahentai/src/eu/kanade/tachiyomi/extension/pt/horahentai/HoraHentai.kt
+++ b/src/pt/horahentai/src/eu/kanade/tachiyomi/extension/pt/horahentai/HoraHentai.kt
@@ -21,6 +21,7 @@ import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
 import kotlin.time.Instant
 
 @Source
@@ -91,6 +92,11 @@ abstract class HoraHentai : KeiSource() {
     ): SMangaUpdate {
         val document = client.get(getMangaUrl(manga)).asJsoup()
 
+        val galleries = document.select("div.galeriaTabItem")
+        val date = document.selectFirst("meta[property=article:published_time]")
+            ?.attr("content")
+            .toTimestamp()
+
         val updatedManga = SManga.create().apply {
             url = manga.url
             title = document.selectFirst("h1.post-titulo")!!.text()
@@ -99,27 +105,57 @@ abstract class HoraHentai : KeiSource() {
             genre = document.select("ul.post-itens a[href*=/category/] .postTagNome, ul.post-itens a[href*=/tag/] .postTagNome")
                 .joinToString { it.text() }
             status = SManga.COMPLETED
-            update_strategy = UpdateStrategy.ONLY_FETCH_ONCE
+            // Galleries are a series that can still receive chapters, unlike a single post.
+            update_strategy = if (galleries.isEmpty()) UpdateStrategy.ONLY_FETCH_ONCE else UpdateStrategy.ALWAYS_UPDATE
         }
 
-        val chapter = SChapter.create().apply {
-            url = manga.url
-            name = "Capítulo"
-            chapter_number = 1F
-            date_upload = document.selectFirst("meta[property=article:published_time]")
-                ?.attr("content")
-                .toTimestamp()
+        val chapters = when {
+            galleries.isEmpty() -> listOf(
+                SChapter.create().apply {
+                    url = manga.url
+                    name = "Capítulo"
+                    chapter_number = 1F
+                    date_upload = date
+                },
+            )
+            else -> galleries.mapNotNull { it.toSChapter(manga.url, date) }.reversed()
         }
 
-        return SMangaUpdate(updatedManga, listOf(chapter))
+        return SMangaUpdate(updatedManga, chapters)
     }
 
-    override suspend fun getPageList(chapter: SChapter): List<Page> = client.get(getChapterUrl(chapter)).asJsoup()
-        .select("ul.post-fotos li img")
-        .mapIndexed { index, img ->
+    private fun Element.toSChapter(mangaUrl: String, date: Long): SChapter? {
+        val galleryId = selectFirst("div.galeriaConteudo[id~=^galeria-\\d+$]")?.id() ?: return null
+        val label = selectFirst(".galeriaTabCapitulo")?.text().orEmpty()
+        val chapterTitle = selectFirst(".galeriaTabTitulo")?.text().orEmpty()
+
+        return SChapter.create().apply {
+            // Every gallery lives on the same page, so the anchor is what makes a chapter unique.
+            url = "$mangaUrl#$galleryId"
+            name = when {
+                label.isEmpty() -> chapterTitle.ifEmpty { "Capítulo" }
+                chapterTitle.isEmpty() -> label
+                else -> "$label: $chapterTitle"
+            }
+            chapter_number = CHAPTER_NUMBER_REGEX.find(label)?.groupValues?.get(1)?.toFloatOrNull() ?: -1F
+            date_upload = date
+        }
+    }
+
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        val galleryId = chapter.url.substringAfter('#', "")
+        val document = client.get(baseUrl + chapter.url.substringBefore('#')).asJsoup()
+
+        val images = when {
+            galleryId.isEmpty() -> document.select("ul.post-fotos li img")
+            else -> document.select("div.galeriaConteudo#$galleryId img")
+        }
+
+        return images.mapIndexed { index, img ->
             val imageUrl = img.absUrl("data-src").ifEmpty { img.absUrl("src") }
             Page(index, imageUrl = imageUrl)
         }
+    }
 
     override val supportsFilterFetching get() = true
 
@@ -152,4 +188,8 @@ abstract class HoraHentai : KeiSource() {
     }
 
     private fun String?.toTimestamp(): Long = this?.let { Instant.parseOrNull(it)?.toEpochMilliseconds() } ?: 0L
+
+    companion object {
+        private val CHAPTER_NUMBER_REGEX = Regex("""(\d+(?:\.\d+)?)""")
+    }
 }


### PR DESCRIPTION
Closes #17939

## Root cause

Every post was treated as a one-shot: `fetchMangaUpdate` always returned a single hardcoded chapter, and `getPageList` always read `ul.post-fotos li img`.

Posts that hold more than one chapter use a different layout, with one tab per chapter:

```html
<div class="galeriaTabItem">
  <div class="galeriaTab carregaGaleriaImagens" data-id="1">
    <div class="galeriaTabCapitulo">Capítulo 1</div>
    <div class="galeriaTabPaginas">21 páginas</div>
    <div class="galeriaTabTitulo">A Proprietária Gentil</div>
  </div>
  <div class="galeriaConteudo" id="galeria-1">
    <p><img class="galeriaConteudoImg" data-src="..." /> ...</p>
  </div>
</div>
```

These pages carry no `ul.post-fotos` element at all, which is why the single chapter that was listed also failed to open — the selector matched nothing.

Sampling the 27 works on the front page, 26 are one-shots using `ul.post-fotos` and one uses the gallery layout, so both layouts are live and the existing path had to be preserved.

## Changes

- Parse one chapter per `div.galeriaTabItem`, using the tab label, title and gallery id, and fall back to the previous single-chapter behaviour when no gallery is present.
- Since every gallery lives on the same page, the gallery id is kept as the chapter URL fragment so chapters stay distinct, and `getPageList` reads images from that gallery.
- Use `ONLY_FETCH_ONCE` only for single posts. A gallery is a series that can still receive chapters, so pinning it would hide them.

## Validation

- `:src:pt:horahentai:spotlessCheck :assembleDebug :assembleRelease`
- On device, *A Priorietária Gentil* (the reported work) now lists 3 chapters with their titles, and chapter 2 opens with 20 pages, matching the 21/20/23 page counts the tabs declare.
- Regression on a one-shot: *Luz Púrpura* still lists a single chapter and opens with 32 pages.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code) — not a theme change
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed — neither changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension — not a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop