### PR TITLE
Ikiru: Update base URL

### DIFF
--- a/src/id/mangatale/build.gradle.kts
+++ b/src/id/mangatale/build.gradle.kts
@@ -6,14 +6,14 @@ plugins {
 
 keiyoushi {
     name = "Ikiru"
-    versionCode = 48
+    versionCode = 49
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
     theme = "natsuid"
 
     source {
         lang = "id"
-        baseUrl = "https://06.ikiru.wtf"
+        baseUrl = "https://07.ikiru.wtf"
         // Formerly "MangaTale"
         id = 1532456597012176985L
     }


### PR DESCRIPTION
Closes #18058
Closes #18065

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [ ] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
