### PR TITLE
fix(hentaihand/nhentaicom): fix lookup filters parsing numeric ids

### DIFF
--- a/lib-multisrc/hentaihand/build.gradle.kts
+++ b/lib-multisrc/hentaihand/build.gradle.kts
@@ -3,6 +3,6 @@ plugins {
 }
 
 keiyoushi {
-    baseVersionCode = 4
+    baseVersionCode = 5
     libVersion = "1.4"
 }

--- a/lib-multisrc/hentaihand/src/eu/kanade/tachiyomi/multisrc/hentaihand/Dto.kt
+++ b/lib-multisrc/hentaihand/src/eu/kanade/tachiyomi/multisrc/hentaihand/Dto.kt
@@ -131,4 +131,4 @@ class NameDto(val name: String)
 fun List<NameDto>.toNames() = if (this.isEmpty()) null else this.joinToString { it.name }
 
 @Serializable
-class IdDto(val id: String)
+class IdDto(val id: Int)

--- a/lib-multisrc/hentaihand/src/eu/kanade/tachiyomi/multisrc/hentaihand/HentaiHand.kt
+++ b/lib-multisrc/hentaihand/src/eu/kanade/tachiyomi/multisrc/hentaihand/HentaiHand.kt
@@ -96,7 +96,7 @@ abstract class HentaiHand :
                 if (idList.isEmpty()) {
                     return@map null
                 } else {
-                    idList.first().toInt()
+                    idList.first()
                 }
             }.toBlocking().first()
     }


### PR DESCRIPTION
Fixes the lookup filters (Tags, Categories, Artists, etc.) crashing with a
serialization error. The API returns numeric JSON ids, but `IdDto` was parsing
them as `String`, which kotlinx.serialization cannot coerce, so every lookup
search threw before reaching the manual `.toInt()`.

- Change `IdDto.id` from `String` to `Int`
- Drop the now-redundant `.toInt()` in `lookupFilterId`
- Bump `baseVersionCode` 4 -> 5


Testing

- Built the extension via Android Studio / `./gradlew :src:all:nhentaicom:assembleDebug :src:all:hentaihand:assembleDebug`
- Installed the APK on a physical device (Android 16)
- Confirmed lookup filters with tags returns filtered comics (previously crashed with a serialization error)

Closes #13291 

Checklist:

- [ ] Updated `versionCode` value in `build.gradle.kts` (auto-bumped via multisrc `baseVersionCode`)
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

