### PR TITLE
Hive Scans: Hide false scanlator

### DIFF
--- a/src/en/infernalvoidscans/build.gradle.kts
+++ b/src/en/infernalvoidscans/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Hive Scans"
-    versionCode = 43
+    versionCode = 44
     contentWarning = ContentWarning.SAFE
     libVersion = "1.6"
     theme = "iken"

--- a/src/en/infernalvoidscans/src/eu/kanade/tachiyomi/extension/en/infernalvoidscans/HiveScans.kt
+++ b/src/en/infernalvoidscans/src/eu/kanade/tachiyomi/extension/en/infernalvoidscans/HiveScans.kt
@@ -3,6 +3,9 @@ package eu.kanade.tachiyomi.extension.en.infernalvoidscans
 import eu.kanade.tachiyomi.multisrc.iken.Iken
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import keiyoushi.annotation.Source
 import okhttp3.CacheControl
 import okhttp3.Request
@@ -15,4 +18,13 @@ abstract class HiveScans : Iken() {
         headers,
         CacheControl.Builder().noCache().build(),
     )
+
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate = super.fetchMangaUpdate(manga, chapters, fetchDetails, fetchChapters).apply {
+        this.chapters.forEach { it.scanlator = null }
+    }
 }


### PR DESCRIPTION
The username of the person who uploaded the chapter was being displayed in the scanlator

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by running the extension
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
