### PR TITLE
Fix Manga Şehri.net popular and latest listings

### DIFF
--- a/src/tr/mangasehrinet/build.gradle.kts
+++ b/src/tr/mangasehrinet/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Manga Şehri.net"
-    versionCode = 1
+    versionCode = 2
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
     theme = "madara"

--- a/src/tr/mangasehrinet/src/eu/kanade/tachiyomi/extension/tr/mangasehrinet/MangaSehriNet.kt
+++ b/src/tr/mangasehrinet/src/eu/kanade/tachiyomi/extension/tr/mangasehrinet/MangaSehriNet.kt
@@ -8,6 +8,9 @@ import java.util.Locale
 @Source
 abstract class MangaSehriNet : Madara() {
     override val dateFormat = SimpleDateFormat("d MMMM yyyy", Locale("tr"))
-    override val useLoadMoreRequest = LoadMoreStrategy.AutoDetect
+
+    override val useLoadMoreRequest = LoadMoreStrategy.Always
     override val useNewChapterEndpoint = false
+
+    override fun popularMangaSelector() = "div.page-item-detail"
 }


### PR DESCRIPTION
- Fixed popular and latest manga listings for Manga Şehri.net (resolved HTTP 500 errors caused by outdated Madara AJAX endpoints).
- Bumped `versionCode` to 2.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
