### PR TITLE
Japscan: fix chapter list

### DIFF
--- a/src/fr/japscan/build.gradle.kts
+++ b/src/fr/japscan/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Japscan"
-    versionCode = 70
+    versionCode = 71
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -13,6 +13,8 @@ import android.view.View
 import android.webkit.ConsoleMessage
 import android.webkit.JavascriptInterface
 import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.preference.ListPreference
@@ -49,6 +51,8 @@ import org.jsoup.nodes.Element
 import rx.Observable
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.io.ByteArrayInputStream
+import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.concurrent.CountDownLatch
@@ -161,6 +165,20 @@ abstract class Japscan :
         private const val DESKTOP_USER_AGENT =
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
                 "(KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36"
+
+        // The reader page pulls in rotating ad/tracker hosts (acscdn.com, jnbhi.com,
+        // usrpubtrk.com, … — they change every few weeks) whose vignette and popunder
+        // modals break the detached descrambler. A blocklist would rot, so allowlist
+        // the handful of origins the reader actually needs and drop everything else.
+        private val ALLOWED_HOSTS = listOf(
+            "japscan.foo",
+            "cdnjs.cloudflare.com",
+            "code.jquery.com",
+            "cdn.jsdelivr.net",
+            "fonts.googleapis.com",
+            "fonts.gstatic.com",
+            "challenges.cloudflare.com",
+        )
         private val prefsEntries = arrayOf("Montrer uniquement les chapitres traduit en Français", "Montrer les chapitres spoiler")
         private val prefsEntryValues = arrayOf("hide", "show")
     }
@@ -567,9 +585,48 @@ abstract class Japscan :
             }
 
             innerWv.webViewClient = object : WebViewClient() {
+                // Called off the UI thread for every subresource — keep it to the
+                // string comparison, no logging in this hot path.
+                override fun shouldInterceptRequest(
+                    view: WebView?,
+                    request: WebResourceRequest,
+                ): WebResourceResponse? {
+                    val host = request.url.host ?: return null
+                    val allowed = ALLOWED_HOSTS.any { host == it || host.endsWith(".$it") }
+                    // Empty stream rather than a null one: a null body makes some WebView
+                    // builds keep the request pending, which would stall the whole capture.
+                    return if (allowed) {
+                        null
+                    } else {
+                        WebResourceResponse("text/plain", "utf-8", ByteArrayInputStream(ByteArray(0)))
+                    }
+                }
+
                 override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
                     super.onPageStarted(view, url, favicon)
                     Log.d("Japscan", "[wv-kt] onPageStarted url=$url")
+                    // Both modes: satisfy the reader's anti-adblock check before it runs.
+                    // ~3s after load it looks for `window.aclib` (needs 3+ own keys and 2+
+                    // real functions among runPop/runBanner/runNative) and, if it's missing,
+                    // calls triggerProtection() -> readerArea.replaceChildren(), which wipes
+                    // the descrambled canvases both drivers read. Blocking acscdn.com in
+                    // shouldInterceptRequest is exactly what makes the real aclib absent, so
+                    // this is required alongside the allowlist, not instead of it. Regular
+                    // `function` declarations (not arrows) so `.prototype` is truthy.
+                    view?.evaluateJavascript(
+                        """
+                            (function(){
+                                if (window.aclib) return;
+                                window.aclib = {
+                                    runPop: function runPop(){},
+                                    runBanner: function runBanner(){},
+                                    runNative: function runNative(){},
+                                    runInPagePush: function runInPagePush(){},
+                                    isShowingPop: false,
+                                };
+                            })();
+                        """.trimIndent(),
+                    ) {}
                     // Pierce closed shadow roots BEFORE any reader script runs: the descrambler
                     // composites each chapter page into canvases hosted by `<w-f1db5>` elements
                     // whose shadow root is `attachShadow({ mode: 'closed' })`. Forcing every

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -70,7 +70,6 @@ abstract class Japscan :
     private val preferences: SharedPreferences by getPreferencesLazy()
 
     override val client: OkHttpClient = network.client.newBuilder()
-        .rateLimit(1, 2.seconds)
         // Pages from fetchPageList are decoded blobs cached on disk; their imageUrl is
         // `https://japscan-cache.local/<absolute-cache-path>`. We can't override
         // fetchImage (final), so an interceptor catches that sentinel host and serves
@@ -92,6 +91,9 @@ abstract class Japscan :
                 .body(bytes.toResponseBody("image/jpeg".toMediaType()))
                 .build()
         }
+        // rateLimit returns a RateLimitBuilder; it must come last as all other
+        // OkHttpClient.Builder configuration has to happen before it.
+        .rateLimit(1, 2.seconds)
         .build()
 
     private val captchaRegex = """window\.__captcha\s*=\s*\{\s*needed\s*:\s*true\s*,?""".toRegex()

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -45,7 +45,6 @@ import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
-import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import rx.Observable
 import uy.kohesive.injekt.Injekt
@@ -498,6 +497,28 @@ abstract class Japscan :
             }
         }
 
