### PR TITLE
(Inmortal Scan): New domain and selectors

### DIFF
--- a/src/es/inmortalscan/build.gradle.kts
+++ b/src/es/inmortalscan/build.gradle.kts
@@ -6,13 +6,13 @@ plugins {
 
 keiyoushi {
     name = "Inmortal Scan"
-    versionCode = 3
+    versionCode = 4
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
     theme = "madara"
 
     source {
         lang = "es"
-        baseUrl = "https://scanimnortal.com"
+        baseUrl = "https://scan-inmortal.com"
     }
 }

--- a/src/es/inmortalscan/src/eu/kanade/tachiyomi/extension/es/inmortalscan/InmortalScan.kt
+++ b/src/es/inmortalscan/src/eu/kanade/tachiyomi/extension/es/inmortalscan/InmortalScan.kt
@@ -27,11 +27,9 @@ abstract class InmortalScan : Madara() {
 
     override fun popularMangaNextPageSelector() = "a:contains(Siguiente)"
 
-    override fun latestUpdatesRequest(page: Int): Request =
-        GET("$baseUrl/$mangaSubString/?catalog_page=$page&catalog_order=updated", headers)
+    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/$mangaSubString/?catalog_page=$page&catalog_order=updated", headers)
 
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request =
-        GET("$baseUrl/$mangaSubString/?catalog_page=$page&catalog_search=$query", headers)
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request = GET("$baseUrl/$mangaSubString/?catalog_page=$page&catalog_search=$query", headers)
 
     override fun searchMangaSelector() = popularMangaSelector()
 

--- a/src/es/inmortalscan/src/eu/kanade/tachiyomi/extension/es/inmortalscan/InmortalScan.kt
+++ b/src/es/inmortalscan/src/eu/kanade/tachiyomi/extension/es/inmortalscan/InmortalScan.kt
@@ -1,16 +1,47 @@
 package eu.kanade.tachiyomi.extension.es.inmortalscan
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.source.model.FilterList
 import keiyoushi.annotation.Source
+import okhttp3.Request
 import java.text.SimpleDateFormat
 import java.util.Locale
 
 @Source
 abstract class InmortalScan : Madara() {
     override val dateFormat = SimpleDateFormat("MMM dd, yyyy", Locale("es"))
+
     override val mangaSubString = "mg"
 
     override val useLoadMoreRequest = LoadMoreStrategy.Never
 
     override val useNewChapterEndpoint = true
+
+    override fun popularMangaSelector() = "article.scanim-catalog-card"
+
+    override val popularMangaUrlSelector = "h3 a"
+    override val popularMangaUrlSelectorImg = "a.scanim-catalog-card__cover img"
+
+    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/$mangaSubString/?catalog_page=$page&catalog_order=rating", headers)
+
+    override fun popularMangaNextPageSelector() = "a:contains(Siguiente)"
+
+    override fun latestUpdatesRequest(page: Int): Request =
+        GET("$baseUrl/$mangaSubString/?catalog_page=$page&catalog_order=updated", headers)
+
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request =
+        GET("$baseUrl/$mangaSubString/?catalog_page=$page&catalog_search=$query", headers)
+
+    override fun searchMangaSelector() = popularMangaSelector()
+
+    override val searchMangaUrlSelector = popularMangaUrlSelector
+
+    // Manga Details Selector
+    override val mangaDetailsSelectorTitle = "h1"
+    override val mangaDetailsSelectorStatus = "span.scanim-series-status"
+    override val mangaDetailsSelectorDescription = "div.scanim-series-description p:not(.scanim-seo-info p)"
+    override val mangaDetailsSelectorThumbnail = "div.scanim-series-cover img"
+    override val mangaDetailsSelectorGenre = "a[href*='manga-genre']"
+    override val altNameSelector = "p.scanim-series-alternative"
 }


### PR DESCRIPTION
Closes #17942 

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
