### PR TITLE
HoneyManga (UA) - fix search

### DIFF
--- a/src/uk/honeymanga/build.gradle.kts
+++ b/src/uk/honeymanga/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "HoneyManga"
-    versionCode = 8
+    versionCode = 9
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
 

--- a/src/uk/honeymanga/src/eu/kanade/tachiyomi/extension/uk/honeymanga/HoneyManga.kt
+++ b/src/uk/honeymanga/src/eu/kanade/tachiyomi/extension/uk/honeymanga/HoneyManga.kt
@@ -233,7 +233,7 @@ abstract class HoneyManga :
 
     // ============================= Utilities ==============================
     companion object {
-        private val cleanSearch = """[^\p{L}\s]""".toRegex()
+        private val cleanSearch = """[^\p{L}\d\s]""".toRegex()
         private const val DEFAULT_PAGE_SIZE = 30
         private const val GENRES_PREF = "pref_genres_exclude"
         private const val GENRES_PREF_TITLE = "Приховані жанри"

--- a/src/uk/honeymanga/src/eu/kanade/tachiyomi/extension/uk/honeymanga/HoneyManga.kt
+++ b/src/uk/honeymanga/src/eu/kanade/tachiyomi/extension/uk/honeymanga/HoneyManga.kt
@@ -57,8 +57,9 @@ abstract class HoneyManga :
             if (query.length < 3) {
                 throw Exception("Запит має містити щонайменше 3 символи / The query must contain at least 3 characters")
             }
+            val cleanQuery = cleanSearch.replace(query, "")
             val url = searchApiUrl.toHttpUrl().newBuilder()
-                .addQueryParameter("query", query)
+                .addQueryParameter("query", cleanQuery)
                 .build()
 
             client.get(url).use { response ->
@@ -232,6 +233,7 @@ abstract class HoneyManga :
 
     // ============================= Utilities ==============================
     companion object {
+        private val cleanSearch = """[^\p{L}\s]""".toRegex()
         private const val DEFAULT_PAGE_SIZE = 30
         private const val GENRES_PREF = "pref_genres_exclude"
         private const val GENRES_PREF_TITLE = "Приховані жанри"


### PR DESCRIPTION
Checklist:

Search on the site doesn't work if any symbols other than letter/whitespace are present in the search
Adding regex that will remove any other symbol from search

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