+        // Pick the reader driver from the chapter URL's first path segment. Japscan
+        // shapes every chapter URL as `/<type>/<slug>/<num>/` (the `CHAPTER_PATH_TYPES`
+        // set above curates the valid types), and the type maps cleanly to a reader
+        // format: `manhwa` / `manhua` are vertical/long-strip (webtoon); `manga`,
+        // `bd`, `comic` are paginated.
+        //
+        // We do NOT detect from the server-rendered HTML: the reader DOM
+        // (`#full-reader` / `#single-reader` and the `d-none` toggle) is mounted
+        // client-side by the reader JS, so Jsoup on the initial HTML returns
+        // "paginated" for every chapter — including manhwa.
+        //
+        // The two drivers need incompatible JS hooks: paginated uses a minimal
+        // `URL.createObjectURL` capture and would be tripped by the shadow-DOM /
+        // drawImage / RAF / viewport overrides the webtoon driver needs, so we
+        // MUST commit to one driver before any hook is installed.
+        val urlSegment = chapter.url.trimStart('/').substringBefore('/').lowercase()
+        val isWebtoon = urlSegment == "manhwa" || urlSegment == "manhua"
+        Log.d(
+            "Japscan",
+            "[wv-kt] reader mode hint from URL segment='$urlSegment' → ${if (isWebtoon) "webtoon" else "paginated"}",
+        )
+
         handler.post {
             val innerWv = WebView(context)
 
@@ -513,21 +534,25 @@ abstract class Japscan :
             // JS layer (navigator.userAgent / innerWidth / matchMedia / etc.)
             // in the page-started hook below.
             innerWv.settings.userAgentString = headers["User-Agent"]
-            // Use wide viewport so window.innerWidth reflects the layout width
-            // we force on the WebView (instead of the device's mobile width).
-            innerWv.settings.useWideViewPort = true
-            innerWv.settings.loadWithOverviewMode = false
             innerWv.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
-            // Force a real viewport size on the detached WebView so the page actually
-            // gets a non-zero layout. Without this, `document.documentElement.clientWidth`
-            // is 0, no element gets bounding-rect dimensions, and the descrambler only
-            // renders the top tile of each page (everything past the first viewport
-            // height stays unmaterialized).
-            innerWv.measure(
-                View.MeasureSpec.makeMeasureSpec(WEBVIEW_VIEWPORT_WIDTH, View.MeasureSpec.EXACTLY),
-                View.MeasureSpec.makeMeasureSpec(WEBVIEW_VIEWPORT_HEIGHT, View.MeasureSpec.EXACTLY),
-            )
-            innerWv.layout(0, 0, WEBVIEW_VIEWPORT_WIDTH, WEBVIEW_VIEWPORT_HEIGHT)
+            if (isWebtoon) {
+                // Webtoon-only: wide viewport so window.innerWidth reflects the
+                // layout width we force on the WebView. Without this the
+                // descrambler picks a mobile-tile-per-page path that only
+                // materialises one tile and stalls.
+                innerWv.settings.useWideViewPort = true
+                innerWv.settings.loadWithOverviewMode = false
+                // Force a real viewport size on the detached WebView so the page actually
+                // gets a non-zero layout. Without this, `document.documentElement.clientWidth`
+                // is 0, no element gets bounding-rect dimensions, and the descrambler only
+                // renders the top tile of each page (everything past the first viewport
+                // height stays unmaterialized).
+                innerWv.measure(
+                    View.MeasureSpec.makeMeasureSpec(WEBVIEW_VIEWPORT_WIDTH, View.MeasureSpec.EXACTLY),
+                    View.MeasureSpec.makeMeasureSpec(WEBVIEW_VIEWPORT_HEIGHT, View.MeasureSpec.EXACTLY),
+                )
+                innerWv.layout(0, 0, WEBVIEW_VIEWPORT_WIDTH, WEBVIEW_VIEWPORT_HEIGHT)
+            }
             innerWv.addJavascriptInterface(jsInterface, interfaceName)
 
             // Forward in-page console.log calls to Logcat (tag "Japscan") so the JS
@@ -554,6 +579,44 @@ abstract class Japscan :
                     // and sets `__poisoned = true`, which makes the reader refuse to render.
                     // We therefore (a) override attachShadow only, (b) mask its `.toString` so it
                     // still reads as native, and (c) leave atob/replace/fetch/drawImage alone.
+                    //
+                    // Webtoon-only payload below: the wide-spectrum hook set is required for the
+                    // descrambler to paint every tile of a long-strip page. The paginated reader
+                    // refuses to deliver its payload if these same hooks are present (the
+                    // `__poisoned = true` bot-detect trips on too many tampered built-ins), so
+                    // the paginated path uses a separate minimal hook installed in the `else`
+                    // branch further down.
+                    if (!isWebtoon) {
+                        // Paginated mode: minimal createObjectURL capture, ported verbatim
+                        // from the fix/japscan branch. The descrambler surfaces each
+                        // composited page as a `blob:` URL via URL.createObjectURL —
+                        // capturing the latest one per page-click is enough.
+                        view?.evaluateJavascript(
+                            $$"""
+                                (function(){
+                                    if (window.__japscanHooked) return;
+                                    window.__japscanHooked = true;
+                                    window.__japscanLastBlob = null;
+                                    var _orig = URL.createObjectURL.bind(URL);
+                                    URL.createObjectURL = function(obj){
+                                        var u = _orig(obj);
+                                        try {
+                                            if (obj && obj.type && /^image\//.test(obj.type)) {
+                                                window.__japscanLastBlob = u;
+                                            }
+                                        } catch(e) {}
+                                        return u;
+                                    };
+                                    try {
+                                        URL.createObjectURL.toString = function(){
+                                            return 'function createObjectURL() { [native code] }';
+                                        };
+                                    } catch(e) {}
+                                })();
+                            """.trimIndent(),
+                        ) {}
+                        return
+                    }
                     view?.evaluateJavascript(
                         $$"""
                             (function(){
@@ -822,13 +885,124 @@ abstract class Japscan :
                     // we're detached. resumeTimers is global to all WebViews in the process.
                     view?.onResume()
                     view?.resumeTimers()
-                    // Drive the reader through every chapter page and composite each page out
-                    // of the shadow-DOM canvases. The page is rendered as a stack of <canvas>
-                    // tiles inside `<w-f1db5>` elements with a (formerly closed, now forced
-                    // open by the attachShadow hook) shadow root. We walk every canvas in the
-                    // page container, project each onto a fresh master canvas at the natural
-                    // tile resolution using bounding-rect coordinates, and ship the result
-                    // through the JS interface as a data: URI.
+                    if (!isWebtoon) {
+                        // Paginated driver, ported verbatim from the fix/japscan branch.
+                        // Drives the reader through every page via the #block-right /
+                        // #block-left click-zones; the createObjectURL hook installed in
+                        // onPageStarted gives us one blob per page in `__japscanLastBlob`.
+                        view?.evaluateJavascript(
+                            $$"""
+                                (async function(){
+                                    var sleep = function(ms){ return new Promise(function(r){ setTimeout(r, ms); }); };
+
+                                    async function saveBlobUrl(u){
+                                        if (!u) return false;
+                                        try {
+                                            var r = await fetch(u);
+                                            var b = await r.blob();
+                                            var d = await new Promise(function(res, rej){
+                                                var fr = new FileReader();
+                                                fr.onload = function(){ res(fr.result); };
+                                                fr.onerror = rej;
+                                                fr.readAsDataURL(b);
+                                            });
+                                            if (typeof d === 'string' && d.indexOf('data:image/') === 0) {
+                                                window.$$interfaceName.savePage(d);
+                                                return true;
+                                            }
+                                        } catch(e) {
+                                            console.log('[japscan] saveBlobUrl failed: ' + e);
+                                        } finally {
+                                            try { URL.revokeObjectURL(u); } catch(e) {}
+                                        }
+                                        return false;
+                                    }
+
+                                    async function waitForBlob(timeoutMs){
+                                        var w = 0;
+                                        while (!window.__japscanLastBlob && w < timeoutMs) {
+                                            await sleep(100); w += 100;
+                                        }
+                                        if (!window.__japscanLastBlob) return -1;
+                                        var lastUrl = window.__japscanLastBlob;
+                                        var stable = 0;
+                                        while (stable < 400) {
+                                            await sleep(100);
+                                            if (window.__japscanLastBlob !== lastUrl) {
+                                                lastUrl = window.__japscanLastBlob;
+                                                stable = 0;
+                                            } else {
+                                                stable += 100;
+                                            }
+                                        }
+                                        return w;
+                                    }
+
+                                    var sel = document.getElementById('pages');
+                                    var total = sel ? sel.options.length : 1;
+                                    var nextBtn = document.getElementById('block-right');
+                                    var prevBtn = document.getElementById('block-left');
+                                    console.log('[japscan] paginated mode, total = ' + total + ', next=' + !!nextBtn + ', prev=' + !!prevBtn);
+
+                                    function nav(btn, fallbackKey){
+                                        try {
+                                            if (btn) { btn.click(); return; }
+                                            document.dispatchEvent(new KeyboardEvent('keydown', {
+                                                key: fallbackKey, code: fallbackKey,
+                                                which: fallbackKey === 'ArrowRight' ? 39 : 37,
+                                                keyCode: fallbackKey === 'ArrowRight' ? 39 : 37,
+                                                bubbles: true,
+                                            }));
+                                        } catch(e) {
+                                            console.log('[japscan] nav failed: ' + e);
+                                        }
+                                    }
+
+                                    // The reader pre-renders pages on load (the final pre-render is
+                                    // the *last* page, not page 1), so the very first blob the hook
+                                    // sees is unreliable. Wait for things to settle, discard whatever
+                                    // was captured, then bounce next->prev to force a clean page-1
+                                    // render before we start harvesting.
+                                    await sleep(5000);
+                                    window.__japscanLastBlob = null;
+
+                                    nav(nextBtn, 'ArrowRight');
+                                    await waitForBlob(8000);
+                                    window.__japscanLastBlob = null;
+
+                                    nav(prevBtn, 'ArrowLeft');
+                                    var t0 = await waitForBlob(8000);
+                                    var u0 = window.__japscanLastBlob;
+                                    window.__japscanLastBlob = null;
+                                    if (total > 1) nav(nextBtn, 'ArrowRight');
+                                    var saved = u0 ? ((await saveBlobUrl(u0)) ? 1 : 0) : 0;
+                                    console.log('[japscan] page 1 captured after ' + t0 + 'ms (saved=' + saved + ')');
+
+                                    for (var i = 1; i < total; i++) {
+                                        var t = await waitForBlob(8000);
+                                        var u = window.__japscanLastBlob;
+                                        window.__japscanLastBlob = null;
+                                        if (i < total - 1) nav(nextBtn, 'ArrowRight');
+                                        var ok = u ? await saveBlobUrl(u) : false;
+                                        if (ok) saved++;
+                                        console.log('[japscan] page ' + (i + 1) + ' captured after ' + t + 'ms (saved=' + saved + ')');
+                                    }
+
+                                    console.log('[japscan] done, ' + saved + ' / ' + total + ' pages saved');
+                                    try {
+                                        window.$$interfaceName.passDone();
+                                    } catch(e) {
+                                        console.log('[japscan] passDone failed: ' + e);
+                                    }
+                                })();
+                            """.trimIndent(),
+                        ) { result -> Log.d("Japscan", "[wv-kt] paginated driver eval result=$result") }
+                        return
+                    }
+                    // Webtoon driver: drives the reader through every chapter page and composites
+                    // each page out of the shadow-DOM canvases. The page is rendered as a stack
+                    // of <canvas> tiles inside `<w-f1db5>` elements with a (formerly closed, now
+                    // forced open by the attachShadow hook) shadow root.
                     view?.evaluateJavascript(
                         $$"""
                             (async function(){
@@ -1123,7 +1297,13 @@ abstract class Japscan :
                                     : [];
                                 var singleHidden = singleReader && singleReader.classList.contains('d-none');
                                 var isWebtoon = dImgContainers.length > 0 && (singleHidden || !singleReader);
-                                window.__jlog('[japscan] mode: webtoon=' + isWebtoon + ' pages=' + dImgContainers.length);
+                                // The Kotlin side picked us based on the URL segment ($$urlSegment).
+                                // Compare against what the DOM actually mounted so a misclassified
+                                // series shows up in Logcat instead of producing silent garbage.
+                                var urlHint = '$$urlSegment';
+                                var hintMode = (urlHint === 'manhwa' || urlHint === 'manhua') ? 'webtoon' : 'paginated';
+                                var domMode = isWebtoon ? 'webtoon' : 'paginated';
+                                window.__jlog('[japscan] mode: webtoon=' + isWebtoon + ' pages=' + dImgContainers.length + ' urlHint=' + hintMode + ' dom=' + domMode + (hintMode !== domMode ? ' MISMATCH' : ''));
 
 
 

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -142,6 +142,24 @@ abstract class Japscan :
         // Sentinel host used to route page-image requests to a local cache file via
         // an OkHttp interceptor (see `client` builder).
         private const val JAPSCAN_CACHE_HOST = "japscan-cache.local"
+
+        // Synthetic viewport used to force-layout the detached WebView. We use a
+        // desktop-class width because the reader picks a "mobile" rendering path
+        // for viewports under ~1280 px wide that only materializes one tile-host
+        // per long page (then lazy-loads more on scroll, which our detached WebView
+        // can't reliably trigger). With a desktop-class width the reader pre-creates
+        // every tile-host upfront, exactly like it does in a real Chrome window —
+        // see live-Chrome inspection: innerWidth=5468 yields 7-8 hosts per long
+        // page; innerWidth=1080 yields 1.
+        private const val WEBVIEW_VIEWPORT_WIDTH = 1920
+        private const val WEBVIEW_VIEWPORT_HEIGHT = 16384
+
+        // Desktop Chrome UA matching what the descrambler's working code path
+        // expects (the source's own headersBuilder UA is Android-mobile flavored,
+        // which makes the descrambler take a one-tile-per-page mobile path).
+        private const val DESKTOP_USER_AGENT =
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+                "(KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36"
         private val prefsEntries = arrayOf("Montrer uniquement les chapitres traduit en Français", "Montrer les chapitres spoiler")
         private val prefsEntryValues = arrayOf("hide", "show")
     }
@@ -489,8 +507,27 @@ abstract class Japscan :
             // The reader fetches scrambled tiles and reassembles them onto canvases;
             // images must be allowed to load for the descrambling to run.
             innerWv.settings.blockNetworkImage = false
+            // Keep the WebSettings UA matched to the rest of mihon's traffic so
+            // Cloudflare doesn't issue a fresh challenge for this request.
+            // The "desktop" appearance the descrambler needs is faked at the
+            // JS layer (navigator.userAgent / innerWidth / matchMedia / etc.)
+            // in the page-started hook below.
             innerWv.settings.userAgentString = headers["User-Agent"]
+            // Use wide viewport so window.innerWidth reflects the layout width
+            // we force on the WebView (instead of the device's mobile width).
+            innerWv.settings.useWideViewPort = true
+            innerWv.settings.loadWithOverviewMode = false
             innerWv.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
+            // Force a real viewport size on the detached WebView so the page actually
+            // gets a non-zero layout. Without this, `document.documentElement.clientWidth`
+            // is 0, no element gets bounding-rect dimensions, and the descrambler only
+            // renders the top tile of each page (everything past the first viewport
+            // height stays unmaterialized).
+            innerWv.measure(
+                View.MeasureSpec.makeMeasureSpec(WEBVIEW_VIEWPORT_WIDTH, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(WEBVIEW_VIEWPORT_HEIGHT, View.MeasureSpec.EXACTLY),
+            )
+            innerWv.layout(0, 0, WEBVIEW_VIEWPORT_WIDTH, WEBVIEW_VIEWPORT_HEIGHT)
             innerWv.addJavascriptInterface(jsInterface, interfaceName)
 
             // Forward in-page console.log calls to Logcat (tag "Japscan") so the JS
@@ -505,48 +542,274 @@ abstract class Japscan :
             innerWv.webViewClient = object : WebViewClient() {
                 override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
                     super.onPageStarted(view, url, favicon)
-                    // Install the createObjectURL hook as early as possible. Each chapter page is
-                    // descrambled onto canvases by the page's own JS and surfaced as a `blob:` URL
-                    // via URL.createObjectURL — capturing those gives us the final rendered images.
-                    // We deliberately avoid overriding String.prototype.replace / atob / fetch:
-                    // the new bot detection checks `replace.toString().includes('[native code]')`
-                    // and trips `__poisoned = true` if any built-in is monkey-patched, which
-                    // makes the page refuse to deliver the payload.
+                    Log.d("Japscan", "[wv-kt] onPageStarted url=$url")
+                    // Pierce closed shadow roots BEFORE any reader script runs: the descrambler
+                    // composites each chapter page into canvases hosted by `<w-f1db5>` elements
+                    // whose shadow root is `attachShadow({ mode: 'closed' })`. Forcing every
+                    // attachShadow call to `open` lets us read `.shadowRoot` from outside and
+                    // grab the painted canvases.
                     //
-                    // We stream the conversion (blob -> base64 data URI) as soon as each blob is
-                    // created and revoke the original blob right after, so memory doesn't grow
-                    // unboundedly across the 13+ pages we drive through (otherwise the renderer
-                    // OOMs with all the page canvases held simultaneously).
+                    // We must not mutate behavior of any other built-in. The site's bot
+                    // detection trips on `String.prototype.replace.toString().includes('[native code]')`
+                    // and sets `__poisoned = true`, which makes the reader refuse to render.
+                    // We therefore (a) override attachShadow only, (b) mask its `.toString` so it
+                    // still reads as native, and (c) leave atob/replace/fetch/drawImage alone.
                     view?.evaluateJavascript(
                         $$"""
                             (function(){
+                                // Pin a logging channel through the Java bridge BEFORE the
+                                // site has a chance to silence `console.log` (some pages do
+                                // `console.log = function(){}` once their reader scripts run,
+                                // which would swallow every diagnostic the rest of the driver
+                                // emits via `console.log`).
+                                try {
+                                    var jl = window.$$interfaceName && window.$$interfaceName.log;
+                                    if (jl) {
+                                        window.__jlog = function(){
+                                            try {
+                                                var parts = [];
+                                                for (var i = 0; i < arguments.length; i++) parts.push(String(arguments[i]));
+                                                window.$$interfaceName.log(parts.join(' '));
+                                            } catch(e) {}
+                                        };
+                                    } else {
+                                        window.__jlog = function(){ try { console.log.apply(console, arguments); } catch(e) {} };
+                                    }
+                                } catch(e) {
+                                    window.__jlog = function(){};
+                                }
+                                window.__jlog('[japscan] onPageStarted JS entered, alreadyHooked=' + (window.__japscanHooked === true) + ' url=' + location.href);
                                 if (window.__japscanHooked) return;
                                 window.__japscanHooked = true;
-                                // Single slot tracking the most-recent image blob. Used by the
-                                // paginated-reader driver, which harvests one blob per page
-                                // navigation. The webtoon driver ignores this slot and instead
-                                // iterates `<img id="img-N">.src` in DOM order. We do NOT
-                                // auto-revoke the previous blob here: in webtoon mode all
-                                // blobs are pinned to <img> elements, and revoking them
-                                // before we fetch their bytes makes the URL unfetchable.
-                                window.__japscanLastBlob = null;
-                                var _orig = URL.createObjectURL.bind(URL);
-                                URL.createObjectURL = function(obj){
-                                    var u = _orig(obj);
-                                    try {
-                                        if (obj && obj.type && /^image\//.test(obj.type)) {
-                                            window.__japscanLastBlob = u;
-                                        }
-                                    } catch(e) {}
-                                    return u;
+
+                                // Patch table: maps each patched function to the canonical
+                                // native-code string for its name. We override
+                                // Function.prototype.toString so the site sees the original
+                                // native source whenever it stringifies one of our hooks —
+                                // the reader trips `__poisoned = true` if it spots a
+                                // tampered built-in (it explicitly checks `replace`,
+                                // `atob` and friends, and likely checks `attachShadow`
+                                // and the `shadowRoot` getter as well).
+                                var masked = new WeakMap();
+                                var origFnToString = Function.prototype.toString;
+                                function mask(fn, name){
+                                    try { masked.set(fn, 'function ' + name + '() { [native code] }'); } catch(e) {}
+                                    return fn;
+                                }
+                                var patchedToString = function toString(){
+                                    var m = masked.get(this);
+                                    if (m !== undefined) return m;
+                                    return origFnToString.call(this);
                                 };
-                                // Make our hook look like a native function in case the site ever
-                                // adds the same `[native code]` tripwire to createObjectURL.
+                                Function.prototype.toString = patchedToString;
+                                mask(patchedToString, 'toString');
+
+                                // Force every shadow root open at attach time so we can
+                                // read its canvases later — but track which ones the
+                                // caller *requested* be closed, and hide those from the
+                                // public `Element.prototype.shadowRoot` getter. The site
+                                // sees `el.shadowRoot === null` for its `<w-f1db5>` hosts
+                                // (matching the unpatched behavior); only our compositor,
+                                // via `window.__japscanShadowRootFor(el)`, can reach them.
                                 try {
-                                    URL.createObjectURL.toString = function(){
-                                        return 'function createObjectURL() { [native code] }';
+                                    var closedRoots = new WeakMap();
+                                    var _attach = Element.prototype.attachShadow;
+                                    var newAttach = function attachShadow(init){
+                                        var requested = (init && init.mode) || 'open';
+                                        var opts = {};
+                                        if (init) { for (var k in init) opts[k] = init[k]; }
+                                        opts.mode = 'open';
+                                        var sr = _attach.call(this, opts);
+                                        if (requested === 'closed') {
+                                            try { closedRoots.set(this, sr); } catch(e) {}
+                                        }
+                                        return sr;
                                     };
-                                } catch(e) {}
+                                    Element.prototype.attachShadow = newAttach;
+                                    mask(newAttach, 'attachShadow');
+
+                                    var origDesc = Object.getOwnPropertyDescriptor(Element.prototype, 'shadowRoot');
+                                    var origGetter = origDesc && origDesc.get;
+                                    var newGetter = function get(){
+                                        if (closedRoots.has(this)) return null;
+                                        return origGetter ? origGetter.call(this) : null;
+                                    };
+                                    Object.defineProperty(Element.prototype, 'shadowRoot', {
+                                        get: newGetter,
+                                        configurable: true,
+                                    });
+                                    mask(newGetter, 'get shadowRoot');
+
+                                    window.__japscanShadowRootFor = function(el){
+                                        try {
+                                            if (closedRoots.has(el)) return closedRoots.get(el);
+                                            return origGetter ? origGetter.call(el) : el.shadowRoot;
+                                        } catch(e) { return null; }
+                                    };
+                                } catch(e) {
+                                    window.__jlog('[japscan] shadow hook failed: ' + e);
+                                }
+
+                                // Android throttles requestAnimationFrame for non-visible WebViews
+                                // (our WebView is detached, so it's never visible). The reader
+                                // drives its tile-creation loop on RAF; without ticks it renders
+                                // only the first tile per page and stalls. Force RAF to fire via
+                                // setTimeout so the loop keeps progressing.
+                                try {
+                                    var _rAF = window.requestAnimationFrame;
+                                    var newRAF = function requestAnimationFrame(cb){
+                                        return setTimeout(function(){
+                                            try { cb(performance.now()); } catch(e) {}
+                                        }, 16);
+                                    };
+                                    window.requestAnimationFrame = newRAF;
+                                    mask(newRAF, 'requestAnimationFrame');
+                                } catch(e) {
+                                    window.__jlog('[japscan] rAF hook failed: ' + e);
+                                }
+
+                                // Track canvas drawing activity so the compositor can wait for
+                                // descrambling to settle before reading pixels. Wrapping
+                                // drawImage is detectable via .toString — masked above.
+                                try {
+                                    window.__japscanLastDraw = 0;
+                                    window.__japscanDrawCount = 0;
+                                    var _drawImage = CanvasRenderingContext2D.prototype.drawImage;
+                                    var newDrawImage = function drawImage(){
+                                        try {
+                                            window.__japscanLastDraw = Date.now();
+                                            window.__japscanDrawCount++;
+                                        } catch(e) {}
+                                        return _drawImage.apply(this, arguments);
+                                    };
+                                    CanvasRenderingContext2D.prototype.drawImage = newDrawImage;
+                                    mask(newDrawImage, 'drawImage');
+                                } catch(e) {
+                                    window.__jlog('[japscan] draw hook failed: ' + e);
+                                }
+
+                                // Spoof JS-side environment to match a desktop Chrome on this
+                                // chapter. The WebView's native viewport/screen/touch signals
+                                // tell the descrambler "you're a phone" and it takes the
+                                // single-tile-per-page mobile path. Override the values that
+                                // the differential probe identified:
+                                //   innerWidth/innerHeight, devicePixelRatio,
+                                //   screen.width/height, navigator.platform/maxTouchPoints,
+                                //   matchMedia for (pointer: fine), (hover: hover),
+                                //   and (min-width: <N>px). UA is already set at the
+                                //   WebSettings level.
+                                try {
+                                    var defineGetter = function(obj, name, val){
+                                        try {
+                                            Object.defineProperty(obj, name, {
+                                                get: function(){ return val; },
+                                                configurable: true,
+                                            });
+                                        } catch(e) { window.__jlog('[japscan] defineGetter ' + name + ' failed: ' + e); }
+                                    };
+                                    defineGetter(window, 'innerWidth', 2560);
+                                    defineGetter(window, 'innerHeight', 1214);
+                                    defineGetter(window, 'devicePixelRatio', 0.75);
+                                    defineGetter(window.screen, 'width', 1920);
+                                    defineGetter(window.screen, 'height', 1080);
+                                    defineGetter(window.screen, 'availWidth', 1920);
+                                    defineGetter(window.screen, 'availHeight', 1040);
+                                    defineGetter(navigator, 'userAgent', '$$DESKTOP_USER_AGENT');
+                                    defineGetter(navigator, 'appVersion', '$$DESKTOP_USER_AGENT'.substring(8));
+                                    defineGetter(navigator, 'platform', 'Win32');
+                                    defineGetter(navigator, 'maxTouchPoints', 0);
+                                    defineGetter(navigator, 'hardwareConcurrency', 12);
+                                    // Remove ontouchstart so feature-detect-based mobile
+                                    // branches see a non-touch device.
+                                    try { delete window.ontouchstart; } catch(e) {}
+
+                                    // Stub window.chrome with the shape a real desktop Chrome has.
+                                    // The descrambler's anti-bot path checks for window.chrome and
+                                    // treats its absence as "this is a headless/automated browser",
+                                    // then renders only 1 tile per page as a defense.
+                                    try {
+                                        if (typeof window.chrome === 'undefined' || !window.chrome.loadTimes) {
+                                            var chromeStub = {
+                                                loadTimes: function loadTimes(){ return {}; },
+                                                csi: function csi(){ return {}; },
+                                                app: { isInstalled: false, InstallState: { DISABLED: 'disabled', INSTALLED: 'installed', NOT_INSTALLED: 'not_installed' }, RunningState: { CANNOT_RUN: 'cannot_run', READY_TO_RUN: 'ready_to_run', RUNNING: 'running' } },
+                                            };
+                                            mask(chromeStub.loadTimes, 'loadTimes');
+                                            mask(chromeStub.csi, 'csi');
+                                            Object.defineProperty(window, 'chrome', { get: function(){ return chromeStub; }, configurable: true });
+                                        }
+                                    } catch(e) { window.__jlog('[japscan] chrome stub failed: ' + e); }
+
+                                    // Fake plugins/mimeTypes — WebView reports 0 for both, real
+                                    // Chrome reports 5/2. Bot-detection scripts flag length=0.
+                                    try {
+                                        var fakeMime = function(type, suffixes, desc){
+                                            return { type: type, suffixes: suffixes, description: desc, enabledPlugin: null };
+                                        };
+                                        var fakePlugin = function(name, filename, desc, mimes){
+                                            var p = { name: name, filename: filename, description: desc, length: mimes.length };
+                                            for (var i = 0; i < mimes.length; i++) { p[i] = mimes[i]; mimes[i].enabledPlugin = p; }
+                                            return p;
+                                        };
+                                        var pdfMime = fakeMime('application/pdf', 'pdf', 'Portable Document Format');
+                                        var pdfViewerMime = fakeMime('text/pdf', 'pdf', 'Portable Document Format');
+                                        var plugins = [
+                                            fakePlugin('PDF Viewer', 'internal-pdf-viewer', 'Portable Document Format', [pdfMime, pdfViewerMime]),
+                                            fakePlugin('Chrome PDF Viewer', 'internal-pdf-viewer', 'Portable Document Format', [pdfMime, pdfViewerMime]),
+                                            fakePlugin('Chromium PDF Viewer', 'internal-pdf-viewer', 'Portable Document Format', [pdfMime, pdfViewerMime]),
+                                            fakePlugin('Microsoft Edge PDF Viewer', 'internal-pdf-viewer', 'Portable Document Format', [pdfMime, pdfViewerMime]),
+                                            fakePlugin('WebKit built-in PDF', 'internal-pdf-viewer', 'Portable Document Format', [pdfMime, pdfViewerMime]),
+                                        ];
+                                        plugins.length = 5;
+                                        plugins.item = function(i){ return plugins[i] || null; };
+                                        plugins.namedItem = function(n){ for (var i=0;i<plugins.length;i++) if (plugins[i].name===n) return plugins[i]; return null; };
+                                        plugins.refresh = function(){};
+                                        Object.defineProperty(navigator, 'plugins', { get: function(){ return plugins; }, configurable: true });
+
+                                        var mimeTypes = [pdfMime, pdfViewerMime];
+                                        mimeTypes.length = 2;
+                                        mimeTypes.item = function(i){ return mimeTypes[i] || null; };
+                                        mimeTypes.namedItem = function(n){ for (var i=0;i<mimeTypes.length;i++) if (mimeTypes[i].type===n) return mimeTypes[i]; return null; };
+                                        Object.defineProperty(navigator, 'mimeTypes', { get: function(){ return mimeTypes; }, configurable: true });
+                                    } catch(e) { window.__jlog('[japscan] plugins stub failed: ' + e); }
+
+                                    // languages: real Chrome has multiple, WebView has 1.
+                                    try {
+                                        Object.defineProperty(navigator, 'languages', { get: function(){ return ['fr', 'fr-FR', 'en', 'en-US']; }, configurable: true });
+                                        Object.defineProperty(navigator, 'language', { get: function(){ return 'fr'; }, configurable: true });
+                                    } catch(e) {}
+
+                                    // Some bot-detection scripts check navigator.webdriver explicitly;
+                                    // ensure it reads as undefined (default, but defensive).
+                                    try {
+                                        Object.defineProperty(navigator, 'webdriver', { get: function(){ return undefined; }, configurable: true });
+                                    } catch(e) {}
+
+                                    var _mm = window.matchMedia.bind(window);
+                                    var newMM = function matchMedia(q){
+                                        var orig = _mm(q);
+                                        var shouldForceTrue = (
+                                            q === '(pointer: fine)' ||
+                                            q === '(hover: hover)' ||
+                                            /\(min-width:\s*\d+px\)/.test(q) ||
+                                            /\(min-device-width:\s*\d+px\)/.test(q)
+                                        );
+                                        if (!shouldForceTrue) return orig;
+                                        return new Proxy(orig, {
+                                            get: function(t, k){
+                                                if (k === 'matches') return true;
+                                                var v = t[k];
+                                                return typeof v === 'function' ? v.bind(t) : v;
+                                            },
+                                        });
+                                    };
+                                    window.matchMedia = newMM;
+                                    mask(newMM, 'matchMedia');
+                                } catch(e) {
+                                    window.__jlog('[japscan] env spoof failed: ' + e);
+                                }
+
+                                window.__jlog('[japscan] hooks installed');
                             })();
                         """.trimIndent(),
                     ) {}
@@ -554,154 +817,413 @@ abstract class Japscan :
 
                 override fun onPageFinished(view: WebView?, url: String?) {
                     super.onPageFinished(view, url)
+                    Log.d("Japscan", "[wv-kt] onPageFinished url=$url")
                     // Force-keep the WebView "alive" so its JS timers don't get suspended while
                     // we're detached. resumeTimers is global to all WebViews in the process.
                     view?.onResume()
                     view?.resumeTimers()
-                    // Drive the reader through every chapter page (the `<select id="pages">`
-                    // element drives navigation). The createObjectURL hook installed in
-                    // onPageStarted converts each blob to a data URI as soon as it's produced,
-                    // so we just drive the UI and wait for window.__japscanImages to stabilize.
+                    // Drive the reader through every chapter page and composite each page out
+                    // of the shadow-DOM canvases. The page is rendered as a stack of <canvas>
+                    // tiles inside `<w-f1db5>` elements with a (formerly closed, now forced
+                    // open by the attachShadow hook) shadow root. We walk every canvas in the
+                    // page container, project each onto a fresh master canvas at the natural
+                    // tile resolution using bounding-rect coordinates, and ship the result
+                    // through the JS interface as a data: URI.
                     view?.evaluateJavascript(
                         $$"""
                             (async function(){
                                 var sleep = function(ms){ return new Promise(function(r){ setTimeout(r, ms); }); };
+                                window.__jlog('[japscan] driver start');
 
-                                // Convert a blob URL to a base64 data URI and save it via the
-                                // JS interface. Returns true on success.
-                                async function saveBlobUrl(u){
-                                    if (!u) return false;
+                                // Collect every <canvas> reachable from `root`, descending
+                                // through shadow roots (including the formerly-closed ones
+                                // the attachShadow hook stashed in __japscanShadowRootFor).
+                                var shadowFor = window.__japscanShadowRootFor || function(){ return null; };
+                                function gatherCanvases(root, out) {
+                                    if (!root) return;
+                                    if (root.nodeType === 1 && root.tagName === 'CANVAS') {
+                                        out.push(root);
+                                    }
+                                    var sr = null;
+                                    try { sr = shadowFor(root); } catch(e) {}
+                                    if (sr) {
+                                        var sk = sr.children;
+                                        if (sk) {
+                                            for (var i = 0; i < sk.length; i++) gatherCanvases(sk[i], out);
+                                        }
+                                    }
+                                    var ch = root.children;
+                                    if (ch) {
+                                        for (var j = 0; j < ch.length; j++) gatherCanvases(ch[j], out);
+                                    }
+                                }
+
+                                // Discover the tile hosts that make up `#d-img-N`. The reader uses
+                                // a custom element (e.g. <b-123e6>, <w-f1db5> — the tag name is
+                                // randomized per series) that exposes the composited tile bitmap
+                                // as `tile.canvas` (an own-property set in the custom element's
+                                // constructor when it has actually rendered).
+                                //
+                                // STRUCTURAL discovery, not readiness: we identify a tile by its
+                                // tag (any hyphenated custom-element tag) that is a direct child
+                                // either of #d-img-N or of #d-img-N > div.cc80466. We deliberately
+                                // do NOT require `.canvas` to exist yet, because the descrambler
+                                // is lazy and only renders tiles after they are scrolled into the
+                                // viewport — chicken-and-egg if we filter on `.canvas` here.
+                                // Walk every node reachable from `root` (including across open and
+                                // recovered-closed shadow roots) and return the unique hyphenated-
+                                // tag custom elements that have a `.canvas` HTMLCanvasElement own-
+                                // property — or, structurally, ANY hyphenated-tag element if no
+                                // `.canvas`-bearing one exists yet (the constructor sets `.canvas`
+                                // only after the descrambler renders).
+                                // Discover tile groups in `#d-img-N`'s subtree. Canvases-first
+                                // approach: walk canvases (works regardless of whether the host
+                                // custom element is exposed in light DOM), group them by their
+                                // shadow-root host, and treat each unique host as one tile.
+                                //
+                                // Returns an array of `{ host, canvases }` records in stable order
+                                // of first appearance. The host is the custom element (whose
+                                // `.canvas` own-property, when set, gives the descrambled bitmap);
+                                // `canvases` is the layered set inside its shadow root.
+                                function discoverTiles(container){
+                                    if (!container) return [];
+                                    // Long-page WebView layout: container has a `cc...`-class
+                                    // wrapper holding 7-8 direct <canvas> children (one per
+                                    // descrambled vertical slice). Emit each canvas as a
+                                    // standalone tile so toDataURL is called per slice and
+                                    // the webtoon reader stitches them.
+                                    var wrap = null;
+                                    for (var ci = 0; ci < container.children.length; ci++) {
+                                        var ch = container.children[ci];
+                                        if (ch.tagName === 'DIV' && ('' + ch.className).indexOf('cc') === 0) {
+                                            wrap = ch; break;
+                                        }
+                                    }
+                                    if (wrap) {
+                                        var direct = [];
+                                        for (var di = 0; di < wrap.children.length; di++) {
+                                            var w = wrap.children[di];
+                                            if (w.tagName === 'CANVAS' && w.width > 0 && w.height > 0) {
+                                                direct.push(w);
+                                            }
+                                        }
+                                        if (direct.length > 0) {
+                                            var outArr = [];
+                                            for (var di2 = 0; di2 < direct.length; di2++) {
+                                                outArr.push({ host: direct[di2], canvases: [direct[di2]] });
+                                            }
+                                            return outArr;
+                                        }
+                                    }
+                                    // Short-page / single-tile layout: canvases live inside a
+                                    // custom-element host (e.g. <t-b8432>). Group them by
+                                    // shadow-root host so each host yields one tile.
+                                    var canvases = [];
+                                    gatherCanvases(container, canvases);
+                                    if (canvases.length === 0) return [];
+                                    var map = new Map();
+                                    var order = [];
+                                    for (var i = 0; i < canvases.length; i++) {
+                                        var c = canvases[i];
+                                        if (c.width <= 0 || c.height <= 0) continue;
+                                        var rn = c.getRootNode && c.getRootNode();
+                                        var host = (rn && rn.host) ? rn.host : container;
+                                        if (!map.has(host)) {
+                                            map.set(host, []);
+                                            order.push(host);
+                                        }
+                                        map.get(host).push(c);
+                                    }
+                                    var out = [];
+                                    for (var k = 0; k < order.length; k++) {
+                                        out.push({ host: order[k], canvases: map.get(order[k]) });
+                                    }
+                                    return out;
+                                }
+
+                                // Resolve a tile to a single canvas for export. Preference order:
+                                //   1. `host.canvas` own-property — the descrambler's explicit
+                                //      pointer to the final composited bitmap.
+                                //   2. The lone canvas with `position: relative` in the layered
+                                //      set — it establishes the visible tile and on inspection
+                                //      consistently holds the real bitmap; siblings are decoys.
+                                //   3. The first non-empty canvas — last-resort.
+                                function pickTileCanvas(tile){
                                     try {
-                                        var r = await fetch(u);
-                                        var b = await r.blob();
-                                        var d = await new Promise(function(res, rej){
-                                            var fr = new FileReader();
-                                            fr.onload = function(){ res(fr.result); };
-                                            fr.onerror = rej;
-                                            fr.readAsDataURL(b);
-                                        });
-                                        if (typeof d === 'string' && d.indexOf('data:image/') === 0) {
-                                            window.$$interfaceName.savePage(d);
-                                            return true;
+                                        if (tile.host && tile.host.canvas instanceof HTMLCanvasElement) {
+                                            return tile.host.canvas;
                                         }
-                                    } catch(e) {
-                                        console.log('[japscan] saveBlobUrl failed: ' + e);
-                                    } finally {
-                                        try { URL.revokeObjectURL(u); } catch(e) {}
+                                    } catch(e) {}
+                                    var arr = tile.canvases || [];
+                                    for (var i = 0; i < arr.length; i++) {
+                                        var s = null;
+                                        try { s = window.getComputedStyle(arr[i]); } catch(e) {}
+                                        if (s && s.position === 'relative') return arr[i];
                                     }
-                                    return false;
+                                    return arr[0] || null;
                                 }
 
-                                // Paginated mode: harvest the latest blob from the slot.
-                                async function harvest(){
-                                    var u = window.__japscanLastBlob;
-                                    if (!u) return false;
-                                    window.__japscanLastBlob = null;
-                                    return await saveBlobUrl(u);
-                                }
-
-                                // Wait for a fresh blob to appear (slot starts null after each
-                                // harvest). After it appears, settle for a bit so any later
-                                // re-render of the same page replaces the slot with the final
-                                // composited image.
-                                async function waitForBlob(timeoutMs){
+                                // Wait until at least one of the tile's canvases (or its
+                                // host.canvas) has non-zero dimensions and the descrambler has
+                                // gone quiet (no drawImage calls for ≥ quietMs).
+                                async function waitForTileReady(tile, timeoutMs){
                                     var w = 0;
-                                    while (!window.__japscanLastBlob && w < timeoutMs) {
-                                        await sleep(100); w += 100;
-                                    }
-                                    if (!window.__japscanLastBlob) return -1;
-                                    var lastUrl = window.__japscanLastBlob;
-                                    var stable = 0;
-                                    while (stable < 400) {
-                                        await sleep(100);
-                                        if (window.__japscanLastBlob !== lastUrl) {
-                                            lastUrl = window.__japscanLastBlob;
-                                            stable = 0;
-                                        } else {
-                                            stable += 100;
+                                    var quietMs = 600;
+                                    while (w < timeoutMs) {
+                                        var anySized = false;
+                                        try {
+                                            if (tile.host && tile.host.canvas && tile.host.canvas.width > 0) anySized = true;
+                                        } catch(e) {}
+                                        if (!anySized) {
+                                            var arr = tile.canvases || [];
+                                            for (var i = 0; i < arr.length; i++) {
+                                                if (arr[i].width > 0 && arr[i].height > 0) { anySized = true; break; }
+                                            }
                                         }
+                                        if (anySized) {
+                                            // Honor the host's own ready flags if present.
+                                            var hostReady = true;
+                                            try {
+                                                if (tile.host && ('cw' in tile.host)) {
+                                                    hostReady = !!(tile.host.cw && tile.host.ch);
+                                                }
+                                            } catch(e) {}
+                                            var sinceDraw = Date.now() - (window.__japscanLastDraw || 0);
+                                            if (hostReady && sinceDraw >= quietMs) return w;
+                                        }
+                                        await sleep(150);
+                                        w += 150;
                                     }
-                                    return w;
+                                    return -1;
+                                }
+
+                                function tileToDataUri(tile){
+                                    try {
+                                        var c = pickTileCanvas(tile);
+                                        if (!c || !c.width || !c.height) return null;
+                                        return c.toDataURL('image/jpeg', 0.92);
+                                    } catch(e) { return null; }
+                                }
+
+                                // Paginated mode only: composite the (#single-reader-XXX) container's
+                                // direct canvas children. Layered canvases at the same position, so
+                                // we draw them all at (0, 0) in DOM order. No shadow roots, no
+                                // custom-element tiles in this layout — it's the simple legacy form.
+                                function paginatedComposite(container, label) {
+                                    if (!container) return null;
+                                    var canvases = container.querySelectorAll(':scope > canvas');
+                                    if (canvases.length === 0) {
+                                        window.__jlog('[japscan] ' + label + ' compose: no direct canvas children');
+                                        return null;
+                                    }
+                                    var W = 0, H = 0;
+                                    for (var i = 0; i < canvases.length; i++) {
+                                        if (canvases[i].width  > W) W = canvases[i].width;
+                                        if (canvases[i].height > H) H = canvases[i].height;
+                                    }
+                                    if (W === 0 || H === 0) return null;
+                                    var master = document.createElement('canvas');
+                                    master.width = W; master.height = H;
+                                    var mctx = master.getContext('2d');
+                                    if (!mctx) return null;
+                                    var drawn = 0;
+                                    for (var k = 0; k < canvases.length; k++) {
+                                        try { mctx.drawImage(canvases[k], 0, 0); drawn++; } catch(e) {}
+                                    }
+                                    window.__jlog('[japscan] ' + label + ' compose: ' + W + 'x' + H + ' canvases=' + canvases.length + ' drawn=' + drawn);
+                                    var uri = null;
+                                    try { uri = master.toDataURL('image/jpeg', 0.92); } catch(e) {}
+                                    master.width = 0; master.height = 0;
+                                    return uri;
+                                }
+
+                                // Wait for the descrambler to populate the container's shadow-DOM
+                                // canvases, then settle until the canvas count is stable for a bit.
+                                // Settle on TWO independent signals:
+                                //  - canvas count is non-zero and stable (DOM structure done),
+                                //  - no drawImage calls for `quietMs` (descrambler done painting).
+                                // Without the second signal we capture mid-paint and only the
+                                // first few layered passes have been drawn, so the rendered page
+                                // is incomplete.
+                                async function waitForRender(container, timeoutMs, label) {
+                                    var quietMs = 800;
+                                    var minTotal = 1500;
+                                    var pollMs = 150;
+                                    var w = 0;
+                                    var prevCount = -1;
+                                    var structuralStable = 0;
+                                    var lastLogN = -1;
+                                    while (w < timeoutMs) {
+                                        var arr = [];
+                                        gatherCanvases(container, arr);
+                                        var n = arr.length;
+                                        var hasContent = false;
+                                        var maxW = 0, maxH = 0;
+                                        for (var i = 0; i < arr.length; i++) {
+                                            if (arr[i].width > maxW) maxW = arr[i].width;
+                                            if (arr[i].height > maxH) maxH = arr[i].height;
+                                            if (arr[i].width > 0 && arr[i].height > 0) hasContent = true;
+                                        }
+                                        var now = Date.now();
+                                        var sinceDraw = now - (window.__japscanLastDraw || 0);
+                                        if (label && (n !== lastLogN) && (w === 0 || w >= 500)) {
+                                            window.__jlog('[japscan] ' + label + ' poll @' + w + 'ms canvases=' + n + ' hasContent=' + hasContent + ' max=' + maxW + 'x' + maxH + ' sinceDraw=' + sinceDraw + 'ms drawCount=' + (window.__japscanDrawCount || 0));
+                                            lastLogN = n;
+                                        }
+                                        if (hasContent && n === prevCount) {
+                                            structuralStable += pollMs;
+                                        } else {
+                                            structuralStable = 0;
+                                            prevCount = n;
+                                        }
+                                        if (structuralStable >= 600 && sinceDraw >= quietMs && w >= minTotal) {
+                                            if (label) window.__jlog('[japscan] ' + label + ' settled @' + w + 'ms (sinceDraw=' + sinceDraw + 'ms drawCount=' + (window.__japscanDrawCount || 0) + ')');
+                                            return w;
+                                        }
+                                        await sleep(pollMs);
+                                        w += pollMs;
+                                    }
+                                    if (label) window.__jlog('[japscan] ' + label + ' settle timed out @' + w + 'ms');
+                                    return -1;
+                                }
+
+                                async function savePaginated(container, label) {
+                                    var t = await waitForRender(container, 20000, label);
+                                    if (t < 0) {
+                                        window.__jlog('[japscan] ' + label + ' render timed out');
+                                        return false;
+                                    }
+                                    var uri = paginatedComposite(container, label);
+                                    if (!uri || uri.indexOf('data:image/') !== 0) {
+                                        window.__jlog('[japscan] ' + label + ' composite failed');
+                                        return false;
+                                    }
+                                    try {
+                                        window.$$interfaceName.savePage(uri);
+                                        window.__jlog('[japscan] ' + label + ' saved after ' + t + 'ms (' + uri.length + ' chars)');
+                                        return true;
+                                    } catch(e) {
+                                        window.__jlog('[japscan] savePage failed: ' + e);
+                                        return false;
+                                    }
                                 }
 
                                 // Detect reader mode. Webtoon (long-strip) puts everything in
-                                // `#full-reader` with one `<img id="img-N">` per page and hides
-                                // `#single-reader` (class `d-none`); paginated mode is the
-                                // opposite. We use a different driver per mode.
+                                // `#full-reader` with one `<img id="img-N">` per page (each in
+                                // its `<div id="d-img-N">` container) and hides `#single-reader`
+                                // (class `d-none`); paginated mode is the opposite.
                                 var fullReader = document.getElementById('full-reader');
                                 var singleReader = document.querySelector('[id^="single-reader"]');
-                                var webtoonImgs = fullReader
-                                    ? Array.from(fullReader.querySelectorAll('img[id^="img-"]'))
+                                var dImgContainers = fullReader
+                                    ? Array.from(fullReader.querySelectorAll('div[id^="d-img-"]'))
                                           .sort(function(a, b){
-                                              return parseInt(a.id.replace('img-', ''), 10)
-                                                   - parseInt(b.id.replace('img-', ''), 10);
+                                              return parseInt(a.id.replace('d-img-', ''), 10)
+                                                   - parseInt(b.id.replace('d-img-', ''), 10);
                                           })
                                     : [];
                                 var singleHidden = singleReader && singleReader.classList.contains('d-none');
-                                var isWebtoon = webtoonImgs.length > 0 && (singleHidden || !singleReader);
+                                var isWebtoon = dImgContainers.length > 0 && (singleHidden || !singleReader);
+                                window.__jlog('[japscan] mode: webtoon=' + isWebtoon + ' pages=' + dImgContainers.length);
+
+
 
                                 if (isWebtoon) {
-                                    var total = webtoonImgs.length;
-                                    console.log('[japscan] webtoon mode, total = ' + total);
-                                    var saved = 0;
-                                    // Each webtoon page is rendered into ~8 layered canvases
-                                    // inside a closed shadow root and then composited to a
-                                    // pinned `<img>.src` blob. Holding all 14 pages worth of
-                                    // canvases and bitmaps in the DOM concurrently OOMs the
-                                    // renderer (≈ 14 × 8 × 940 × 2100 × 4 ≈ 880 MB), so we
-                                    // tear down each `#d-img-N` container as soon as we've
-                                    // grabbed the bytes for that page.
-                                    //
-                                    // We also remove the (hidden) single-reader subtree up
-                                    // front to drop its stale layer-canvases; in webtoon mode
-                                    // it's `d-none` and only adds memory pressure.
+                                    var total = dImgContainers.length;
+                                    // Drop the hidden single-reader subtree to keep its stale
+                                    // layer-canvases from adding memory pressure.
                                     if (singleReader && singleReader.parentNode) {
                                         try { singleReader.parentNode.removeChild(singleReader); } catch(e) {}
                                     }
-                                    for (var i = 0; i < total; i++) {
-                                        var img = webtoonImgs[i];
-                                        var container = document.getElementById('d-img-' + i);
-                                        try { img.scrollIntoView({ block: 'start' }); } catch(e) {}
-                                        // Wait for the descrambler to set img.src to a blob URL.
-                                        var w = 0;
-                                        while ((!img.src || img.src.indexOf('blob:') !== 0) && w < 20000) {
-                                            await sleep(250); w += 250;
-                                        }
-                                        if (img.src && img.src.indexOf('blob:') === 0) {
-                                            var ok = await saveBlobUrl(img.src);
-                                            if (ok) saved++;
-                                        }
-                                        // Free the page's DOM/bitmap memory before moving on.
-                                        try {
-                                            img.src = '';
-                                            img.removeAttribute('src');
-                                            if (container && container.parentNode) {
-                                                container.parentNode.removeChild(container);
+                                    // For each `#d-img-N`: determine the expected tile count up
+                                    // front (number of direct <canvas> children of the cc...
+                                    // wrapper for long pages, else 1 for single-tile pages).
+                                    // Try a one-pass capture first; if all expected tiles are
+                                    // already drawn, we're done in <1s. Only fall back to the
+                                    // slow scroll-and-discover loop if a tile is still missing.
+                                    var tilesEmitted = 0;
+                                    function expectedTileCount(container){
+                                        for (var ci = 0; ci < container.children.length; ci++) {
+                                            var ch = container.children[ci];
+                                            if (ch.tagName === 'DIV' && ('' + ch.className).indexOf('cc') === 0) {
+                                                var n = 0;
+                                                for (var ki = 0; ki < ch.children.length; ki++) {
+                                                    if (ch.children[ki].tagName === 'CANVAS') n++;
+                                                }
+                                                return n > 0 ? n : 1;
                                             }
-                                        } catch(e) {}
-                                        webtoonImgs[i] = null;
-                                        // Drop the slot ref too — the hook will overwrite it
-                                        // for the next page; nulling here lets any earlier
-                                        // (already-saved) blob be GCed promptly.
-                                        window.__japscanLastBlob = null;
-                                        console.log('[japscan] webtoon page ' + (i + 1) + ' / ' + total + ' after ' + w + 'ms (saved=' + saved + ')');
+                                        }
+                                        return 1;
                                     }
-                                    console.log('[japscan] webtoon done, ' + saved + ' / ' + total + ' pages saved');
+                                    async function captureOnce(container, pageLabel, savedHosts){
+                                        var saved = 0;
+                                        var tiles = discoverTiles(container);
+                                        for (var ti = 0; ti < tiles.length; ti++) {
+                                            var tile = tiles[ti];
+                                            if (!tile.host || savedHosts.has(tile.host)) continue;
+                                            var ready = await waitForTileReady(tile, 6000);
+                                            if (ready < 0) continue;
+                                            var picked = pickTileCanvas(tile);
+                                            if (!picked || !picked.width || !picked.height) continue;
+                                            var uri = tileToDataUri(tile);
+                                            if (!uri) continue;
+                                            try {
+                                                window.$$interfaceName.savePage(uri);
+                                                savedHosts.add(tile.host);
+                                                saved++;
+                                                tilesEmitted++;
+                                                window.__jlog('[japscan] ' + pageLabel + ' tile #' + savedHosts.size + ' saved (' + picked.width + 'x' + picked.height + ', ' + uri.length + ' chars)');
+                                            } catch(e) {
+                                                window.__jlog('[japscan] ' + pageLabel + ' savePage failed: ' + e);
+                                            }
+                                        }
+                                        return saved;
+                                    }
+                                    for (var i = 0; i < total; i++) {
+                                        var container = dImgContainers[i];
+                                        var pageLabel = 'd-img-' + i;
+                                        var expected = expectedTileCount(container);
+                                        // Bring the container into view so any layout-dependent
+                                        // measurements settle, then attempt a one-pass capture.
+                                        try { container.scrollIntoView({ block: 'start' }); } catch(e) {}
+                                        await sleep(100);
+                                        var savedHosts = new Set();
+                                        await captureOnce(container, pageLabel, savedHosts);
+                                        // If something is still missing (rare — only the lazy
+                                        // single-tile path), fall back to the scroll loop with
+                                        // a short total budget.
+                                        if (savedHosts.size < expected) {
+                                            var contRect = container.getBoundingClientRect();
+                                            var baseY = (window.scrollY || 0) + contRect.top;
+                                            var contH = container.offsetHeight || contRect.height || 2100;
+                                            var step = Math.max(400, Math.floor((window.innerHeight || 4096) * 0.5));
+                                            for (var sy = 0; sy <= contH + step && savedHosts.size < expected; sy += step) {
+                                                window.scrollTo(0, baseY + sy - 100);
+                                                await sleep(400);
+                                                await captureOnce(container, pageLabel, savedHosts);
+                                            }
+                                        }
+                                        window.__jlog('[japscan] ' + pageLabel + ' completed: ' + savedHosts.size + '/' + expected + ' tile(s)');
+                                        try {
+                                            if (container.parentNode) container.parentNode.removeChild(container);
+                                        } catch(e) {}
+                                        dImgContainers[i] = null;
+                                    }
+                                    window.__jlog('[japscan] webtoon done, ' + tilesEmitted + ' tile(s) saved across ' + total + ' d-img containers');
                                     try { window.$$interfaceName.passDone(); } catch(e) {}
                                     return;
                                 }
 
                                 // ---- Paginated mode ----
-                                // Total page count from the (hidden) <select>. Navigation goes
-                                // through the reader's click-zones (`#block-left` / `#block-right`).
-                                // Slimselect option clicks don't work because `.ss-content` is
-                                // hidden until the dropdown is opened; click-zones are what real
-                                // users tap and reliably trigger a per-page render.
+                                // The currently-displayed page lives inside the single-reader
+                                // container. Total page count comes from the (hidden) <select>;
+                                // navigation uses the reader's click-zones (#block-left/right) —
+                                // slimselect option clicks don't work because `.ss-content`
+                                // is hidden until the dropdown opens.
                                 var sel = document.getElementById('pages');
                                 var total = sel ? sel.options.length : 1;
                                 var nextBtn = document.getElementById('block-right');
                                 var prevBtn = document.getElementById('block-left');
-                                console.log('[japscan] paginated mode, total = ' + total + ', next=' + !!nextBtn + ', prev=' + !!prevBtn);
+                                window.__jlog('[japscan] paginated mode, total = ' + total + ', next=' + !!nextBtn + ', prev=' + !!prevBtn);
 
                                 function nav(btn, fallbackKey){
                                     try {
@@ -713,56 +1235,106 @@ abstract class Japscan :
                                             bubbles: true,
                                         }));
                                     } catch(e) {
-                                        console.log('[japscan] nav failed: ' + e);
+                                        window.__jlog('[japscan] nav failed: ' + e);
                                     }
                                 }
 
+                                // Wait until the canvas content inside the single-reader container
+                                // changes compared to the previous page (compared via a tiny pixel
+                                // fingerprint of the widest canvas).
+                                function fingerprint(container) {
+                                    var arr = [];
+                                    gatherCanvases(container, arr);
+                                    if (arr.length === 0) return '';
+                                    var ref = arr[0];
+                                    for (var i = 1; i < arr.length; i++) {
+                                        if (arr[i].width > ref.width) ref = arr[i];
+                                    }
+                                    try {
+                                        var ctx = ref.getContext('2d');
+                                        if (!ctx) return '';
+                                        var pts = [
+                                            [0, 0],
+                                            [Math.max(0, ref.width - 1), 0],
+                                            [Math.floor(ref.width / 2), Math.floor(ref.height / 2)],
+                                            [0, Math.max(0, ref.height - 1)],
+                                            [Math.max(0, ref.width - 1), Math.max(0, ref.height - 1)],
+                                        ];
+                                        var s = '';
+                                        for (var i = 0; i < pts.length; i++) {
+                                            var d = ctx.getImageData(pts[i][0], pts[i][1], 1, 1).data;
+                                            s += d[0] + ',' + d[1] + ',' + d[2] + ',' + d[3] + ';';
+                                        }
+                                        return s;
+                                    } catch(e) { return ''; }
+                                }
+
+                                async function waitForPageChange(container, prevFp, timeoutMs) {
+                                    var w = 0;
+                                    while (w < timeoutMs) {
+                                        var fp = fingerprint(container);
+                                        if (fp && fp !== prevFp) {
+                                            // Settle: keep checking until fp stops changing.
+                                            var lastFp = fp;
+                                            var stable = 0;
+                                            while (stable < 600 && w < timeoutMs) {
+                                                await sleep(200); w += 200;
+                                                var nfp = fingerprint(container);
+                                                if (nfp !== lastFp) { lastFp = nfp; stable = 0; }
+                                                else { stable += 200; }
+                                            }
+                                            return w;
+                                        }
+                                        await sleep(200); w += 200;
+                                    }
+                                    return -1;
+                                }
+
+                                var paginatedContainer = singleReader;
+                                if (!paginatedContainer) {
+                                    window.__jlog('[japscan] no single-reader container found');
+                                    try { window.$$interfaceName.passDone(); } catch(e) {}
+                                    return;
+                                }
+
                                 // The reader pre-renders pages on load (the final pre-render is
-                                // the *last* page, not page 1), so the very first blob the hook
-                                // sees is unreliable. Wait for things to settle, discard whatever
-                                // was captured, then bounce next->prev to force a clean page-1
-                                // render before we start harvesting.
-                                await sleep(5000);
-                                window.__japscanLastBlob = null;
-
-                                nav(nextBtn, 'ArrowRight');
-                                await waitForBlob(8000);
-                                window.__japscanLastBlob = null;
-
-                                nav(prevBtn, 'ArrowLeft');
-                                var t0 = await waitForBlob(8000);
-                                // Capture page 1's blob synchronously, then kick off page 2 BEFORE
-                                // we start encoding+saving page 1. The descrambler's per-page
-                                // pipeline (tile fetch + decode + composite) overlaps with our
-                                // blob → base64 → disk-write, shaving roughly one save-latency
-                                // off every page.
-                                var u0 = window.__japscanLastBlob;
-                                window.__japscanLastBlob = null;
-                                if (total > 1) nav(nextBtn, 'ArrowRight');
-                                var saved = u0 ? ((await saveBlobUrl(u0)) ? 1 : 0) : 0;
-                                console.log('[japscan] page 1 captured after ' + t0 + 'ms (saved=' + saved + ')');
-
-                                for (var i = 1; i < total; i++) {
-                                    var t = await waitForBlob(8000);
-                                    var u = window.__japscanLastBlob;
-                                    window.__japscanLastBlob = null;
-                                    // Pre-click the next page so its render starts now; we'll
-                                    // encode + save the current page concurrently below.
-                                    if (i < total - 1) nav(nextBtn, 'ArrowRight');
-                                    var ok = u ? await saveBlobUrl(u) : false;
-                                    if (ok) saved++;
-                                    console.log('[japscan] page ' + (i + 1) + ' captured after ' + t + 'ms (saved=' + saved + ')');
+                                // the *last* page, not page 1). Give it time to settle, then
+                                // bounce next->prev to force a clean page-1 render.
+                                await sleep(3000);
+                                if (total > 1) {
+                                    nav(nextBtn, 'ArrowRight');
+                                    await sleep(1500);
+                                    nav(prevBtn, 'ArrowLeft');
+                                    await sleep(1500);
                                 }
 
-                                console.log('[japscan] done, ' + saved + ' / ' + total + ' pages saved');
-                                try {
-                                    window.$$interfaceName.passDone();
-                                } catch(e) {
-                                    console.log('[japscan] passDone failed: ' + e);
+                                var savedP = 0;
+                                var prevFp = '';
+                                for (var p = 0; p < total; p++) {
+                                    var t = await waitForRender(paginatedContainer, 15000);
+                                    if (t < 0) {
+                                        window.__jlog('[japscan] paginated page ' + (p + 1) + ' render timed out');
+                                    } else {
+                                        var uri = paginatedComposite(paginatedContainer, 'paginated page ' + (p + 1));
+                                        if (uri && uri.indexOf('data:image/') === 0) {
+                                            try { window.$$interfaceName.savePage(uri); savedP++; } catch(e) {}
+                                            window.__jlog('[japscan] paginated page ' + (p + 1) + '/' + total + ' saved after ' + t + 'ms');
+                                        } else {
+                                            window.__jlog('[japscan] paginated page ' + (p + 1) + ' composite failed');
+                                        }
+                                    }
+                                    prevFp = fingerprint(paginatedContainer);
+                                    if (p < total - 1) {
+                                        nav(nextBtn, 'ArrowRight');
+                                        await waitForPageChange(paginatedContainer, prevFp, 15000);
+                                    }
                                 }
+
+                                window.__jlog('[japscan] paginated done, ' + savedP + ' / ' + total + ' pages saved');
+                                try { window.$$interfaceName.passDone(); } catch(e) {}
                             })();
                         """.trimIndent(),
-                    ) {}
+                    ) { result -> Log.d("Japscan", "[wv-kt] driver eval result=$result") }
                 }
             }
 
@@ -842,6 +1414,12 @@ abstract class Japscan :
             } catch (_: Exception) {
                 // best effort — page just won't be in the list
             }
+        }
+
+        @JavascriptInterface
+        @Suppress("UNUSED")
+        fun log(message: String) {
+            Log.d("Japscan", "[js] $message")
         }
 
         @JavascriptInterface

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -359,49 +359,19 @@ abstract class Japscan :
         return filterOutlierChapters(chapters)
     }
 
-    // Defense in depth: if a honeypot ever slips past the per-row hidden-style
-    // heuristics, its number tends to be wildly out of range (e.g. 483181 vs.
-    // real 1181, or 000001..000008 vs. real 1174..1181). Real chapter numbers are
-    // near-consecutive, so split them on gaps that are much larger than the typical
-    // spacing and drop the clusters that are a clear minority next to the largest —
-    // agnostic to whether the honeypots sit above or below the real range.
+    // Backstop for a honeypot that clears the slug/number binding in parseChapter: its
+    // number comes out wildly out of range (observed: 483181 among real 1174..1181). Real
+    // chapter numbers never sit orders of magnitude above the median, so cap on that.
+    // Low-side honeypots (000001..000008) are already rejected by the leading-zero check
+    // on the URL id, so this only needs to cap the top.
     //
-    // Cluster on chapter_number, NOT on the trailing URL id: Japscan writes
-    // "Chapitre 1100.5" as /11005/, which sits ~9000 away from its neighbours and
-    // would be split off and dropped as an outlier. By chapter number it is 0.5
-    // from 1100 and stays put.
+    // Compare chapter_number, NOT the trailing URL id: Japscan writes "Chapitre 1100.5" as
+    // /11005/, which would read as a 10x outlier. By chapter number it is 0.5 from 1100.
     private fun filterOutlierChapters(chapters: List<SChapter>): List<SChapter> {
-        val withNum = chapters.filter { it.chapter_number >= 0f }
-        if (withNum.size < 2) return chapters
-        val sorted = withNum.sortedBy { it.chapter_number }
-        val gaps = (1 until sorted.size).map { sorted[it].chapter_number - sorted[it - 1].chapter_number }
-        val medianGap = gaps.sorted()[gaps.size / 2].coerceAtLeast(1f)
-        // Treat a gap as a cluster boundary when it dwarfs the typical spacing.
-        // The absolute floor (100) keeps short lists with tiny medians from
-        // splitting on noise; the 50x ratio handles dense lists where the
-        // median is already large.
-        val threshold = maxOf(medianGap * 50, 100f)
-        val clusters = mutableListOf(mutableListOf(sorted[0]))
-        for (i in 1 until sorted.size) {
-            if (sorted[i].chapter_number - sorted[i - 1].chapter_number > threshold) {
-                clusters.add(mutableListOf())
-            }
-            clusters.last().add(sorted[i])
-        }
-        if (clusters.size == 1) return chapters
-        // Only prune when one cluster clearly dominates. On a tie we cannot tell
-        // which side is real (honeypots sit above OR below), and guessing wrong
-        // deletes the entire chapter list — much worse than letting a honeypot
-        // through, since the visibility prune is the primary defense and this is
-        // only a backstop.
-        val largest = clusters.maxOf { it.size }
-        if (clusters.count { it.size == largest } > 1) return chapters
-        // Drop a cluster only if it is a small fraction of the main run. Anything
-        // comparable in size is far more likely a genuine gap in Japscan's catalogue
-        // (a series resuming at a much higher number) than a block of honeypots, and
-        // keeping only the largest cluster would silently delete those real chapters.
-        val keep = clusters.filter { it.size * 4 > largest }.flatten().toSet()
-        return chapters.filter { it.chapter_number < 0f || it in keep }
+        val nums = chapters.map { it.chapter_number }.filter { it >= 0f }.sorted()
+        if (nums.size < 3) return chapters
+        val ceiling = nums[nums.size / 2] * 10 + 100
+        return chapters.filter { it.chapter_number <= ceiling }
     }
 
     private fun extractMangaSlug(url: HttpUrl): String? {
@@ -442,17 +412,9 @@ abstract class Japscan :
             .mapNotNull { el ->
                 // Find the first attribute whose value matches the chapter URL pattern
                 val attrMatch = el.attributes().asList().firstOrNull { attr ->
-                    val value = attr.value
-                    value.startsWith("/manga/") || value.startsWith("/manhua/") || value.startsWith("/manhwa/") || value.startsWith("/bd/") || value.startsWith("/comic/")
+                    CHAPTER_PATH_TYPES.any { attr.value.startsWith("/$it/") }
                 }
-                if (attrMatch != null) {
-                    val name = el.ownText().ifBlank { el.text() }
-                    // Mark if the attribute is not "href"
-                    val isNonHref = attrMatch.key != "href"
-                    Triple(name, attrMatch.value, isNonHref)
-                } else {
-                    null
-                }
+                attrMatch?.let { Pair(el.ownText().ifBlank { el.text() }, it.value) }
             }
             .distinctBy { it.second }
 
@@ -463,7 +425,7 @@ abstract class Japscan :
         // Honeypots use a different slug (e.g. /manga/cv/N/) with sequential numbers that match a
         // fake "Chapitre N" label, so name/number alone is not enough — slug check is what stops them.
         val filtered = allUrlPairs
-            .filter { (name, url, _) ->
+            .filter { (name, url) ->
                 val segments = url.split('/').filter { it.isNotEmpty() }
                 if (segments.size != 3) return@filter false
                 if (segments[0] !in CHAPTER_PATH_TYPES) return@filter false
@@ -478,17 +440,12 @@ abstract class Japscan :
                 chapterNum == urlNum
             }
 
-        // Fall back to the unfiltered list in case the heuristics are too aggressive.
-        // Defense in depth: when the slug filter is unavailable, prefer the longest URL — real
-        // slugs (e.g. "one-piece") are usually longer than honeypot slugs (e.g. "cv").
-        val urlPairs = (filtered.ifEmpty { allUrlPairs })
-            .sortedWith(
-                compareByDescending<Triple<String, String, Boolean>> { it.third }
-                    .thenByDescending { it.second.length },
-            ) // Prefer non-href first, then longer URLs
-            .map { Pair(it.first, it.second) }
-
-        val foundPair = urlPairs.firstOrNull()
+        // Fall back to the unfiltered list in case the heuristics are too aggressive. There
+        // we prefer the longest URL — real slugs (e.g. "one-piece") are usually longer than
+        // honeypot slugs (e.g. "cv"). The binding above admits at most one URL per row, so
+        // nothing needs ordering on the normal path.
+        val foundPair = filtered.firstOrNull()
+            ?: allUrlPairs.maxByOrNull { it.second.length }
             ?: throw Exception("Impossible de trouver l'URL du chapitre")
 
         val chapter = SChapter.create()
@@ -1172,6 +1129,8 @@ abstract class Japscan :
                                 //      consistently holds the real bitmap; siblings are decoys.
                                 //   3. The first non-empty canvas — last-resort.
                                 function pickTileCanvas(tile){
+                                    // cc-wrapper slices are their own host — nothing to resolve.
+                                    if (tile.host instanceof HTMLCanvasElement) return tile.host;
                                     try {
                                         if (tile.host && tile.host.canvas instanceof HTMLCanvasElement) {
                                             return tile.host.canvas;
@@ -1378,7 +1337,7 @@ abstract class Japscan :
         // Wrap each absolute cache path in the sentinel host so OkHttp accepts it
         // and our interceptor serves the file. Paths under /data/data/... are
         // already URL-safe (alphanumerics, dots, slashes, hyphens).
-        val images = jsInterface.images
+        val images = jsInterface.snapshot()
             .mapIndexed { i, path -> Page(i, imageUrl = "https://$JAPSCAN_CACHE_HOST$path") }
         return Observable.just(images)
     }
@@ -1428,10 +1387,6 @@ abstract class Japscan :
         private val latch: CountDownLatch,
         private val cacheDir: File,
     ) {
-        // Absolute file paths in the app's cache dir, in capture order.
-        var images: List<String> = listOf()
-            private set
-
         // Last time the driver made progress, for fetchPageList's idle watchdog.
         @Volatile
         var lastActivity: Long = System.currentTimeMillis()
@@ -1439,6 +1394,9 @@ abstract class Japscan :
 
         private val savedPaths = mutableListOf<String>()
         private val sessionTag = "$CACHE_FILE_PREFIX${System.currentTimeMillis()}"
+
+        // Absolute file paths in the app's cache dir, in capture order.
+        fun snapshot(): List<String> = synchronized(savedPaths) { savedPaths.toList() }
 
         @JavascriptInterface
         @Suppress("UNUSED")
@@ -1468,7 +1426,6 @@ abstract class Japscan :
         @JavascriptInterface
         @Suppress("UNUSED")
         fun passDone() {
-            images = synchronized(savedPaths) { savedPaths.toList() }
             latch.countDown()
         }
     }

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.extension.fr.japscan
 
-import android.app.Application
 import android.content.ComponentName
 import android.content.Intent
 import android.content.SharedPreferences
@@ -11,6 +10,7 @@ import android.util.Base64
 import android.util.Log
 import android.view.View
 import android.webkit.ConsoleMessage
+import android.webkit.CookieManager
 import android.webkit.JavascriptInterface
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
@@ -32,6 +32,7 @@ import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.annotation.Source
 import keiyoushi.network.rateLimit
+import keiyoushi.utils.applicationContext
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.string
@@ -50,14 +51,13 @@ import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.jsoup.nodes.Element
 import rx.Observable
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.collections.mapIndexed
 import kotlin.time.Duration.Companion.seconds
 
@@ -167,6 +167,16 @@ abstract class Japscan :
         // How long fetchPageList waits with zero saved pages before deciding the
         // WebView driver is wedged rather than merely slow.
         private const val IDLE_TIMEOUT_MS = 45_000L
+
+        // Captcha flow. Same values as the sibling ScanManga extension, which runs the
+        // near-identical Cloudflare dance.
+        private const val CF_POLL_INTERVAL_MS = 5000L
+        private const val CF_MAX_POLLS = 15
+
+        // Settle window that lets Cloudflare's Turnstile beacon commit cf_clearance
+        // before the warmup WebView is torn down.
+        private const val WARMUP_SETTLE_MS = 200L
+        private const val WARMUP_TIMEOUT_SECONDS = 8L
 
         // Synthetic viewport used to force-layout the detached WebView. Must stay
         // desktop-class: under ~1280 px wide the reader takes a "mobile" path that
@@ -463,7 +473,8 @@ abstract class Japscan :
 
     override fun fetchPageList(chapter: SChapter): Observable<List<Page>> {
         val interfaceName = randomString()
-        val context = Injekt.get<Application>()
+        val context = applicationContext
+        val chapterUrl = "$internalBaseUrl${chapter.url}"
         sweepPageCache(context.cacheDir)
         val isReader = Exception().stackTrace.any { it.className.contains("reader") }
 
@@ -471,16 +482,29 @@ abstract class Japscan :
         val latch = CountDownLatch(1)
         val jsInterface = JsInterface(latch, context.cacheDir)
         var webView: WebView? = null
-        var request: Response = client.newCall(GET("$internalBaseUrl${chapter.url}", headers)).execute()
-        var pageContent = request.body.string()
-        val matchResult = captchaRegex.find(pageContent)
 
-        if (matchResult != null) {
+        // The probe body is never reused — the WebView re-fetches the chapter itself — so
+        // this only answers "is the captcha in the way right now?".
+        fun captchaPresent(): Boolean = client.newCall(GET(chapterUrl, headers)).execute().use {
+            captchaRegex.containsMatchIn(it.body.string())
+        }
+
+        var blocked = captchaPresent()
+        if (blocked) {
+            // Cold-session path: CF refuses to issue cf_clearance to a session that's never
+            // touched the host. Warm up by loading the homepage in a hidden WebView, then
+            // re-probe — usually clears it without ever bothering the user. (Ported from the
+            // sibling ScanManga extension, which runs the same dance.)
+            warmupWebViewSession()
+            blocked = captchaPresent()
+        }
+
+        if (blocked) {
             try {
                 val intent = Intent().apply {
                     component = ComponentName(context, "eu.kanade.tachiyomi.ui.webview.WebViewActivity")
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    putExtra("url_key", "$internalBaseUrl${chapter.url}")
+                    putExtra("url_key", chapterUrl)
                     putExtra("source_key", id)
                     putExtra("title_key", "Résolvez le captcha, fermez la Webview et réouvrez le chapitre.")
                 }
@@ -490,13 +514,10 @@ abstract class Japscan :
                 // Suwayomi etc.
                 throw Exception("Résolvez le captcha de ce chapitre depuis la WebView et réouvrez le chapitre.")
             }
-            var captchaWait = 0
-            while (captchaWait < 15) {
-                Thread.sleep(5000)
-                request = client.newCall(GET("$internalBaseUrl${chapter.url}", headers)).execute()
-                pageContent = request.body.string()
-                val isGood = captchaRegex.find(pageContent)
-                if (isGood == null) {
+            for (attempt in 1..CF_MAX_POLLS) {
+                Thread.sleep(CF_POLL_INTERVAL_MS)
+                if (!captchaPresent()) {
+                    blocked = false
                     val closeIntent = Intent().apply {
                         val targetClass = if (isReader) {
                             "eu.kanade.tachiyomi.ui.reader.ReaderActivity"
@@ -508,11 +529,12 @@ abstract class Japscan :
                     }
                     context.startActivity(closeIntent)
                     break
-                } else {
-                    captchaWait++
                 }
             }
-            if (captchaWait >= 15) {
+            if (blocked) {
+                // The WebView flow exhausted itself, so the warmup wasn't enough either.
+                // Clear the gate so the next attempt warms again from scratch.
+                sessionWarmedUp.set(false)
                 throw Exception("Résolvez le captcha, fermez la Webview et réouvrez le chapitre.")
             }
         }
@@ -1308,10 +1330,7 @@ abstract class Japscan :
                 }
             }
 
-            innerWv.loadUrl(
-                "$internalBaseUrl${chapter.url}",
-                headers.toMap(),
-            )
+            innerWv.loadUrl(chapterUrl, headers.toMap())
         }
 
         // Generous ceiling: the JS sequentially drives every page through the
@@ -1362,6 +1381,53 @@ abstract class Japscan :
             setDefaultValue("hide")
         }
         screen.addPreference(chapterListPref)
+    }
+
+    private val sessionWarmedUp = AtomicBoolean(false)
+
+    // Load the homepage in a hidden WebView so Cloudflare issues cf_clearance for this
+    // session. Runs once per process; the gate is reset by the captcha flow when the whole
+    // dance fails, so a later attempt warms again from scratch.
+    private fun warmupWebViewSession() {
+        if (!sessionWarmedUp.compareAndSet(false, true)) return
+
+        val latch = CountDownLatch(1)
+        val mainHandler = Handler(Looper.getMainLooper())
+
+        mainHandler.post {
+            val wv = WebView(applicationContext)
+            wv.settings.javaScriptEnabled = true
+            wv.settings.domStorageEnabled = true
+
+            CookieManager.getInstance().apply {
+                setAcceptCookie(true)
+                setAcceptThirdPartyCookies(wv, true)
+            }
+
+            wv.webViewClient = object : WebViewClient() {
+                override fun onPageFinished(view: WebView?, url: String?) {
+                    // Schedule teardown on the main looper directly — view.postDelayed is
+                    // silently dropped because the WebView isn't attached to a window.
+                    // The settle window lets CF's Turnstile beacon commit cf_clearance.
+                    mainHandler.postDelayed({
+                        runCatching {
+                            view?.stopLoading()
+                            view?.destroy()
+                        }
+                        latch.countDown()
+                    }, WARMUP_SETTLE_MS)
+                }
+            }
+            wv.loadUrl("$internalBaseUrl/")
+        }
+
+        try {
+            if (!latch.await(WARMUP_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                sessionWarmedUp.set(false)
+            }
+        } catch (_: InterruptedException) {
+            sessionWarmedUp.set(false)
+        }
     }
 
     // Spooled page files outlive the interceptor that serves them, so the reader can

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -7,8 +7,12 @@ import android.content.SharedPreferences
 import android.graphics.Bitmap
 import android.os.Handler
 import android.os.Looper
+import android.util.Base64
+import android.util.Log
 import android.view.View
+import android.webkit.ConsoleMessage
 import android.webkit.JavascriptInterface
+import android.webkit.WebChromeClient
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.preference.ListPreference
@@ -35,9 +39,13 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import okhttp3.FormBody
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
+import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import rx.Observable
 import uy.kohesive.injekt.Injekt
@@ -64,6 +72,27 @@ abstract class Japscan :
 
     override val client: OkHttpClient = network.client.newBuilder()
         .rateLimit(1, 2.seconds)
+        // Pages from fetchPageList are decoded blobs cached on disk; their imageUrl is
+        // `https://japscan-cache.local/<absolute-cache-path>`. We can't override
+        // fetchImage (final), so an interceptor catches that sentinel host and serves
+        // the file bytes synthetically.
+        .addInterceptor { chain ->
+            val req = chain.request()
+            if (req.url.host != JAPSCAN_CACHE_HOST) return@addInterceptor chain.proceed(req)
+            val path = "/" + req.url.pathSegments.joinToString("/")
+            val file = File(path)
+            val bytes = file.readBytes()
+            try {
+                file.delete()
+            } catch (_: Exception) {}
+            Response.Builder()
+                .request(req)
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(bytes.toResponseBody("image/jpeg".toMediaType()))
+                .build()
+        }
         .build()
 
     private val captchaRegex = """window\.__captcha\s*=\s*\{\s*needed\s*:\s*true\s*,?""".toRegex()
@@ -109,6 +138,10 @@ abstract class Japscan :
 
         private const val SHOW_SPOILER_CHAPTERS_TITLE = "Les chapitres en Anglais ou non traduit sont upload en tant que \" Spoilers \" sur Japscan"
         private const val SHOW_SPOILER_CHAPTERS = "JAPSCAN_SPOILER_CHAPTERS"
+
+        // Sentinel host used to route page-image requests to a local cache file via
+        // an OkHttp interceptor (see `client` builder).
+        private const val JAPSCAN_CACHE_HOST = "japscan-cache.local"
         private val prefsEntries = arrayOf("Montrer uniquement les chapitres traduit en Français", "Montrer les chapitres spoiler")
         private val prefsEntryValues = arrayOf("hide", "show")
     }
@@ -399,7 +432,7 @@ abstract class Japscan :
 
         val handler = Handler(Looper.getMainLooper())
         val latch = CountDownLatch(1)
-        val jsInterface = JsInterface(latch)
+        val jsInterface = JsInterface(latch, context.cacheDir)
         var webView: WebView? = null
         var request: Response = client.newCall(GET("$internalBaseUrl${chapter.url}", headers)).execute()
         var pageContent = request.body.string()
@@ -453,161 +486,68 @@ abstract class Japscan :
             webView = innerWv
             innerWv.settings.domStorageEnabled = true
             innerWv.settings.javaScriptEnabled = true
-            innerWv.settings.blockNetworkImage = true
+            // The reader fetches scrambled tiles and reassembles them onto canvases;
+            // images must be allowed to load for the descrambling to run.
+            innerWv.settings.blockNetworkImage = false
             innerWv.settings.userAgentString = headers["User-Agent"]
             innerWv.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
             innerWv.addJavascriptInterface(jsInterface, interfaceName)
 
+            // Forward in-page console.log calls to Logcat (tag "Japscan") so the JS
+            // pagination driver's progress is visible during debugging.
+            innerWv.webChromeClient = object : WebChromeClient() {
+                override fun onConsoleMessage(msg: ConsoleMessage): Boolean {
+                    Log.d("Japscan", "[wv] ${msg.message()}")
+                    return true
+                }
+            }
+
             innerWv.webViewClient = object : WebViewClient() {
                 override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
                     super.onPageStarted(view, url, favicon)
+                    // Install the createObjectURL hook as early as possible. Each chapter page is
+                    // descrambled onto canvases by the page's own JS and surfaced as a `blob:` URL
+                    // via URL.createObjectURL — capturing those gives us the final rendered images.
+                    // We deliberately avoid overriding String.prototype.replace / atob / fetch:
+                    // the new bot detection checks `replace.toString().includes('[native code]')`
+                    // and trips `__poisoned = true` if any built-in is monkey-patched, which
+                    // makes the page refuse to deliver the payload.
+                    //
+                    // We stream the conversion (blob -> base64 data URI) as soon as each blob is
+                    // created and revoke the original blob right after, so memory doesn't grow
+                    // unboundedly across the 13+ pages we drive through (otherwise the renderer
+                    // OOMs with all the page canvases held simultaneously).
                     view?.evaluateJavascript(
                         $$"""
-                            function waitForRC(callback) {
-                                if (window.__rc) {
-                                    callback();
-                                } else {
-                                    setTimeout(() => waitForRC(callback), 100);
-                                }
-                            }
-
-                            // Hook atob — Japscan delivers the chapter payload as a base64-encoded
-                            // JSON whose `cc` array contains the c4.japscan.foo image URLs. The
-                            // payload no longer goes through String.replace, so atob is the only
-                            // reliable interception point.
-                            const originalAtob = window.atob;
-                            window.atob = function(str) {
-                                const result = originalAtob.call(this, str);
-                                try {
-                                    let utf8 = result;
+                            (function(){
+                                if (window.__japscanHooked) return;
+                                window.__japscanHooked = true;
+                                // Single slot tracking the most-recent image blob. Used by the
+                                // paginated-reader driver, which harvests one blob per page
+                                // navigation. The webtoon driver ignores this slot and instead
+                                // iterates `<img id="img-N">.src` in DOM order. We do NOT
+                                // auto-revoke the previous blob here: in webtoon mode all
+                                // blobs are pinned to <img> elements, and revoking them
+                                // before we fetch their bytes makes the URL unfetchable.
+                                window.__japscanLastBlob = null;
+                                var _orig = URL.createObjectURL.bind(URL);
+                                URL.createObjectURL = function(obj){
+                                    var u = _orig(obj);
                                     try {
-                                        utf8 = decodeURIComponent(
-                                            Array.from(result, c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)).join('')
-                                        );
-                                    } catch (e) { return result; }
-                                    if (utf8.indexOf('c4.japscan.foo') !== -1 && !window.__createCalled) {
-                                        try {
-                                            const parsed = JSON.parse(utf8);
-                                            waitForRC(() => create(parsed));
-                                        } catch (e) { /* not JSON */ }
-                                    }
-                                } catch (e) { /* swallow */ }
-                                return result;
-                            };
-
-                            const originalReplace = String.prototype.replace;
-
-                            function tryDecodeBase64ToJsonKeysOnly(str) {
-                              const s = String(str).trim();
-                              if (!/^[A-Za-z0-9+/]+={0,2}$/.test(s) || s.length % 4 === 1) return null;
-                              try {
-                                const bin = atob(s);
-                                const utf8 = decodeURIComponent(
-                                  Array.from(bin, c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)).join('')
-                                );
-                                if(!utf8.includes(location.pathname.replaceAll("/", "\\/"))) return null;
-                                const parsed = JSON.parse(utf8);
-                                return parsed
-                              } catch (e) {
-                                return null;
-                              }
-                              return null;
-                            }
-
-                            String.prototype.replace = function(searchValue, replaceValue) {
-                              const receiver = this;
-
-                              const effectiveReplace = (typeof replaceValue === 'function')
-                                ? function(...args) { return replaceValue.apply(this, args); }
-                                : replaceValue;
-
-                              const rawResult = originalReplace.call(receiver, searchValue, effectiveReplace);
-
-                              if (typeof rawResult === 'string') {
-                                const parsed = tryDecodeBase64ToJsonKeysOnly(rawResult);
-                                if (parsed) {
-                                  waitForRC(() => create(parsed))
-                                }
-                              }
-
-                              return rawResult;
-                            };
-
-                            function findFirstArray(obj) {
-                              let found = null;
-                              (function visit(value) {
-                                if (found) return;
-                                if (value && typeof value === 'object') {
-                                  if (Array.isArray(value)) {
-                                    found = value;
-                                    return;
-                                  }
-                                  for (const k in value) {
-                                    if (Object.prototype.hasOwnProperty.call(value, k)) {
-                                      visit(value[k]);
-                                      if (found) return;
-                                    }
-                                  }
-                                }
-                              })(obj);
-                              return found;
-                            }
-
-                            // Pick the array whose elements look like CDN image URLs.
-                            // Japscan's payload also embeds a path-segments array (e.g.
-                            // ["manga","one-piece","1181"]) that findFirstArray would otherwise grab.
-                            function findImageArray(obj) {
-                              let found = null;
-                              (function visit(value) {
-                                if (found) return;
-                                if (Array.isArray(value) && value.length > 0 &&
-                                    value.every(v => typeof v === 'string' && v.indexOf('c4.japscan.foo') !== -1)) {
-                                  found = value;
-                                  return;
-                                }
-                                if (value && typeof value === 'object') {
-                                  for (const k in value) {
-                                    if (Object.prototype.hasOwnProperty.call(value, k)) {
-                                      visit(value[k]);
-                                      if (found) return;
-                                    }
-                                  }
-                                }
-                              })(obj);
-                              return found;
-                            }
-
-                            function create(parsed) {
-                                if (window.__createCalled) return;
-                                let arr = findImageArray(parsed) || findFirstArray(parsed);
-                                const arrLen = arr ? arr.length : -1;
-                                if (!arr || arr.length === 0) return;
-                                window.__createCalled = true;
-                                const chapterMatch = location.pathname.match(/\/(\d+)(?:\/|$)/);
-                                const chapterNum = chapterMatch ? Number(chapterMatch[1]) : null;
-                                let candidate = null;
-                                (function visit(obj) {
-                                    if (candidate) return;
-                                        if (obj && typeof obj === 'object') {
-                                            for (const k in obj) {
-                                                if (!Object.prototype.hasOwnProperty.call(obj, k)) continue;
-                                                const v = obj[k];
-                                                if (typeof v === 'number' && Number.isFinite(v) && Math.floor(v) === v) {
-                                                const n = v;
-                                                if (n > 0 && n <= arrLen && n !== chapterNum) { candidate = n; return; }
-                                            }
-                                            if (typeof v === 'string' && /^[0-9]+$/.test(v)) {
-                                                const n = Number(v);
-                                                if (n > 0 && n <= arrLen && n !== chapterNum) { candidate = n; return; }
-                                            }
-                                            if (typeof v === 'object') visit(v);
-                                            if (candidate) return;
+                                        if (obj && obj.type && /^image\//.test(obj.type)) {
+                                            window.__japscanLastBlob = u;
                                         }
-                                    }
-                                })(parsed);
-                                const finalNum = candidate || chapterNum || 0;
-                                window.$$interfaceName.passPayload(JSON.stringify(arr), window.__rc.p, window.__rc.v, finalNum.toString());
-                            }
+                                    } catch(e) {}
+                                    return u;
+                                };
+                                // Make our hook look like a native function in case the site ever
+                                // adds the same `[native code]` tripwire to createObjectURL.
+                                try {
+                                    URL.createObjectURL.toString = function(){
+                                        return 'function createObjectURL() { [native code] }';
+                                    };
+                                } catch(e) {}
+                            })();
                         """.trimIndent(),
                     ) {}
                 }
@@ -618,6 +558,211 @@ abstract class Japscan :
                     // we're detached. resumeTimers is global to all WebViews in the process.
                     view?.onResume()
                     view?.resumeTimers()
+                    // Drive the reader through every chapter page (the `<select id="pages">`
+                    // element drives navigation). The createObjectURL hook installed in
+                    // onPageStarted converts each blob to a data URI as soon as it's produced,
+                    // so we just drive the UI and wait for window.__japscanImages to stabilize.
+                    view?.evaluateJavascript(
+                        $$"""
+                            (async function(){
+                                var sleep = function(ms){ return new Promise(function(r){ setTimeout(r, ms); }); };
+
+                                // Convert a blob URL to a base64 data URI and save it via the
+                                // JS interface. Returns true on success.
+                                async function saveBlobUrl(u){
+                                    if (!u) return false;
+                                    try {
+                                        var r = await fetch(u);
+                                        var b = await r.blob();
+                                        var d = await new Promise(function(res, rej){
+                                            var fr = new FileReader();
+                                            fr.onload = function(){ res(fr.result); };
+                                            fr.onerror = rej;
+                                            fr.readAsDataURL(b);
+                                        });
+                                        if (typeof d === 'string' && d.indexOf('data:image/') === 0) {
+                                            window.$$interfaceName.savePage(d);
+                                            return true;
+                                        }
+                                    } catch(e) {
+                                        console.log('[japscan] saveBlobUrl failed: ' + e);
+                                    } finally {
+                                        try { URL.revokeObjectURL(u); } catch(e) {}
+                                    }
+                                    return false;
+                                }
+
+                                // Paginated mode: harvest the latest blob from the slot.
+                                async function harvest(){
+                                    var u = window.__japscanLastBlob;
+                                    if (!u) return false;
+                                    window.__japscanLastBlob = null;
+                                    return await saveBlobUrl(u);
+                                }
+
+                                // Wait for a fresh blob to appear (slot starts null after each
+                                // harvest). After it appears, settle for a bit so any later
+                                // re-render of the same page replaces the slot with the final
+                                // composited image.
+                                async function waitForBlob(timeoutMs){
+                                    var w = 0;
+                                    while (!window.__japscanLastBlob && w < timeoutMs) {
+                                        await sleep(100); w += 100;
+                                    }
+                                    if (!window.__japscanLastBlob) return -1;
+                                    var lastUrl = window.__japscanLastBlob;
+                                    var stable = 0;
+                                    while (stable < 400) {
+                                        await sleep(100);
+                                        if (window.__japscanLastBlob !== lastUrl) {
+                                            lastUrl = window.__japscanLastBlob;
+                                            stable = 0;
+                                        } else {
+                                            stable += 100;
+                                        }
+                                    }
+                                    return w;
+                                }
+
+                                // Detect reader mode. Webtoon (long-strip) puts everything in
+                                // `#full-reader` with one `<img id="img-N">` per page and hides
+                                // `#single-reader` (class `d-none`); paginated mode is the
+                                // opposite. We use a different driver per mode.
+                                var fullReader = document.getElementById('full-reader');
+                                var singleReader = document.querySelector('[id^="single-reader"]');
+                                var webtoonImgs = fullReader
+                                    ? Array.from(fullReader.querySelectorAll('img[id^="img-"]'))
+                                          .sort(function(a, b){
+                                              return parseInt(a.id.replace('img-', ''), 10)
+                                                   - parseInt(b.id.replace('img-', ''), 10);
+                                          })
+                                    : [];
+                                var singleHidden = singleReader && singleReader.classList.contains('d-none');
+                                var isWebtoon = webtoonImgs.length > 0 && (singleHidden || !singleReader);
+
+                                if (isWebtoon) {
+                                    var total = webtoonImgs.length;
+                                    console.log('[japscan] webtoon mode, total = ' + total);
+                                    var saved = 0;
+                                    // Each webtoon page is rendered into ~8 layered canvases
+                                    // inside a closed shadow root and then composited to a
+                                    // pinned `<img>.src` blob. Holding all 14 pages worth of
+                                    // canvases and bitmaps in the DOM concurrently OOMs the
+                                    // renderer (≈ 14 × 8 × 940 × 2100 × 4 ≈ 880 MB), so we
+                                    // tear down each `#d-img-N` container as soon as we've
+                                    // grabbed the bytes for that page.
+                                    //
+                                    // We also remove the (hidden) single-reader subtree up
+                                    // front to drop its stale layer-canvases; in webtoon mode
+                                    // it's `d-none` and only adds memory pressure.
+                                    if (singleReader && singleReader.parentNode) {
+                                        try { singleReader.parentNode.removeChild(singleReader); } catch(e) {}
+                                    }
+                                    for (var i = 0; i < total; i++) {
+                                        var img = webtoonImgs[i];
+                                        var container = document.getElementById('d-img-' + i);
+                                        try { img.scrollIntoView({ block: 'start' }); } catch(e) {}
+                                        // Wait for the descrambler to set img.src to a blob URL.
+                                        var w = 0;
+                                        while ((!img.src || img.src.indexOf('blob:') !== 0) && w < 20000) {
+                                            await sleep(250); w += 250;
+                                        }
+                                        if (img.src && img.src.indexOf('blob:') === 0) {
+                                            var ok = await saveBlobUrl(img.src);
+                                            if (ok) saved++;
+                                        }
+                                        // Free the page's DOM/bitmap memory before moving on.
+                                        try {
+                                            img.src = '';
+                                            img.removeAttribute('src');
+                                            if (container && container.parentNode) {
+                                                container.parentNode.removeChild(container);
+                                            }
+                                        } catch(e) {}
+                                        webtoonImgs[i] = null;
+                                        // Drop the slot ref too — the hook will overwrite it
+                                        // for the next page; nulling here lets any earlier
+                                        // (already-saved) blob be GCed promptly.
+                                        window.__japscanLastBlob = null;
+                                        console.log('[japscan] webtoon page ' + (i + 1) + ' / ' + total + ' after ' + w + 'ms (saved=' + saved + ')');
+                                    }
+                                    console.log('[japscan] webtoon done, ' + saved + ' / ' + total + ' pages saved');
+                                    try { window.$$interfaceName.passDone(); } catch(e) {}
+                                    return;
+                                }
+
+                                // ---- Paginated mode ----
+                                // Total page count from the (hidden) <select>. Navigation goes
+                                // through the reader's click-zones (`#block-left` / `#block-right`).
+                                // Slimselect option clicks don't work because `.ss-content` is
+                                // hidden until the dropdown is opened; click-zones are what real
+                                // users tap and reliably trigger a per-page render.
+                                var sel = document.getElementById('pages');
+                                var total = sel ? sel.options.length : 1;
+                                var nextBtn = document.getElementById('block-right');
+                                var prevBtn = document.getElementById('block-left');
+                                console.log('[japscan] paginated mode, total = ' + total + ', next=' + !!nextBtn + ', prev=' + !!prevBtn);
+
+                                function nav(btn, fallbackKey){
+                                    try {
+                                        if (btn) { btn.click(); return; }
+                                        document.dispatchEvent(new KeyboardEvent('keydown', {
+                                            key: fallbackKey, code: fallbackKey,
+                                            which: fallbackKey === 'ArrowRight' ? 39 : 37,
+                                            keyCode: fallbackKey === 'ArrowRight' ? 39 : 37,
+                                            bubbles: true,
+                                        }));
+                                    } catch(e) {
+                                        console.log('[japscan] nav failed: ' + e);
+                                    }
+                                }
+
+                                // The reader pre-renders pages on load (the final pre-render is
+                                // the *last* page, not page 1), so the very first blob the hook
+                                // sees is unreliable. Wait for things to settle, discard whatever
+                                // was captured, then bounce next->prev to force a clean page-1
+                                // render before we start harvesting.
+                                await sleep(5000);
+                                window.__japscanLastBlob = null;
+
+                                nav(nextBtn, 'ArrowRight');
+                                await waitForBlob(8000);
+                                window.__japscanLastBlob = null;
+
+                                nav(prevBtn, 'ArrowLeft');
+                                var t0 = await waitForBlob(8000);
+                                // Capture page 1's blob synchronously, then kick off page 2 BEFORE
+                                // we start encoding+saving page 1. The descrambler's per-page
+                                // pipeline (tile fetch + decode + composite) overlaps with our
+                                // blob → base64 → disk-write, shaving roughly one save-latency
+                                // off every page.
+                                var u0 = window.__japscanLastBlob;
+                                window.__japscanLastBlob = null;
+                                if (total > 1) nav(nextBtn, 'ArrowRight');
+                                var saved = u0 ? ((await saveBlobUrl(u0)) ? 1 : 0) : 0;
+                                console.log('[japscan] page 1 captured after ' + t0 + 'ms (saved=' + saved + ')');
+
+                                for (var i = 1; i < total; i++) {
+                                    var t = await waitForBlob(8000);
+                                    var u = window.__japscanLastBlob;
+                                    window.__japscanLastBlob = null;
+                                    // Pre-click the next page so its render starts now; we'll
+                                    // encode + save the current page concurrently below.
+                                    if (i < total - 1) nav(nextBtn, 'ArrowRight');
+                                    var ok = u ? await saveBlobUrl(u) : false;
+                                    if (ok) saved++;
+                                    console.log('[japscan] page ' + (i + 1) + ' captured after ' + t + 'ms (saved=' + saved + ')');
+                                }
+
+                                console.log('[japscan] done, ' + saved + ' / ' + total + ' pages saved');
+                                try {
+                                    window.$$interfaceName.passDone();
+                                } catch(e) {
+                                    console.log('[japscan] passDone failed: ' + e);
+                                }
+                            })();
+                        """.trimIndent(),
+                    ) {}
                 }
             }
 
@@ -627,23 +772,20 @@ abstract class Japscan :
             )
         }
 
-        latch.await(30, TimeUnit.SECONDS)
+        // Generous timeout: the JS sequentially drives every page through the
+        // reader's pagination and waits for each blob, which can easily exceed
+        // a minute on long chapters.
+        latch.await(3, TimeUnit.MINUTES)
         handler.post { webView?.destroy() }
 
         if (latch.count == 1L) {
             throw Exception("Erreur lors de la récupération des pages")
         }
-        val baseUrlHost = internalBaseUrl.toHttpUrl().host.substringAfter("www.")
+        // Wrap each absolute cache path in the sentinel host so OkHttp accepts it
+        // and our interceptor serves the file. Paths under /data/data/... are
+        // already URL-safe (alphanumerics, dots, slashes, hyphens).
         val images = jsInterface.images
-            .filter { it.toHttpUrl().host.endsWith(baseUrlHost) }
-            .mapIndexed { i, url ->
-                if (i != jsInterface.pi) {
-                    Page(i, imageUrl = "$url&${jsInterface.p}=${jsInterface.v}")
-                } else {
-                    null
-                }
-            }
-            .filterNotNull()
+            .mapIndexed { i, path -> Page(i, imageUrl = "https://$JAPSCAN_CACHE_HOST$path") }
         return Observable.just(images)
     }
 
@@ -674,29 +816,39 @@ abstract class Japscan :
         return List(length) { charPool.random() }.joinToString("")
     }
 
