### PR TITLE
Hentaiclub (zh) fix search url error

### DIFF
--- a/src/zh/hentaiclub/build.gradle.kts
+++ b/src/zh/hentaiclub/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Shenshi Huisuo"
-    versionCode = 2
+    versionCode = 3
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 

--- a/src/zh/hentaiclub/src/eu/kanade/tachiyomi/extension/zh/hentaiclub/HentaiClub.kt
+++ b/src/zh/hentaiclub/src/eu/kanade/tachiyomi/extension/zh/hentaiclub/HentaiClub.kt
@@ -55,7 +55,7 @@ abstract class HentaiClub : HttpSource() {
                 .addPathSegment(query.trim())
                 .build()
                 .toString()
-            val url = if (page > 1) "$searchUrl/page/$page/" else "$searchUrl/"
+            val url = if (page > 1) "$searchUrl/$page/" else "$searchUrl/"
             return GET(url, headers)
         }
 


### PR DESCRIPTION
Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
