### PR TITLE
url updated for we love manga

### DIFF
--- a/src/ja/rawlh/build.gradle.kts
+++ b/src/ja/rawlh/build.gradle.kts
@@ -6,14 +6,14 @@ plugins {
 
 keiyoushi {
     name = "WeLoveManga"
-    versionCode = 5
+    versionCode = 6
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
     theme = "fmreader"
 
     source {
         lang = "ja"
-        baseUrl = "https://weloma.art"
+        baseUrl = "https://weloma.net"
         // Formerly "RawLH"
         id = 7595224096258102519L
     }


### PR DESCRIPTION
closes #17998


Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