-    internal class JsInterface(private val latch: CountDownLatch) {
+    internal class JsInterface(
+        private val latch: CountDownLatch,
+        private val cacheDir: File,
+    ) {
+        // Absolute file paths in the app's cache dir, in capture order.
         var images: List<String> = listOf()
             private set
-        var p: String = ""
-            private set
-        var v: String = ""
-            private set
-        var pi: Int = -1
-            private set
+        private val savedPaths = mutableListOf<String>()
+        private val sessionTag = "japscan-${System.currentTimeMillis()}"
 
         @JavascriptInterface
         @Suppress("UNUSED")
-        fun passPayload(rawData: String, p: String, v: String, pi: String) {
+        fun savePage(dataUri: String) {
             try {
-                images = rawData.parseAs<List<String>>()
-                    .map { "$it?y=1" }
-                this.p = p
-                this.v = v
-                this.pi = pi.toInt()
-                latch.countDown()
+                val commaIdx = dataUri.indexOf(',')
+                if (commaIdx <= 0) return
+                val base64 = dataUri.substring(commaIdx + 1)
+                val bytes = Base64.decode(base64, Base64.DEFAULT)
+                synchronized(savedPaths) {
+                    val file = File(cacheDir, "$sessionTag-${savedPaths.size}.bin")
+                    file.writeBytes(bytes)
+                    savedPaths.add(file.absolutePath)
+                }
             } catch (_: Exception) {
-                return
+                // best effort — page just won't be in the list
             }
+        }
+
+        @JavascriptInterface
+        @Suppress("UNUSED")
+        fun passDone() {
+            images = synchronized(savedPaths) { savedPaths.toList() }
+            latch.countDown()
         }
     }
 }

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -73,14 +73,20 @@ abstract class Japscan :
         private val HIDDEN_STYLE_TOKENS = listOf(
             "display:none",
             "visibility:hidden",
+            "visibility:collapse",
+            "content-visibility:hidden",
             "opacity:0",
+            "filter:opacity(0",
             "width:0",
             "height:0",
             "pointer-events:none",
             "clip-path:inset(100%",
-            "clip-path:circle(0)",
+            "clip-path:circle(0",
+            "clip-path:ellipse(0",
+            "clip-path:polygon(0,0,0,0",
             "clip:rect(0,0,0,0",
             "font-size:0",
+            "line-height:0",
             "text-indent:-",
         )
 
@@ -95,7 +101,7 @@ abstract class Japscan :
         private val OFFSCREEN_OFFSET_REGEX = Regex(
             """(?:top|bottom|left|right|inset):-?\d{3,}""" +
                 """|transform:translate(?:3d|x|y)?\([^)]*-?\d{3,}""" +
-                """|transform:scale(?:3d)?\(0[,)]""" +
+                """|transform:scale(?:3d|x|y)?\(0[,)]""" +
                 """|transform:matrix\(0,0,0,0""" +
                 """|max-(?:width|height):0""",
         )
@@ -259,8 +265,11 @@ abstract class Japscan :
     }
 
     // Defense in depth: if a honeypot ever slips past the per-row hidden-style
-    // heuristics, its URL number is wildly out of range (e.g. 483181 vs. real 1181).
-    // Drop the upper cluster when consecutive chapter numbers jump by more than 1000.
+    // heuristics, its URL number tends to be wildly out of range (e.g. 483181 vs.
+    // real 1181, or 000001..000008 vs. real 1174..1181). Real chapter URL ids are
+    // near-consecutive, so split sorted ids on gaps that are much larger than the
+    // typical spacing and keep only the largest cluster — agnostic to whether the
+    // honeypots sit above or below the real range.
     private fun filterOutlierChapters(chapters: List<SChapter>): List<SChapter> {
         val withNum = chapters.mapNotNull { ch ->
             val n = ch.url.trimEnd('/').substringAfterLast('/').toLongOrNull() ?: return@mapNotNull null
@@ -268,17 +277,22 @@ abstract class Japscan :
         }
         if (withNum.size < 2) return chapters
         val sorted = withNum.sortedBy { it.second }
-        var gapIdx = -1
-        var gapSize = 0L
+        val gaps = (1 until sorted.size).map { sorted[it].second - sorted[it - 1].second }
+        val medianGap = gaps.sorted()[gaps.size / 2].coerceAtLeast(1L)
+        // Treat a gap as a cluster boundary when it dwarfs the typical spacing.
+        // The absolute floor (100) keeps short lists with tiny medians from
+        // splitting on noise; the 50x ratio handles dense lists where the
+        // median is already large.
+        val threshold = maxOf(medianGap * 50, 100L)
+        val clusters = mutableListOf<MutableList<Pair<SChapter, Long>>>(mutableListOf(sorted[0]))
         for (i in 1 until sorted.size) {
-            val g = sorted[i].second - sorted[i - 1].second
-            if (g > gapSize) {
-                gapSize = g
-                gapIdx = i
+            if (sorted[i].second - sorted[i - 1].second > threshold) {
+                clusters.add(mutableListOf())
             }
+            clusters.last().add(sorted[i])
         }
-        if (gapSize <= 1000) return chapters
-        val keep = sorted.take(gapIdx).map { it.first }.toSet()
+        if (clusters.size == 1) return chapters
+        val keep = clusters.maxBy { it.size }.map { it.first }.toSet()
         return chapters.filter { it in keep }
     }
 

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -40,6 +40,7 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import okhttp3.FormBody
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -78,21 +79,22 @@ abstract class Japscan :
         // `https://japscan-cache.local/<absolute-cache-path>`. We can't override
         // fetchImage (final), so an interceptor catches that sentinel host and serves
         // the file bytes synthetically.
+        //
+        // This must short-circuit *before* rateLimit: serving a local file is not a
+        // network request, and letting it fall through would throttle page loads to one
+        // per 2s. Files are left on disk (the reader may request the same page again,
+        // e.g. on retry) and reaped by sweepPageCache on the next fetchPageList.
         .addInterceptor { chain ->
             val req = chain.request()
             if (req.url.host != JAPSCAN_CACHE_HOST) return@addInterceptor chain.proceed(req)
             val path = "/" + req.url.pathSegments.joinToString("/")
-            val file = File(path)
-            val bytes = file.readBytes()
-            try {
-                file.delete()
-            } catch (_: Exception) {}
+            val bytes = runCatching { File(path).readBytes() }.getOrNull()
             Response.Builder()
                 .request(req)
                 .protocol(Protocol.HTTP_1_1)
-                .code(200)
-                .message("OK")
-                .body(bytes.toResponseBody("image/jpeg".toMediaType()))
+                .code(if (bytes != null) 200 else 404)
+                .message(if (bytes != null) "OK" else "Not Found")
+                .body((bytes ?: ByteArray(0)).toResponseBody("image/jpeg".toMediaType()))
                 .build()
         }
         // rateLimit returns a RateLimitBuilder; it must come last as all other
@@ -109,10 +111,6 @@ abstract class Japscan :
             "visibility:hidden",
             "visibility:collapse",
             "content-visibility:hidden",
-            "opacity:0",
-            "filter:opacity(0",
-            "width:0",
-            "height:0",
             "pointer-events:none",
             "clip-path:inset(100%",
             "clip-path:circle(0",
@@ -125,21 +123,35 @@ abstract class Japscan :
         )
 
         // Match styles that visually remove an element while leaving it in the DOM:
+        //  - fully transparent via `opacity` or `filter:opacity()`
+        //  - collapsed via `width` / `height` / `max-width` / `max-height`
         //  - large absolute offset (3+ digits) via top/bottom/left/right or `inset:` shorthand
         //  - `transform: translate / translateX / translateY / translated` with a 3+ digit offset
         //  - `transform: scale(0)` / `scale3d(0,...)` (collapsed to nothing)
         //  - `transform: matrix(0,0,0,0,...)` (also collapsed)
-        //  - `max-width:0` / `max-height:0` (mirror of the existing width:0/height:0 tokens)
+        //
         // 3 digits is enough to be off-screen even with viewport units (200vh, 999vw, …)
         // while still tolerating fine adjustments like top:-1px or right:99px.
-        private val OFFSCREEN_OFFSET_REGEX = Regex(
-            """(?:top|bottom|left|right|inset):-?\d{3,}""" +
+        //
+        // The zero-value alternatives are anchored on both sides, because a substring
+        // match would also fire on values that are perfectly visible and very common on
+        // real rows: `opacity:0.9`, `filter:opacity(0.5)`, `min-width:0`. A false positive
+        // here drops a real chapter, so these must not match loosely. Matched against the
+        // inline style with spaces stripped, hence `;` as the left boundary.
+        private val HIDDEN_STYLE_REGEX = Regex(
+            """(?:^|;)opacity:0(?![.\d])""" +
+                """|filter:opacity\(0(?![.\d])""" +
+                """|(?:^|;)(?:width|height):0(?![.\d])""" +
+                """|max-(?:width|height):0(?![.\d])""" +
+                """|(?:top|bottom|left|right|inset):-?\d{3,}""" +
                 """|transform:translate(?:3d|x|y)?\([^)]*-?\d{3,}""" +
                 """|transform:scale(?:3d|x|y)?\(0[,)]""" +
-                """|transform:matrix\(0,0,0,0""" +
-                """|max-(?:width|height):0""",
+                """|transform:matrix\(0,0,0,0""",
         )
         val dateFormat = SimpleDateFormat("dd MMM yyyy", Locale.US)
+
+        // "Chapitre 1100.5: Title" -> 1100.5
+        private val CHAPTER_NUM_REGEX = Regex("""(?i)chapitre\s+([\d.]+)""")
 
         private const val SHOW_SPOILER_CHAPTERS_TITLE = "Les chapitres en Anglais ou non traduit sont upload en tant que \" Spoilers \" sur Japscan"
         private const val SHOW_SPOILER_CHAPTERS = "JAPSCAN_SPOILER_CHAPTERS"
@@ -148,14 +160,19 @@ abstract class Japscan :
         // an OkHttp interceptor (see `client` builder).
         private const val JAPSCAN_CACHE_HOST = "japscan-cache.local"
 
-        // Synthetic viewport used to force-layout the detached WebView. We use a
-        // desktop-class width because the reader picks a "mobile" rendering path
-        // for viewports under ~1280 px wide that only materializes one tile-host
-        // per long page (then lazy-loads more on scroll, which our detached WebView
-        // can't reliably trigger). With a desktop-class width the reader pre-creates
-        // every tile-host upfront, exactly like it does in a real Chrome window —
-        // see live-Chrome inspection: innerWidth=5468 yields 7-8 hosts per long
-        // page; innerWidth=1080 yields 1.
+        // Prefix for the spooled page files in the app cache dir, shared by the writer
+        // (JsInterface.savePage) and the reaper (sweepPageCache).
+        private const val CACHE_FILE_PREFIX = "japscan-"
+
+        // How long fetchPageList waits with zero saved pages before deciding the
+        // WebView driver is wedged rather than merely slow.
+        private const val IDLE_TIMEOUT_MS = 45_000L
+
+        // Synthetic viewport used to force-layout the detached WebView. Must stay
+        // desktop-class: under ~1280 px wide the reader takes a "mobile" path that
+        // materializes one tile-host per long page and lazy-loads the rest on scroll,
+        // which a detached WebView can't reliably trigger. Above it, every tile-host
+        // is created upfront.
         private const val WEBVIEW_VIEWPORT_WIDTH = 1920
         private const val WEBVIEW_VIEWPORT_HEIGHT = 16384
 
@@ -181,6 +198,14 @@ abstract class Japscan :
         )
         private val prefsEntries = arrayOf("Montrer uniquement les chapitres traduit en Français", "Montrer les chapitres spoiler")
         private val prefsEntryValues = arrayOf("hide", "show")
