### PR TITLE
MangaPoisk (RU): Migrate to 1.6 + update url

### DIFF
--- a/src/ru/mangapoisk/build.gradle.kts
+++ b/src/ru/mangapoisk/build.gradle.kts
@@ -8,10 +8,16 @@ keiyoushi {
     name = "MangaPoisk"
     versionCode = 16
     contentWarning = ContentWarning.MIXED
-    libVersion = "1.4"
+    libVersion = "1.6"
 
     source {
         lang = "ru"
-        baseUrl = "https://mangapsk.ru"
+        baseUrl {
+            custom("https://mangapoisk.me")
+        }
+    }
+
+    deeplink {
+        path("/manga/..*")
     }
 }

--- a/src/ru/mangapoisk/src/eu/kanade/tachiyomi/extension/ru/mangapoisk/Filters.kt
+++ b/src/ru/mangapoisk/src/eu/kanade/tachiyomi/extension/ru/mangapoisk/Filters.kt
@@ -2,65 +2,118 @@ package eu.kanade.tachiyomi.extension.ru.mangapoisk
 
 import eu.kanade.tachiyomi.source.model.Filter
 
-class CheckFilter(name: String, val id: String) : Filter.CheckBox(name)
+abstract class OrderByFilter(
+    displayName: String,
+    val options: List<Pair<String, String>>,
+    state: Selection,
+) : Filter.Sort(
+    displayName,
+    options.map { it.first }.toTypedArray(),
+    state,
+) {
+    val selected get() = options[state!!.index].second
+    val order get() = when (selected) {
+        "name", "popular" -> if (state!!.ascending) "-" else ""
+        else -> if (state!!.ascending) "" else "-"
+    }
+}
 
-class StatusList(statuses: List<CheckFilter>) : Filter.Group<CheckFilter>("Статус", statuses)
-class GenreList(genres: List<CheckFilter>) : Filter.Group<CheckFilter>("Жанры", genres)
+internal class MultiValueOption(name: String, val value: String) : Filter.CheckBox(name)
 
-class OrderBy :
-    Filter.Sort(
+internal abstract class MultiValueFilter(
+    name: String,
+    values: List<Pair<String, String>>,
+) : Filter.Group<MultiValueOption>(
+    name = name,
+    state = values.map { MultiValueOption(it.first, it.second) },
+) {
+    val checked: List<String>? get() = state.filter { it.state && it.value.isNotEmpty() }.map { it.value }.takeIf { it.isNotEmpty() }
+}
+
+class TriStateFilter(name: String, val id: String) : Filter.TriState(name)
+
+abstract class TriStateGroup(
+    name: String,
+    options: List<Pair<String, String>>,
+) : Filter.Group<TriStateFilter>(
+    name,
+    options.map { TriStateFilter(it.first, it.second) },
+) {
+    val included get() = state.filter { it.isIncluded() }.map { it.id }.takeUnless { it.isEmpty() }
+    val excluded get() = state.filter { it.isExcluded() }.map { it.id }.takeUnless { it.isEmpty() }
+}
+
+internal class OrderBy :
+    OrderByFilter(
         "Сортировка",
-        arrayOf("Год", "Популярности", "Алфавиту", "Дате добавления", "Дате обновления"),
+        listOf(
+            "Год" to "year",
+            "Популярность" to "popular",
+            "Алфавит" to "name",
+            "Дата добавления" to "published_at",
+            "Дата обновления" to "last_chapter_at",
+            "Количество глав" to "chapters_count",
+        ),
         Selection(1, false),
     )
 
-fun getStatusList() = listOf(
-    CheckFilter("Выпускается", "0"),
-    CheckFilter("Завершена", "1"),
-)
+internal class StatusList : MultiValueFilter("Статус", statuses) {
+    companion object {
+        val statuses = listOf(
+            "Выпускается" to "0",
+            "Завершена" to "1",
+        )
+    }
+}
 
-fun getGenreList() = listOf(
-    CheckFilter("приключения", "1"),
-    CheckFilter("романтика", "2"),
-    CheckFilter("боевик", "3"),
-    CheckFilter("комедия", "4"),
-    CheckFilter("сверхъестественное", "5"),
-    CheckFilter("драма", "6"),
-    CheckFilter("фэнтези", "7"),
-    CheckFilter("сёнэн", "8"),
-    CheckFilter("этти", "7"),
-    CheckFilter("вампиры", "10"),
-    CheckFilter("школа", "11"),
-    CheckFilter("сэйнэн", "12"),
-    CheckFilter("повседневность", "18"),
-    CheckFilter("сёнэн-ай", "19"),
-    CheckFilter("гарем", "29"),
-    CheckFilter("героическое фэнтези", "30"),
-    CheckFilter("боевые искусства", "31"),
-    CheckFilter("психология", "38"),
-    CheckFilter("сёдзё", "57"),
-    CheckFilter("игра", "105"),
-    CheckFilter("триллер", "120"),
-    CheckFilter("детектив", "121"),
-    CheckFilter("трагедия", "122"),
-    CheckFilter("история", "123"),
-    CheckFilter("сёдзё-ай", "147"),
-    CheckFilter("спорт", "160"),
-    CheckFilter("научная фантастика", "171"),
-    CheckFilter("гендерная интрига", "172"),
-    CheckFilter("дзёсэй", "230"),
-    CheckFilter("ужасы", "260"),
-    CheckFilter("постапокалиптика", "310"),
-    CheckFilter("киберпанк", "355"),
-    CheckFilter("меха", "356"),
-    CheckFilter("эротика", "380"),
-    CheckFilter("яой", "612"),
-    CheckFilter("самурайский боевик", "916"),
-    CheckFilter("махо-сёдзё", "1472"),
-    CheckFilter("додзинси", "1785"),
-    CheckFilter("кодомо", "1789"),
-    CheckFilter("юри", "3197"),
-    CheckFilter("арт", "7332"),
-    CheckFilter("омегаверс", "7514"),
-    CheckFilter("бара", "8119"),
-)
+internal class GenresFilter : TriStateGroup("Жанры", genres) {
+    companion object {
+        val genres = listOf(
+            "Арт" to "7332",
+            "Боевик" to "3",
+            "Боевые искусства" to "31",
+            "Вампиры" to "10",
+            "Гарем" to "29",
+            "Гендерная интрига" to "172",
+            "Героическое фэнтези" to "30",
+            "Детектив" to "121",
+            "Дзёсэй" to "230",
+            "Додзинси" to "1785",
+            "Драма" to "6",
+            "Игра" to "105",
+            "Исэкай" to "8120",
+            "Исторя" to "123",
+            "Киберпанк" to "355",
+            "Комедия" to "4",
+            "Кодомо" to "1789",
+            "Махо-сёдзё" to "1472",
+            "Меха" to "356",
+            "Музыка" to "34948",
+            "Научная фантастика" to "171",
+            "Образование" to "987",
+            "Омегаверс" to "7514",
+            "Пародия" to "34402",
+            "Повседневность" to "18",
+            "Повседневность" to "10163",
+            "Постапокалиптика" to "310",
+            "Постапокалиптика" to "44805",
+            "Приключения" to "1",
+            "Психология" to "38",
+            "Романтика" to "2",
+            "Самурайский боевик" to "916",
+            "Сверхъестественное" to "5",
+            "Сёдзё" to "57",
+            "Сёдзё-ай" to "147",
+            "Сёнэн" to "8",
+            "Сэйнэн" to "12",
+            "Спорт" to "160",
+            "Триллер" to "120",
+            "Трагедия" to "122",
+            "Уся" to "10128",
+            "Ужасы" to "260",
+            "Фэнтези" to "7",
+            "Школа" to "11",
+            "Щанься" to "9321",
+        )
+    }
+}

--- a/src/ru/mangapoisk/src/eu/kanade/tachiyomi/extension/ru/mangapoisk/MangaPoisk.kt
+++ b/src/ru/mangapoisk/src/eu/kanade/tachiyomi/extension/ru/mangapoisk/MangaPoisk.kt
@@ -208,7 +208,7 @@ abstract class MangaPoisk : KeiSource() {
 
     // =========================== Utilities ============================
     private fun Element.imgAttr(): String = when {
-        hasAttr("data-src") -> absUrl("data-src")
+        hasAttr("data-src") && absUrl("data-src").isNotBlank() -> absUrl("data-src")
         else -> absUrl("src")
     }
 

--- a/src/ru/mangapoisk/src/eu/kanade/tachiyomi/extension/ru/mangapoisk/MangaPoisk.kt
+++ b/src/ru/mangapoisk/src/eu/kanade/tachiyomi/extension/ru/mangapoisk/MangaPoisk.kt
@@ -1,76 +1,82 @@
 package eu.kanade.tachiyomi.extension.ru.mangapoisk
 
-import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.annotation.Source
-import keiyoushi.utils.firstInstanceOrNull
-import keiyoushi.utils.tryParse
-import okhttp3.Headers
+import keiyoushi.network.get
+import keiyoushi.source.KeiSource
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.json.JsonElement
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Element
-import rx.Observable
-import java.text.SimpleDateFormat
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 
-private val chapterRegex = Regex("""Глава\s(\d+)""", RegexOption.IGNORE_CASE)
-private val dateFormat = SimpleDateFormat("dd MMMM yyyy", Locale("ru"))
-
 @Source
-abstract class MangaPoisk : HttpSource() {
+abstract class MangaPoisk : KeiSource() {
 
-    override val supportsLatest = true
+    // ============================== Popular ===============================
+    override suspend fun getPopularManga(page: Int): MangasPage = makeCatalogRequest(page, "popular")
 
-    override fun headersBuilder(): Headers.Builder = super.headersBuilder()
-        .add("Referer", baseUrl)
+    // ============================== Latest ===============================
+    override suspend fun getLatestUpdates(page: Int): MangasPage = makeCatalogRequest(page, "-last_chapter_at")
 
-    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/manga?sortBy=popular&page=$page", headers)
-
-    override fun popularMangaParse(response: Response): MangasPage = searchMangaParse(response)
-
-    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/manga?sortBy=-last_chapter_at&page=$page", headers)
-
-    override fun latestUpdatesParse(response: Response): MangasPage = searchMangaParse(response)
-
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+    // ============================== Search ===============================
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
         if (query.isNotBlank()) {
+            if (query.length < 3) {
+                throw Exception("Запрос должен содержать не менее 3 символов. / The query must contain at least 3 characters")
+            }
             val url = "$baseUrl/search".toHttpUrl().newBuilder()
                 .addQueryParameter("q", query)
                 .addQueryParameter("page", page.toString())
                 .build()
-            return GET(url, headers)
+
+            client.get(url).use {
+                return mangaParse(it)
+            }
         }
 
-        val url = "$baseUrl/manga".toHttpUrl().newBuilder()
-            .addQueryParameter("page", page.toString())
-
-        val filterList = filters.ifEmpty { getFilterList() }
-
-        filterList.firstInstanceOrNull<OrderBy>()?.let { orderBy ->
-            val ord = arrayOf("-year", "popular", "name", "-published_at", "-last_chapter_at")[orderBy.state!!.index]
-            val ordRev = arrayOf("year", "-popular", "-name", "published_at", "last_chapter_at")[orderBy.state!!.index]
-            url.addQueryParameter("sortBy", if (orderBy.state!!.ascending) ordRev else ord)
-        }
-
-        filterList.firstInstanceOrNull<StatusList>()?.state?.filter { it.state }?.forEach { status ->
-            url.addQueryParameter("translated[]", status.id)
-        }
-
-        filterList.firstInstanceOrNull<GenreList>()?.state?.filter { it.state }?.forEach { genre ->
-            url.addQueryParameter("genres[]", genre.id)
-        }
-
-        return GET(url.build(), headers)
+        return makeCatalogRequest(page, "likes", filters)
     }
 
-    override fun searchMangaParse(response: Response): MangasPage {
+    // ============================== Search Utilities ===============================
+    private suspend fun makeCatalogRequest(page: Int, sortBy: String, filters: FilterList? = null): MangasPage {
+        val url = "$baseUrl/manga".toHttpUrl().newBuilder().apply {
+            filters?.forEach { filter ->
+                when (filter) {
+                    is OrderBy -> addQueryParameter("sortBy", "${filter.order}${filter.selected}")
+                    is StatusList -> filter.checked?.let { addQueryParameter("translated", "[${it.joinToString(",")}]") }
+                    is GenresFilter -> {
+                        filter.included?.let { addQueryParameter("genres", "[${it.joinToString(",")}]") }
+                        filter.excluded?.let { addQueryParameter("genres-exclude", "[${it.joinToString(",")}]") }
+                    }
+                    else -> {}
+                }
+            }
+
+            if (filters == null) {
+                addQueryParameter("sortBy", sortBy)
+            }
+            addQueryParameter("page", page.toString())
+        }.build()
+
+        client.get(url).use {
+            return mangaParse(it)
+        }
+    }
+
+    private fun mangaParse(response: Response): MangasPage {
         val document = response.asJsoup()
         val isSearch = response.request.url.queryParameter("q") != null
         val selector = if (isSearch) "article.card" else ".manga-card"
@@ -93,7 +99,7 @@ abstract class MangaPoisk : HttpSource() {
             }.substringBefore("/")
 
             SManga.create().apply {
-                thumbnail_url = element.selectFirst("a > img")?.let { getImage(it) } ?: ""
+                thumbnail_url = element.selectFirst("a > img")?.imgAttr() ?: ""
                 setUrlWithoutDomain(urlElement.attr("href"))
                 title = titleParsed
             }
@@ -102,58 +108,74 @@ abstract class MangaPoisk : HttpSource() {
         return MangasPage(mangas, hasNextPage)
     }
 
-    private fun getImage(element: Element): String {
-        val image = element.attr("abs:data-src")
-        if (image.isNotEmpty()) return image
-        return element.attr("abs:src")
-    }
-
-    override fun mangaDetailsParse(response: Response): SManga {
-        val document = response.asJsoup()
-        val infoElement = document.selectFirst("div.card:has(header)") ?: return SManga.create()
-
-        return SManga.create().apply {
-            title = infoElement.selectFirst(".text-base span")?.text() ?: ""
-            genre = infoElement.select("span:contains(Жанр:) a").joinToString { it.text() }
-            description = infoElement.select(".manga-description").text()
-            status = parseStatus(infoElement.selectFirst("span:contains(Статус:)")?.text() ?: "")
-            thumbnail_url = infoElement.selectFirst("img.w-full")?.attr("abs:src")
+    // =========================== Deeplink ============================
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+        if (url.host == baseUrl.toHttpUrl().host && url.pathSegments[0] == "manga") {
+            val tmpManga = SManga.create().apply {
+                this.url = url.encodedPath
+            }
+            return getMangaUpdate(tmpManga, emptyList(), fetchDetails = true, fetchChapters = false).manga
         }
+        return null
     }
 
-    private fun parseStatus(status: String): Int = when {
-        status.contains("Завершена") -> SManga.COMPLETED
-        status.contains("Выпускается") -> SManga.ONGOING
-        else -> SManga.UNKNOWN
-    }
+    // =========================== Manga Details ============================
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate = coroutineScope {
+        val mangaSlug = manga.url
+        val mangaAsync = async {
+            if (fetchDetails) {
+                val requestUrl = "$baseUrl${manga.url}"
+                val document = client.get(requestUrl).use { it.asJsoup() }
+                val infoElement = document.selectFirst("div.card:has(header)") ?: throw Exception("Не получилось найти информацию о манге")
 
-    override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> = Observable.fromCallable {
-        val document = client.newCall(GET("$baseUrl${manga.url}?tab=chapters", headers)).execute().asJsoup()
-        if (document.selectFirst(".text-md:contains(Главы удалены по требованию правообладателя)") != null) {
-            throw Exception("Лицензировано - Нет глав")
+                SManga.create().apply {
+                    url = mangaSlug
+                    title = infoElement.selectFirst(".text-base span")?.text() ?: ""
+                    genre = infoElement.select("span:contains(Жанр:) a").joinToString { it.text() }
+                    description = infoElement.select(".manga-description").text()
+                    status = parseStatus(infoElement.selectFirst("span:contains(Статус:)")?.text() ?: "")
+                    thumbnail_url = infoElement.selectFirst("img.w-full")?.attr("abs:src")
+                }
+            } else {
+                manga
+            }
         }
 
-        val firstPageResponse = client.newCall(chapterListRequest(manga)).execute()
-        val firstPageDocument = firstPageResponse.asJsoup()
-        val chapters = mutableListOf<SChapter>()
+        val chaptersAsync = async {
+            if (fetchChapters) {
+                val document = client.get("${baseUrl}$mangaSlug?tab=chapters").use { it.asJsoup() }
+                if (document.selectFirst(".text-md:contains(Главы удалены по требованию правообладателя)") != null) {
+                    throw Exception("Лицензировано - Нет глав")
+                }
 
-        chapters.addAll(firstPageDocument.select(".chapter-item").mapNotNull { chapterFromElement(it) })
+                val firstPageDocument = client.get("${baseUrl}$mangaSlug/chaptersList").use { it.asJsoup() }
+                val chaptersList = mutableListOf<SChapter>()
 
-        val lastPage = firstPageDocument.select("li.page-item")
-            .mapNotNull { it.text().toIntOrNull() }
-            .maxOrNull() ?: 1
+                chaptersList.addAll(firstPageDocument.select(".chapter-item").mapNotNull { chapterFromElement(it) })
 
-        for (page in 2..lastPage) {
-            val response = client.newCall(chapterPageListRequest(manga, page)).execute()
-            chapters.addAll(response.asJsoup().select(".chapter-item").mapNotNull { chapterFromElement(it) })
+                val lastPage = firstPageDocument.select("li.page-item")
+                    .mapNotNull { it.text().toIntOrNull() }
+                    .maxOrNull() ?: 1
+
+                for (page in 2..lastPage) {
+                    val response = client.get("${baseUrl}$mangaSlug/chaptersList?page=$page").use { it.asJsoup() }
+                    chaptersList.addAll(response.select(".chapter-item").mapNotNull { chapterFromElement(it) })
+                }
+                chaptersList
+            } else {
+                chapters
+            }
         }
-        chapters
+
+        SMangaUpdate(mangaAsync.await(), chaptersAsync.await())
     }
 
-    override fun chapterListRequest(manga: SManga): Request = GET("$baseUrl${manga.url}/chaptersList", headers)
-
-    private fun chapterPageListRequest(manga: SManga, page: Int): Request = GET("$baseUrl${manga.url}/chaptersList?page=$page", headers)
-
+    // =========================== Chapters ============================
     private fun chapterFromElement(element: Element): SChapter? {
         val title = element.selectFirst("span.chapter-title")?.text() ?: return null
         val urlElement = element.selectFirst("a") ?: return null
@@ -166,32 +188,50 @@ abstract class MangaPoisk : HttpSource() {
         }
     }
 
+    // =========================== Pages ============================
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        val document = client.get("$baseUrl${chapter.url}").use { it.asJsoup() }
+        if (document.html().contains("text-error-500-400-token")) {
+            throw Exception("Лицензировано - Глава удалена по требованию правообладателя.")
+        }
+        return document.select("img.page-image").mapIndexed { idx, element ->
+            Page(idx, imageUrl = element.imgAttr())
+        }
+    }
+
+    // =========================== Filters ============================
+    override fun getFilterList(data: JsonElement?) = FilterList(
+        OrderBy(),
+        GenresFilter(),
+        StatusList(),
+    )
+
+    // =========================== Utilities ============================
+    private fun Element.imgAttr(): String = when {
+        hasAttr("data-src") -> absUrl("data-src")
+        else -> absUrl("src")
+    }
+
+    private fun parseStatus(status: String): Int = when {
+        status.contains("Завершена") -> SManga.COMPLETED
+        status.contains("Выпускается") -> SManga.ONGOING
+        else -> SManga.UNKNOWN
+    }
+
     private fun parseDate(dateStr: String): Long {
         val amount = dateStr.substringBefore(" ").toLongOrNull()
         return when {
             amount != null && dateStr.contains("минут") -> System.currentTimeMillis() - amount * 60 * 1000
             amount != null && dateStr.contains("час") -> System.currentTimeMillis() - amount * 60 * 60 * 1000
             amount != null && (dateStr.contains("дня") || dateStr.contains("дней")) -> System.currentTimeMillis() - amount * 24 * 60 * 60 * 1000
-            else -> dateFormat.tryParse(dateStr)
+            else -> runCatching {
+                LocalDate.parse(dateStr, dateFormat).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+            }.getOrDefault(0L)
         }
     }
 
-    override fun pageListParse(response: Response): List<Page> {
-        val document = response.asJsoup()
-        if (document.html().contains("text-error-500-400-token")) {
-            throw Exception("Лицензировано - Глава удалена по требованию правообладателя.")
-        }
-        return document.select(".page-image").mapIndexed { index, element ->
-            Page(index, imageUrl = getImage(element))
-        }
+    companion object {
+        private val chapterRegex = Regex("""Глава\s(\d+)""", RegexOption.IGNORE_CASE)
+        private val dateFormat = DateTimeFormatter.ofPattern("dd MMMM yyyy", Locale.forLanguageTag("ru"))
     }
-
-    override fun getFilterList() = FilterList(
-        OrderBy(),
-        StatusList(getStatusList()),
-        GenreList(getGenreList()),
-    )
-
-    override fun chapterListParse(response: Response): List<SChapter> = throw UnsupportedOperationException()
-    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
 }


### PR DESCRIPTION
Checklist:

Closes #17958 - another url change just one month after previous. Adding custom url preference
Migrate to 1.6
Added deeplink support
Updated filters to support excluded genres

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
