### PR TITLE
Mangas Origines / Hentai Origines (FR): adapt to the site rework

### DIFF
--- a/src/fr/hentaiorigines/build.gradle.kts
+++ b/src/fr/hentaiorigines/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Hentai Origines"
-    versionCode = 1
+    versionCode = 2
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
     theme = "madara"

--- a/src/fr/hentaiorigines/src/eu/kanade/tachiyomi/extension/fr/hentaiorigines/HentaiOrigines.kt
+++ b/src/fr/hentaiorigines/src/eu/kanade/tachiyomi/extension/fr/hentaiorigines/HentaiOrigines.kt
@@ -1,30 +1,289 @@
 package eu.kanade.tachiyomi.extension.fr.hentaiorigines
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
 import keiyoushi.annotation.Source
-import java.text.SimpleDateFormat
+import keiyoushi.utils.firstInstanceOrNull
+import keiyoushi.utils.parseAs
+import keiyoushi.utils.tryParseDate
+import kotlinx.serialization.Serializable
+import okhttp3.FormBody
+import okhttp3.Request
+import okhttp3.Response
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
+import java.time.temporal.ChronoField
 import java.util.Locale
-import java.util.TimeZone
 
 @Source
 abstract class HentaiOrigines : Madara() {
-    override val dateFormat = SimpleDateFormat("d MMMM yyyy", Locale.FRENCH).apply {
-        timeZone = TimeZone.getTimeZone("Europe/Paris")
+    override val useNewChapterEndpoint = true
+    override val useLoadMoreRequest = LoadMoreStrategy.Never
+
+    // The child theme no longer exposes the genres the Madara way, they are listed below instead.
+    override val fetchGenres = false
+
+    override fun popularMangaRequest(page: Int): Request = catalogueRequest(page, "", FilterList(), defaultSort = "populaire")
+
+    override fun popularMangaParse(response: Response): MangasPage = catalogueParse(response)
+
+    override fun latestUpdatesRequest(page: Int): Request = catalogueRequest(page, "", FilterList(), defaultSort = "recents")
+
+    override fun latestUpdatesParse(response: Response): MangasPage = catalogueParse(response)
+
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request = catalogueRequest(page, query, filters, defaultSort = "recents")
+
+    override fun searchMangaParse(response: Response): MangasPage = catalogueParse(response)
+
+    /**
+     * The listing pages only render their first batch server-side: paging, sorting and filtering
+     * all go through this admin-ajax action, which returns the entries as a HTML fragment.
+     */
+    private fun catalogueRequest(
+        page: Int,
+        query: String,
+        filters: FilterList,
+        defaultSort: String,
+    ): Request {
+        val genres = filters.firstInstanceOrNull<GenreFilter>()
+            ?.state.orEmpty()
+            .filter(GenreCheckBox::state)
+            .joinToString(",", transform = GenreCheckBox::slug)
+
+        val form = FormBody.Builder()
+            .add("action", "madara_child_catalogue")
+            .add("s", query)
+            .add("genres", genres)
+            .add("statut", filters.firstInstanceOrNull<StatusFilter>()?.selected ?: "tous")
+            .add("note", filters.firstInstanceOrNull<RatingFilter>()?.selected ?: "0")
+            .add("origine", "")
+            .add("tri", filters.firstInstanceOrNull<SortFilter>()?.selected ?: defaultSort)
+            .add("chmin", filters.firstInstanceOrNull<ChapterMinFilter>()?.value ?: "0")
+            .add("chmax", filters.firstInstanceOrNull<ChapterMaxFilter>()?.value ?: "0")
+            .add("page", page.toString())
+            .add("auteur", "")
+            .add("artiste", "")
+            .add("annee", "")
+            .build()
+
+        return POST("$baseUrl/wp-admin/admin-ajax.php", xhrHeaders, form)
     }
 
-    override val useLoadMoreRequest = LoadMoreStrategy.Never
-    override val useNewChapterEndpoint = true
+    private fun catalogueParse(response: Response): MangasPage {
+        val data = response.parseAs<CatalogueResponse>().data
+            ?: return MangasPage(emptyList(), false)
 
-    override val mangaDetailsSelectorAuthor = "div.author-content > a"
-    override val mangaDetailsSelectorDescription = "div.summary__content > p"
-    override val seriesTypeSelector = "span.manga-title-badges > span"
+        val entries = Jsoup.parseBodyFragment(data.html, baseUrl)
+            .select("a.ori-card:has(span.ori-card-title)")
+            .map { element ->
+                SManga.create().apply {
+                    setUrlWithoutDomain(element.attr("abs:href"))
+                    title = element.selectFirst("span.ori-card-title")!!.text()
+                    thumbnail_url = element.selectFirst("img")
+                        ?.let { processThumbnail(imageFromElement(it), true) }
+                }
+            }
 
-    override fun getFilterList(): FilterList {
-        val filters = super.getFilterList().list.filterNot {
-            it.name.lowercase().contains("adult content")
-        }
+        return MangasPage(entries, data.more)
+    }
 
-        return FilterList(filters)
+    @Serializable
+    private class CatalogueResponse(
+        val data: CatalogueData? = null,
+    )
+
+    @Serializable
+    private class CatalogueData(
+        val html: String = "",
+        val more: Boolean = false,
+    )
+
+    override val mangaDetailsSelectorAuthor = "dt:contains(Scénario) + dd, dt:contains(Auteur) + dd"
+    override val mangaDetailsSelectorArtist = "dt:contains(Dessin) + dd, dt:contains(Artiste) + dd"
+    override val mangaDetailsSelectorStatus = "dt:contains(Statut) + dd"
+    override val mangaDetailsSelectorDescription = "div.ori-sr-syn-texte"
+    override val mangaDetailsSelectorThumbnail = "div.ori-sr-cover img"
+    override val mangaDetailsSelectorGenre = "div.ori-sr-genres a.ori-sr-genre"
+    override val seriesTypeSelector = "dt:contains(Type) + dd"
+    override val altNameSelector = "dt:contains(Nom alternatif) + dd"
+
+    override fun chapterListSelector() = "div.ori-chl-row"
+
+    override val chapterUrlSelector = "a.ori-chl-corps"
+
+    override fun chapterDateSelector() = "span.ori-chl-date"
+
+    override fun chapterFromElement(element: Element): SChapter = super.chapterFromElement(element).apply {
+        element.selectFirst("span.ori-chl-nom")?.let { name = it.text() }
+    }
+
+    override fun parseChapterDate(date: String?): Long = DATE_FORMATTER.tryParseDate(date, TIME_ZONE)
+
+    override fun getFilterList() = FilterList(
+        SortFilter(),
+        StatusFilter(),
+        RatingFilter(),
+        ChapterMinFilter(),
+        ChapterMaxFilter(),
+        Filter.Separator(),
+        GenreFilter(),
+    )
+
+    private open class SelectFilter(
+        name: String,
+        private val options: List<Pair<String, String>>,
+    ) : Filter.Select<String>(name, options.map { it.first }.toTypedArray()) {
+        val selected get() = options[state].second
+    }
+
+    private class SortFilter :
+        SelectFilter(
+            "Tri",
+            listOf(
+                "Récents" to "recents",
+                "Populaire" to "populaire",
+                "Mieux notés" to "notes",
+                "A → Z" to "az",
+            ),
+        )
+
+    private class StatusFilter :
+        SelectFilter(
+            "Statut",
+            listOf(
+                "Tous" to "tous",
+                "En cours" to "en-cours",
+                "Terminé" to "termine",
+            ),
+        )
+
+    private class RatingFilter :
+        SelectFilter(
+            "Note minimum",
+            listOf(
+                "Toutes" to "0",
+                "1 étoile et plus" to "1",
+                "2 étoiles et plus" to "2",
+                "3 étoiles et plus" to "3",
+                "4 étoiles et plus" to "4",
+                "5 étoiles" to "5",
+            ),
+        )
+
+    private open class NumberFilter(name: String) : Filter.Text(name) {
+        val value get() = state.takeIf { it.isNotEmpty() && it.all(Char::isDigit) } ?: "0"
+    }
+
+    private class ChapterMinFilter : NumberFilter("Chapitres (minimum)")
+
+    private class ChapterMaxFilter : NumberFilter("Chapitres (maximum)")
+
+    private class GenreCheckBox(name: String, val slug: String) : Filter.CheckBox(name)
+
+    private class GenreFilter :
+        Filter.Group<GenreCheckBox>(
+            "Genres",
+            GENRES.map { GenreCheckBox(it.first, it.second) },
+        )
+
+    companion object {
+        private val TIME_ZONE = ZoneId.of("Europe/Paris")
+
+        // Chapter dates are written with shortened, capitalized month names (`Juil`, `Sep`, `Déc`)
+        // that no localized pattern matches.
+        private val DATE_FORMATTER: DateTimeFormatter = DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .appendPattern("d ")
+            .appendText(
+                ChronoField.MONTH_OF_YEAR,
+                mapOf(
+                    1L to "Jan",
+                    2L to "Fév",
+                    3L to "Mar",
+                    4L to "Avr",
+                    5L to "Mai",
+                    6L to "Juin",
+                    7L to "Juil",
+                    8L to "Août",
+                    9L to "Sep",
+                    10L to "Oct",
+                    11L to "Nov",
+                    12L to "Déc",
+                ),
+            )
+            .appendPattern(" yyyy")
+            .toFormatter(Locale.FRENCH)
+
+        private val GENRES = listOf(
+            "Action" to "action",
+            "Alien" to "alien",
+            "Alpha" to "alpha",
+            "Amitié" to "amitie",
+            "Art martiaux" to "art-martiaux",
+            "Aventure" to "aventure",
+            "Belle-mère" to "belle-mere",
+            "Boy's Love" to "yaoi",
+            "Campus" to "campus",
+            "Comédie" to "comedie",
+            "Domination" to "domination",
+            "Drame" to "drame",
+            "Démon" to "demon",
+            "Ecchi" to "ecchi",
+            "Fantasy" to "fantasy",
+            "Furry" to "furry",
+            "Futanari" to "futanari",
+            "Fétichisme" to "fetichisme",
+            "Gallerie" to "gallerie",
+            "Gangster" to "gangster",
+            "Gofast" to "gofast",
+            "Gore" to "gore",
+            "Guideverse" to "guideverse",
+            "Hardcore" to "hardcore",
+            "Harem" to "harem",
+            "Historique" to "historique",
+            "Horreur" to "horreur",
+            "Humiliation" to "humiliation",
+            "Inceste" to "inceste",
+            "Isekai" to "isekai",
+            "Josei" to "josei",
+            "Loli" to "loli",
+            "Love" to "love",
+            "Magie" to "magie",
+            "Mature" to "mature",
+            "Milf" to "milf",
+            "Mini-série" to "mini-serie",
+            "Monsters girls" to "monsters-girls",
+            "Ntr" to "ntr",
+            "Office" to "office",
+            "Omégaverse" to "omegaverse",
+            "Oneshot" to "oneshot",
+            "Parodie" to "parodie",
+            "Professeur" to "professeur",
+            "Psychologie" to "psychologie",
+            "Rape" to "rape",
+            "Romance" to "romance",
+            "Réincarnation" to "reincarnation",
+            "School life" to "school-life",
+            "Sci-fi" to "sci-fi",
+            "Shonen-ai" to "shonen-ai",
+            "Slice of life" to "slice-of-life",
+            "Smut" to "smut",
+            "Soft" to "soft",
+            "Sport" to "sport",
+            "Surnaturel" to "surnaturel",
+            "Tomgirl" to "tomgirl",
+            "Tragédie" to "tragedie",
+            "Triangle amoureux" to "triangle-amoureux",
+            "Uncensored" to "uncensored",
+            "Yuri" to "yuri",
+        )
     }
 }

--- a/src/fr/mangasoriginesfr/build.gradle.kts
+++ b/src/fr/mangasoriginesfr/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Mangas-Origines.fr"
-    versionCode = 4
+    versionCode = 5
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
     theme = "madara"

--- a/src/fr/mangasoriginesfr/src/eu/kanade/tachiyomi/extension/fr/mangasoriginesfr/MangasOriginesFr.kt
+++ b/src/fr/mangasoriginesfr/src/eu/kanade/tachiyomi/extension/fr/mangasoriginesfr/MangasOriginesFr.kt
@@ -1,20 +1,302 @@
 package eu.kanade.tachiyomi.extension.fr.mangasoriginesfr
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.source.model.Filter
+import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
 import keiyoushi.annotation.Source
-import java.text.SimpleDateFormat
+import keiyoushi.utils.firstInstanceOrNull
+import keiyoushi.utils.parseAs
+import keiyoushi.utils.tryParseDate
+import kotlinx.serialization.Serializable
+import okhttp3.FormBody
+import okhttp3.Request
+import okhttp3.Response
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
+import java.time.temporal.ChronoField
 import java.util.Locale
-import java.util.TimeZone
 
 @Source
 abstract class MangasOriginesFr : Madara() {
-    override val dateFormat = SimpleDateFormat("d MMMM yyyy", Locale("fr")).apply {
-        timeZone = TimeZone.getTimeZone("Europe/Paris")
-    }
-    override val mangaSubString = "catalogues"
+    override val mangaSubString = "oeuvre"
     override val useNewChapterEndpoint = true
     override val useLoadMoreRequest = LoadMoreStrategy.Never
 
-    override val mangaDetailsSelectorAuthor = "div.author-content > a"
-    override val mangaDetailsSelectorDescription = "div.summary__content > p"
+    // The child theme no longer exposes the genres the Madara way, they are listed below instead.
+    override val fetchGenres = false
+
+    override fun popularMangaRequest(page: Int): Request = catalogueRequest(page, "", FilterList(), defaultSort = "populaire")
+
+    override fun popularMangaParse(response: Response): MangasPage = catalogueParse(response)
+
+    override fun latestUpdatesRequest(page: Int): Request = catalogueRequest(page, "", FilterList(), defaultSort = "recents")
+
+    override fun latestUpdatesParse(response: Response): MangasPage = catalogueParse(response)
+
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request = catalogueRequest(page, query, filters, defaultSort = "recents")
+
+    override fun searchMangaParse(response: Response): MangasPage = catalogueParse(response)
+
+    /**
+     * The listing pages only render their first batch server-side: paging, sorting and filtering
+     * all go through this admin-ajax action, which returns the entries as a HTML fragment.
+     */
+    private fun catalogueRequest(
+        page: Int,
+        query: String,
+        filters: FilterList,
+        defaultSort: String,
+    ): Request {
+        val genres = filters.firstInstanceOrNull<GenreFilter>()
+            ?.state.orEmpty()
+            .filter(GenreCheckBox::state)
+            .joinToString(",", transform = GenreCheckBox::slug)
+
+        val form = FormBody.Builder()
+            .add("action", "madara_child_catalogue")
+            .add("s", query)
+            .add("genres", genres)
+            .add("statut", filters.firstInstanceOrNull<StatusFilter>()?.selected ?: "tous")
+            .add("note", filters.firstInstanceOrNull<RatingFilter>()?.selected ?: "0")
+            .add("origine", filters.firstInstanceOrNull<TypeFilter>()?.selected.orEmpty())
+            .add("tri", filters.firstInstanceOrNull<SortFilter>()?.selected ?: defaultSort)
+            .add("chmin", filters.firstInstanceOrNull<ChapterMinFilter>()?.value ?: "0")
+            .add("chmax", filters.firstInstanceOrNull<ChapterMaxFilter>()?.value ?: "0")
+            .add("page", page.toString())
+            .add("auteur", "")
+            .add("artiste", "")
+            .add("annee", "")
+            .build()
+
+        return POST("$baseUrl/wp-admin/admin-ajax.php", xhrHeaders, form)
+    }
+
+    private fun catalogueParse(response: Response): MangasPage {
+        val data = response.parseAs<CatalogueResponse>().data
+            ?: return MangasPage(emptyList(), false)
+
+        val entries = Jsoup.parseBodyFragment(data.html, baseUrl)
+            .select("a.ori-card:has(span.ori-card-title)")
+            .map { element ->
+                SManga.create().apply {
+                    setUrlWithoutDomain(element.attr("abs:href"))
+                    title = element.selectFirst("span.ori-card-title")!!.text()
+                    thumbnail_url = element.selectFirst("img")
+                        ?.let { processThumbnail(imageFromElement(it), true) }
+                }
+            }
+
+        return MangasPage(entries, data.more)
+    }
+
+    @Serializable
+    private class CatalogueResponse(
+        val data: CatalogueData? = null,
+    )
+
+    @Serializable
+    private class CatalogueData(
+        val html: String = "",
+        val more: Boolean = false,
+    )
+
+    override val mangaDetailsSelectorAuthor = "dt:contains(Scénario) + dd, dt:contains(Auteur) + dd"
+    override val mangaDetailsSelectorArtist = "dt:contains(Dessin) + dd, dt:contains(Artiste) + dd"
+    override val mangaDetailsSelectorStatus = "dt:contains(Statut) + dd"
+    override val mangaDetailsSelectorDescription = "div.ori-sr-syn-texte"
+    override val mangaDetailsSelectorThumbnail = "div.ori-sr-cover img"
+    override val mangaDetailsSelectorGenre = "div.ori-sr-genres a.ori-sr-genre"
+    override val seriesTypeSelector = "dt:contains(Type) + dd"
+    override val altNameSelector = "dt:contains(Nom alternatif) + dd"
+
+    override fun chapterListSelector() = "div.ori-chl-row"
+
+    override val chapterUrlSelector = "a.ori-chl-corps"
+
+    override fun chapterDateSelector() = "span.ori-chl-date"
+
+    override fun chapterFromElement(element: Element): SChapter = super.chapterFromElement(element).apply {
+        element.selectFirst("span.ori-chl-nom")?.let { name = it.text() }
+    }
+
+    override fun parseChapterDate(date: String?): Long = DATE_FORMATTER.tryParseDate(date, TIME_ZONE)
+
+    override fun getFilterList() = FilterList(
+        SortFilter(),
+        StatusFilter(),
+        TypeFilter(),
+        RatingFilter(),
+        ChapterMinFilter(),
+        ChapterMaxFilter(),
+        Filter.Separator(),
+        GenreFilter(),
+    )
+
+    private open class SelectFilter(
+        name: String,
+        private val options: List<Pair<String, String>>,
+    ) : Filter.Select<String>(name, options.map { it.first }.toTypedArray()) {
+        val selected get() = options[state].second
+    }
+
+    private class SortFilter :
+        SelectFilter(
+            "Tri",
+            listOf(
+                "Récents" to "recents",
+                "Populaire" to "populaire",
+                "Mieux notés" to "notes",
+                "A → Z" to "az",
+            ),
+        )
+
+    private class StatusFilter :
+        SelectFilter(
+            "Statut",
+            listOf(
+                "Tous" to "tous",
+                "En cours" to "en-cours",
+                "Terminé" to "termine",
+            ),
+        )
+
+    private class TypeFilter :
+        SelectFilter(
+            "Type",
+            listOf(
+                "Tous" to "",
+                "Manhwa" to "manhwa",
+                "Manhua" to "manhua",
+                "Manga" to "manga",
+            ),
+        )
+
+    private class RatingFilter :
+        SelectFilter(
+            "Note minimum",
+            listOf(
+                "Toutes" to "0",
+                "1 étoile et plus" to "1",
+                "2 étoiles et plus" to "2",
+                "3 étoiles et plus" to "3",
+                "4 étoiles et plus" to "4",
+                "5 étoiles" to "5",
+            ),
+        )
+
+    private open class NumberFilter(name: String) : Filter.Text(name) {
+        val value get() = state.takeIf { it.isNotEmpty() && it.all(Char::isDigit) } ?: "0"
+    }
+
+    private class ChapterMinFilter : NumberFilter("Chapitres (minimum)")
+
+    private class ChapterMaxFilter : NumberFilter("Chapitres (maximum)")
+
+    private class GenreCheckBox(name: String, val slug: String) : Filter.CheckBox(name)
+
+    private class GenreFilter :
+        Filter.Group<GenreCheckBox>(
+            "Genres",
+            GENRES.map { GenreCheckBox(it.first, it.second) },
+        )
+
+    companion object {
+        private val TIME_ZONE = ZoneId.of("Europe/Paris")
+
+        // Chapter dates are written with shortened, capitalized month names (`Juil`, `Sep`, `Déc`)
+        // that no localized pattern matches.
+        private val DATE_FORMATTER: DateTimeFormatter = DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .appendPattern("d ")
+            .appendText(
+                ChronoField.MONTH_OF_YEAR,
+                mapOf(
+                    1L to "Jan",
+                    2L to "Fév",
+                    3L to "Mar",
+                    4L to "Avr",
+                    5L to "Mai",
+                    6L to "Juin",
+                    7L to "Juil",
+                    8L to "Août",
+                    9L to "Sep",
+                    10L to "Oct",
+                    11L to "Nov",
+                    12L to "Déc",
+                ),
+            )
+            .appendPattern(" yyyy")
+            .toFormatter(Locale.FRENCH)
+
+        private val GENRES = listOf(
+            "Action" to "action",
+            "Adventure" to "adventure",
+            "Amitié" to "amitie",
+            "Amour" to "amour",
+            "Art Martiaux" to "art-martiaux",
+            "Aventure" to "aventure",
+            "BL" to "bl",
+            "Boys" to "boys",
+            "Combat" to "combat",
+            "Comedy" to "comedy",
+            "Comédie" to "comedie",
+            "Dark Fantasy" to "dark-fantasy",
+            "Drama" to "drama",
+            "Drame" to "drame",
+            "Dystopie" to "dystopie",
+            "Démon" to "demon",
+            "Ecchi" to "ecchi",
+            "Erotique" to "erotique",
+            "Fantastique" to "fantastique",
+            "Fantasy" to "fantasy",
+            "Guerre" to "guerre",
+            "Harem" to "harem",
+            "Historique" to "historique",
+            "Horreur" to "horreur",
+            "Isekai" to "isekai",
+            "Jeu" to "jeu",
+            "Josei" to "josei",
+            "Magie" to "magie",
+            "Malédiction" to "malediction",
+            "Mature" to "mature",
+            "Moderne" to "moderne",
+            "Mort" to "mort",
+            "Murim" to "murim",
+            "Musique" to "musique",
+            "Mystère" to "mystere",
+            "Novel" to "novel",
+            "Post-Apo" to "post-apo",
+            "Prison" to "prison",
+            "Psychologique" to "psychologique",
+            "Religion" to "religion",
+            "Returner" to "returner",
+            "Romance" to "romance",
+            "Réincarnation" to "reincarnation",
+            "Régression" to "regression",
+            "School life" to "school-life",
+            "Sci-fi" to "sci-fi",
+            "Seinen" to "seinen",
+            "Shojo" to "shojo",
+            "Shonen" to "shonen",
+            "Slice of Life" to "slice-of-life",
+            "Société" to "societe",
+            "Sorcellerie" to "sorcellerie",
+            "Sport" to "sport",
+            "Steampunk" to "steampunk",
+            "Supernaturel" to "supernaturel",
+            "Surnaturel" to "surnaturel",
+            "Tragédie" to "tragedie",
+            "Vengeance" to "vengeance",
+            "Webcomic" to "webcomic",
+            "Yuri" to "yuri",
+            "École" to "ecole",
+        )
+    }
 }


### PR DESCRIPTION
Closes #18236

Both sites moved to a custom Madara child theme (`child-origines`) at the beginning of August.
`madara-core` is still installed — the plugin scripts, the `manga` JS object and
`#manga-chapters-holder` are all still in the page — but the listing, details and chapter
templates were rewritten, which breaks everything except page/image parsing.

What changed on the site:

- **Listings only render their first batch server-side.** Paging, sorting and filtering now go
  through a theme action: `POST /wp-admin/admin-ajax.php` with `action=madara_child_catalogue`,
  answering `{success, data: {html, more, total}}`. URL paging is dead — `/catalogues/page/2/` and
  `/page/2/?s=…&post_type=wp-manga` both return the same entries as page 1, and `?m_orderby=…` is
  ignored.
- Entries are now `a.ori-card`, no more `div.page-item-detail` / `div.c-tabs-item__content`.
- Series moved from `/catalogues/<slug>/` to `/oeuvre/<slug>/`. The old path still redirects
  (canonical points at `/oeuvre/`), so `versionId` is left alone and existing library entries keep
  working.
- Details lost `div.summary__content`, `div.author-content` and friends: metadata is now in a
  `<dl>`, the synopsis in `div.ori-sr-syn-texte`, the cover in `div.ori-sr-cover`.
- `/ajax/chapters` still answers, but returns the theme's own markup (`div.ori-chl-row`) instead of
  `li.wp-manga-chapter`. The old `manga_get_chapters` endpoint answers 400.
- Chapter dates read `8 Août 2026`, `21 Juil 2026` — capitalized, shortened month names that no
  localized pattern parses, hence the explicit month map.
- Filters are rebuilt from the new catalogue panel (sort, status, type, minimum rating, chapter
  count range, genres). They had to be replaced rather than dropped: once the listing request goes
  through the AJAX action, the inherited Madara filters would still be displayed while silently
  doing nothing.

hentai-origines.com runs the same child theme and the same AJAX action, with its own genre list, no
`origine` filter, and `mangaSubString` still `manga`.

Page and image parsing is untouched — `div.page-break` and `img.wp-manga-chapter-img` are unchanged.

Heads-up: the site presents this rework as a trial version ("Des choses peuvent encore casser"), so
the markup may still move over the coming weeks.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

Built with `./gradlew :src:fr:mangasoriginesfr:assembleRelease
:src:fr:hentaiorigines:assembleRelease` and run on a device: browsing, search, opening a series,
the chapter list and reading a chapter all work again on Mangas-Origines.

🤖 This PR was opened by an AI agent (Claude Code). I was asked to look into the "no chapter found"
reports on these two sources, find the cause, write the fix and open the pull request. Everything
above was verified against the live site; the human maintaining this fork reviewed the diff and
tested the built extension on a device.
