### PR TITLE
MangaLivreOrg: fix 404 on chapter pages

### DIFF
--- a/src/pt/mangalivreorg/build.gradle.kts
+++ b/src/pt/mangalivreorg/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "MangaLivre.org"
-    versionCode = 1
+    versionCode = 2
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
 

--- a/src/pt/mangalivreorg/src/eu/kanade/tachiyomi/extension/pt/mangalivreorg/MangaLivreOrg.kt
+++ b/src/pt/mangalivreorg/src/eu/kanade/tachiyomi/extension/pt/mangalivreorg/MangaLivreOrg.kt
@@ -29,7 +29,10 @@ abstract class MangaLivreOrg : KeiSource() {
 
     override fun OkHttpClient.Builder.configureClient(): OkHttpClient.Builder = rateLimit(2)
 
-    override fun Headers.Builder.configureHeaders(): Headers.Builder = add("Accept-Language", "pt-BR,pt;q=0.9,en;q=0.8")
+    override fun Headers.Builder.configureHeaders(): Headers.Builder = this
+        .add("Accept-Language", "pt-BR,pt;q=0.9,en;q=0.8")
+        // The chapter endpoint answers 404 unless this header is present, with any value.
+        .add("Sec-Fetch-Site", "same-origin")
 
     override suspend fun getPopularManga(page: Int): MangasPage = getMangaList(page, "views", period = "ever")
 


### PR DESCRIPTION
Follow-up to #17934.

## Root cause

The chapter endpoint started answering `404` unless the request carries a `Sec-Fetch-Site` header, so browsing works but every chapter fails to open.

Isolated by bisecting the headers a browser sends against the same endpoint:

| Request | Result |
|---|---|
| Without `Sec-Fetch-Site` | **404** |
| With `Sec-Fetch-Site` (any non-empty value) | 200 |
| With `Sec-Fetch-Site: ` (empty) | 404 |

Removing any other header from the working set (`Accept`, `Accept-Language`, `Referer`, `sec-ch-ua`, `sec-fetch-dest`, `sec-fetch-mode`) still returns 200, so this header is the only requirement. The listing, details and genre endpoints are unaffected, which is why only reading broke.

## Changes

- Send `Sec-Fetch-Site` alongside the existing `Accept-Language`.

## Validation

- `:src:pt:mangalivreorg:assembleDebug :assembleRelease`
- On device: catalog, details (294 chapters) and a chapter opening at `1 / 7` with the page rendered.

Note: `spotlessCheck` passes for this module, but a full run currently fails on this machine inside `:core:spotlessKotlinApply` with `NoClassDefFoundError` from ktlint, in a module this PR does not touch. That looks like a local toolchain issue rather than anything in this change.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code) — not a theme change
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed — neither changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension — not a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop