### PR TITLE
Madokami [EN]: Fix URL Encoding

### DIFF
--- a/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
+++ b/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
@@ -175,7 +175,7 @@ abstract class Madokami :
         if (isArchiveUrl(url)) return null
 
         val manga = SManga.create().apply {
-            setUrlWithoutDomain(url.toString())
+            this.url = url.encodedPath
         }
 
         return try {
@@ -229,7 +229,7 @@ abstract class Madokami :
         if (segments.isEmpty()) return null
 
         return SManga.create().apply {
-            setUrlWithoutDomain(url.toString())
+            this.url = url.encodedPath
             description = segments.last()
             var i = segments.lastIndex
             while (i > 0 && segments[i].startsWith("!")) {


### PR DESCRIPTION
Closes #18062.
To be merged with #18057. 

Checklist:

- [ ] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
