### PR TITLE
Asmodeus Scans: fix broken manga

### DIFF
--- a/src/en/asmotoon/build.gradle.kts
+++ b/src/en/asmotoon/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Asmodeus Scans"
-    versionCode = 2
+    versionCode = 3
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
     theme = "keyoapp"

--- a/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/Asmotoon.kt
+++ b/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/Asmotoon.kt
@@ -5,6 +5,7 @@ import eu.kanade.tachiyomi.source.model.SManga
 import keiyoushi.annotation.Source
 import keiyoushi.network.rateLimit
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Request
 import org.jsoup.nodes.Document
 import java.util.Locale
 import kotlin.time.Duration.Companion.seconds
@@ -26,6 +27,27 @@ abstract class Asmotoon : Keyoapp() {
 
     override val genreSelector: String = ".gap-3 .gap-1 a"
 
+    private fun titleToSlug(title: String): String = title
+        .lowercase(Locale.ENGLISH)
+        .replace("[^a-z0-9\\s-]".toRegex(), "")
+        .trim()
+        .replace("[\\s-]+".toRegex(), "-")
+        .trim('-')
+
+    private fun SManga.fix(): SManga = apply {
+        if (url.substringAfterLast('/').matches(OLD_CHAPTER_SLUG_REGEX)) {
+            url = "${url.substringBeforeLast('/')}/${titleToSlug(title)}"
+        }
+    }
+
+    override fun getMangaUrl(manga: SManga): String = super.getMangaUrl(manga.fix())
+
+    override fun chapterListRequest(manga: SManga): Request = super.chapterListRequest(manga.fix())
+
+    override fun mangaDetailsRequest(manga: SManga): Request = super.mangaDetailsRequest(manga.fix())
+
+    override fun relatedMangaListRequest(manga: SManga): Request = super.relatedMangaListRequest(manga.fix())
+
     override fun mangaDetailsParse(document: Document): SManga = super.mangaDetailsParse(document).apply {
         genre = buildList {
             document.selectFirst(typeSelector)?.text()?.replaceFirstChar {
@@ -39,5 +61,9 @@ abstract class Asmotoon : Keyoapp() {
             }?.let(::add)
             document.select(genreSelector).forEach { add(it.text().removeSuffix(",")) }
         }.joinToString()
+    }
+
+    companion object {
+        private val OLD_CHAPTER_SLUG_REGEX = "[0-9a-f]{11}".toRegex()
     }
 }

--- a/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/Asmotoon.kt
+++ b/src/en/asmotoon/src/eu/kanade/tachiyomi/extension/en/asmotoon/Asmotoon.kt
@@ -35,9 +35,7 @@ abstract class Asmotoon : Keyoapp() {
         .trim('-')
 
     private fun SManga.fix(): SManga = apply {
-        if (url.substringAfterLast('/').matches(OLD_CHAPTER_SLUG_REGEX)) {
-            url = "${url.substringBeforeLast('/')}/${titleToSlug(title)}"
-        }
+        url = url.replace(OLD_CHAPTER_SLUG_REGEX) { titleToSlug(title) }
     }
 
     override fun getMangaUrl(manga: SManga): String = super.getMangaUrl(manga.fix())
@@ -64,6 +62,6 @@ abstract class Asmotoon : Keyoapp() {
     }
 
     companion object {
-        private val OLD_CHAPTER_SLUG_REGEX = "[0-9a-f]{11}".toRegex()
+        private val OLD_CHAPTER_SLUG_REGEX = "(?<=/series/)[0-9a-f]{11}(?=/)".toRegex()
     }
 }


### PR DESCRIPTION
Asmodeus Scans has migrated from id-based slugs to title-based slugs. This fixes manga entries with id-based slugs.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
