### PR TITLE
MangaPlus: fix latest list

### DIFF
--- a/src/all/mangaplus/build.gradle.kts
+++ b/src/all/mangaplus/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "MANGA Plus by SHUEISHA"
-    versionCode = 63
+    versionCode = 64
     contentWarning = ContentWarning.SAFE
     libVersion = "1.6"
 

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/Dto.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/Dto.kt
@@ -130,14 +130,14 @@ class TitleDetailView(
             .joinToString("\n\n")
         genre = genreList.mapNotNull { it.name.takeIf(String::isNotEmpty) }.joinToString()
         status = when {
-            isOneShot || nonAppearanceInfo.contains(COMPLETED_REGEX) -> SManga.COMPLETED
+            isOneShot || nonAppearanceInfo.contains(COMPLETED_REGEX) || viewingPeriodDescription.contains("latest 0 chapters") -> SManga.COMPLETED
             nonAppearanceInfo.contains(HIATUS_REGEX) -> SManga.ON_HIATUS
             else -> SManga.ONGOING
         }
     }
 
     companion object {
-        private val COMPLETED_REGEX = "completado|complete|completo".toRegex(RegexOption.IGNORE_CASE)
+        private val COMPLETED_REGEX = "completado|completed?|completo".toRegex(RegexOption.IGNORE_CASE)
         private val HIATUS_REGEX = "on a hiatus".toRegex(RegexOption.IGNORE_CASE)
     }
 }

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlus.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlus.kt
@@ -24,6 +24,8 @@ import keiyoushi.utils.getPreferences
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.parseAsProto
 import keiyoushi.utils.toJsonElement
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.json.JsonElement
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -115,13 +117,31 @@ abstract class MangaPlus :
     }
 
     override suspend fun getLatestUpdates(page: Int): MangasPage {
-        val result = client.get("$API_URL/web/web_homeV4?lang=$internalLangName&clang=$internalLangName")
-            .parseAsProto<MangaPlusResponse>()
+        val (latestResult, allTitlesResult) = coroutineScope {
+            val latest = async {
+                client.get("$API_URL/web/web_homeV4?lang=$internalLangName&clang=$internalLangName")
+                    .parseAsProto<MangaPlusResponse>()
+            }
+            val allTitles = async {
+                client.get("$API_URL/title_list/allV2").parseAsProto<MangaPlusResponse>()
+            }
+            latest.await() to allTitles.await()
+        }
 
-        val titles = result.successOrThrow().webHomeView!!.groups
+        val latestTitles = latestResult.successOrThrow().webHomeView!!.groups
             .flatMap(UpdatedTitleGroup::titles)
             .mapNotNull(UpdatedTitle::title)
-            .filterByLang()
+
+        val allTitlesGroups = allTitlesResult.successOrThrow().allTitlesView!!.allTitlesGroup
+
+        val titles = latestTitles
+            .mapNotNull { latestTitle ->
+                allTitlesGroups
+                    .firstOrNull { group -> group.titles.any { it.titleId == latestTitle.titleId } }
+                    ?.titles
+                    ?.firstOrNull { it.language == internalLangCode }
+            }
+            .distinctBy(Title::titleId)
 
         return MangasPage(titles.map(Title::toSManga), hasNextPage = false)
     }


### PR DESCRIPTION
closes https://github.com/keiyoushi/extensions-source/issues/17910
closes https://github.com/keiyoushi/extensions-source/issues/17916

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
