### PR TITLE
Natsu: Change base URL

### DIFF
--- a/src/id/natsu/build.gradle.kts
+++ b/src/id/natsu/build.gradle.kts
@@ -6,13 +6,13 @@ plugins {
 
 keiyoushi {
     name = "Natsu"
-    versionCode = 32
+    versionCode = 33
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
     theme = "natsuid"
 
     source {
         lang = "id"
-        baseUrl = "https://natsu.tv"
+        baseUrl = "https://natsu.one"
     }
 }


### PR DESCRIPTION
Closes #17954

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
