### PR TITLE
MangaDex: migrate to 1.6

### DIFF
--- a/src/all/mangadex/build.gradle.kts
+++ b/src/all/mangadex/build.gradle.kts
@@ -6,9 +6,9 @@ plugins {
 
 keiyoushi {
     name = "MangaDex"
-    versionCode = 211
+    versionCode = 212
     contentWarning = ContentWarning.MIXED
-    libVersion = "1.4"
+    libVersion = "1.6"
 
     listOf(
         "af", "sq", "ar", "az", "eu", "be", "bn", "bg", "my", "ca", "zh-Hans", "zh-Hant",

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Constants.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Constants.kt
@@ -1,12 +1,9 @@
 package eu.kanade.tachiyomi.extension.all.mangadex
 
 import keiyoushi.lib.i18n.Intl
-import java.text.SimpleDateFormat
-import java.util.Locale
-import java.util.TimeZone
 import kotlin.time.Duration.Companion.minutes
 
-object MDConstants {
+object Constants {
 
     val uuidRegex =
         Regex("[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}")
@@ -33,9 +30,6 @@ object MDConstants {
     val whitespaceRegex = "\\s".toRegex()
 
     val mdAtHomeTokenLifespan = 5.minutes.inWholeMilliseconds
-
-    val dateFormatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss+SSS", Locale.US)
-        .apply { timeZone = TimeZone.getTimeZone("UTC") }
 
     const val PREFIX_ID_SEARCH = "id:"
     const val PREFIX_CH_SEARCH = "ch:"
@@ -88,10 +82,10 @@ object MDConstants {
     fun getContentRatingPrefKey(dexLang: String): String = "${CONTENT_RATING_PREF}_$dexLang"
 
     private const val ORIGINAL_LANGUAGE_PREF = "originalLanguage"
-    const val ORIGINAL_LANGUAGE_PREF_VAL_JAPANESE = MangaDexIntl.JAPANESE
-    const val ORIGINAL_LANGUAGE_PREF_VAL_CHINESE = MangaDexIntl.CHINESE
+    const val ORIGINAL_LANGUAGE_PREF_VAL_JAPANESE = MDIntl.JAPANESE
+    const val ORIGINAL_LANGUAGE_PREF_VAL_CHINESE = MDIntl.CHINESE
     const val ORIGINAL_LANGUAGE_PREF_VAL_CHINESE_HK = "zh-hk"
-    const val ORIGINAL_LANGUAGE_PREF_VAL_KOREAN = MangaDexIntl.KOREAN
+    const val ORIGINAL_LANGUAGE_PREF_VAL_KOREAN = MDIntl.KOREAN
     val originalLanguagePrefDefaults = emptySet<String>()
 
     fun getOriginalLanguagePrefKey(dexLang: String): String = "${ORIGINAL_LANGUAGE_PREF}_$dexLang"
@@ -145,9 +139,9 @@ object MDConstants {
     const val TAG_ONE_SHOT_UUID = "0234a31e-a729-4e28-9d6a-3f87c4966b9e"
 
     val romanizedLangCodes = mapOf(
-        MangaDexIntl.JAPANESE to "ja-ro",
-        MangaDexIntl.KOREAN to "ko-ro",
-        MangaDexIntl.CHINESE to "zh-ro",
+        MDIntl.JAPANESE to "ja-ro",
+        MDIntl.KOREAN to "ko-ro",
+        MDIntl.CHINESE to "zh-ro",
         "zh-hk" to "zh-ro",
     )
 }

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Filters.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Filters.kt
@@ -9,7 +9,7 @@ import eu.kanade.tachiyomi.source.model.FilterList
 import keiyoushi.lib.i18n.Intl
 import okhttp3.HttpUrl
 
-class MangaDexFilters {
+class Filters {
 
     internal fun getMDFilterList(
         preferences: SharedPreferences,
@@ -58,10 +58,10 @@ class MangaDexFilters {
             state.filter(OriginalLanguage::state)
                 .forEach { lang ->
                     // dex has zh and zh-hk for chinese manhua
-                    if (lang.isoCode == MDConstants.ORIGINAL_LANGUAGE_PREF_VAL_CHINESE) {
+                    if (lang.isoCode == Constants.ORIGINAL_LANGUAGE_PREF_VAL_CHINESE) {
                         url.addQueryParameter(
                             "originalLanguage[]",
-                            MDConstants.ORIGINAL_LANGUAGE_PREF_VAL_CHINESE_HK,
+                            Constants.ORIGINAL_LANGUAGE_PREF_VAL_CHINESE_HK,
                         )
                     }
 
@@ -76,7 +76,7 @@ class MangaDexFilters {
         intl: Intl,
     ): List<OriginalLanguage> {
         val originalLanguages = preferences.getStringSet(
-            MDConstants.getOriginalLanguagePrefKey(dexLang),
+            Constants.getOriginalLanguagePrefKey(dexLang),
             setOf(),
         )!!
 
@@ -84,26 +84,26 @@ class MangaDexFilters {
             OriginalLanguage(
                 name = intl.format(
                     "original_language_filter_japanese",
-                    intl.languageDisplayName(MangaDexIntl.JAPANESE),
+                    intl.languageDisplayName(MDIntl.JAPANESE),
                 ),
-                isoCode = MDConstants.ORIGINAL_LANGUAGE_PREF_VAL_JAPANESE,
-                state = MDConstants.ORIGINAL_LANGUAGE_PREF_VAL_JAPANESE in originalLanguages,
+                isoCode = Constants.ORIGINAL_LANGUAGE_PREF_VAL_JAPANESE,
+                state = Constants.ORIGINAL_LANGUAGE_PREF_VAL_JAPANESE in originalLanguages,
             ),
             OriginalLanguage(
                 name = intl.format(
                     "original_language_filter_chinese",
-                    intl.languageDisplayName(MangaDexIntl.CHINESE),
+                    intl.languageDisplayName(MDIntl.CHINESE),
                 ),
-                isoCode = MDConstants.ORIGINAL_LANGUAGE_PREF_VAL_CHINESE,
-                state = MDConstants.ORIGINAL_LANGUAGE_PREF_VAL_CHINESE in originalLanguages,
+                isoCode = Constants.ORIGINAL_LANGUAGE_PREF_VAL_CHINESE,
+                state = Constants.ORIGINAL_LANGUAGE_PREF_VAL_CHINESE in originalLanguages,
             ),
             OriginalLanguage(
                 name = intl.format(
                     "original_language_filter_korean",
-                    intl.languageDisplayName(MangaDexIntl.KOREAN),
+                    intl.languageDisplayName(MDIntl.KOREAN),
                 ),
-                isoCode = MDConstants.ORIGINAL_LANGUAGE_PREF_VAL_KOREAN,
-                state = MDConstants.ORIGINAL_LANGUAGE_PREF_VAL_KOREAN in originalLanguages,
+                isoCode = Constants.ORIGINAL_LANGUAGE_PREF_VAL_KOREAN,
+                state = Constants.ORIGINAL_LANGUAGE_PREF_VAL_KOREAN in originalLanguages,
             ),
         )
     }
@@ -125,22 +125,22 @@ class MangaDexFilters {
         intl: Intl,
     ): List<ContentRating> {
         val contentRatings = preferences.getStringSet(
-            MDConstants.getContentRatingPrefKey(dexLang),
-            MDConstants.contentRatingPrefDefaults,
+            Constants.getContentRatingPrefKey(dexLang),
+            Constants.contentRatingPrefDefaults,
         )
 
         return listOf(
             ContentRating(intl["content_rating_safe"], ContentRatingDto.SAFE.value).apply {
-                state = contentRatings?.contains(MDConstants.CONTENT_RATING_PREF_VAL_SAFE) ?: true
+                state = contentRatings?.contains(Constants.CONTENT_RATING_PREF_VAL_SAFE) ?: true
             },
             ContentRating(intl["content_rating_suggestive"], ContentRatingDto.SUGGESTIVE.value).apply {
-                state = contentRatings?.contains(MDConstants.CONTENT_RATING_PREF_VAL_SUGGESTIVE) ?: true
+                state = contentRatings?.contains(Constants.CONTENT_RATING_PREF_VAL_SUGGESTIVE) ?: true
             },
             ContentRating(intl["content_rating_erotica"], ContentRatingDto.EROTICA.value).apply {
-                state = contentRatings?.contains(MDConstants.CONTENT_RATING_PREF_VAL_EROTICA) ?: false
+                state = contentRatings?.contains(Constants.CONTENT_RATING_PREF_VAL_EROTICA) ?: false
             },
             ContentRating(intl["content_rating_pornographic"], ContentRatingDto.PORNOGRAPHIC.value).apply {
-                state = contentRatings?.contains(MDConstants.CONTENT_RATING_PREF_VAL_PORNOGRAPHIC) ?: false
+                state = contentRatings?.contains(Constants.CONTENT_RATING_PREF_VAL_PORNOGRAPHIC) ?: false
             },
         )
     }
@@ -389,7 +389,7 @@ class MangaDexFilters {
     }
 
     private fun List<Tag>.sortIfTranslated(intl: Intl): List<Tag> = apply {
-        if (intl.chosenLanguage == MangaDexIntl.ENGLISH) {
+        if (intl.chosenLanguage == MDIntl.ENGLISH) {
             return this
         }
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Helper.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Helper.kt
@@ -34,6 +34,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import keiyoushi.lib.i18n.Intl
+import keiyoushi.network.get
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.plus
@@ -45,13 +46,13 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.jsoup.parser.Parser
-import java.util.Date
 import java.util.Locale
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
-class MangaDexHelper(lang: String) {
+class Helper(lang: String) {
 
-    val mdFilters = MangaDexFilters()
+    val mdFilters = Filters()
 
     val json = Json {
         isLenient = true
@@ -87,13 +88,13 @@ class MangaDexHelper(lang: String) {
 
     val intl = Intl(
         language = lang,
-        baseLanguage = MangaDexIntl.ENGLISH,
-        availableLanguages = MangaDexIntl.AVAILABLE_LANGS,
+        baseLanguage = MDIntl.ENGLISH,
+        availableLanguages = MDIntl.AVAILABLE_LANGS,
         classLoader = this::class.java.classLoader!!,
         createMessageFileName = { lang ->
             when (lang) {
-                MangaDexIntl.SPANISH_LATAM -> Intl.createDefaultMessageFileName(MangaDexIntl.SPANISH)
-                MangaDexIntl.PORTUGUESE -> Intl.createDefaultMessageFileName(MangaDexIntl.BRAZILIAN_PORTUGUESE)
+                MDIntl.SPANISH_LATAM -> Intl.createDefaultMessageFileName(MDIntl.SPANISH)
+                MDIntl.PORTUGUESE -> Intl.createDefaultMessageFileName(MDIntl.BRAZILIAN_PORTUGUESE)
                 else -> Intl.createDefaultMessageFileName(lang)
             }
         },
@@ -107,9 +108,9 @@ class MangaDexHelper(lang: String) {
     /**
      * Get chapters for manga (aka manga/$id/feed endpoint)
      */
-    fun getChapterEndpoint(mangaId: String, offset: Int, langCode: String) = "${MDConstants.API_MANGA_URL}/$mangaId/feed".toHttpUrl().newBuilder()
-        .addQueryParameter("includes[]", MDConstants.SCANLATION_GROUP)
-        .addQueryParameter("includes[]", MDConstants.USER)
+    fun getChapterEndpoint(mangaId: String, offset: Int, langCode: String) = "${Constants.API_MANGA_URL}/$mangaId/feed".toHttpUrl().newBuilder()
+        .addQueryParameter("includes[]", Constants.SCANLATION_GROUP)
+        .addQueryParameter("includes[]", Constants.USER)
         .addQueryParameter("limit", "500")
         .addQueryParameter("offset", offset.toString())
         .addQueryParameter("translatedLanguage[]", langCode)
@@ -122,22 +123,22 @@ class MangaDexHelper(lang: String) {
     /**
      * Check if the manga url is a valid uuid
      */
-    fun containsUuid(url: String) = url.contains(MDConstants.uuidRegex)
+    fun containsUuid(url: String) = url.contains(Constants.uuidRegex)
 
     /**
      * Check if the string is a valid uuid
      */
-    fun isUuid(text: String) = MDConstants.uuidRegex matches text
+    fun isUuid(text: String) = Constants.uuidRegex matches text
 
     /**
      * Get the manga offset pages are 1 based, so subtract 1
      */
-    fun getMangaListOffset(page: Int): String = (MDConstants.MANGA_LIMIT * (page - 1)).toString()
+    fun getMangaListOffset(page: Int): String = (Constants.MANGA_LIMIT * (page - 1)).toString()
 
     /**
      * Get the latest chapter offset pages are 1 based, so subtract 1
      */
-    fun getLatestChapterOffset(page: Int): String = (MDConstants.LATEST_CHAPTER_LIMIT * (page - 1)).toString()
+    fun getLatestChapterOffset(page: Int): String = (Constants.LATEST_CHAPTER_LIMIT * (page - 1)).toString()
 
     /**
      * Remove any HTML characters in manga or chapter name to actual
@@ -176,8 +177,8 @@ class MangaDexHelper(lang: String) {
         val publishedOrCancelled = tempStatus == SManga.PUBLISHING_FINISHED ||
             tempStatus == SManga.CANCELLED
 
-        val isOneShot = attr.tags.any { it.id == MDConstants.TAG_ONE_SHOT_UUID } &&
-            attr.tags.none { it.id == MDConstants.TAG_ANTHOLOGY_UUID }
+        val isOneShot = attr.tags.any { it.id == Constants.TAG_ONE_SHOT_UUID } &&
+            attr.tags.none { it.id == Constants.TAG_ANTHOLOGY_UUID }
 
         return when {
             chaptersList.contains(attr.lastChapter) && publishedOrCancelled -> SManga.COMPLETED
@@ -185,8 +186,6 @@ class MangaDexHelper(lang: String) {
             else -> tempStatus
         }
     }
-
-    private fun parseDate(dateAsString: String): Long = MDConstants.dateFormatter.parse(dateAsString)?.time ?: 0
 
     /**
      * Chapter URL where we get the token, last request time.
@@ -198,8 +197,8 @@ class MangaDexHelper(lang: String) {
             .maxStale(Int.MAX_VALUE.seconds)
             .build()
 
-        val markdownLinksRegex = "\\[([^]]+)\\]\\(([^)]+)\\)".toRegex()
-        val markdownItalicBoldRegex = "\\*+\\s*([^\\*]*)\\s*\\*+".toRegex()
+        val markdownLinksRegex = "\\[([^]]+)]\\(([^)]+)\\)".toRegex()
+        val markdownItalicBoldRegex = "\\*+\\s*([^*]*)\\s*\\*+".toRegex()
         val markdownItalicRegex = "_+\\s*([^_]*)\\s*_+".toRegex()
 
         val titleSpecialCharactersRegex = "[^a-z0-9]+".toRegex()
@@ -210,16 +209,16 @@ class MangaDexHelper(lang: String) {
     /**
      * Check the token map to see if the MD@Home host is still valid.
      */
-    fun getValidImageUrlForPage(page: Page, headers: Headers, client: OkHttpClient): Request {
+    suspend fun getValidImageUrlForPage(page: Page, headers: Headers, client: OkHttpClient): Request {
         val (host, tokenRequestUrl, time) = page.url.split(",")
 
         val mdAtHomeServerUrl =
-            when (Date().time - time.toLong() > MDConstants.mdAtHomeTokenLifespan) {
+            when (System.currentTimeMillis() - time.toLong() > Constants.mdAtHomeTokenLifespan) {
                 false -> host
 
                 true -> {
-                    val tokenLifespan = Date().time - (tokenTracker[tokenRequestUrl] ?: 0)
-                    val cacheControl = if (tokenLifespan > MDConstants.mdAtHomeTokenLifespan) {
+                    val tokenLifespan = System.currentTimeMillis() - (tokenTracker[tokenRequestUrl] ?: 0)
+                    val cacheControl = if (tokenLifespan > Constants.mdAtHomeTokenLifespan) {
                         CacheControl.FORCE_NETWORK
                     } else {
                         USE_CACHE
@@ -234,14 +233,17 @@ class MangaDexHelper(lang: String) {
     /**
      * Get the MD@Home URL.
      */
-    private fun getMdAtHomeUrl(
+    private suspend fun getMdAtHomeUrl(
         tokenRequestUrl: String,
         client: OkHttpClient,
         headers: Headers,
         cacheControl: CacheControl,
     ): String {
-        val request = mdAtHomeRequest(tokenRequestUrl, headers, cacheControl)
-        val response = client.newCall(request).execute()
+        if (cacheControl == CacheControl.FORCE_NETWORK) {
+            mdRefreshToken(tokenRequestUrl)
+        }
+
+        val response = client.get(tokenRequestUrl, headers, cacheControl)
 
         // This check is for the error that causes pages to fail to load.
         // It should never be entered, but in case it is, we retry the request.
@@ -254,18 +256,10 @@ class MangaDexHelper(lang: String) {
     }
 
     /**
-     * create an md at home Request
+     * Set the token time to now
      */
-    fun mdAtHomeRequest(
-        tokenRequestUrl: String,
-        headers: Headers,
-        cacheControl: CacheControl,
-    ): Request {
-        if (cacheControl == CacheControl.FORCE_NETWORK) {
-            tokenTracker[tokenRequestUrl] = Date().time
-        }
-
-        return GET(tokenRequestUrl, headers, cacheControl)
+    fun mdRefreshToken(tokenRequestUrl: String) {
+        tokenTracker[tokenRequestUrl] = System.currentTimeMillis()
     }
 
     private fun List<Map<String, String>>.findTitleByLang(lang: String): String? = firstOrNull { it[lang] != null }?.values?.singleOrNull()
@@ -299,8 +293,8 @@ class MangaDexHelper(lang: String) {
 
         coverFileName?.let {
             thumbnail_url = when (!coverSuffix.isNullOrEmpty()) {
-                true -> "${MDConstants.CDN_URL}/covers/${mangaDataDto.id}/$coverFileName$coverSuffix"
-                else -> "${MDConstants.CDN_URL}/covers/${mangaDataDto.id}/$coverFileName"
+                true -> "${Constants.CDN_URL}/covers/${mangaDataDto.id}/$coverFileName$coverSuffix"
+                else -> "${Constants.CDN_URL}/covers/${mangaDataDto.id}/$coverFileName"
             }
         }
     }
@@ -356,7 +350,7 @@ class MangaDexHelper(lang: String) {
             .groupBy({ it.attributes!!.group }) { tagDto -> tags[tagDto.id] }
             .mapValues { it.value.filterNotNull().sortedWith(intl.collator) }
 
-        val genreList = MDConstants.TAG_GROUPS_ORDER.flatMap { genresMap[it].orEmpty() } + nonGenres
+        val genreList = Constants.TAG_GROUPS_ORDER.flatMap { genresMap[it].orEmpty() } + nonGenres
 
         // Build description
         val desc = mutableListOf<String>()
@@ -366,7 +360,7 @@ class MangaDexHelper(lang: String) {
             ?.let { desc.add(it) }
 
         if (altTitlesInDesc) {
-            val romanizedOriginalLang = MDConstants.romanizedLangCodes[attr.originalLanguage].orEmpty()
+            val romanizedOriginalLang = Constants.romanizedLangCodes[attr.originalLanguage].orEmpty()
             val altTitles = attr.altTitles
                 .filter { it.containsKey(lang) || it.containsKey(romanizedOriginalLang) }
                 .mapNotNull { it.values.singleOrNull() }
@@ -410,7 +404,7 @@ class MangaDexHelper(lang: String) {
 
         val groups = chapterDataDto.relationships
             .filterIsInstance<ScanlationGroupDto>()
-            .filterNot { it.id == MDConstants.LEGACY_NO_GROUP_ID } // 'no group' left over from MDv3
+            .filterNot { it.id == Constants.LEGACY_NO_GROUP_ID } // 'no group' left over from MDv3
             .mapNotNull { it.attributes?.name }
             .joinToString(" & ")
             .ifEmpty {
@@ -453,7 +447,7 @@ class MangaDexHelper(lang: String) {
 
         // In future calculate [END] if non mvp api doesn't provide it
 
-        val unavailablePrefix = if (attr.isUnavailable == true) {
+        val unavailablePrefix = if (attr.isUnavailable) {
             intl["chapter_unavailable_prefix"] + " - "
         } else {
             ""
@@ -462,7 +456,7 @@ class MangaDexHelper(lang: String) {
         return SChapter.create().apply {
             url = "/chapter/${chapterDataDto.id}"
             name = chapterName.joinToString(" ").removeEntities()
-            date_upload = parseDate(attr.publishAt)
+            date_upload = Instant.parseOrNull(attr.publishAt)?.toEpochMilliseconds() ?: 0L
             scanlator = unavailablePrefix + groups
         }
     }

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MDIntl.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MDIntl.kt
@@ -1,6 +1,6 @@
 package eu.kanade.tachiyomi.extension.all.mangadex
 
-object MangaDexIntl {
+object MDIntl {
     const val BRAZILIAN_PORTUGUESE = "pt-BR"
     const val CHINESE = "zh"
     const val ENGLISH = "en"

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDex.kt
@@ -21,35 +21,107 @@ import eu.kanade.tachiyomi.extension.all.mangadex.dto.MangaDataDto
 import eu.kanade.tachiyomi.extension.all.mangadex.dto.MangaDto
 import eu.kanade.tachiyomi.extension.all.mangadex.dto.MangaListDto
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.asObservable
-import eu.kanade.tachiyomi.network.asObservableSuccess
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.annotation.Source
+import keiyoushi.network.get
 import keiyoushi.network.rateLimit
+import keiyoushi.source.KeiSource
 import keiyoushi.utils.getPreferencesLazy
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonElement
 import okhttp3.CacheControl
 import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
-import rx.Observable
 import java.util.Date
+import kotlin.collections.orEmpty
+import kotlin.collections.toMutableSet
+import kotlin.getValue
 
+/**
+ * Wrapper class for compatibility with Komikku
+ */
 @Source
-class MangaDex(
-    override val name: String,
-    override val lang: String,
-    override val baseUrl: String,
-    override val id: Long,
-) : HttpSource(),
+abstract class MangaDex :
+    HttpSource(),
+    ConfigurableSource {
+
+    private val delegate = object : MangaDexImpl() {
+        override val name: String get() = this@MangaDex.name
+        override val lang: String get() = this@MangaDex.lang
+        override val baseUrl: String get() = this@MangaDex.baseUrl
+        override val id: Long get() = this@MangaDex.id
+    }
+
+    @Suppress("unused")
+    val helper: Helper get() = delegate.helper
+
+    override fun getHomeUrl(): String = delegate.getHomeUrl()
+
+    override val supportsLatest get() = delegate.supportsLatest
+
+    override val client get() = delegate.client
+
+    override fun toString() = delegate.toString()
+
+    override suspend fun getPopularManga(page: Int): MangasPage = delegate.getPopularManga(page)
+
+    override suspend fun getLatestUpdates(page: Int): MangasPage = delegate.getLatestUpdates(page)
+
+    /**
+     * Komikku calls [latestUpdatesRequest] and [latestUpdatesParse] for MangaDex instead of [getLatestUpdates]
+     */
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun latestUpdatesRequest(page: Int): Request = delegate.delegateLatestUpdatesRequest(page)
+
+    /**
+     * Komikku calls [latestUpdatesRequest] and [latestUpdatesParse] for MangaDex instead of [getLatestUpdates]
+     */
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun latestUpdatesParse(response: Response): MangasPage = delegate.delegateLatestUpdatesParse(response)
+
+    override suspend fun getSearchManga(
+        page: Int,
+        query: String,
+        filters: FilterList,
+    ): MangasPage = delegate.getSearchManga(
+        page,
+        query,
+        filters,
+    )
+
+    override suspend fun getMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate = delegate.getMangaUpdate(manga, chapters, fetchDetails, fetchChapters)
+
+    override suspend fun getPageList(chapter: SChapter): List<Page> = delegate.getPageList(chapter)
+
+    override suspend fun getImageUrl(page: Page): String = delegate.getImageUrl(page)
+
+    override fun getMangaUrl(manga: SManga): String = delegate.getMangaUrl(manga)
+
+    override fun getChapterUrl(chapter: SChapter): String = delegate.getChapterUrl(chapter)
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) = delegate.setupPreferenceScreen(screen)
+}
+
+private abstract class MangaDexImpl :
+    KeiSource(),
     ConfigurableSource {
 
     private val dexLang: String
@@ -62,49 +134,23 @@ class MangaDex(
             else -> lang
         }
 
-    override val supportsLatest = true
-
     private val preferences by getPreferencesLazy { sanitizeExistingUuidPrefs() }
 
-    private val helper = MangaDexHelper(lang)
+    val helper = Helper(lang)
 
-    final override fun headersBuilder(): Headers.Builder {
+    override fun Headers.Builder.configureHeaders(): Headers.Builder = apply {
         val extraHeader = "Android/${Build.VERSION.RELEASE} " +
             "Tachiyomi/${AppInfo.getVersionName()} " +
-            "MangaDex/1.4.${BuildConfig.VERSION_CODE} " +
+            "MangaDex/${BuildConfig.VERSION_NAME} " +
             "Keiyoushi"
 
-        val builder = super.headersBuilder().apply {
-            set("User-Agent", "Tachiyomi " + System.getProperty("http.agent"))
-            set("Referer", "$baseUrl/")
-            set("Origin", baseUrl)
-            set("Extra", extraHeader)
-        }
-
-        return builder
+        set("User-Agent", "Tachiyomi " + System.getProperty("http.agent"))
+        set("Extra", extraHeader)
     }
 
-    override val client = network.client.newBuilder()
-        .rateLimit(3)
-        .build()
+    override fun OkHttpClient.Builder.configureClient(): OkHttpClient.Builder = rateLimit(3)
 
-    // Popular manga section
-
-    override fun popularMangaRequest(page: Int): Request {
-        val url = MDConstants.API_MANGA_URL.toHttpUrl().newBuilder()
-            .addQueryParameter("order[followedCount]", "desc")
-            .addQueryParameter("availableTranslatedLanguage[]", dexLang)
-            .addQueryParameter("limit", MDConstants.MANGA_LIMIT.toString())
-            .addQueryParameter("offset", helper.getMangaListOffset(page))
-            .addQueryParameter("includes[]", MDConstants.COVER_ART)
-            .addQueryParameter("contentRating[]", preferences.contentRating)
-            .addQueryParameter("originalLanguage[]", preferences.originalLanguages)
-            .build()
-
-        return GET(url, headers, CacheControl.FORCE_NETWORK)
-    }
-
-    override fun popularMangaParse(response: Response): MangasPage {
+    private suspend fun parseMangasPage(response: Response): MangasPage {
         if (response.code == 204) {
             return MangasPage(emptyList(), false)
         }
@@ -126,51 +172,50 @@ class MangaDex(
         return MangasPage(mangaList, mangaListDto.hasNextPage)
     }
 
+    // Popular manga section
+
+    override suspend fun getPopularManga(page: Int): MangasPage = parseMangasPage(
+        client.get(
+            url = Constants.API_MANGA_URL.toHttpUrl().newBuilder()
+                .addQueryParameter("order[followedCount]", "desc")
+                .addQueryParameter("availableTranslatedLanguage[]", dexLang)
+                .addQueryParameter("limit", Constants.MANGA_LIMIT.toString())
+                .addQueryParameter("offset", helper.getMangaListOffset(page))
+                .addQueryParameter("includes[]", Constants.COVER_ART)
+                .addQueryParameter("contentRating[]", preferences.contentRating)
+                .addQueryParameter("originalLanguage[]", preferences.originalLanguages)
+                .build(),
+            cacheControl = CacheControl.FORCE_NETWORK,
+        ),
+    )
+
     // Latest manga section
-
-    override fun latestUpdatesRequest(page: Int): Request {
-        val url = MDConstants.API_CHAPTER_URL.toHttpUrl().newBuilder()
-            .addQueryParameter("offset", helper.getLatestChapterOffset(page))
-            .addQueryParameter("limit", MDConstants.LATEST_CHAPTER_LIMIT.toString())
-            .addQueryParameter("translatedLanguage[]", dexLang)
-            .addQueryParameter("order[publishAt]", "desc")
-            .addQueryParameter("includeFutureUpdates", "0")
-            .addQueryParameter("originalLanguage[]", preferences.originalLanguages)
-            .addQueryParameter("contentRating[]", preferences.contentRating)
-            .addQueryParameter(
-                "excludedGroups[]",
-                MDConstants.defaultBlockedGroups + preferences.blockedGroups,
-            )
-            .addQueryParameter("excludedUploaders[]", preferences.blockedUploaders)
-            .addQueryParameter("includeFuturePublishAt", "0")
-            .addQueryParameter("includeEmptyPages", "0")
-            .build()
-
-        return GET(url, headers, CacheControl.FORCE_NETWORK)
-    }
 
     /**
      * The API endpoint can't sort by date yet, so not implemented.
      */
-    override fun latestUpdatesParse(response: Response): MangasPage {
+    private suspend fun parseLatestUpdates(response: Response): MangasPage {
         val chapterListDto = response.parseAs<ChapterListDto>()
 
         val mangaIds = chapterListDto.data
+            .asSequence()
             .flatMap { it.relationships }
             .filterIsInstance<MangaDataDto>()
             .map { it.id }
             .distinct()
             .toSet()
 
-        val mangaApiUrl = MDConstants.API_MANGA_URL.toHttpUrl().newBuilder()
-            .addQueryParameter("includes[]", MDConstants.COVER_ART)
+        val mangaApiUrl = Constants.API_MANGA_URL.toHttpUrl().newBuilder()
+            .addQueryParameter("includes[]", Constants.COVER_ART)
             .addQueryParameter("limit", mangaIds.size.toString())
             .addQueryParameter("contentRating[]", preferences.contentRating)
             .addQueryParameter("ids[]", mangaIds)
             .build()
 
-        val mangaRequest = GET(mangaApiUrl, headers, CacheControl.FORCE_NETWORK)
-        val mangaResponse = client.newCall(mangaRequest).execute()
+        val mangaResponse = client.get(
+            url = mangaApiUrl,
+            cacheControl = CacheControl.FORCE_NETWORK,
+        )
         val mangaListDto = mangaResponse.parseAs<MangaListDto>()
         val firstVolumeCovers = fetchFirstVolumeCovers(mangaListDto.data).orEmpty()
 
@@ -190,61 +235,97 @@ class MangaDex(
         return MangasPage(mangaList, chapterListDto.hasNextPage)
     }
 
+    private fun latestUpdatesUrl(page: Int) = Constants.API_CHAPTER_URL.toHttpUrl().newBuilder()
+        .addQueryParameter("offset", helper.getLatestChapterOffset(page))
+        .addQueryParameter("limit", Constants.LATEST_CHAPTER_LIMIT.toString())
+        .addQueryParameter("translatedLanguage[]", dexLang)
+        .addQueryParameter("order[publishAt]", "desc")
+        .addQueryParameter("includeFutureUpdates", "0")
+        .addQueryParameter("originalLanguage[]", preferences.originalLanguages)
+        .addQueryParameter("contentRating[]", preferences.contentRating)
+        .addQueryParameter(
+            "excludedGroups[]",
+            Constants.defaultBlockedGroups + preferences.blockedGroups,
+        )
+        .addQueryParameter("excludedUploaders[]", preferences.blockedUploaders)
+        .addQueryParameter("includeFuturePublishAt", "0")
+        .addQueryParameter("includeEmptyPages", "0")
+        .build()
+
+    fun delegateLatestUpdatesRequest(page: Int): Request = GET(latestUpdatesUrl(page), headers, CacheControl.FORCE_NETWORK)
+
+    fun delegateLatestUpdatesParse(response: Response): MangasPage = runBlocking { parseLatestUpdates(response) }
+
+    override suspend fun getLatestUpdates(page: Int): MangasPage = parseLatestUpdates(client.get(latestUpdatesUrl(page), headers, CacheControl.FORCE_NETWORK))
+
     // Search manga section
 
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
-        var newQuery = query
-        val url = query.trim().toHttpUrlOrNull()
-        if (url != null && url.host.endsWith("mangadex.org")) {
-            val searchPrefix = url.pathSegments.firstOrNull()?.let { MDConstants.pathToSearchPrefix[it] }
+    override suspend fun getMangasByUrl(url: HttpUrl, page: Int): MangasPage {
+        if (url.host.endsWith("mangadex.org")) {
+            val searchPrefix = url.pathSegments.firstOrNull()?.let { Constants.pathToSearchPrefix[it] }
             if (searchPrefix != null) {
-                val match = MDConstants.uuidRegex.find(url.toString())
+                val match = Constants.uuidRegex.find(url.toString())
                 if (match != null) {
-                    newQuery = searchPrefix + match.value
+                    return getSearchMangaList(page, searchPrefix + match.value, FilterList())
                 }
             }
         }
-
-        return when {
-            newQuery.startsWith(MDConstants.PREFIX_CH_SEARCH) ->
-                getMangaIdFromChapterId(newQuery.removePrefix(MDConstants.PREFIX_CH_SEARCH))
-                    .flatMap { mangaId ->
-                        super.fetchSearchManga(
-                            page = page,
-                            query = MDConstants.PREFIX_ID_SEARCH + mangaId,
-                            filters = filters,
-                        )
-                    }
-
-            newQuery.startsWith(MDConstants.PREFIX_USER_SEARCH) ->
-                client
-                    .newCall(
-                        request = searchMangaUploaderRequest(
-                            page = page,
-                            uploader = newQuery.removePrefix(MDConstants.PREFIX_USER_SEARCH),
-                        ),
-                    )
-                    .asObservableSuccess()
-                    .map { latestUpdatesParse(it) }
-
-            newQuery.startsWith(MDConstants.PREFIX_LIST_SEARCH) ->
-                client
-                    .newCall(
-                        request = searchMangaListRequest(
-                            list = newQuery.removePrefix(MDConstants.PREFIX_LIST_SEARCH),
-                        ),
-                    )
-                    .asObservableSuccess()
-                    .map { searchMangaListParse(it, page, filters) }
-
-            else -> super.fetchSearchManga(page, newQuery.trim(), filters)
-        }
+        return getSearchMangaList(page, url.toString(), FilterList())
     }
 
-    private fun getMangaIdFromChapterId(id: String): Observable<String> = client.newCall(GET("${MDConstants.API_CHAPTER_URL}/$id", headers))
-        .asObservable()
-        .map { response ->
-            if (response.isSuccessful.not()) {
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage = when {
+        query.startsWith(Constants.PREFIX_CH_SEARCH) ->
+            client
+                .get(
+                    url = searchMangaUrl(
+                        page = page,
+                        query = Constants.PREFIX_ID_SEARCH + getMangaIdFromChapterId(query.removePrefix(Constants.PREFIX_CH_SEARCH)),
+                        filters = filters,
+                    ),
+                    cacheControl = CacheControl.FORCE_NETWORK,
+                )
+                .let { parseMangasPage(it) }
+
+        query.startsWith(Constants.PREFIX_USER_SEARCH) ->
+            client
+                .get(
+                    url = searchMangaUploaderUrl(
+                        page = page,
+                        uploader = query.removePrefix(Constants.PREFIX_USER_SEARCH),
+                    ),
+                    cacheControl = CacheControl.FORCE_NETWORK,
+                )
+                .let { parseLatestUpdates(it) }
+
+        query.startsWith(Constants.PREFIX_LIST_SEARCH) ->
+            client
+                .get(
+                    url = searchMangaListUrl(
+                        list = query.removePrefix(Constants.PREFIX_LIST_SEARCH),
+                    ),
+                    cacheControl = CacheControl.FORCE_NETWORK,
+                )
+                .let { parseSearchMangaList(it, page, filters) }
+
+        else ->
+            client
+                .get(
+                    url = searchMangaUrl(
+                        page = page,
+                        query = query.trim(),
+                        filters = filters,
+                    ),
+                    cacheControl = CacheControl.FORCE_NETWORK,
+                )
+                .let { parseMangasPage(it) }
+    }
+
+    private suspend fun getMangaIdFromChapterId(id: String): String = client.get(
+        url = "${Constants.API_CHAPTER_URL}/$id",
+        ensureSuccess = false,
+    )
+        .let { response ->
+            if (!response.isSuccessful) {
                 throw Exception(helper.intl.format("unable_to_process_chapter_request", response.code))
             }
 
@@ -252,31 +333,29 @@ class MangaDex(
                 .firstInstanceOrNull<MangaDataDto>()!!.id
         }
 
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        if (query.startsWith(MDConstants.PREFIX_ID_SEARCH)) {
-            val mangaId = query.removePrefix(MDConstants.PREFIX_ID_SEARCH)
+    private fun searchMangaUrl(page: Int, query: String, filters: FilterList): HttpUrl {
+        if (query.startsWith(Constants.PREFIX_ID_SEARCH)) {
+            val mangaId = query.removePrefix(Constants.PREFIX_ID_SEARCH)
 
             if (!helper.containsUuid(mangaId)) {
                 throw Exception(helper.intl["invalid_manga_id"])
             }
 
-            val url = MDConstants.API_MANGA_URL.toHttpUrl().newBuilder()
-                .addQueryParameter("ids[]", query.removePrefix(MDConstants.PREFIX_ID_SEARCH))
-                .addQueryParameter("includes[]", MDConstants.COVER_ART)
-                .addQueryParameter("contentRating[]", MDConstants.allContentRatings)
+            return Constants.API_MANGA_URL.toHttpUrl().newBuilder()
+                .addQueryParameter("ids[]", query.removePrefix(Constants.PREFIX_ID_SEARCH))
+                .addQueryParameter("includes[]", Constants.COVER_ART)
+                .addQueryParameter("contentRating[]", Constants.allContentRatings)
                 .build()
-
-            return GET(url, headers, CacheControl.FORCE_NETWORK)
         }
 
-        val tempUrl = MDConstants.API_MANGA_URL.toHttpUrl().newBuilder()
-            .addQueryParameter("limit", MDConstants.MANGA_LIMIT.toString())
+        val tempUrl = Constants.API_MANGA_URL.toHttpUrl().newBuilder()
+            .addQueryParameter("limit", Constants.MANGA_LIMIT.toString())
             .addQueryParameter("offset", helper.getMangaListOffset(page))
-            .addQueryParameter("includes[]", MDConstants.COVER_ART)
+            .addQueryParameter("includes[]", Constants.COVER_ART)
 
         when {
-            query.startsWith(MDConstants.PREFIX_GRP_SEARCH) -> {
-                val groupId = query.removePrefix(MDConstants.PREFIX_GRP_SEARCH)
+            query.startsWith(Constants.PREFIX_GRP_SEARCH) -> {
+                val groupId = query.removePrefix(Constants.PREFIX_GRP_SEARCH)
 
                 if (!helper.containsUuid(groupId)) {
                     throw Exception(helper.intl["invalid_group_id"])
@@ -285,8 +364,8 @@ class MangaDex(
                 tempUrl.addQueryParameter("group", groupId)
             }
 
-            query.startsWith(MDConstants.PREFIX_AUTHOR_SEARCH) -> {
-                val authorId = query.removePrefix(MDConstants.PREFIX_AUTHOR_SEARCH)
+            query.startsWith(Constants.PREFIX_AUTHOR_SEARCH) -> {
+                val authorId = query.removePrefix(Constants.PREFIX_AUTHOR_SEARCH)
 
                 if (!helper.containsUuid(authorId)) {
                     throw Exception(helper.intl["invalid_author_id"])
@@ -296,7 +375,7 @@ class MangaDex(
             }
 
             else -> {
-                val actualQuery = query.replace(MDConstants.whitespaceRegex, " ")
+                val actualQuery = query.replace(Constants.whitespaceRegex, " ")
 
                 if (actualQuery.isNotBlank()) {
                     tempUrl.addQueryParameter("title", actualQuery)
@@ -310,14 +389,12 @@ class MangaDex(
             dexLang = dexLang,
         )
 
-        return GET(finalUrl, headers, CacheControl.FORCE_NETWORK)
+        return finalUrl
     }
 
-    override fun searchMangaParse(response: Response): MangasPage = popularMangaParse(response)
+    private fun searchMangaListUrl(list: String): HttpUrl = "${Constants.API_LIST_URL}/$list".toHttpUrl()
 
-    private fun searchMangaListRequest(list: String): Request = GET("${MDConstants.API_LIST_URL}/$list", headers, CacheControl.FORCE_NETWORK)
-
-    private fun searchMangaListParse(response: Response, page: Int, filters: FilterList): MangasPage {
+    private suspend fun parseSearchMangaList(response: Response, page: Int, filters: FilterList): MangasPage {
         val listDto = response.parseAs<ListDto>()
         val listDtoFiltered = listDto.data!!.relationships.filterIsInstance<MangaDataDto>()
         val amount = listDtoFiltered.count()
@@ -326,15 +403,15 @@ class MangaDex(
             throw Exception(helper.intl["no_series_in_list"])
         }
 
-        val minIndex = (page - 1) * MDConstants.MANGA_LIMIT
+        val minIndex = (page - 1) * Constants.MANGA_LIMIT
 
-        val tempUrl = MDConstants.API_MANGA_URL.toHttpUrl().newBuilder()
-            .addQueryParameter("limit", MDConstants.MANGA_LIMIT.toString())
+        val tempUrl = Constants.API_MANGA_URL.toHttpUrl().newBuilder()
+            .addQueryParameter("limit", Constants.MANGA_LIMIT.toString())
             .addQueryParameter("offset", "0")
-            .addQueryParameter("includes[]", MDConstants.COVER_ART)
+            .addQueryParameter("includes[]", Constants.COVER_ART)
 
         val ids = listDtoFiltered
-            .filterIndexed { i, _ -> i >= minIndex && i < (minIndex + MDConstants.MANGA_LIMIT) }
+            .filterIndexed { i, _ -> i >= minIndex && i < (minIndex + Constants.MANGA_LIMIT) }
             .map(MangaDataDto::id)
             .toSet()
 
@@ -346,30 +423,25 @@ class MangaDex(
             dexLang = dexLang,
         )
 
-        val mangaRequest = GET(finalUrl, headers, CacheControl.FORCE_NETWORK)
-        val mangaResponse = client.newCall(mangaRequest).execute()
-        val mangaList = searchMangaListParse(mangaResponse)
+        val mangaResponse = client.get(
+            url = finalUrl,
+            cacheControl = CacheControl.FORCE_NETWORK,
+        )
+        val mangaList = parseSearchMangaList(mangaResponse)
 
-        val hasNextPage = amount.toFloat() / MDConstants.MANGA_LIMIT - (page.toFloat() - 1) > 1 &&
-            ids.size == MDConstants.MANGA_LIMIT
+        val hasNextPage = amount.toFloat() / Constants.MANGA_LIMIT - (page.toFloat() - 1) > 1 &&
+            ids.size == Constants.MANGA_LIMIT
 
         return MangasPage(mangaList, hasNextPage)
     }
 
-    private fun searchMangaListParse(response: Response): List<SManga> {
-        // This check will be used as the source is doing additional requests to this
-        // that are not parsed by the asObservableSuccess() method. It should throw the
-        // HttpException from the app if it becomes available in a future version of extensions-lib.
-        if (response.isSuccessful.not()) {
-            throw Exception("HTTP error ${response.code}")
-        }
-
+    private suspend fun parseSearchMangaList(response: Response): List<SManga> {
         val mangaListDto = response.parseAs<MangaListDto>()
         val firstVolumeCovers = fetchFirstVolumeCovers(mangaListDto.data).orEmpty()
 
         val coverSuffix = preferences.coverQuality
 
-        val mangaList = mangaListDto.data.map { mangaDataDto ->
+        return mangaListDto.data.map { mangaDataDto ->
             val fileName = firstVolumeCovers.getOrElse(mangaDataDto.id) {
                 mangaDataDto.relationships
                     .firstInstanceOrNull<CoverArtDto>()
@@ -377,31 +449,25 @@ class MangaDex(
             }
             helper.createBasicManga(mangaDataDto, fileName, coverSuffix, dexLang, preferences.preferExtensionLangTitle)
         }
-
-        return mangaList
     }
 
-    private fun searchMangaUploaderRequest(page: Int, uploader: String): Request {
-        val url = MDConstants.API_CHAPTER_URL.toHttpUrl().newBuilder()
-            .addQueryParameter("offset", helper.getLatestChapterOffset(page))
-            .addQueryParameter("limit", MDConstants.LATEST_CHAPTER_LIMIT.toString())
-            .addQueryParameter("translatedLanguage[]", dexLang)
-            .addQueryParameter("order[publishAt]", "desc")
-            .addQueryParameter("includeFutureUpdates", "0")
-            .addQueryParameter("includeFuturePublishAt", "0")
-            .addQueryParameter("includeEmptyPages", "0")
-            .addQueryParameter("uploader", uploader)
-            .addQueryParameter("originalLanguage[]", preferences.originalLanguages)
-            .addQueryParameter("contentRating[]", preferences.contentRating)
-            .addQueryParameter(
-                "excludedGroups[]",
-                MDConstants.defaultBlockedGroups + preferences.blockedGroups,
-            )
-            .addQueryParameter("excludedUploaders[]", preferences.blockedUploaders)
-            .build()
-
-        return GET(url, headers, CacheControl.FORCE_NETWORK)
-    }
+    private fun searchMangaUploaderUrl(page: Int, uploader: String): HttpUrl = Constants.API_CHAPTER_URL.toHttpUrl().newBuilder()
+        .addQueryParameter("offset", helper.getLatestChapterOffset(page))
+        .addQueryParameter("limit", Constants.LATEST_CHAPTER_LIMIT.toString())
+        .addQueryParameter("translatedLanguage[]", dexLang)
+        .addQueryParameter("order[publishAt]", "desc")
+        .addQueryParameter("includeFutureUpdates", "0")
+        .addQueryParameter("includeFuturePublishAt", "0")
+        .addQueryParameter("includeEmptyPages", "0")
+        .addQueryParameter("uploader", uploader)
+        .addQueryParameter("originalLanguage[]", preferences.originalLanguages)
+        .addQueryParameter("contentRating[]", preferences.contentRating)
+        .addQueryParameter(
+            "excludedGroups[]",
+            Constants.defaultBlockedGroups + preferences.blockedGroups,
+        )
+        .addQueryParameter("excludedUploaders[]", preferences.blockedUploaders)
+        .build()
 
     // Manga Details section
 
@@ -412,21 +478,22 @@ class MangaDex(
      *
      * @throws Exception if the url is the old format so people migrate
      */
-    override fun mangaDetailsRequest(manga: SManga): Request {
-        if (!helper.containsUuid(manga.url.trim())) {
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga {
+        if (!helper.containsUuid(url.toString())) {
             throw Exception(helper.intl["migrate_warning"])
         }
 
-        val url = (MDConstants.API_URL + manga.url).toHttpUrl().newBuilder()
-            .addQueryParameter("includes[]", MDConstants.COVER_ART)
-            .addQueryParameter("includes[]", MDConstants.AUTHOR)
-            .addQueryParameter("includes[]", MDConstants.ARTIST)
-            .build()
+        val response = client.get(
+            url = "${Constants.API_URL}/manga/${url.pathSegments[1]}"
+                .toHttpUrl()
+                .newBuilder()
+                .addQueryParameter("includes[]", Constants.COVER_ART)
+                .addQueryParameter("includes[]", Constants.AUTHOR)
+                .addQueryParameter("includes[]", Constants.ARTIST)
+                .build(),
+            cacheControl = CacheControl.FORCE_NETWORK,
+        )
 
-        return GET(url, headers, CacheControl.FORCE_NETWORK)
-    }
-
-    override fun mangaDetailsParse(response: Response): SManga {
         val manga = response.parseAs<MangaDto>()
 
         return helper.createManga(
@@ -445,12 +512,12 @@ class MangaDex(
      * Get a quick-n-dirty list of the chapters to be used in determining the manga status.
      * Uses the 'aggregate' endpoint.
      *
-     * @see MangaDexHelper.getPublicationStatus
+     * @see Helper.getPublicationStatus
      * @see AggregateDto
      */
-    private fun fetchSimpleChapterList(manga: MangaDto, langCode: String): Map<String, AggregateVolume> {
-        val url = "${MDConstants.API_MANGA_URL}/${manga.data!!.id}/aggregate?translatedLanguage[]=$langCode"
-        val response = client.newCall(GET(url, headers)).execute()
+    private suspend fun fetchSimpleChapterList(manga: MangaDto, langCode: String): Map<String, AggregateVolume> {
+        val url = "${Constants.API_MANGA_URL}/${manga.data!!.id}/aggregate?translatedLanguage[]=$langCode"
+        val response = client.get(url)
 
         return runCatching { response.parseAs<AggregateDto>() }
             .getOrNull()?.volumes.orEmpty()
@@ -462,7 +529,7 @@ class MangaDex(
      *
      * @see CoverArtListDto
      */
-    private fun fetchFirstVolumeCover(manga: MangaDto): String? = fetchFirstVolumeCovers(listOf(manga.data!!))?.get(manga.data.id)
+    private suspend fun fetchFirstVolumeCover(manga: MangaDto): String? = fetchFirstVolumeCovers(listOf(manga.data!!))?.get(manga.data.id)
 
     /**
      * Attempt to get the first volume cover if the setting is enabled.
@@ -470,7 +537,7 @@ class MangaDex(
      *
      * @see CoverArtListDto
      */
-    private fun fetchFirstVolumeCovers(mangaList: List<MangaDataDto>): Map<String, String>? {
+    private suspend fun fetchFirstVolumeCovers(mangaList: List<MangaDataDto>): Map<String, String>? {
         if (!preferences.tryUsingFirstVolumeCover || mangaList.isEmpty()) {
             return null
         }
@@ -480,7 +547,7 @@ class MangaDex(
         val locales = safeMangaList.mapNotNull { it.attributes!!.originalLanguage }.distinct()
         val limit = (mangaMap.size * locales.size).coerceAtMost(100)
 
-        val apiUrl = "${MDConstants.API_URL}/cover".toHttpUrl().newBuilder()
+        val apiUrl = "${Constants.API_URL}/cover".toHttpUrl().newBuilder()
             .addQueryParameter("order[volume]", "asc")
             .addQueryParameter("manga[]", mangaMap.keys)
             .addQueryParameter("locales[]", locales.toSet())
@@ -489,7 +556,7 @@ class MangaDex(
             .build()
 
         val result = runCatching {
-            client.newCall(GET(apiUrl, headers)).execute().parseAs<CoverArtListDto>().data
+            client.get(apiUrl).parseAs<CoverArtListDto>().data
         }
 
         val covers = result.getOrNull() ?: return null
@@ -506,33 +573,30 @@ class MangaDex(
     // Chapter list section
 
     /**
+     * Required because the chapter list API endpoint is paginated.
+     */
+    private fun paginatedChapterListUrl(mangaId: String, offset: Int): HttpUrl = helper
+        .getChapterEndpoint(mangaId, offset, dexLang)
+        .toHttpUrl()
+        .newBuilder()
+        .addQueryParameter("contentRating[]", Constants.allContentRatings)
+        .addQueryParameter("excludedGroups[]", preferences.blockedGroups)
+        .addQueryParameter("excludedUploaders[]", preferences.blockedUploaders)
+        .addQueryParameter("includeUnavailable", if (preferences.includeUnavailable) "1" else "0")
+        .build()
+
+    /**
      * Get the API endpoint URL for the first page of chapter list.
      *
      * @throws Exception if the url is the old format so people migrate
      */
-    override fun chapterListRequest(manga: SManga): Request {
+    private suspend fun parseChapterList(manga: SManga): List<SChapter> {
         if (!helper.containsUuid(manga.url)) {
             throw Exception(helper.intl["migrate_warning"])
         }
 
-        return paginatedChapterListRequest(helper.getUUIDFromUrl(manga.url), 0)
-    }
+        val response = client.get(paginatedChapterListUrl(helper.getUUIDFromUrl(manga.url), 0))
 
-    /**
-     * Required because the chapter list API endpoint is paginated.
-     */
-    private fun paginatedChapterListRequest(mangaId: String, offset: Int): Request {
-        val url = helper.getChapterEndpoint(mangaId, offset, dexLang).toHttpUrl().newBuilder()
-            .addQueryParameter("contentRating[]", MDConstants.allContentRatings)
-            .addQueryParameter("excludedGroups[]", preferences.blockedGroups)
-            .addQueryParameter("excludedUploaders[]", preferences.blockedUploaders)
-            .addQueryParameter("includeUnavailable", if (preferences.includeUnavailable) "1" else "0")
-            .build()
-
-        return GET(url, headers, CacheControl.FORCE_NETWORK)
-    }
-
-    override fun chapterListParse(response: Response): List<SChapter> {
         if (response.code == 204) {
             return emptyList()
         }
@@ -543,7 +607,7 @@ class MangaDex(
 
         val mangaId = response.request.url.toString()
             .substringBefore("/feed")
-            .substringAfter("${MDConstants.API_MANGA_URL}/")
+            .substringAfter("${Constants.API_MANGA_URL}/")
 
         var offset = chapterListResponse.offset
         var hasNextPage = chapterListResponse.hasNextPage
@@ -553,8 +617,10 @@ class MangaDex(
         while (hasNextPage) {
             offset += chapterListResponse.limit
 
-            val newRequest = paginatedChapterListRequest(mangaId, offset)
-            val newResponse = client.newCall(newRequest).execute()
+            val newResponse = client.get(
+                url = paginatedChapterListUrl(mangaId, offset),
+                cacheControl = CacheControl.FORCE_NETWORK,
+            )
             val newChapterList = newResponse.parseAs<ChapterListDto>()
             chapterListResults.addAll(newChapterList.data)
 
@@ -568,23 +634,23 @@ class MangaDex(
 
     override fun getChapterUrl(chapter: SChapter): String = baseUrl + chapter.url
 
-    override fun pageListRequest(chapter: SChapter): Request {
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
         if (!helper.containsUuid(chapter.url)) {
             throw Exception(helper.intl["migrate_warning"])
         }
 
         val chapterId = chapter.url.substringAfter("/chapter/")
         val atHomeRequestUrl = if (preferences.forceStandardHttps) {
-            "${MDConstants.API_URL}/at-home/server/$chapterId?forcePort443=true"
+            "${Constants.API_URL}/at-home/server/$chapterId?forcePort443=true"
         } else {
-            "${MDConstants.API_URL}/at-home/server/$chapterId"
+            "${Constants.API_URL}/at-home/server/$chapterId"
         }
 
-        return helper.mdAtHomeRequest(atHomeRequestUrl, headers, CacheControl.FORCE_NETWORK)
-    }
-
-    override fun pageListParse(response: Response): List<Page> {
-        val atHomeRequestUrl = response.request.url
+        helper.mdRefreshToken(atHomeRequestUrl)
+        val response = client.get(
+            url = atHomeRequestUrl,
+            cacheControl = CacheControl.FORCE_NETWORK,
+        )
         val atHomeDto = response.parseAs<AtHomeDto>()
         val host = atHomeDto.baseUrl
 
@@ -604,18 +670,16 @@ class MangaDex(
         }
     }
 
-    override fun imageRequest(page: Page): Request = helper.getValidImageUrlForPage(page, headers, client)
-
-    override fun imageUrlParse(response: Response): String = ""
+    override fun imageRequest(page: Page): Request = runBlocking { helper.getValidImageUrlForPage(page, headers, client) }
 
     @Suppress("UNCHECKED_CAST")
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         val coverQualityPref = ListPreference(screen.context).apply {
-            key = MDConstants.getCoverQualityPreferenceKey(dexLang)
+            key = Constants.getCoverQualityPreferenceKey(dexLang)
             title = helper.intl["cover_quality"]
-            entries = MDConstants.getCoverQualityPreferenceEntries(helper.intl)
-            entryValues = MDConstants.getCoverQualityPreferenceEntryValues()
-            setDefaultValue(MDConstants.getCoverQualityPreferenceDefaultValue())
+            entries = Constants.getCoverQualityPreferenceEntries(helper.intl)
+            entryValues = Constants.getCoverQualityPreferenceEntryValues()
+            setDefaultValue(Constants.getCoverQualityPreferenceDefaultValue())
             summary = "%s"
 
             setOnPreferenceChangeListener { _, newValue ->
@@ -624,28 +688,28 @@ class MangaDex(
                 val entry = entryValues[index] as String
 
                 preferences.edit()
-                    .putString(MDConstants.getCoverQualityPreferenceKey(dexLang), entry)
+                    .putString(Constants.getCoverQualityPreferenceKey(dexLang), entry)
                     .commit()
             }
         }
 
         val tryUsingFirstVolumeCoverPref = SwitchPreferenceCompat(screen.context).apply {
-            key = MDConstants.getTryUsingFirstVolumeCoverPrefKey(dexLang)
+            key = Constants.getTryUsingFirstVolumeCoverPrefKey(dexLang)
             title = helper.intl["try_using_first_volume_cover"]
             summary = helper.intl["try_using_first_volume_cover_summary"]
-            setDefaultValue(MDConstants.TRY_USING_FIRST_VOLUME_COVER_DEFAULT)
+            setDefaultValue(Constants.TRY_USING_FIRST_VOLUME_COVER_DEFAULT)
 
             setOnPreferenceChangeListener { _, newValue ->
                 val checkValue = newValue as Boolean
 
                 preferences.edit()
-                    .putBoolean(MDConstants.getTryUsingFirstVolumeCoverPrefKey(dexLang), checkValue)
+                    .putBoolean(Constants.getTryUsingFirstVolumeCoverPrefKey(dexLang), checkValue)
                     .commit()
             }
         }
 
         val dataSaverPref = SwitchPreferenceCompat(screen.context).apply {
-            key = MDConstants.getDataSaverPreferenceKey(dexLang)
+            key = Constants.getDataSaverPreferenceKey(dexLang)
             title = helper.intl["data_saver"]
             summary = helper.intl["data_saver_summary"]
             setDefaultValue(false)
@@ -654,13 +718,13 @@ class MangaDex(
                 val checkValue = newValue as Boolean
 
                 preferences.edit()
-                    .putBoolean(MDConstants.getDataSaverPreferenceKey(dexLang), checkValue)
+                    .putBoolean(Constants.getDataSaverPreferenceKey(dexLang), checkValue)
                     .commit()
             }
         }
 
         val standardHttpsPortPref = SwitchPreferenceCompat(screen.context).apply {
-            key = MDConstants.getStandardHttpsPreferenceKey(dexLang)
+            key = Constants.getStandardHttpsPreferenceKey(dexLang)
             title = helper.intl["standard_https_port"]
             summary = helper.intl["standard_https_port_summary"]
             setDefaultValue(false)
@@ -669,13 +733,13 @@ class MangaDex(
                 val checkValue = newValue as Boolean
 
                 preferences.edit()
-                    .putBoolean(MDConstants.getStandardHttpsPreferenceKey(dexLang), checkValue)
+                    .putBoolean(Constants.getStandardHttpsPreferenceKey(dexLang), checkValue)
                     .commit()
             }
         }
 
         val contentRatingPref = MultiSelectListPreference(screen.context).apply {
-            key = MDConstants.getContentRatingPrefKey(dexLang)
+            key = Constants.getContentRatingPrefKey(dexLang)
             title = helper.intl["standard_content_rating"]
             summary = helper.intl["standard_content_rating_summary"]
             entries = arrayOf(
@@ -685,49 +749,49 @@ class MangaDex(
                 helper.intl["content_rating_pornographic"],
             )
             entryValues = arrayOf(
-                MDConstants.CONTENT_RATING_PREF_VAL_SAFE,
-                MDConstants.CONTENT_RATING_PREF_VAL_SUGGESTIVE,
-                MDConstants.CONTENT_RATING_PREF_VAL_EROTICA,
-                MDConstants.CONTENT_RATING_PREF_VAL_PORNOGRAPHIC,
+                Constants.CONTENT_RATING_PREF_VAL_SAFE,
+                Constants.CONTENT_RATING_PREF_VAL_SUGGESTIVE,
+                Constants.CONTENT_RATING_PREF_VAL_EROTICA,
+                Constants.CONTENT_RATING_PREF_VAL_PORNOGRAPHIC,
             )
-            setDefaultValue(MDConstants.contentRatingPrefDefaults)
+            setDefaultValue(Constants.contentRatingPrefDefaults)
 
             setOnPreferenceChangeListener { _, newValue ->
                 val checkValue = newValue as Set<String>
 
                 preferences.edit()
-                    .putStringSet(MDConstants.getContentRatingPrefKey(dexLang), checkValue)
+                    .putStringSet(Constants.getContentRatingPrefKey(dexLang), checkValue)
                     .commit()
             }
         }
 
         val originalLanguagePref = MultiSelectListPreference(screen.context).apply {
-            key = MDConstants.getOriginalLanguagePrefKey(dexLang)
+            key = Constants.getOriginalLanguagePrefKey(dexLang)
             title = helper.intl["filter_original_languages"]
             summary = helper.intl["filter_original_languages_summary"]
             entries = arrayOf(
-                helper.intl.languageDisplayName(MangaDexIntl.JAPANESE),
-                helper.intl.languageDisplayName(MangaDexIntl.CHINESE),
-                helper.intl.languageDisplayName(MangaDexIntl.KOREAN),
+                helper.intl.languageDisplayName(MDIntl.JAPANESE),
+                helper.intl.languageDisplayName(MDIntl.CHINESE),
+                helper.intl.languageDisplayName(MDIntl.KOREAN),
             )
             entryValues = arrayOf(
-                MDConstants.ORIGINAL_LANGUAGE_PREF_VAL_JAPANESE,
-                MDConstants.ORIGINAL_LANGUAGE_PREF_VAL_CHINESE,
-                MDConstants.ORIGINAL_LANGUAGE_PREF_VAL_KOREAN,
+                Constants.ORIGINAL_LANGUAGE_PREF_VAL_JAPANESE,
+                Constants.ORIGINAL_LANGUAGE_PREF_VAL_CHINESE,
+                Constants.ORIGINAL_LANGUAGE_PREF_VAL_KOREAN,
             )
-            setDefaultValue(MDConstants.originalLanguagePrefDefaults)
+            setDefaultValue(Constants.originalLanguagePrefDefaults)
 
             setOnPreferenceChangeListener { _, newValue ->
                 val checkValue = newValue as Set<String>
 
                 preferences.edit()
-                    .putStringSet(MDConstants.getOriginalLanguagePrefKey(dexLang), checkValue)
+                    .putStringSet(Constants.getOriginalLanguagePrefKey(dexLang), checkValue)
                     .commit()
             }
         }
 
         val blockedGroupsPref = EditTextPreference(screen.context).apply {
-            key = MDConstants.getBlockedGroupsPrefKey(dexLang)
+            key = Constants.getBlockedGroupsPrefKey(dexLang)
             title = helper.intl["block_group_by_uuid"]
             summary = helper.intl["block_group_by_uuid_summary"]
 
@@ -735,13 +799,13 @@ class MangaDex(
 
             setOnPreferenceChangeListener { _, newValue ->
                 preferences.edit()
-                    .putString(MDConstants.getBlockedGroupsPrefKey(dexLang), newValue.toString())
+                    .putString(Constants.getBlockedGroupsPrefKey(dexLang), newValue.toString())
                     .commit()
             }
         }
 
         val blockedUploaderPref = EditTextPreference(screen.context).apply {
-            key = MDConstants.getBlockedUploaderPrefKey(dexLang)
+            key = Constants.getBlockedUploaderPrefKey(dexLang)
             title = helper.intl["block_uploader_by_uuid"]
             summary = helper.intl["block_uploader_by_uuid_summary"]
 
@@ -749,13 +813,13 @@ class MangaDex(
 
             setOnPreferenceChangeListener { _, newValue ->
                 preferences.edit()
-                    .putString(MDConstants.getBlockedUploaderPrefKey(dexLang), newValue.toString())
+                    .putString(Constants.getBlockedUploaderPrefKey(dexLang), newValue.toString())
                     .commit()
             }
         }
 
         val altTitlesInDescPref = SwitchPreferenceCompat(screen.context).apply {
-            key = MDConstants.getAltTitlesInDescPrefKey(dexLang)
+            key = Constants.getAltTitlesInDescPrefKey(dexLang)
             title = helper.intl["alternative_titles_in_description"]
             summary = helper.intl["alternative_titles_in_description_summary"]
             setDefaultValue(false)
@@ -764,13 +828,13 @@ class MangaDex(
                 val checkValue = newValue as Boolean
 
                 preferences.edit()
-                    .putBoolean(MDConstants.getAltTitlesInDescPrefKey(dexLang), checkValue)
+                    .putBoolean(Constants.getAltTitlesInDescPrefKey(dexLang), checkValue)
                     .commit()
             }
         }
 
         val preferExtensionLangTitlePref = SwitchPreferenceCompat(screen.context).apply {
-            key = MDConstants.getPreferExtensionLangTitlePrefKey(dexLang)
+            key = Constants.getPreferExtensionLangTitlePrefKey(dexLang)
             title = helper.intl["prefer_title_in_extension_language"]
             summary = helper.intl["prefer_title_in_extension_language_summary"]
             setDefaultValue(true)
@@ -779,13 +843,13 @@ class MangaDex(
                 val checkValue = newValue as Boolean
 
                 preferences.edit()
-                    .putBoolean(MDConstants.getPreferExtensionLangTitlePrefKey(dexLang), checkValue)
+                    .putBoolean(Constants.getPreferExtensionLangTitlePrefKey(dexLang), checkValue)
                     .commit()
             }
         }
 
         val finalChapterInDescPref = SwitchPreferenceCompat(screen.context).apply {
-            key = MDConstants.getFinalChapterInDescPrefKey(dexLang)
+            key = Constants.getFinalChapterInDescPrefKey(dexLang)
             title = helper.intl["final_chapter_in_description"]
             summary = helper.intl["final_chapter_in_description_summary"]
             setDefaultValue(true)
@@ -794,13 +858,13 @@ class MangaDex(
                 val checkValue = newValue as Boolean
 
                 preferences.edit()
-                    .putBoolean(MDConstants.getFinalChapterInDescPrefKey(dexLang), checkValue)
+                    .putBoolean(Constants.getFinalChapterInDescPrefKey(dexLang), checkValue)
                     .commit()
             }
         }
 
         val includeUnavailablePref = SwitchPreferenceCompat(screen.context).apply {
-            key = MDConstants.getIncludeUnavailablePrefKey(dexLang)
+            key = Constants.getIncludeUnavailablePrefKey(dexLang)
             title = helper.intl["include_unavailable"]
             summary = helper.intl["include_unavailable_summary"]
             setDefaultValue(false)
@@ -809,7 +873,7 @@ class MangaDex(
                 val checkValue = newValue as Boolean
 
                 preferences.edit()
-                    .putBoolean(MDConstants.getIncludeUnavailablePrefKey(dexLang), checkValue)
+                    .putBoolean(Constants.getIncludeUnavailablePrefKey(dexLang), checkValue)
                     .commit()
             }
         }
@@ -828,7 +892,23 @@ class MangaDex(
         screen.addPreference(blockedUploaderPref)
     }
 
-    override fun getFilterList(): FilterList = helper.mdFilters.getMDFilterList(preferences, dexLang, helper.intl)
+    override fun getFilterList(data: JsonElement?): FilterList = helper.mdFilters.getMDFilterList(preferences, dexLang, helper.intl)
+
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate = coroutineScope {
+        val mangaDeferred = async {
+            if (fetchDetails) getMangaByUrl(getMangaUrl(manga).toHttpUrl()) else manga
+        }
+        val chaptersDeferred = async {
+            if (fetchChapters) parseChapterList(manga) else chapters
+        }
+
+        SMangaUpdate(mangaDeferred.await(), chaptersDeferred.await())
+    }
 
     private fun HttpUrl.Builder.addQueryParameter(name: String, value: Set<String>?) = apply {
         value?.forEach { addQueryParameter(name, it) }
@@ -842,37 +922,37 @@ class MangaDex(
 
     private val SharedPreferences.contentRating
         get() = getStringSet(
-            MDConstants.getContentRatingPrefKey(dexLang),
-            MDConstants.contentRatingPrefDefaults,
+            Constants.getContentRatingPrefKey(dexLang),
+            Constants.contentRatingPrefDefaults,
         )
 
     private val SharedPreferences.originalLanguages: Set<String>
         get() {
             val prefValues = getStringSet(
-                MDConstants.getOriginalLanguagePrefKey(dexLang),
-                MDConstants.originalLanguagePrefDefaults,
+                Constants.getOriginalLanguagePrefKey(dexLang),
+                Constants.originalLanguagePrefDefaults,
             )
 
             val originalLanguages = prefValues.orEmpty().toMutableSet()
 
-            if (MDConstants.ORIGINAL_LANGUAGE_PREF_VAL_CHINESE in originalLanguages) {
-                originalLanguages.add(MDConstants.ORIGINAL_LANGUAGE_PREF_VAL_CHINESE_HK)
+            if (Constants.ORIGINAL_LANGUAGE_PREF_VAL_CHINESE in originalLanguages) {
+                originalLanguages.add(Constants.ORIGINAL_LANGUAGE_PREF_VAL_CHINESE_HK)
             }
 
             return originalLanguages
         }
 
     private val SharedPreferences.coverQuality
-        get() = getString(MDConstants.getCoverQualityPreferenceKey(dexLang), "")
+        get() = getString(Constants.getCoverQualityPreferenceKey(dexLang), "")
 
     private val SharedPreferences.tryUsingFirstVolumeCover
         get() = getBoolean(
-            MDConstants.getTryUsingFirstVolumeCoverPrefKey(dexLang),
-            MDConstants.TRY_USING_FIRST_VOLUME_COVER_DEFAULT,
+            Constants.getTryUsingFirstVolumeCoverPrefKey(dexLang),
+            Constants.TRY_USING_FIRST_VOLUME_COVER_DEFAULT,
         )
 
     private val SharedPreferences.blockedGroups
-        get() = getString(MDConstants.getBlockedGroupsPrefKey(dexLang), "")
+        get() = getString(Constants.getBlockedGroupsPrefKey(dexLang), "")
             ?.split(",")
             ?.map(String::trim)
             ?.filter(String::isNotEmpty)
@@ -881,7 +961,7 @@ class MangaDex(
             .toSet()
 
     private val SharedPreferences.blockedUploaders
-        get() = getString(MDConstants.getBlockedUploaderPrefKey(dexLang), "")
+        get() = getString(Constants.getBlockedUploaderPrefKey(dexLang), "")
             ?.split(",")
             ?.map(String::trim)
             ?.filter(String::isNotEmpty)
@@ -890,22 +970,22 @@ class MangaDex(
             .toSet()
 
     private val SharedPreferences.forceStandardHttps
-        get() = getBoolean(MDConstants.getStandardHttpsPreferenceKey(dexLang), false)
+        get() = getBoolean(Constants.getStandardHttpsPreferenceKey(dexLang), false)
 
     private val SharedPreferences.useDataSaver
-        get() = getBoolean(MDConstants.getDataSaverPreferenceKey(dexLang), false)
+        get() = getBoolean(Constants.getDataSaverPreferenceKey(dexLang), false)
 
     private val SharedPreferences.altTitlesInDesc
-        get() = getBoolean(MDConstants.getAltTitlesInDescPrefKey(dexLang), false)
+        get() = getBoolean(Constants.getAltTitlesInDescPrefKey(dexLang), false)
 
     private val SharedPreferences.preferExtensionLangTitle
-        get() = getBoolean(MDConstants.getPreferExtensionLangTitlePrefKey(dexLang), true)
+        get() = getBoolean(Constants.getPreferExtensionLangTitlePrefKey(dexLang), true)
 
     private val SharedPreferences.finalChapterInDesc
-        get() = getBoolean(MDConstants.getFinalChapterInDescPrefKey(dexLang), true)
+        get() = getBoolean(Constants.getFinalChapterInDescPrefKey(dexLang), true)
 
     private val SharedPreferences.includeUnavailable
-        get() = getBoolean(MDConstants.getIncludeUnavailablePrefKey(dexLang), false)
+        get() = getBoolean(Constants.getIncludeUnavailablePrefKey(dexLang), false)
 
     /**
      * Previous versions of the extension allowed invalid UUID values to be stored in the
@@ -913,26 +993,26 @@ class MangaDex(
      * a previous version with that behaviour.
      */
     private fun SharedPreferences.sanitizeExistingUuidPrefs() {
-        if (getBoolean(MDConstants.getHasSanitizedUuidsPrefKey(dexLang), false)) {
+        if (getBoolean(Constants.getHasSanitizedUuidsPrefKey(dexLang), false)) {
             return
         }
 
-        val blockedGroups = getString(MDConstants.getBlockedGroupsPrefKey(dexLang), "")!!
+        val blockedGroups = getString(Constants.getBlockedGroupsPrefKey(dexLang), "")!!
             .split(",")
             .map(String::trim)
             .filter(helper::isUuid)
             .joinToString(", ")
 
-        val blockedUploaders = getString(MDConstants.getBlockedUploaderPrefKey(dexLang), "")!!
+        val blockedUploaders = getString(Constants.getBlockedUploaderPrefKey(dexLang), "")!!
             .split(",")
             .map(String::trim)
             .filter(helper::isUuid)
             .joinToString(", ")
 
         edit()
-            .putString(MDConstants.getBlockedGroupsPrefKey(dexLang), blockedGroups)
-            .putString(MDConstants.getBlockedUploaderPrefKey(dexLang), blockedUploaders)
-            .putBoolean(MDConstants.getHasSanitizedUuidsPrefKey(dexLang), true)
+            .putString(Constants.getBlockedGroupsPrefKey(dexLang), blockedGroups)
+            .putString(Constants.getBlockedUploaderPrefKey(dexLang), blockedUploaders)
+            .putBoolean(Constants.getHasSanitizedUuidsPrefKey(dexLang), true)
             .apply()
     }
 }

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDex.kt
@@ -20,7 +20,6 @@ import eu.kanade.tachiyomi.extension.all.mangadex.dto.ListDto
 import eu.kanade.tachiyomi.extension.all.mangadex.dto.MangaDataDto
 import eu.kanade.tachiyomi.extension.all.mangadex.dto.MangaDto
 import eu.kanade.tachiyomi.extension.all.mangadex.dto.MangaListDto
-import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
@@ -28,7 +27,6 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.SMangaUpdate
-import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.annotation.Source
 import keiyoushi.network.get
 import keiyoushi.network.rateLimit
@@ -42,6 +40,7 @@ import okhttp3.CacheControl
 import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -50,80 +49,13 @@ import kotlin.collections.orEmpty
 import kotlin.collections.toMutableSet
 import kotlin.getValue
 
-/**
- * Wrapper class for compatibility with Komikku
- */
 @Source
-abstract class MangaDex :
-    HttpSource(),
-    ConfigurableSource {
-
-    private val delegate = object : MangaDexImpl() {
-        override val name: String get() = this@MangaDex.name
-        override val lang: String get() = this@MangaDex.lang
-        override val baseUrl: String get() = this@MangaDex.baseUrl
-        override val id: Long get() = this@MangaDex.id
-    }
-
-    @Suppress("unused")
-    val helper: Helper get() = delegate.helper
-
-    override fun getHomeUrl(): String = delegate.getHomeUrl()
-
-    override val supportsLatest get() = delegate.supportsLatest
-
-    override val client get() = delegate.client
-
-    override fun toString() = delegate.toString()
-
-    override suspend fun getPopularManga(page: Int): MangasPage = delegate.getPopularManga(page)
-
-    override suspend fun getLatestUpdates(page: Int): MangasPage = delegate.getLatestUpdates(page)
-
-    /**
-     * Komikku calls [latestUpdatesRequest] and [latestUpdatesParse] for MangaDex instead of [getLatestUpdates]
-     */
-    @Suppress("OVERRIDE_DEPRECATION")
-    override fun latestUpdatesRequest(page: Int): Request = delegate.delegateLatestUpdatesRequest(page)
-
-    /**
-     * Komikku calls [latestUpdatesRequest] and [latestUpdatesParse] for MangaDex instead of [getLatestUpdates]
-     */
-    @Suppress("OVERRIDE_DEPRECATION")
-    override fun latestUpdatesParse(response: Response): MangasPage = delegate.delegateLatestUpdatesParse(response)
-
-    override suspend fun getSearchManga(
-        page: Int,
-        query: String,
-        filters: FilterList,
-    ): MangasPage = delegate.getSearchManga(
-        page,
-        query,
-        filters,
-    )
-
-    override suspend fun getMangaUpdate(
-        manga: SManga,
-        chapters: List<SChapter>,
-        fetchDetails: Boolean,
-        fetchChapters: Boolean,
-    ): SMangaUpdate = delegate.getMangaUpdate(manga, chapters, fetchDetails, fetchChapters)
-
-    override suspend fun getPageList(chapter: SChapter): List<Page> = delegate.getPageList(chapter)
-
-    override suspend fun getImageUrl(page: Page): String = delegate.getImageUrl(page)
-
-    override fun getMangaUrl(manga: SManga): String = delegate.getMangaUrl(manga)
-
-    override fun getChapterUrl(chapter: SChapter): String = delegate.getChapterUrl(chapter)
-
-    override fun imageRequest(page: Page): Request = delegate.delegateImageRequest(page)
-
-    override fun setupPreferenceScreen(screen: PreferenceScreen) = delegate.setupPreferenceScreen(screen)
-}
-
-private abstract class MangaDexImpl :
-    KeiSource(),
+class MangaDex(
+    override val name: String,
+    override val lang: String,
+    override val baseUrl: String,
+    override val id: Long,
+) : KeiSource(),
     ConfigurableSource {
 
     private val dexLang: String
@@ -138,7 +70,7 @@ private abstract class MangaDexImpl :
 
     private val preferences by getPreferencesLazy { sanitizeExistingUuidPrefs() }
 
-    val helper = Helper(lang)
+    private val helper = Helper(lang)
 
     override fun Headers.Builder.configureHeaders(): Headers.Builder = apply {
         val extraHeader = "Android/${Build.VERSION.RELEASE} " +
@@ -237,12 +169,12 @@ private abstract class MangaDexImpl :
         return MangasPage(mangaList, chapterListDto.hasNextPage)
     }
 
-    private fun latestUpdatesUrl(page: Int) = Constants.API_CHAPTER_URL.toHttpUrl().newBuilder()
+    private fun latestUpdatesUrl(page: Int, komikku: Boolean = false) = Constants.API_CHAPTER_URL.toHttpUrl().newBuilder()
         .addQueryParameter("offset", helper.getLatestChapterOffset(page))
         .addQueryParameter("limit", Constants.LATEST_CHAPTER_LIMIT.toString())
         .addQueryParameter("translatedLanguage[]", dexLang)
         .addQueryParameter("order[publishAt]", "desc")
-        .addQueryParameter("includeFutureUpdates", "0")
+        .addQueryParameter("includeFutureUpdates", if (komikku) "1" else "0")
         .addQueryParameter("originalLanguage[]", preferences.originalLanguages)
         .addQueryParameter("contentRating[]", preferences.contentRating)
         .addQueryParameter(
@@ -254,28 +186,50 @@ private abstract class MangaDexImpl :
         .addQueryParameter("includeEmptyPages", "0")
         .build()
 
-    fun delegateLatestUpdatesRequest(page: Int): Request = GET(latestUpdatesUrl(page), headers, CacheControl.FORCE_NETWORK)
+    override suspend fun getLatestUpdates(page: Int): MangasPage = parseLatestUpdates(
+        client.get(
+            url = latestUpdatesUrl(page),
+            cacheControl = CacheControl.FORCE_NETWORK,
+        ),
+    )
 
-    fun delegateLatestUpdatesParse(response: Response): MangasPage = runBlocking { parseLatestUpdates(response) }
-
-    override suspend fun getLatestUpdates(page: Int): MangasPage = parseLatestUpdates(client.get(latestUpdatesUrl(page), headers, CacheControl.FORCE_NETWORK))
+    @Suppress("unused")
+    suspend fun komikkuGetLatestUpdates(page: Int): MangasPage = parseLatestUpdates(
+        client.get(
+            url = latestUpdatesUrl(page, true),
+            cacheControl = CacheControl.FORCE_NETWORK,
+        ),
+    )
 
     // Search manga section
 
-    override suspend fun getMangasByUrl(url: HttpUrl, page: Int): MangasPage {
+    override suspend fun getMangasByUrl(url: HttpUrl, page: Int): MangasPage = getMangasByUrl(url, page, false)
+
+    private suspend fun getMangasByUrl(url: HttpUrl, page: Int, komikku: Boolean): MangasPage {
         if (url.host.endsWith("mangadex.org")) {
             val searchPrefix = url.pathSegments.firstOrNull()?.let { Constants.pathToSearchPrefix[it] }
             if (searchPrefix != null) {
                 val match = Constants.uuidRegex.find(url.toString())
                 if (match != null) {
-                    return getSearchMangaList(page, searchPrefix + match.value, FilterList())
+                    return getSearchMangaList(page, searchPrefix + match.value, FilterList(), komikku)
                 }
             }
         }
-        return getSearchMangaList(page, url.toString(), FilterList())
+        return getSearchMangaList(page, url.toString(), FilterList(), komikku)
     }
 
-    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage = when {
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage = getSearchMangaList(page, query, filters, false)
+
+    @Suppress("unused")
+    suspend fun komikkuGetSearchManga(page: Int, query: String, filters: FilterList): MangasPage {
+        query.toHttpUrlOrNull()?.also { url ->
+            return getMangasByUrl(url, page, true)
+        }
+
+        return getSearchMangaList(page, query, filters, true)
+    }
+
+    private suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList, komikku: Boolean): MangasPage = when {
         query.startsWith(Constants.PREFIX_CH_SEARCH) ->
             client
                 .get(
@@ -294,6 +248,7 @@ private abstract class MangaDexImpl :
                     url = searchMangaUploaderUrl(
                         page = page,
                         uploader = query.removePrefix(Constants.PREFIX_USER_SEARCH),
+                        komikku = komikku,
                     ),
                     cacheControl = CacheControl.FORCE_NETWORK,
                 )
@@ -453,12 +408,12 @@ private abstract class MangaDexImpl :
         }
     }
 
-    private fun searchMangaUploaderUrl(page: Int, uploader: String): HttpUrl = Constants.API_CHAPTER_URL.toHttpUrl().newBuilder()
+    private fun searchMangaUploaderUrl(page: Int, uploader: String, komikku: Boolean = false): HttpUrl = Constants.API_CHAPTER_URL.toHttpUrl().newBuilder()
         .addQueryParameter("offset", helper.getLatestChapterOffset(page))
         .addQueryParameter("limit", Constants.LATEST_CHAPTER_LIMIT.toString())
         .addQueryParameter("translatedLanguage[]", dexLang)
         .addQueryParameter("order[publishAt]", "desc")
-        .addQueryParameter("includeFutureUpdates", "0")
+        .addQueryParameter("includeFutureUpdates", if (komikku) "1" else "0")
         .addQueryParameter("includeFuturePublishAt", "0")
         .addQueryParameter("includeEmptyPages", "0")
         .addQueryParameter("uploader", uploader)
@@ -673,8 +628,6 @@ private abstract class MangaDexImpl :
     }
 
     override fun imageRequest(page: Page): Request = runBlocking { helper.getValidImageUrlForPage(page, headers, client) }
-
-    fun delegateImageRequest(page: Page): Request = imageRequest(page)
 
     @Suppress("UNCHECKED_CAST")
     override fun setupPreferenceScreen(screen: PreferenceScreen) {

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDex.kt
@@ -117,6 +117,8 @@ abstract class MangaDex :
 
     override fun getChapterUrl(chapter: SChapter): String = delegate.getChapterUrl(chapter)
 
+    override fun imageRequest(page: Page): Request = delegate.delegateImageRequest(page)
+
     override fun setupPreferenceScreen(screen: PreferenceScreen) = delegate.setupPreferenceScreen(screen)
 }
 
@@ -671,6 +673,8 @@ private abstract class MangaDexImpl :
     }
 
     override fun imageRequest(page: Page): Request = runBlocking { helper.getValidImageUrlForPage(page, headers, client) }
+
+    fun delegateImageRequest(page: Page): Request = imageRequest(page)
 
     @Suppress("UNCHECKED_CAST")
     override fun setupPreferenceScreen(screen: PreferenceScreen) {

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/dto/AuthorDto.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/dto/AuthorDto.kt
@@ -1,15 +1,15 @@
 package eu.kanade.tachiyomi.extension.all.mangadex.dto
 
-import eu.kanade.tachiyomi.extension.all.mangadex.MDConstants
+import eu.kanade.tachiyomi.extension.all.mangadex.Constants
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-@SerialName(MDConstants.AUTHOR)
+@SerialName(Constants.AUTHOR)
 data class AuthorDto(override val attributes: AuthorArtistAttributesDto? = null) : EntityDto()
 
 @Serializable
-@SerialName(MDConstants.ARTIST)
+@SerialName(Constants.ARTIST)
 data class ArtistDto(override val attributes: AuthorArtistAttributesDto? = null) : EntityDto()
 
 @Serializable

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/dto/ChapterDto.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/dto/ChapterDto.kt
@@ -1,6 +1,6 @@
 package eu.kanade.tachiyomi.extension.all.mangadex.dto
 
-import eu.kanade.tachiyomi.extension.all.mangadex.MDConstants
+import eu.kanade.tachiyomi.extension.all.mangadex.Constants
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -9,7 +9,7 @@ typealias ChapterListDto = PaginatedResponseDto<ChapterDataDto>
 typealias ChapterDto = ResponseDto<ChapterDataDto>
 
 @Serializable
-@SerialName(MDConstants.CHAPTER)
+@SerialName(Constants.CHAPTER)
 data class ChapterDataDto(override val attributes: ChapterAttributesDto? = null) : EntityDto()
 
 @Serializable

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/dto/CoverArtDto.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/dto/CoverArtDto.kt
@@ -1,13 +1,13 @@
 package eu.kanade.tachiyomi.extension.all.mangadex.dto
 
-import eu.kanade.tachiyomi.extension.all.mangadex.MDConstants
+import eu.kanade.tachiyomi.extension.all.mangadex.Constants
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 typealias CoverArtListDto = PaginatedResponseDto<CoverArtDto>
 
 @Serializable
-@SerialName(MDConstants.COVER_ART)
+@SerialName(Constants.COVER_ART)
 data class CoverArtDto(override val attributes: CoverArtAttributesDto? = null) : EntityDto()
 
 @Serializable

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/dto/ListDto.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/dto/ListDto.kt
@@ -1,13 +1,13 @@
 package eu.kanade.tachiyomi.extension.all.mangadex.dto
 
-import eu.kanade.tachiyomi.extension.all.mangadex.MDConstants
+import eu.kanade.tachiyomi.extension.all.mangadex.Constants
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 typealias ListDto = ResponseDto<ListDataDto>
 
 @Serializable
-@SerialName(MDConstants.LIST)
+@SerialName(Constants.LIST)
 data class ListDataDto(override val attributes: ListAttributesDto? = null) : EntityDto()
 
 @Serializable

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/dto/MangaDto.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/dto/MangaDto.kt
@@ -1,6 +1,6 @@
 package eu.kanade.tachiyomi.extension.all.mangadex.dto
 
-import eu.kanade.tachiyomi.extension.all.mangadex.MDConstants
+import eu.kanade.tachiyomi.extension.all.mangadex.Constants
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -18,7 +18,7 @@ typealias MangaListDto = PaginatedResponseDto<MangaDataDto>
 typealias MangaDto = ResponseDto<MangaDataDto>
 
 @Serializable
-@SerialName(MDConstants.MANGA)
+@SerialName(Constants.MANGA)
 data class MangaDataDto(override val attributes: MangaAttributesDto? = null) : EntityDto()
 
 @Serializable
@@ -84,7 +84,7 @@ enum class StatusDto(val value: String) {
 }
 
 @Serializable
-@SerialName(MDConstants.TAG)
+@SerialName(Constants.TAG)
 data class TagDto(override val attributes: TagAttributesDto? = null) : EntityDto()
 
 @Serializable

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/dto/ScanlationGroupDto.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/dto/ScanlationGroupDto.kt
@@ -1,11 +1,11 @@
 package eu.kanade.tachiyomi.extension.all.mangadex.dto
 
-import eu.kanade.tachiyomi.extension.all.mangadex.MDConstants
+import eu.kanade.tachiyomi.extension.all.mangadex.Constants
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-@SerialName(MDConstants.SCANLATION_GROUP)
+@SerialName(Constants.SCANLATION_GROUP)
 data class ScanlationGroupDto(override val attributes: ScanlationGroupAttributes? = null) : EntityDto()
 
 @Serializable

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/dto/UserDto.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/dto/UserDto.kt
@@ -1,11 +1,11 @@
 package eu.kanade.tachiyomi.extension.all.mangadex.dto
 
-import eu.kanade.tachiyomi.extension.all.mangadex.MDConstants
+import eu.kanade.tachiyomi.extension.all.mangadex.Constants
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-@SerialName(MDConstants.USER)
+@SerialName(Constants.USER)
 data class UserDto(override val attributes: UserAttributes? = null) : EntityDto()
 
 @Serializable


### PR DESCRIPTION
This change is a bit hacky due to Komikku using MangaDex's `latestUpdatesRequest` and `latestUpdatesParse`.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
