### PR TITLE
VyvyManga [EN]: Update Domain

### DIFF
--- a/src/en/vyvymanga/build.gradle.kts
+++ b/src/en/vyvymanga/build.gradle.kts
@@ -6,13 +6,13 @@ plugins {
 
 keiyoushi {
     name = "VyvyManga"
-    versionCode = 41
+    versionCode = 42
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
 
     source {
         lang = "en"
-        baseUrl = "https://vymanga.net"
+        baseUrl = "https://mangavyvy.net"
     }
 
     deeplink {


### PR DESCRIPTION
Closes #18194.
Closes #18268.

*Tested PR APK, and latest was fixed with it*

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
