### PR TITLE
Upload extensions as github release

### DIFF
--- a/.github/scripts/publish-repo.py
+++ b/.github/scripts/publish-repo.py
@@ -1,6 +1,8 @@
 import gzip
 import html
 import json
+import math
+import subprocess
 import sys
 from pathlib import Path
 
@@ -24,6 +26,8 @@ JAR_BASE_URL = "https://raw.githubusercontent.com/keiyoushi/extensions/repo/jar"
 ICON_BASE_URL = "https://cdn.jsdelivr.net/gh/keiyoushi/extensions-source@main"
 
 to_delete: list[str] = json.loads(sys.argv[1])
+current_sha = sys.argv[2]
+current_sha_short = current_sha[:7]
 
 # Drop apks/icons for modules that were deleted or rebuilt (rebuilt ones are re-added below).
 for module in to_delete:
@@ -37,7 +41,7 @@ for module in to_delete:
 # Build index entries for the freshly built apks. Each extension's metadata comes from the
 # source-info JSON emitted by its assembleRelease task (see GenerateSourceInfoTask); its APK is a
 # sibling in the same build dir. aapt reads the icon out of the APK
-new_extensions: list[index_pb2.Extension] = []
+new_extensions: list[tuple[index_pb2.Extension, Path, Path]] = []
 
 SOURCE_DIR = Path(__file__).resolve().parents[2]
 ICON_FILE = "res/mipmap-xhdpi/ic_launcher.png"
@@ -74,31 +78,30 @@ for info_file in ARTIFACTS_DIR.glob("**/keiyoushi-source-info.json"):
     (REPO_APK_DIR / apk.name).write_bytes(apk.read_bytes())
     (REPO_JAR_DIR / jar.name).write_bytes(jar.read_bytes())
 
-    new_extensions.append(
-        index_pb2.Extension(
-            name=info["name"],
-            packageName=package_name,
-            resources=index_pb2.Resources(
-                apkUrl=f"{APK_BASE_URL}/{apk.name}",
-                jarUrl=f"{JAR_BASE_URL}/{jar.name}",
-                iconUrl=get_icon_url(info["module"], info.get("theme")),
-            ),
-            extensionLib=info["extensionLib"],
-            versionCode=info["versionCode"],
-            versionName=info["versionName"],
-            contentWarning=info["contentWarning"],
-            sources=[
-                index_pb2.Source(
-                    id=int(source["id"]),
-                    name=source["name"],
-                    language=source["lang"],
-                    homeUrl=source["baseUrl"],
-                    mirrorUrls=source.get("mirrorUrls", []),
-                )
-                for source in info["sources"]
-            ],
-        )
+    ext = index_pb2.Extension(
+        name=info["name"],
+        packageName=package_name,
+        resources=index_pb2.Resources(
+            apkUrl=f"{APK_BASE_URL}/{apk.name}",
+            jarUrl=f"{JAR_BASE_URL}/{jar.name}",
+            iconUrl=get_icon_url(info["module"], info.get("theme")),
+        ),
+        extensionLib=info["extensionLib"],
+        versionCode=info["versionCode"],
+        versionName=info["versionName"],
+        contentWarning=info["contentWarning"],
+        sources=[
+            index_pb2.Source(
+                id=int(source["id"]),
+                name=source["name"],
+                language=source["lang"],
+                homeUrl=source["baseUrl"],
+                mirrorUrls=source.get("mirrorUrls", []),
+            )
+            for source in info["sources"]
+        ],
     )
+    new_extensions.append((ext, apk, jar))
 
 # Merge with the already-published index, dropping the deleted/rebuilt modules.
 with REPO_DIR.joinpath("index.json").open() as f:
@@ -109,7 +112,7 @@ all_extensions = [
     for ext in remote_proto.extensionList.extensions
     if not any(ext.packageName.endswith(f".{module}") for module in to_delete)
 ]
-all_extensions.extend(new_extensions)
+all_extensions.extend([i[0] for i in new_extensions])
 all_extensions.sort(key=lambda ext: ext.packageName)
 
 index = index_pb2.Index(
@@ -143,3 +146,50 @@ with REPO_DIR.joinpath("index.html").open("w", encoding="utf-8") as f:
         name_escaped = html.escape(f"Tachiyomi: {ext.name}")
         f.write(f'<a href="{apk_escaped}">{name_escaped}</a>\n')
     f.write("</pre>\n</body>\n</html>\n")
+
+# --- Upload assets as release ---
+if not new_extensions:
+    sys.exit(0)
+
+REPO_NAME = "keiyoushi/extensions"
+ASSET_LIMIT = 495 # Actual limit is 1000 but we upload 2 item per extension.
+total_extensions = len(new_extensions)
+release_count = (total_extensions // ASSET_LIMIT) + 1
+ext_per_release = math.ceil(total_extensions / release_count)
+
+def run_gh(*args: str, success_codes: list[int] = []) -> str:
+    result = subprocess.run(["gh", *args], capture_output=True, text=True)
+    if result.returncode == 0 or result.returncode in success_codes:
+        return result.stdout.strip()
+
+    print(f"gh {' '.join(args)} failed: {result.stderr}")
+    sys.exit(result.returncode)
+
+def create_release(tag: str):
+    print(f"Creating release {tag}")
+    run_gh(
+        "release", "create", tag,
+        "--repo", REPO_NAME,
+        "--title", f"Repository Update {tag}",
+        "--notes", f"Automated update from keiyoushi/extensions-source@{current_sha}",
+    )
+
+def upload_assets(tag: str, files: list[Path]):
+    if not files:
+        return
+    print(f"Uploading {len(files)} assets to {tag}")
+    run_gh("release", "upload", tag, *[str(f) for f in files], "--repo", REPO_NAME, "--clobber")
+
+def get_release_tag(c_index: int) -> str:
+    return f"{current_sha_short}-{c_index}" if release_count > 1 else current_sha_short
+
+for i in range(0, total_extensions, ext_per_release):
+    batch = new_extensions[i:i + ext_per_release]
+    tag = get_release_tag(i // ext_per_release)
+    create_release(tag)
+
+    files_to_upload = []
+    for ext, apk, jar in batch:
+        files_to_upload.extend([apk, jar])
+
+    upload_assets(tag, files_to_upload)

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -139,10 +139,11 @@ jobs:
       - name: Publish and deploy repo
         env:
           DELETE: ${{ needs.prepare.outputs.delete }}
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
         run: |
           cd repo
           pip install protobuf
-          python ../main/.github/scripts/publish-repo.py "$DELETE"
+          python ../main/.github/scripts/publish-repo.py "$DELETE" "$GITHUB_SHA"
           git config --global user.email "156378334+keiyoushi-bot@users.noreply.github.com"
           git config --global user.name "keiyoushi-bot"
           git status


### PR DESCRIPTION
no cleanup logic in place, nor is it used in index.

Checklist:

- [ ] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
