### PR TITLE
MGeko: Hide broken last credit image

### DIFF
--- a/src/en/mangarawclub/build.gradle.kts
+++ b/src/en/mangarawclub/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "MangaGeko"
-    versionCode = 33
+    versionCode = 34
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 

--- a/src/en/mangarawclub/src/eu/kanade/tachiyomi/extension/en/mangarawclub/MangaRawClub.kt
+++ b/src/en/mangarawclub/src/eu/kanade/tachiyomi/extension/en/mangarawclub/MangaRawClub.kt
@@ -231,7 +231,9 @@ abstract class MangaRawClub :
     // =============================== Pages ===============================
     override fun pageListParse(response: Response): List<Page> {
         val document = response.asJsoup()
-        return document.select("#chapter-reader img").mapIndexed { i, img ->
+        return document.select("#chapter-reader img")
+        .filterNot { it.absUrl("src").contains("credits-mgeko.png") }
+        .mapIndexed { i, img ->
             Page(i, imageUrl = img.absUrl("src"))
         }
     }


### PR DESCRIPTION
The last page is a credit image (`credits-mgeko.png`) that currently returns **403 Forbidden**, causing a broken image to appear at the end of every chapter, and so unable to download any chapter.

This change filters out that image during page parsing. Since most users likely don't want to see a credit page, this also future-proofs the parser in case the image is moved to a different host (e.g. `imgsrv4.com` → `imgsrv5.com`) while keeping the same filename.


Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
