### PR TITLE
Fix Kuaikan manga details and pages

### DIFF
--- a/src/zh/kuaikanmanhua/build.gradle.kts
+++ b/src/zh/kuaikanmanhua/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Kuaikanmanhua"
-    versionCode = 12
+    versionCode = 13
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/zh/kuaikanmanhua/src/eu/kanade/tachiyomi/extension/zh/kuaikanmanhua/Kuaikanmanhua.kt
+++ b/src/zh/kuaikanmanhua/src/eu/kanade/tachiyomi/extension/zh/kuaikanmanhua/Kuaikanmanhua.kt
@@ -150,38 +150,69 @@ abstract class Kuaikanmanhua : HttpSource() {
 
     override fun fetchMangaDetails(manga: SManga): Observable<SManga> {
         // Convert the stored url to one that works with the api
-        val newUrl = apiUrl + "/v1/topics/" + manga.url.trimEnd('/').substringAfterLast("/")
+        val newUrl = baseUrl + manga.url
         val response = client.newCall(GET(newUrl, headers)).execute()
         val sManga = mangaDetailsParse(response).apply { initialized = true }
         return Observable.just(sManga)
     }
 
-    override fun mangaDetailsParse(response: Response): SManga = SManga.create().apply {
-        val data = response.parseAs<ApiMangaResponse>().data
+    fun parseUpdateStatus(status: String): Int = when (status) {
+        "连载中" -> SManga.ONGOING
+        "已完结" -> SManga.COMPLETED
+        else -> SManga.UNKNOWN
+    }
 
-        title = data.title
-        thumbnail_url = data.verticalImageUrl
-        author = data.user.nickname
-        description = data.description
-        status = data.updateStatusCode
+    override fun mangaDetailsParse(response: Response): SManga {
+        val document = response.asJsoup()
+        val nuxtDefinition = document.selectFirst("script:containsData(__NUXT__)")!!.data()
+
+        return QuickJs.create().use { quickJs ->
+            quickJs.evaluate("var window = {};")
+            quickJs.evaluate(nuxtDefinition)
+            val nuxtJson = quickJs.evaluate("JSON.stringify(window.__NUXT__)") as String
+            val payload = nuxtJson.parseAs<WebMangaPayload>()
+            val mangaData = requireNotNull(payload.data.getOrNull(0)?.topicInfo) {
+                "Source did not return manga details"
+            }
+
+            SManga.create().apply {
+                title = mangaData.title
+                thumbnail_url = mangaData.verticalImageUrl
+                author = mangaData.user.nickname
+                description = mangaData.description
+                status = parseUpdateStatus(mangaData.updateStatus)
+            }
+        }
     }
 
     // Chapters & Pages
 
     override fun chapterListRequest(manga: SManga): Request = GET(
-        apiUrl + "/v1/topics/" + manga.url.trimEnd('/').substringAfterLast("/"),
+        baseUrl + manga.url,
         headers,
     )
 
     override fun chapterListParse(response: Response): List<SChapter> {
-        val data = response.parseAs<ApiMangaResponse>().data
+        val document = response.asJsoup()
+        val nuxtDefinition = document.selectFirst("script:containsData(__NUXT__)")!!.data()
 
-        return data.comics.map { comic ->
-            SChapter.create().apply {
-                url = "/web/comic/${comic.id}"
-                name = comic.title + if (!comic.canView) " \uD83D\uDD12" else ""
-                date_upload = comic.createdAt * 1000
-            }
+        return QuickJs.create().use { quickJs ->
+            quickJs.evaluate("var window = {};")
+            quickJs.evaluate(nuxtDefinition)
+            val nuxtJson = quickJs.evaluate("JSON.stringify(window.__NUXT__)") as String
+            val chapters = nuxtJson.parseAs<WebMangaPayload>()
+                .data
+                .getOrNull(0)
+                ?.comicList
+                .orEmpty()
+
+            chapters.map { comic ->
+                SChapter.create().apply {
+                    url = "/web/comic/${comic.id}"
+                    name = comic.title
+                    date_upload = comic.createdAt
+                }
+            }.reversed()
         }
     }
 
@@ -203,6 +234,8 @@ abstract class Kuaikanmanhua : HttpSource() {
                 .parseAs<WebChapterPayload>()
                 .data
                 .getOrNull(0)
+                ?.res
+                ?.data
                 ?.comicInfo
                 ?.comicImages
                 .orEmpty()

--- a/src/zh/kuaikanmanhua/src/eu/kanade/tachiyomi/extension/zh/kuaikanmanhua/KuaikanmanhuaDto.kt
+++ b/src/zh/kuaikanmanhua/src/eu/kanade/tachiyomi/extension/zh/kuaikanmanhua/KuaikanmanhuaDto.kt
@@ -35,26 +35,30 @@ internal data class ApiManga(
 )
 
 @Serializable
-internal data class ApiMangaResponse(val data: ApiMangaData)
+internal data class WebMangaPayload(val data: List<WebMangaData> = emptyList())
 
 @Serializable
-internal data class ApiMangaData(
-    val title: String,
-    @SerialName("vertical_image_url") val verticalImageUrl: String,
-    val user: ApiUser,
-    val description: String,
-    @SerialName("update_status_code") val updateStatusCode: Int,
-    val comics: List<ApiChapter> = emptyList(),
+internal data class WebMangaData(
+    val topicInfo: WebMangaDetails,
+    val comicList: List<WebMangaChapter> = emptyList(),
 )
 
 @Serializable
-internal data class ApiUser(val nickname: String)
+internal data class WebMangaDetails(
+    val title: String,
+    @SerialName("vertical_image_url") val verticalImageUrl: String,
+    val user: WebAuthor,
+    val description: String,
+    @SerialName("update_status") val updateStatus: String,
+)
 
 @Serializable
-internal data class ApiChapter(
+internal data class WebAuthor(val nickname: String)
+
+@Serializable
+internal data class WebMangaChapter(
     val id: Int,
     val title: String,
-    @SerialName("can_view") val canView: Boolean = false,
     @SerialName("created_at") val createdAt: Long,
 )
 
@@ -62,10 +66,20 @@ internal data class ApiChapter(
 internal data class WebChapterPayload(val data: List<WebChapterData> = emptyList())
 
 @Serializable
-internal data class WebChapterData(val comicInfo: WebChapter)
+internal data class WebChapterData(val res: WebChapterResponse)
 
 @Serializable
-internal data class WebChapter(val comicImages: List<WebPage> = emptyList())
+internal data class WebChapterResponse(val data: WebChapterResponseData)
+
+@Serializable
+internal data class WebChapterResponseData(
+    @SerialName("comic_info") val comicInfo: WebChapter,
+)
+
+@Serializable
+internal data class WebChapter(
+    @SerialName("comic_images") val comicImages: List<WebPage> = emptyList(),
+)
 
 @Serializable
 internal data class WebPage(val url: String)


### PR DESCRIPTION
Closes #16819

I've only done the bare minimum to get this source functional again. This extension is old, so it still follows a lot of the old extension structure. If you'd like me to update the extension structure in this PR too, please let me know, but doing anything beyond changing the methods I edited would basically require a full extension rewrite...

Checklist:

- [X] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