+
+        // Verbose tracing of the WebView drivers. Off by default; flip to true when the
+        // reader breaks and the capture needs to be followed in Logcat.
+        private const val DEBUG = false
+
+        private fun debugLog(message: String) {
+            if (DEBUG) Log.d("Japscan", message)
+        }
     }
 
     private fun chapterListPref() = preferences.getString(SHOW_SPOILER_CHAPTERS, "hide")
@@ -335,38 +360,51 @@ abstract class Japscan :
     }
 
     // Defense in depth: if a honeypot ever slips past the per-row hidden-style
-    // heuristics, its URL number tends to be wildly out of range (e.g. 483181 vs.
-    // real 1181, or 000001..000008 vs. real 1174..1181). Real chapter URL ids are
-    // near-consecutive, so split sorted ids on gaps that are much larger than the
-    // typical spacing and keep only the largest cluster — agnostic to whether the
-    // honeypots sit above or below the real range.
+    // heuristics, its number tends to be wildly out of range (e.g. 483181 vs.
+    // real 1181, or 000001..000008 vs. real 1174..1181). Real chapter numbers are
+    // near-consecutive, so split them on gaps that are much larger than the typical
+    // spacing and drop the clusters that are a clear minority next to the largest —
+    // agnostic to whether the honeypots sit above or below the real range.
+    //
+    // Cluster on chapter_number, NOT on the trailing URL id: Japscan writes
+    // "Chapitre 1100.5" as /11005/, which sits ~9000 away from its neighbours and
+    // would be split off and dropped as an outlier. By chapter number it is 0.5
+    // from 1100 and stays put.
     private fun filterOutlierChapters(chapters: List<SChapter>): List<SChapter> {
-        val withNum = chapters.mapNotNull { ch ->
-            val n = ch.url.trimEnd('/').substringAfterLast('/').toLongOrNull() ?: return@mapNotNull null
-            ch to n
-        }
+        val withNum = chapters.filter { it.chapter_number >= 0f }
         if (withNum.size < 2) return chapters
-        val sorted = withNum.sortedBy { it.second }
-        val gaps = (1 until sorted.size).map { sorted[it].second - sorted[it - 1].second }
-        val medianGap = gaps.sorted()[gaps.size / 2].coerceAtLeast(1L)
+        val sorted = withNum.sortedBy { it.chapter_number }
+        val gaps = (1 until sorted.size).map { sorted[it].chapter_number - sorted[it - 1].chapter_number }
+        val medianGap = gaps.sorted()[gaps.size / 2].coerceAtLeast(1f)
         // Treat a gap as a cluster boundary when it dwarfs the typical spacing.
         // The absolute floor (100) keeps short lists with tiny medians from
         // splitting on noise; the 50x ratio handles dense lists where the
         // median is already large.
-        val threshold = maxOf(medianGap * 50, 100L)
-        val clusters = mutableListOf<MutableList<Pair<SChapter, Long>>>(mutableListOf(sorted[0]))
+        val threshold = maxOf(medianGap * 50, 100f)
+        val clusters = mutableListOf(mutableListOf(sorted[0]))
         for (i in 1 until sorted.size) {
-            if (sorted[i].second - sorted[i - 1].second > threshold) {
+            if (sorted[i].chapter_number - sorted[i - 1].chapter_number > threshold) {
                 clusters.add(mutableListOf())
             }
             clusters.last().add(sorted[i])
         }
         if (clusters.size == 1) return chapters
-        val keep = clusters.maxBy { it.size }.map { it.first }.toSet()
-        return chapters.filter { it in keep }
+        // Only prune when one cluster clearly dominates. On a tie we cannot tell
+        // which side is real (honeypots sit above OR below), and guessing wrong
+        // deletes the entire chapter list — much worse than letting a honeypot
+        // through, since the visibility prune is the primary defense and this is
+        // only a backstop.
+        val largest = clusters.maxOf { it.size }
+        if (clusters.count { it.size == largest } > 1) return chapters
+        // Drop a cluster only if it is a small fraction of the main run. Anything
+        // comparable in size is far more likely a genuine gap in Japscan's catalogue
+        // (a series resuming at a much higher number) than a block of honeypots, and
+        // keeping only the largest cluster would silently delete those real chapters.
+        val keep = clusters.filter { it.size * 4 > largest }.flatten().toSet()
+        return chapters.filter { it.chapter_number < 0f || it in keep }
     }
 
-    private fun extractMangaSlug(url: okhttp3.HttpUrl): String? {
+    private fun extractMangaSlug(url: HttpUrl): String? {
         val segments = url.pathSegments.filter { it.isNotEmpty() }
         val typeIdx = segments.indexOfFirst { it in CHAPTER_PATH_TYPES }
         if (typeIdx == -1 || typeIdx + 1 >= segments.size) return null
@@ -379,7 +417,7 @@ abstract class Japscan :
         if (el.attr("aria-hidden").equals("true", ignoreCase = true)) return true
         val style = el.attr("style").replace(" ", "").lowercase()
         if (HIDDEN_STYLE_TOKENS.any { style.contains(it) }) return true
-        if (OFFSCREEN_OFFSET_REGEX.containsMatchIn(style)) return true
+        if (HIDDEN_STYLE_REGEX.containsMatchIn(style)) return true
         return false
     }
 
@@ -433,7 +471,7 @@ abstract class Japscan :
                 val urlNum = url.trimEnd('/').substringAfterLast('/')
                 if (!urlNum.all { it.isDigit() }) return@filter false
                 if (urlNum.length > 1 && urlNum.startsWith('0')) return@filter false
-                val chapterNum = Regex("""(?i)chapitre\s+([\d.]+)""").find(name)
+                val chapterNum = CHAPTER_NUM_REGEX.find(name)
                     ?.groupValues?.get(1)?.replace(".", "")
                     ?: name.split(Regex("[^0-9.]+")).lastOrNull { it.isNotEmpty() }?.replace(".", "")
                     ?: return@filter false
@@ -456,6 +494,10 @@ abstract class Japscan :
         val chapter = SChapter.create()
         chapter.setUrlWithoutDomain(foundPair.second)
         chapter.name = foundPair.first
+        // Half-chapters ("Chapitre 1100.5") keep their .5 here, unlike the URL id which
+        // flattens to /11005/. filterOutlierChapters relies on that.
+        chapter.chapter_number = CHAPTER_NUM_REGEX.find(chapter.name)
+            ?.groupValues?.get(1)?.toFloatOrNull() ?: -1f
         chapter.date_upload = element.selectFirst("span")?.text()?.let { parseChapterDate(it) } ?: 0L
         return chapter
     }
@@ -465,6 +507,7 @@ abstract class Japscan :
     override fun fetchPageList(chapter: SChapter): Observable<List<Page>> {
         val interfaceName = randomString()
         val context = Injekt.get<Application>()
+        sweepPageCache(context.cacheDir)
         val isReader = Exception().stackTrace.any { it.className.contains("reader") }
 
         val handler = Handler(Looper.getMainLooper())
@@ -534,10 +577,7 @@ abstract class Japscan :
         // MUST commit to one driver before any hook is installed.
         val urlSegment = chapter.url.trimStart('/').substringBefore('/').lowercase()
         val isWebtoon = urlSegment == "manhwa" || urlSegment == "manhua"
-        Log.d(
-            "Japscan",
-            "[wv-kt] reader mode hint from URL segment='$urlSegment' → ${if (isWebtoon) "webtoon" else "paginated"}",
-        )
+        debugLog("[wv-kt] reader mode hint from URL segment='$urlSegment' → ${if (isWebtoon) "webtoon" else "paginated"}")
 
         handler.post {
             val innerWv = WebView(context)
@@ -579,7 +619,7 @@ abstract class Japscan :
             // pagination driver's progress is visible during debugging.
             innerWv.webChromeClient = object : WebChromeClient() {
                 override fun onConsoleMessage(msg: ConsoleMessage): Boolean {
-                    Log.d("Japscan", "[wv] ${msg.message()}")
+                    debugLog("[wv] ${msg.message()}")
                     return true
                 }
             }
@@ -604,7 +644,7 @@ abstract class Japscan :
 
                 override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
                     super.onPageStarted(view, url, favicon)
-                    Log.d("Japscan", "[wv-kt] onPageStarted url=$url")
+                    debugLog("[wv-kt] onPageStarted url=$url")
                     // Both modes: satisfy the reader's anti-adblock check before it runs.
                     // ~3s after load it looks for `window.aclib` (needs 3+ own keys and 2+
                     // real functions among runPop/runBanner/runNative) and, if it's missing,
@@ -646,10 +686,10 @@ abstract class Japscan :
                     // the paginated path uses a separate minimal hook installed in the `else`
                     // branch further down.
                     if (!isWebtoon) {
-                        // Paginated mode: minimal createObjectURL capture, ported verbatim
-                        // from the fix/japscan branch. The descrambler surfaces each
-                        // composited page as a `blob:` URL via URL.createObjectURL —
-                        // capturing the latest one per page-click is enough.
+                        // Paginated mode: minimal createObjectURL capture. The descrambler
+                        // surfaces each composited page as a `blob:` URL via
+                        // URL.createObjectURL — capturing the latest one per page-click
+                        // is enough.
                         view?.evaluateJavascript(
                             $$"""
                                 (function(){
@@ -795,12 +835,10 @@ abstract class Japscan :
                                 // drawImage is detectable via .toString — masked above.
                                 try {
                                     window.__japscanLastDraw = 0;
-                                    window.__japscanDrawCount = 0;
                                     var _drawImage = CanvasRenderingContext2D.prototype.drawImage;
                                     var newDrawImage = function drawImage(){
                                         try {
                                             window.__japscanLastDraw = Date.now();
-                                            window.__japscanDrawCount++;
                                         } catch(e) {}
                                         return _drawImage.apply(this, arguments);
                                     };
@@ -818,8 +856,14 @@ abstract class Japscan :
                                 //   innerWidth/innerHeight, devicePixelRatio,
                                 //   screen.width/height, navigator.platform/maxTouchPoints,
                                 //   matchMedia for (pointer: fine), (hover: hover),
-                                //   and (min-width: <N>px). UA is already set at the
-                                //   WebSettings level.
+                                //   and (min-width: <N>px).
+                                //
+                                // The UA is spoofed HERE, not at the WebSettings level:
+                                // WebSettings keeps the Android UA on purpose so Cloudflare
+                                // doesn't issue a fresh challenge for this request, and only
+                                // the JS-visible navigator.userAgent reads as desktop.
+                                // Anything not in the list above was tried and dropped —
+                                // don't re-add fake plugins/chrome/webdriver on spec.
                                 try {
                                     var defineGetter = function(obj, name, val){
                                         try {
@@ -844,68 +888,6 @@ abstract class Japscan :
                                     // Remove ontouchstart so feature-detect-based mobile
                                     // branches see a non-touch device.
                                     try { delete window.ontouchstart; } catch(e) {}
-
-                                    // Stub window.chrome with the shape a real desktop Chrome has.
-                                    // The descrambler's anti-bot path checks for window.chrome and
-                                    // treats its absence as "this is a headless/automated browser",
-                                    // then renders only 1 tile per page as a defense.
-                                    try {
-                                        if (typeof window.chrome === 'undefined' || !window.chrome.loadTimes) {
-                                            var chromeStub = {
-                                                loadTimes: function loadTimes(){ return {}; },
-                                                csi: function csi(){ return {}; },
-                                                app: { isInstalled: false, InstallState: { DISABLED: 'disabled', INSTALLED: 'installed', NOT_INSTALLED: 'not_installed' }, RunningState: { CANNOT_RUN: 'cannot_run', READY_TO_RUN: 'ready_to_run', RUNNING: 'running' } },
-                                            };
-                                            mask(chromeStub.loadTimes, 'loadTimes');
-                                            mask(chromeStub.csi, 'csi');
-                                            Object.defineProperty(window, 'chrome', { get: function(){ return chromeStub; }, configurable: true });
-                                        }
-                                    } catch(e) { window.__jlog('[japscan] chrome stub failed: ' + e); }
-
-                                    // Fake plugins/mimeTypes — WebView reports 0 for both, real
-                                    // Chrome reports 5/2. Bot-detection scripts flag length=0.
-                                    try {
-                                        var fakeMime = function(type, suffixes, desc){
-                                            return { type: type, suffixes: suffixes, description: desc, enabledPlugin: null };
-                                        };
-                                        var fakePlugin = function(name, filename, desc, mimes){
-                                            var p = { name: name, filename: filename, description: desc, length: mimes.length };
-                                            for (var i = 0; i < mimes.length; i++) { p[i] = mimes[i]; mimes[i].enabledPlugin = p; }
-                                            return p;
-                                        };
-                                        var pdfMime = fakeMime('application/pdf', 'pdf', 'Portable Document Format');
-                                        var pdfViewerMime = fakeMime('text/pdf', 'pdf', 'Portable Document Format');
-                                        var plugins = [
-                                            fakePlugin('PDF Viewer', 'internal-pdf-viewer', 'Portable Document Format', [pdfMime, pdfViewerMime]),
-                                            fakePlugin('Chrome PDF Viewer', 'internal-pdf-viewer', 'Portable Document Format', [pdfMime, pdfViewerMime]),
-                                            fakePlugin('Chromium PDF Viewer', 'internal-pdf-viewer', 'Portable Document Format', [pdfMime, pdfViewerMime]),
-                                            fakePlugin('Microsoft Edge PDF Viewer', 'internal-pdf-viewer', 'Portable Document Format', [pdfMime, pdfViewerMime]),
-                                            fakePlugin('WebKit built-in PDF', 'internal-pdf-viewer', 'Portable Document Format', [pdfMime, pdfViewerMime]),
-                                        ];
-                                        plugins.length = 5;
-                                        plugins.item = function(i){ return plugins[i] || null; };
-                                        plugins.namedItem = function(n){ for (var i=0;i<plugins.length;i++) if (plugins[i].name===n) return plugins[i]; return null; };
-                                        plugins.refresh = function(){};
-                                        Object.defineProperty(navigator, 'plugins', { get: function(){ return plugins; }, configurable: true });
-
-                                        var mimeTypes = [pdfMime, pdfViewerMime];
-                                        mimeTypes.length = 2;
-                                        mimeTypes.item = function(i){ return mimeTypes[i] || null; };
-                                        mimeTypes.namedItem = function(n){ for (var i=0;i<mimeTypes.length;i++) if (mimeTypes[i].type===n) return mimeTypes[i]; return null; };
-                                        Object.defineProperty(navigator, 'mimeTypes', { get: function(){ return mimeTypes; }, configurable: true });
-                                    } catch(e) { window.__jlog('[japscan] plugins stub failed: ' + e); }
-
-                                    // languages: real Chrome has multiple, WebView has 1.
-                                    try {
-                                        Object.defineProperty(navigator, 'languages', { get: function(){ return ['fr', 'fr-FR', 'en', 'en-US']; }, configurable: true });
-                                        Object.defineProperty(navigator, 'language', { get: function(){ return 'fr'; }, configurable: true });
-                                    } catch(e) {}
-
-                                    // Some bot-detection scripts check navigator.webdriver explicitly;
-                                    // ensure it reads as undefined (default, but defensive).
-                                    try {
-                                        Object.defineProperty(navigator, 'webdriver', { get: function(){ return undefined; }, configurable: true });
-                                    } catch(e) {}
 
                                     var _mm = window.matchMedia.bind(window);
                                     var newMM = function matchMedia(q){
@@ -939,19 +921,24 @@ abstract class Japscan :
 
                 override fun onPageFinished(view: WebView?, url: String?) {
                     super.onPageFinished(view, url)
-                    Log.d("Japscan", "[wv-kt] onPageFinished url=$url")
+                    debugLog("[wv-kt] onPageFinished url=$url")
                     // Force-keep the WebView "alive" so its JS timers don't get suspended while
                     // we're detached. resumeTimers is global to all WebViews in the process.
                     view?.onResume()
                     view?.resumeTimers()
                     if (!isWebtoon) {
-                        // Paginated driver, ported verbatim from the fix/japscan branch.
-                        // Drives the reader through every page via the #block-right /
-                        // #block-left click-zones; the createObjectURL hook installed in
-                        // onPageStarted gives us one blob per page in `__japscanLastBlob`.
+                        // Paginated driver: walks the reader through every page via the
+                        // #block-right / #block-left click-zones; the createObjectURL hook
+                        // installed in onPageStarted leaves one blob per page in
+                        // `__japscanLastBlob`.
                         view?.evaluateJavascript(
                             $$"""
                                 (async function(){
+                                    // onPageFinished fires more than once per load (redirects,
+                                    // iframes, in-page navigations). Without this guard a second
+                                    // driver races the first and saves every page twice.
+                                    if (window.__japscanDriverStarted) return;
+                                    window.__japscanDriverStarted = true;
                                     var sleep = function(ms){ return new Promise(function(r){ setTimeout(r, ms); }); };
 
                                     async function saveBlobUrl(u){
@@ -1019,10 +1006,14 @@ abstract class Japscan :
 
                                     // The reader pre-renders pages on load (the final pre-render is
                                     // the *last* page, not page 1), so the very first blob the hook
-                                    // sees is unreliable. Wait for things to settle, discard whatever
-                                    // was captured, then bounce next->prev to force a clean page-1
-                                    // render before we start harvesting.
-                                    await sleep(5000);
+                                    // sees is unreliable. Wait for the pre-render to settle, discard
+                                    // whatever was captured, then bounce next->prev to force a clean
+                                    // page-1 render before we start harvesting.
+                                    //
+                                    // waitForBlob already means "a blob arrived and stopped changing
+                                    // for 400ms", which is exactly the settle condition — a fixed
+                                    // sleep was both slower here and too short on a loaded device.
+                                    await waitForBlob(10000);
                                     window.__japscanLastBlob = null;
 
                                     nav(nextBtn, 'ArrowRight');
@@ -1055,7 +1046,7 @@ abstract class Japscan :
                                     }
                                 })();
                             """.trimIndent(),
-                        ) { result -> Log.d("Japscan", "[wv-kt] paginated driver eval result=$result") }
+                        ) { result -> debugLog("[wv-kt] paginated driver eval result=$result") }
                         return
                     }
                     // Webtoon driver: drives the reader through every chapter page and composites
@@ -1065,6 +1056,11 @@ abstract class Japscan :
                     view?.evaluateJavascript(
                         $$"""
                             (async function(){
+                                // onPageFinished fires more than once per load (redirects,
+                                // iframes, in-page navigations). Without this guard a second
+                                // driver races the first and saves every tile twice.
+                                if (window.__japscanDriverStarted) return;
+                                window.__japscanDriverStarted = true;
                                 var sleep = function(ms){ return new Promise(function(r){ setTimeout(r, ms); }); };
                                 window.__jlog('[japscan] driver start');
 
@@ -1091,47 +1087,41 @@ abstract class Japscan :
                                     }
                                 }
 
-                                // Discover the tile hosts that make up `#d-img-N`. The reader uses
-                                // a custom element (e.g. <b-123e6>, <w-f1db5> — the tag name is
-                                // randomized per series) that exposes the composited tile bitmap
-                                // as `tile.canvas` (an own-property set in the custom element's
-                                // constructor when it has actually rendered).
-                                //
-                                // STRUCTURAL discovery, not readiness: we identify a tile by its
-                                // tag (any hyphenated custom-element tag) that is a direct child
-                                // either of #d-img-N or of #d-img-N > div.cc80466. We deliberately
-                                // do NOT require `.canvas` to exist yet, because the descrambler
-                                // is lazy and only renders tiles after they are scrolled into the
-                                // viewport — chicken-and-egg if we filter on `.canvas` here.
-                                // Walk every node reachable from `root` (including across open and
-                                // recovered-closed shadow roots) and return the unique hyphenated-
-                                // tag custom elements that have a `.canvas` HTMLCanvasElement own-
-                                // property — or, structurally, ANY hyphenated-tag element if no
-                                // `.canvas`-bearing one exists yet (the constructor sets `.canvas`
-                                // only after the descrambler renders).
-                                // Discover tile groups in `#d-img-N`'s subtree. Canvases-first
-                                // approach: walk canvases (works regardless of whether the host
-                                // custom element is exposed in light DOM), group them by their
-                                // shadow-root host, and treat each unique host as one tile.
-                                //
-                                // Returns an array of `{ host, canvases }` records in stable order
-                                // of first appearance. The host is the custom element (whose
-                                // `.canvas` own-property, when set, gives the descrambled bitmap);
-                                // `canvases` is the layered set inside its shadow root.
-                                function discoverTiles(container){
-                                    if (!container) return [];
-                                    // Long-page WebView layout: container has a `cc...`-class
-                                    // wrapper holding 7-8 direct <canvas> children (one per
-                                    // descrambled vertical slice). Emit each canvas as a
-                                    // standalone tile so toDataURL is called per slice and
-                                    // the webtoon reader stitches them.
-                                    var wrap = null;
+                                // Long-page layout: `#d-img-N` holds a `cc…`-class wrapper whose
+                                // direct <canvas> children are the descrambled vertical slices.
+                                // Single source of truth for finding it — discoverTiles and
+                                // expectedTileCount must agree, or a class rename desyncs them.
+                                function findTileWrapper(container){
+                                    if (!container) return null;
                                     for (var ci = 0; ci < container.children.length; ci++) {
                                         var ch = container.children[ci];
                                         if (ch.tagName === 'DIV' && ('' + ch.className).indexOf('cc') === 0) {
-                                            wrap = ch; break;
+                                            return ch;
                                         }
                                     }
+                                    return null;
+                                }
+
+                                // Discover tile groups in `#d-img-N`'s subtree. Canvases-first:
+                                // walk canvases (works regardless of whether the host custom
+                                // element is exposed in light DOM), group them by their shadow-root
+                                // host, and treat each unique host as one tile.
+                                //
+                                // Returns `{ host, canvases }` records in stable order of first
+                                // appearance. The host is the custom element (e.g. <b-123e6>,
+                                // <w-f1db5> — the tag is randomized per series) whose `.canvas`
+                                // own-property, when set, gives the descrambled bitmap; `canvases`
+                                // is the layered set inside its shadow root.
+                                //
+                                // Discovery is STRUCTURAL, not readiness-based: we deliberately do
+                                // NOT require `.canvas` to exist yet, because the descrambler is
+                                // lazy and only renders a tile once it scrolls into view —
+                                // chicken-and-egg if we filtered on `.canvas` here.
+                                function discoverTiles(container){
+                                    if (!container) return [];
+                                    // Long pages: emit each slice as a standalone tile so
+                                    // toDataURL runs per slice and the webtoon reader stitches them.
+                                    var wrap = findTileWrapper(container);
                                     if (wrap) {
                                         var direct = [];
                                         for (var di = 0; di < wrap.children.length; di++) {
@@ -1238,109 +1228,6 @@ abstract class Japscan :
                                     } catch(e) { return null; }
                                 }
 
-                                // Paginated mode only: composite the (#single-reader-XXX) container's
-                                // direct canvas children. Layered canvases at the same position, so
-                                // we draw them all at (0, 0) in DOM order. No shadow roots, no
-                                // custom-element tiles in this layout — it's the simple legacy form.
-                                function paginatedComposite(container, label) {
-                                    if (!container) return null;
-                                    var canvases = container.querySelectorAll(':scope > canvas');
-                                    if (canvases.length === 0) {
-                                        window.__jlog('[japscan] ' + label + ' compose: no direct canvas children');
-                                        return null;
-                                    }
-                                    var W = 0, H = 0;
-                                    for (var i = 0; i < canvases.length; i++) {
-                                        if (canvases[i].width  > W) W = canvases[i].width;
-                                        if (canvases[i].height > H) H = canvases[i].height;
-                                    }
-                                    if (W === 0 || H === 0) return null;
-                                    var master = document.createElement('canvas');
-                                    master.width = W; master.height = H;
-                                    var mctx = master.getContext('2d');
-                                    if (!mctx) return null;
-                                    var drawn = 0;
-                                    for (var k = 0; k < canvases.length; k++) {
-                                        try { mctx.drawImage(canvases[k], 0, 0); drawn++; } catch(e) {}
-                                    }
-                                    window.__jlog('[japscan] ' + label + ' compose: ' + W + 'x' + H + ' canvases=' + canvases.length + ' drawn=' + drawn);
-                                    var uri = null;
-                                    try { uri = master.toDataURL('image/jpeg', 0.92); } catch(e) {}
-                                    master.width = 0; master.height = 0;
-                                    return uri;
-                                }
-
-                                // Wait for the descrambler to populate the container's shadow-DOM
-                                // canvases, then settle until the canvas count is stable for a bit.
-                                // Settle on TWO independent signals:
-                                //  - canvas count is non-zero and stable (DOM structure done),
-                                //  - no drawImage calls for `quietMs` (descrambler done painting).
-                                // Without the second signal we capture mid-paint and only the
-                                // first few layered passes have been drawn, so the rendered page
-                                // is incomplete.
-                                async function waitForRender(container, timeoutMs, label) {
-                                    var quietMs = 800;
-                                    var minTotal = 1500;
-                                    var pollMs = 150;
-                                    var w = 0;
-                                    var prevCount = -1;
-                                    var structuralStable = 0;
-                                    var lastLogN = -1;
-                                    while (w < timeoutMs) {
-                                        var arr = [];
-                                        gatherCanvases(container, arr);
-                                        var n = arr.length;
-                                        var hasContent = false;
-                                        var maxW = 0, maxH = 0;
-                                        for (var i = 0; i < arr.length; i++) {
-                                            if (arr[i].width > maxW) maxW = arr[i].width;
-                                            if (arr[i].height > maxH) maxH = arr[i].height;
-                                            if (arr[i].width > 0 && arr[i].height > 0) hasContent = true;
-                                        }
-                                        var now = Date.now();
-                                        var sinceDraw = now - (window.__japscanLastDraw || 0);
-                                        if (label && (n !== lastLogN) && (w === 0 || w >= 500)) {
-                                            window.__jlog('[japscan] ' + label + ' poll @' + w + 'ms canvases=' + n + ' hasContent=' + hasContent + ' max=' + maxW + 'x' + maxH + ' sinceDraw=' + sinceDraw + 'ms drawCount=' + (window.__japscanDrawCount || 0));
-                                            lastLogN = n;
-                                        }
-                                        if (hasContent && n === prevCount) {
-                                            structuralStable += pollMs;
-                                        } else {
-                                            structuralStable = 0;
-                                            prevCount = n;
-                                        }
-                                        if (structuralStable >= 600 && sinceDraw >= quietMs && w >= minTotal) {
-                                            if (label) window.__jlog('[japscan] ' + label + ' settled @' + w + 'ms (sinceDraw=' + sinceDraw + 'ms drawCount=' + (window.__japscanDrawCount || 0) + ')');
-                                            return w;
-                                        }
-                                        await sleep(pollMs);
-                                        w += pollMs;
-                                    }
-                                    if (label) window.__jlog('[japscan] ' + label + ' settle timed out @' + w + 'ms');
-                                    return -1;
-                                }
-
-                                async function savePaginated(container, label) {
-                                    var t = await waitForRender(container, 20000, label);
-                                    if (t < 0) {
-                                        window.__jlog('[japscan] ' + label + ' render timed out');
-                                        return false;
-                                    }
-                                    var uri = paginatedComposite(container, label);
-                                    if (!uri || uri.indexOf('data:image/') !== 0) {
-                                        window.__jlog('[japscan] ' + label + ' composite failed');
-                                        return false;
-                                    }
-                                    try {
-                                        window.$$interfaceName.savePage(uri);
-                                        window.__jlog('[japscan] ' + label + ' saved after ' + t + 'ms (' + uri.length + ' chars)');
-                                        return true;
-                                    } catch(e) {
-                                        window.__jlog('[japscan] savePage failed: ' + e);
-                                        return false;
-                                    }
-                                }
-
                                 // Detect reader mode. Webtoon (long-strip) puts everything in
                                 // `#full-reader` with one `<img id="img-N">` per page (each in
                                 // its `<div id="d-img-N">` container) and hides `#single-reader`
@@ -1381,17 +1268,13 @@ abstract class Japscan :
                                     // slow scroll-and-discover loop if a tile is still missing.
                                     var tilesEmitted = 0;
                                     function expectedTileCount(container){
-                                        for (var ci = 0; ci < container.children.length; ci++) {
-                                            var ch = container.children[ci];
-                                            if (ch.tagName === 'DIV' && ('' + ch.className).indexOf('cc') === 0) {
-                                                var n = 0;
-                                                for (var ki = 0; ki < ch.children.length; ki++) {
-                                                    if (ch.children[ki].tagName === 'CANVAS') n++;
-                                                }
-                                                return n > 0 ? n : 1;
-                                            }
+                                        var wrap = findTileWrapper(container);
+                                        if (!wrap) return 1;
+                                        var n = 0;
+                                        for (var ki = 0; ki < wrap.children.length; ki++) {
+                                            if (wrap.children[ki].tagName === 'CANVAS') n++;
                                         }
-                                        return 1;
+                                        return n > 0 ? n : 1;
                                     }
                                     async function captureOnce(container, pageLabel, savedHosts){
                                         var saved = 0;
@@ -1452,128 +1335,17 @@ abstract class Japscan :
                                     return;
                                 }
 
-                                // ---- Paginated mode ----
-                                // The currently-displayed page lives inside the single-reader
-                                // container. Total page count comes from the (hidden) <select>;
-                                // navigation uses the reader's click-zones (#block-left/right) —
-                                // slimselect option clicks don't work because `.ss-content`
-                                // is hidden until the dropdown opens.
-                                var sel = document.getElementById('pages');
-                                var total = sel ? sel.options.length : 1;
-                                var nextBtn = document.getElementById('block-right');
-                                var prevBtn = document.getElementById('block-left');
-                                window.__jlog('[japscan] paginated mode, total = ' + total + ', next=' + !!nextBtn + ', prev=' + !!prevBtn);
-
-                                function nav(btn, fallbackKey){
-                                    try {
-                                        if (btn) { btn.click(); return; }
-                                        document.dispatchEvent(new KeyboardEvent('keydown', {
-                                            key: fallbackKey, code: fallbackKey,
-                                            which: fallbackKey === 'ArrowRight' ? 39 : 37,
-                                            keyCode: fallbackKey === 'ArrowRight' ? 39 : 37,
-                                            bubbles: true,
-                                        }));
-                                    } catch(e) {
-                                        window.__jlog('[japscan] nav failed: ' + e);
-                                    }
-                                }
-
-                                // Wait until the canvas content inside the single-reader container
-                                // changes compared to the previous page (compared via a tiny pixel
-                                // fingerprint of the widest canvas).
-                                function fingerprint(container) {
-                                    var arr = [];
-                                    gatherCanvases(container, arr);
-                                    if (arr.length === 0) return '';
-                                    var ref = arr[0];
-                                    for (var i = 1; i < arr.length; i++) {
-                                        if (arr[i].width > ref.width) ref = arr[i];
-                                    }
-                                    try {
-                                        var ctx = ref.getContext('2d');
-                                        if (!ctx) return '';
-                                        var pts = [
-                                            [0, 0],
-                                            [Math.max(0, ref.width - 1), 0],
-                                            [Math.floor(ref.width / 2), Math.floor(ref.height / 2)],
-                                            [0, Math.max(0, ref.height - 1)],
-                                            [Math.max(0, ref.width - 1), Math.max(0, ref.height - 1)],
-                                        ];
-                                        var s = '';
-                                        for (var i = 0; i < pts.length; i++) {
-                                            var d = ctx.getImageData(pts[i][0], pts[i][1], 1, 1).data;
-                                            s += d[0] + ',' + d[1] + ',' + d[2] + ',' + d[3] + ';';
-                                        }
-                                        return s;
-                                    } catch(e) { return ''; }
-                                }
-
-                                async function waitForPageChange(container, prevFp, timeoutMs) {
-                                    var w = 0;
-                                    while (w < timeoutMs) {
-                                        var fp = fingerprint(container);
-                                        if (fp && fp !== prevFp) {
-                                            // Settle: keep checking until fp stops changing.
-                                            var lastFp = fp;
-                                            var stable = 0;
-                                            while (stable < 600 && w < timeoutMs) {
-                                                await sleep(200); w += 200;
-                                                var nfp = fingerprint(container);
-                                                if (nfp !== lastFp) { lastFp = nfp; stable = 0; }
-                                                else { stable += 200; }
-                                            }
-                                            return w;
-                                        }
-                                        await sleep(200); w += 200;
-                                    }
-                                    return -1;
-                                }
-
-                                var paginatedContainer = singleReader;
-                                if (!paginatedContainer) {
-                                    window.__jlog('[japscan] no single-reader container found');
-                                    try { window.$$interfaceName.passDone(); } catch(e) {}
-                                    return;
-                                }
-
-                                // The reader pre-renders pages on load (the final pre-render is
-                                // the *last* page, not page 1). Give it time to settle, then
-                                // bounce next->prev to force a clean page-1 render.
-                                await sleep(3000);
-                                if (total > 1) {
-                                    nav(nextBtn, 'ArrowRight');
-                                    await sleep(1500);
-                                    nav(prevBtn, 'ArrowLeft');
-                                    await sleep(1500);
-                                }
-
-                                var savedP = 0;
-                                var prevFp = '';
-                                for (var p = 0; p < total; p++) {
-                                    var t = await waitForRender(paginatedContainer, 15000);
-                                    if (t < 0) {
-                                        window.__jlog('[japscan] paginated page ' + (p + 1) + ' render timed out');
-                                    } else {
-                                        var uri = paginatedComposite(paginatedContainer, 'paginated page ' + (p + 1));
-                                        if (uri && uri.indexOf('data:image/') === 0) {
-                                            try { window.$$interfaceName.savePage(uri); savedP++; } catch(e) {}
-                                            window.__jlog('[japscan] paginated page ' + (p + 1) + '/' + total + ' saved after ' + t + 'ms');
-                                        } else {
-                                            window.__jlog('[japscan] paginated page ' + (p + 1) + ' composite failed');
-                                        }
-                                    }
-                                    prevFp = fingerprint(paginatedContainer);
-                                    if (p < total - 1) {
-                                        nav(nextBtn, 'ArrowRight');
-                                        await waitForPageChange(paginatedContainer, prevFp, 15000);
-                                    }
-                                }
-
-                                window.__jlog('[japscan] paginated done, ' + savedP + ' / ' + total + ' pages saved');
+                                // Kotlin committed to the webtoon hook set before this page loaded,
+                                // and the paginated reader refuses to deliver its payload with those
+                                // hooks installed — so there is nothing useful to do from here.
+                                // Report and bail instead of grinding through a driver that cannot
+                                // work; if this ever fires, the fix is to reload the WebView with
+                                // the paginated hooks, not a third capture technique.
+                                window.__jlog('[japscan] MISMATCH: url hinted webtoon but the DOM mounted the paginated reader — giving up');
                                 try { window.$$interfaceName.passDone(); } catch(e) {}
                             })();
                         """.trimIndent(),
-                    ) { result -> Log.d("Japscan", "[wv-kt] driver eval result=$result") }
+                    ) { result -> debugLog("[wv-kt] driver eval result=$result") }
                 }
             }
 
@@ -1583,10 +1355,21 @@ abstract class Japscan :
             )
         }
 
-        // Generous timeout: the JS sequentially drives every page through the
+        // Generous ceiling: the JS sequentially drives every page through the
         // reader's pagination and waits for each blob, which can easily exceed
-        // a minute on long chapters.
-        latch.await(3, TimeUnit.MINUTES)
+        // a minute on long chapters. But a wedged driver would otherwise burn the
+        // whole ceiling doing nothing, so also give up after IDLE_TIMEOUT_MS
+        // without a saved page — each save refreshes the clock, so a healthy long
+        // chapter still gets the full three minutes.
+        val deadline = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3)
+        var done = false
+        while (!done && System.currentTimeMillis() < deadline) {
+            done = latch.await(15, TimeUnit.SECONDS)
+            if (!done && System.currentTimeMillis() - jsInterface.lastActivity > IDLE_TIMEOUT_MS) {
+                debugLog("[wv-kt] no page saved in ${IDLE_TIMEOUT_MS}ms, giving up")
+                break
+            }
+        }
         handler.post { webView?.destroy() }
 
         if (latch.count == 1L) {
@@ -1622,6 +1405,20 @@ abstract class Japscan :
         screen.addPreference(chapterListPref)
     }
 
+    // Spooled page files outlive the interceptor that serves them, so the reader can
+    // re-request a page (retry, re-open). Nothing else deletes them, and a chapter that
+    // is opened but not read through leaves the rest behind, so reap the stale ones here.
+    //
+    // The cutoff is deliberately far longer than a read session: the reader preloads the
+    // next chapter's page list while the current chapter is still open, so this runs with
+    // an in-progress read's files on disk and must not touch them.
+    private fun sweepPageCache(cacheDir: File) {
+        val cutoff = System.currentTimeMillis() - TimeUnit.HOURS.toMillis(24)
+        cacheDir.listFiles()?.forEach {
+            if (it.name.startsWith(CACHE_FILE_PREFIX) && it.lastModified() < cutoff) it.delete()
+        }
+    }
+
     private fun randomString(length: Int = 10): String {
         val charPool = ('a'..'z') + ('A'..'Z')
         return List(length) { charPool.random() }.joinToString("")
@@ -1634,12 +1431,19 @@ abstract class Japscan :
         // Absolute file paths in the app's cache dir, in capture order.
         var images: List<String> = listOf()
             private set
+
+        // Last time the driver made progress, for fetchPageList's idle watchdog.
+        @Volatile
+        var lastActivity: Long = System.currentTimeMillis()
+            private set
+
         private val savedPaths = mutableListOf<String>()
-        private val sessionTag = "japscan-${System.currentTimeMillis()}"
+        private val sessionTag = "$CACHE_FILE_PREFIX${System.currentTimeMillis()}"
 
         @JavascriptInterface
         @Suppress("UNUSED")
         fun savePage(dataUri: String) {
+            lastActivity = System.currentTimeMillis()
             try {
                 val commaIdx = dataUri.indexOf(',')
                 if (commaIdx <= 0) return
@@ -1658,7 +1462,7 @@ abstract class Japscan :
         @JavascriptInterface
         @Suppress("UNUSED")
         fun log(message: String) {
-            Log.d("Japscan", "[js] $message")
+            debugLog("[js] $message")
         }
 
         @JavascriptInterface


### PR DESCRIPTION
honeypot rows are rejected by hidden-style detection + slug/number binding. Pages are captured by loading the chapter in a detached WebView, letting the site's descrambler run, and reading the painted canvases — one driver for paginated (manga/bd/comic), one for webtoon (manhwa/manhua). Captures are spooled to cacheDir and served via an interceptor rather than held in memory.

Two things worth flagging:
- Pages are re-encoded as JPEG. The originals are unreachable now, so this is unavoidable, but quality does drop vs v70.
- Manual `WebView` instead of `runWebView`, which fixes the viewport to device metrics — the webtoon driver needs a forced 1920px viewport or the reader only renders one tile per page. Same pattern as the merged `Comikey` extension. Can add a viewport option to core/WebView.kt as a follow-up.

Closes : #17479 & #17968 

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
