### PR TITLE
fix(zh/manhuashe): add image referer

### DIFF
--- a/src/zh/manhuashe/build.gradle.kts
+++ b/src/zh/manhuashe/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Manhuashe"
-    versionCode = 1
+    versionCode = 2
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/zh/manhuashe/src/eu/kanade/tachiyomi/extension/zh/manhuashe/Manhuashe.kt
+++ b/src/zh/manhuashe/src/eu/kanade/tachiyomi/extension/zh/manhuashe/Manhuashe.kt
@@ -18,6 +18,9 @@ abstract class Manhuashe : HttpSource() {
 
     override val supportsLatest: Boolean = true
 
+    override fun headersBuilder() = super.headersBuilder()
+        .add("Referer", "$baseUrl/")
+
     // Popular
 
     override fun popularMangaRequest(page: Int) = GET("$baseUrl/category/order/hits/page/$page", headers)


### PR DESCRIPTION
## Summary

Fix image loading for Manhuashe by adding the required source-site `Referer` header.

Without the header, the image CDN returns HTTP 567 with an HTML response instead of image data.

## Changes

- Add `Referer: $baseUrl/` to Manhuashe request headers.
- Bump extension `versionCode` from 1 to 2.

## Testing

- Verified the affected image URL returns HTTP 567 without Referer and HTTP 200 `image/webp` with the source Referer.
- Ran `:src:zh:manhuashe:assembleDebug` successfully.
- Installed `tachiyomi-zh.manhuashe-v1.4.2-debug.apk` on a physical Android device.

## Checklist

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (not applicable: no multisrc theme code changed)
- [x] Referenced all related issues in the PR body (not applicable: no related issue provided)
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed (not applicable)
- [ ] Have tested the modifications by compiling and running the extension through Android Studio (but running on real android device)
- [x] Have removed `web_hi_res_512.png` when adding a new extension (not applicable: existing extension)
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

🤖 Codex was asked to diagnose Manhuashe image failures, implement the source-specific Referer fix, build the extension, and deploy the debug APK. This PR was prepared with AI assistance.