### PR TITLE
ext-bootstrap: remove non-abstract method

### DIFF
--- a/ext-bootstrap.py
+++ b/ext-bootstrap.py
@@ -138,9 +138,8 @@ def write_keisource_source(f, classname: str) -> None:
         "\toverride suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage =\n"
         "\t\tthrow UnsupportedOperationException()\n\n"
     )
-    f.write(
-        "\toverride suspend fun getMangaByUrl(url: HttpUrl): SManga? = throw UnsupportedOperationException()\n\n"
-    )
+
+    f.write("\toverride suspend fun getMangaByUrl(url: HttpUrl): SManga? = null\n\n")
 
     f.write("\toverride suspend fun fetchMangaUpdate(\n")
     f.write("\t\tmanga: SManga,\n")
@@ -149,15 +148,6 @@ def write_keisource_source(f, classname: str) -> None:
     f.write("\t\tfetchChapters: Boolean,\n")
     f.write("\t): SMangaUpdate = throw UnsupportedOperationException()\n\n")
 
-    f.write(
-        "\toverride suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> = throw UnsupportedOperationException()\n\n"
-    )
-    f.write(
-        "\toverride fun getMangaUrl(manga: SManga): String = throw UnsupportedOperationException()\n\n"
-    )
-    f.write(
-        "\toverride fun getChapterUrl(chapter: SChapter): String = throw UnsupportedOperationException()\n\n"
-    )
     f.write(
         "\toverride suspend fun getPageList(chapter: SChapter): List<Page> = throw UnsupportedOperationException()\n"
     )


### PR DESCRIPTION
Checklist:

- [ ] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
