### PR TITLE
MangaMoins (FR): fix chapter image URLs

### DIFF
--- a/src/fr/mangamoins/build.gradle.kts
+++ b/src/fr/mangamoins/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "MangaMoins"
-    versionCode = 11
+    versionCode = 12
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/fr/mangamoins/src/eu/kanade/tachiyomi/extension/fr/mangamoins/MangaMoins.kt
+++ b/src/fr/mangamoins/src/eu/kanade/tachiyomi/extension/fr/mangamoins/MangaMoins.kt
@@ -201,7 +201,7 @@ abstract class MangaMoins : HttpSource() {
         val data = response.parseAs<ScanResponse>()
         val salts = getSalts(data.pagesBaseUrl)
 
-        val baseUrl = salts.fold(data.pagesBaseUrl.removeSuffix("/")) { url, salt ->
+        val baseUrl = salts.fold(data.pagesBaseUrl.removeSuffix("/").removeSuffix("_b")) { url, salt ->
             url.replace(salt, "")
         }
 


### PR DESCRIPTION
Closes #17347 

- Remove the obsolete `_b` suffix when constructing MangaMoins chapter image URLs.
- Bump the extension version code.

🤖 This PR is AI-assisted. I asked Codex to diagnose and fix the MangaMoins chapter image URLs, and reviewed the resulting two-line change before opening the PR.


Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop