### PR TITLE
MangaLivre: send chapter route token

### DIFF
--- a/src/pt/mangalivre/build.gradle.kts
+++ b/src/pt/mangalivre/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Manga Livre"
-    versionCode = 86
+    versionCode = 87
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/ReadingGateInterceptor.kt
+++ b/src/pt/mangalivre/src/eu/kanade/tachiyomi/extension/pt/mangalivre/ReadingGateInterceptor.kt
@@ -3,6 +3,8 @@ package eu.kanade.tachiyomi.extension.pt.mangalivre
 import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import okhttp3.CacheControl
+import okhttp3.Cookie
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
@@ -10,6 +12,7 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import java.io.IOException
+import kotlin.random.Random
 
 class ReadingGateInterceptor(
     private val baseUrl: String,
@@ -21,24 +24,38 @@ class ReadingGateInterceptor(
 
     private var cachedSeed: CachedSeed? = null
 
+    private var cachedRouteToken: CachedToken? = null
+
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
         if (request.url.host != baseUrlHost) {
             return chain.proceed(request)
         }
-        return proceedDecrypted(chain, request, seedRetried = false)
+        return proceedDecrypted(chain, request, seedRetried = false, tokenRetried = false)
     }
 
     private fun proceedDecrypted(
         chain: Interceptor.Chain,
         request: Request,
         seedRetried: Boolean,
+        tokenRetried: Boolean,
     ): Response {
-        val response = chain.proceed(request.withSignature(forceRefresh = seedRetried))
+        val chapter = request.url.chapterReference()
+        val response = chain.proceed(
+            request
+                .withSignature(forceRefresh = seedRetried)
+                .withRouteToken(chapter, forceRefresh = tokenRetried),
+        )
 
         if (response.code == 403 && !seedRetried) {
             response.close()
-            return proceedDecrypted(chain, request, seedRetried = true)
+            return proceedDecrypted(chain, request, seedRetried = true, tokenRetried)
+        }
+
+        // A chapter is only served to a request carrying a route token, which expires on its own.
+        if (response.code == 404 && chapter != null && !tokenRetried) {
+            response.close()
+            return proceedDecrypted(chain, request, seedRetried, tokenRetried = true)
         }
 
         val dataKey = response.headers["x-toon-datakey"] ?: return response
@@ -53,6 +70,46 @@ class ReadingGateInterceptor(
         return response.newBuilder()
             .body(decrypted.toResponseBody(contentType))
             .build()
+    }
+
+    private fun HttpUrl.chapterReference(): ChapterReference? {
+        val segments = pathSegments
+        if (segments.size < 5 || segments[0] != "api" || segments[1] != "mangas" || segments[3] != "chapters") {
+            return null
+        }
+        return ChapterReference(segments[2], segments[4])
+    }
+
+    private fun Request.withRouteToken(chapter: ChapterReference?, forceRefresh: Boolean): Request {
+        val token = chapter?.let { resolveRouteToken(this, it, forceRefresh) } ?: return this
+        return newBuilder()
+            .header(ROUTE_TOKEN_HEADER, token)
+            .build()
+    }
+
+    private fun resolveRouteToken(request: Request, chapter: ChapterReference, forceRefresh: Boolean): String? = synchronized(this) {
+        val key = "${chapter.mangaId}/${chapter.chapterId}"
+        val now = System.currentTimeMillis()
+        if (!forceRefresh) {
+            cachedRouteToken?.takeIf { it.key == key && it.expiresAt > now }?.let { return@synchronized it.token }
+        }
+
+        ensureVisitorCookie()
+
+        val tokenRequest = request.newBuilder()
+            .url("$baseUrl/api/chapter-token/${chapter.mangaId}/${chapter.chapterId}")
+            .get()
+            .header(SIGNATURE_HEADER, resolveSeed(request, forceRefresh = false))
+            .removeHeader(ROUTE_TOKEN_HEADER)
+            .cacheControl(CacheControl.FORCE_NETWORK)
+            .build()
+
+        val dto = runCatching {
+            seedClient.newCall(tokenRequest).execute().parseAs<ChapterTokenDto>()
+        }.getOrNull() ?: return@synchronized null
+
+        cachedRouteToken = CachedToken(key, dto.token, now + (dto.expiresMs - TOKEN_EXPIRY_MARGIN_MS).coerceAtLeast(0))
+        dto.token
     }
 
     private fun Request.withSignature(forceRefresh: Boolean): Request = newBuilder()
@@ -76,16 +133,47 @@ class ReadingGateInterceptor(
         token
     }
 
+    /**
+     * The token endpoint only answers a visitor, which the site marks with a cookie generated on
+     * the client, so there is nothing to carry over from a previous response. It goes through the
+     * cookie jar because a `Cookie` header set here would be replaced by the one the jar builds.
+     */
+    private fun ensureVisitorCookie() {
+        val url = baseUrl.toHttpUrl()
+        val jar = seedClient.cookieJar
+        if (jar.loadForRequest(url).any { it.name == VISITOR_COOKIE }) return
+
+        val cookie = Cookie.Builder()
+            .name(VISITOR_COOKIE)
+            .value(List(VISITOR_ID_LENGTH) { VISITOR_ID_ALPHABET.random(Random) }.joinToString(""))
+            .domain(url.host)
+            .path("/")
+            .build()
+        jar.saveFromResponse(url, listOf(cookie))
+    }
+
     data class ReaderPath(val path: String)
+
+    private class ChapterReference(val mangaId: String, val chapterId: String)
 
     private class CachedSeed(val token: String, val expiresAt: Long)
 
+    private class CachedToken(val key: String, val token: String, val expiresAt: Long)
+
     companion object {
         private const val SIGNATURE_HEADER = "x-toon-signature"
+        private const val ROUTE_TOKEN_HEADER = "x-toon-route-token"
+        private const val VISITOR_COOKIE = "toon_v"
+        private const val VISITOR_ID_LENGTH = 26
+        private const val VISITOR_ID_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"
         private const val SEED_CACHE_MS = 25 * 60 * 1000L
+        private const val TOKEN_EXPIRY_MARGIN_MS = 30 * 1000L
         private const val NON_JSON_MESSAGE = "Não foi possível decifrar a resposta."
     }
 }
 
 @Serializable
 private class SeedDto(val token: String)
+
+@Serializable
+private class ChapterTokenDto(val token: String, val expiresMs: Long = 0L)


### PR DESCRIPTION
Follow-up to #17919.

## Root cause

The site added a second gate in front of the chapter endpoint, so recovering the Rabbit constants is no longer enough on its own: the request now fails with `404` before there is any payload to decrypt.

Captured from the site's own reader:

```
1. cookie toon_v=<random>                    generated on the client
2. GET /api/seed                             -> x-toon-signature   (already handled)
3. GET /api/chapter-token/{mangaId}/{chapId} -> {"token":"...","expiresMs":300000}
4. GET /api/mangas/{mangaId}/chapters/{chapId}
      x-toon-route-token: <token>            -> 200 + encrypted payload
```

Each requirement was isolated by reproducing the chain outside the browser:

| Condition | Result |
|---|---|
| No `x-toon-route-token` | **404** — the reported failure |
| With the route token | 200 + `x-toon-datakey` |
| `/api/chapter-token` without the `toon_v` cookie | **403** |
| `/api/chapter-token` with the cookie | 200, token valid for 5 minutes |

The rest of the API (seed, search, details, chapter list) is unaffected, which is why browsing works and only reading fails.

## Changes

- Resolve a route token per manga/chapter pair in the interceptor that already owns the gate, cached against the `expiresMs` the server reports with a small margin.
- Retry once with a fresh token on `404`, mirroring the existing `403` seed refresh.
- Register the visitor cookie through the cookie jar rather than a `Cookie` header, since OkHttp rebuilds that header from the jar and would drop a manually set one.

## Validation

- `:src:pt:mangalivre:assembleDebug :assembleRelease`
- Chain reproduced outside the browser, confirming each gate independently.
- On device: *O Retorno do Cão de Caça dos Baskerville* lists 173 chapters and a chapter opens at `1 / 11` with the page rendered, no error in logcat.

Note: a full build currently fails on this machine inside `:core:spotlessKotlinApply` with `NoClassDefFoundError` from ktlint, in a module this PR does not touch, so that check could not be run locally. It looks like a local toolchain issue rather than anything in this change.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code) — not a theme change
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed — neither changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension — not a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop