### PR TITLE
feat(fr/mangasoriginesfr): update to new domain

### DIFF
--- a/lib-multisrc/origines/build.gradle.kts
+++ b/lib-multisrc/origines/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    alias(kei.plugins.multisrc)
+}
+
+keiyoushi {
+    baseVersionCode = 0
+    libVersion = "1.6"
+}

--- a/lib-multisrc/origines/src/eu/kanade/tachiyomi/multisrc/origines/Dto.kt
+++ b/lib-multisrc/origines/src/eu/kanade/tachiyomi/multisrc/origines/Dto.kt
@@ -1,0 +1,14 @@
+package eu.kanade.tachiyomi.multisrc.origines
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+class CatalogueResponse(
+    val data: CatalogueData,
+)
+
+@Serializable
+class CatalogueData(
+    val html: String = "",
+    val more: Boolean = false,
+)

--- a/lib-multisrc/origines/src/eu/kanade/tachiyomi/multisrc/origines/Filters.kt
+++ b/lib-multisrc/origines/src/eu/kanade/tachiyomi/multisrc/origines/Filters.kt
@@ -1,0 +1,53 @@
+package eu.kanade.tachiyomi.multisrc.origines
+
+import eu.kanade.tachiyomi.source.model.Filter
+
+class CheckBoxFilter(name: String, val slug: String) : Filter.CheckBox(name)
+
+sealed class CheckBoxGroupFilter(name: String, options: List<Pair<String, String>>) : Filter.Group<CheckBoxFilter>(name, options.map { CheckBoxFilter(it.first, it.second) }) {
+    val checked get() = state.filter { it.state }.map { it.slug }
+}
+
+sealed class SelectFilter(name: String, private val options: List<Pair<String, String>>) : Filter.Select<String>(name, options.map { it.first }.toTypedArray()) {
+    val selected get() = options[state].second
+}
+
+sealed class CountFilter(name: String) : Filter.Text(name) {
+    val value get() = state.trim().takeIf { it.isNotEmpty() && it.all(Char::isDigit) } ?: "0"
+}
+
+class OriginFilter(origins: List<Pair<String, String>>) : CheckBoxGroupFilter("Origine", origins)
+
+class GenreFilter(genres: List<Pair<String, String>>) : CheckBoxGroupFilter("Genres", genres)
+
+class StatusFilter : SelectFilter("Statut", STATUSES)
+
+class RatingFilter : SelectFilter("Note minimum", RATINGS)
+
+class SortFilter : SelectFilter("Trier par", SORTS)
+
+class ChapterMinFilter : CountFilter("Chapitres (min)")
+
+class ChapterMaxFilter : CountFilter("Chapitres (max)")
+
+private val STATUSES = listOf(
+    "Tous" to "tous",
+    "En cours" to "en-cours",
+    "Terminé" to "termine",
+)
+
+private val RATINGS = listOf(
+    "Toutes" to "0",
+    "1 étoile et plus" to "1",
+    "2 étoiles et plus" to "2",
+    "3 étoiles et plus" to "3",
+    "4 étoiles et plus" to "4",
+    "5 étoiles" to "5",
+)
+
+private val SORTS = listOf(
+    "Récents" to "recents",
+    "Populaire" to "populaire",
+    "Mieux notés" to "notes",
+    "A → Z" to "az",
+)

--- a/lib-multisrc/origines/src/eu/kanade/tachiyomi/multisrc/origines/Origines.kt
+++ b/lib-multisrc/origines/src/eu/kanade/tachiyomi/multisrc/origines/Origines.kt
@@ -1,0 +1,280 @@
+package eu.kanade.tachiyomi.multisrc.origines
+
+import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
+import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.network.get
+import keiyoushi.network.post
+import keiyoushi.source.KeiSource
+import keiyoushi.utils.firstInstance
+import keiyoushi.utils.firstInstanceOrNull
+import keiyoushi.utils.parseAs
+import kotlinx.serialization.json.JsonElement
+import okhttp3.FormBody
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Locale
+
+/**
+ * Sites running the `child-origines` WordPress theme, a Madara child theme whose listing,
+ * details and chapter templates were rewritten. Only the reader markup is still Madara's.
+ */
+abstract class Origines : KeiSource() {
+
+    /**
+     * Path prefix the entries live under, `<baseUrl>/<mangaPath>/<slug>/`.
+     */
+    protected abstract val mangaPath: String
+
+    /**
+     * Prefixes entries used to be served under. Stored URLs using them are still resolved.
+     */
+    protected open val legacyMangaPaths: Set<String> = emptySet()
+
+    /**
+     * Genres of the catalogue panel, as `label to slug`.
+     */
+    protected abstract val genres: List<Pair<String, String>>
+
+    /**
+     * Origins of the catalogue panel, as `label to slug`. Empty hides the filter.
+     */
+    protected open val origins: List<Pair<String, String>> = emptyList()
+
+    private val knownPaths: Set<String> by lazy { legacyMangaPaths + mangaPath }
+
+    // ============================= Utilities ==============================
+
+    /**
+     * Only the identifying slugs are stored, so entries survive the series path changing.
+     */
+    private fun String.pathSegments(): List<String> {
+        val path = if (startsWith("http")) toHttpUrl().encodedPath else this
+
+        return path.substringBefore('?')
+            .substringBefore('#')
+            .split('/')
+            .filter { it.isNotBlank() && it !in knownPaths }
+    }
+
+    private fun String.toMangaSlug(): String = pathSegments().firstOrNull() ?: this
+
+    private fun String.toChapterSlug(): String = pathSegments().take(2).joinToString("/")
+
+    override fun getMangaUrl(manga: SManga) = "$baseUrl/$mangaPath/${manga.url.toMangaSlug()}/"
+
+    override fun getChapterUrl(chapter: SChapter) = "$baseUrl/$mangaPath/${chapter.url.toChapterSlug()}/"
+
+    // ============================== Catalogue =============================
+
+    /**
+     * Listings only render their first batch server-side: paging, sorting, filtering and
+     * searching all go through this theme action, which answers with a HTML fragment.
+     */
+    private suspend fun getCatalogue(
+        page: Int,
+        query: String = "",
+        genres: String = "",
+        status: String = "tous",
+        rating: String = "0",
+        origin: String = "",
+        sort: String = "recents",
+        chapterMin: String = "0",
+        chapterMax: String = "0",
+    ): MangasPage {
+        val form = FormBody.Builder()
+            .add("action", "madara_child_catalogue")
+            .add("s", query)
+            .add("genres", genres)
+            .add("statut", status)
+            .add("note", rating)
+            .add("origine", origin)
+            .add("tri", sort)
+            .add("chmin", chapterMin)
+            .add("chmax", chapterMax)
+            .add("page", page.toString())
+            .add("auteur", "")
+            .add("artiste", "")
+            .add("annee", "")
+            .build()
+
+        val data = client.post("$baseUrl/wp-admin/admin-ajax.php", form)
+            .parseAs<CatalogueResponse>()
+            .data
+
+        val entries = Jsoup.parseBodyFragment(data.html, baseUrl)
+            .select("a.ori-card:has(span.ori-card-title)")
+            .map(::mangaFromElement)
+
+        return MangasPage(entries, data.more)
+    }
+
+    private fun mangaFromElement(element: Element) = SManga.create().apply {
+        url = element.attr("href").toMangaSlug()
+        title = element.selectFirst("span.ori-card-title")!!.text()
+        thumbnail_url = element.selectFirst("img")?.absUrl("src")
+    }
+
+    override suspend fun getPopularManga(page: Int) = getCatalogue(page, sort = "populaire")
+
+    override suspend fun getLatestUpdates(page: Int) = getCatalogue(page, sort = "recents")
+
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList) = getCatalogue(
+        page = page,
+        query = query,
+        genres = filters.firstInstance<GenreFilter>().checked.joinToString(","),
+        status = filters.firstInstance<StatusFilter>().selected,
+        rating = filters.firstInstance<RatingFilter>().selected,
+        origin = filters.firstInstanceOrNull<OriginFilter>()?.checked.orEmpty().joinToString(","),
+        sort = filters.firstInstance<SortFilter>().selected,
+        chapterMin = filters.firstInstance<ChapterMinFilter>().value,
+        chapterMax = filters.firstInstance<ChapterMaxFilter>().value,
+    )
+
+    override fun getFilterList(data: JsonElement?) = FilterList(
+        buildList {
+            if (origins.isNotEmpty()) {
+                add(OriginFilter(origins))
+            }
+            add(GenreFilter(genres))
+            add(StatusFilter())
+            add(RatingFilter())
+            add(SortFilter())
+            add(ChapterMinFilter())
+            add(ChapterMaxFilter())
+        },
+    )
+
+    // =========================== Manga Details ============================
+
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+        if (url.pathSegments.firstOrNull() !in knownPaths) return null
+
+        val manga = SManga.create().apply { this.url = url.encodedPath.toMangaSlug() }
+
+        return getMangaUpdate(manga, emptyList(), fetchDetails = true, fetchChapters = false).manga
+    }
+
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        val slug = manga.url.toMangaSlug()
+
+        if (fetchDetails) {
+            manga.parseDetails(client.get("$baseUrl/$mangaPath/$slug/").asJsoup())
+        }
+
+        val chapterList = if (fetchChapters) getChapterList(slug) else chapters
+
+        return SMangaUpdate(manga, chapterList)
+    }
+
+    private fun SManga.parseDetails(document: Document) {
+        val infos = document.select("div.ori-sr-infos dt").associate { dt ->
+            dt.text().lowercase(Locale.FRENCH) to dt.nextElementSibling()?.text().orEmpty()
+        }
+
+        title = document.selectFirst("h1.ori-sr-title")!!.text()
+        thumbnail_url = document.selectFirst("div.ori-sr-cover img")?.absUrl("src")
+        author = infos["auteur"] ?: infos["scénario"]
+        artist = infos["artiste"] ?: infos["dessin"]
+        description = buildString {
+            document.select("div.ori-sr-syn-texte p").eachText().forEach(::appendLine)
+
+            infos["nom alternatif"]?.takeIf(String::isNotBlank)?.let {
+                appendLine()
+                append("Nom alternatif: ", it)
+            }
+        }.trim()
+        genre = document.select("div.ori-sr-genres a.ori-sr-genre").eachText()
+            .plus(infos["type"].orEmpty())
+            .filter(String::isNotBlank)
+            .joinToString()
+        status = when (infos["statut"]?.lowercase(Locale.FRENCH)) {
+            "en cours" -> SManga.ONGOING
+            "terminé" -> SManga.COMPLETED
+            "en pause" -> SManga.ON_HIATUS
+            "abandonné", "annulé" -> SManga.CANCELLED
+            else -> SManga.UNKNOWN
+        }
+    }
+
+    // ============================== Chapters ==============================
+
+    private suspend fun getChapterList(slug: String): List<SChapter> {
+        val form = FormBody.Builder().build()
+        val document = client.post("$baseUrl/$mangaPath/$slug/ajax/chapters/", form).asJsoup()
+
+        return document.select("div.ori-chl-row").map { element ->
+            val link = element.selectFirst("a.ori-chl-corps")!!
+
+            SChapter.create().apply {
+                url = link.attr("href").toChapterSlug()
+                name = element.selectFirst("span.ori-chl-nom")?.text() ?: link.text()
+                date_upload = parseChapterDate(element.selectFirst("span.ori-chl-date")?.text())
+            }
+        }
+    }
+
+    /**
+     * Dates read `8 Août 2026`: capitalized, shortened month names no locale pattern parses.
+     */
+    private fun parseChapterDate(date: String?): Long {
+        val (day, month, year) = DATE_REGEX.find(date.orEmpty())?.destructured ?: return 0L
+        val monthNumber = monthNumber(month) ?: return 0L
+
+        return runCatching {
+            LocalDate.of(year.toInt(), monthNumber, day.toInt())
+                .atStartOfDay(TIME_ZONE)
+                .toInstant()
+                .toEpochMilli()
+        }.getOrDefault(0L)
+    }
+
+    private fun monthNumber(month: String): Int? {
+        val name = month.lowercase(Locale.FRENCH)
+
+        return when {
+            name.startsWith("jan") -> 1
+            name.startsWith("fev") || name.startsWith("fév") -> 2
+            name.startsWith("mar") -> 3
+            name.startsWith("avr") -> 4
+            name.startsWith("mai") -> 5
+            name.startsWith("juin") -> 6
+            name.startsWith("juil") -> 7
+            name.startsWith("ao") -> 8
+            name.startsWith("sep") -> 9
+            name.startsWith("oct") -> 10
+            name.startsWith("nov") -> 11
+            name.startsWith("dec") || name.startsWith("déc") -> 12
+            else -> null
+        }
+    }
+
+    // =============================== Pages ================================
+
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        val document = client.get("$baseUrl/$mangaPath/${chapter.url.toChapterSlug()}/").asJsoup()
+
+        return document.select("div.reading-content img.wp-manga-chapter-img").mapIndexed { index, image ->
+            Page(index, imageUrl = image.attr("src").trim())
+        }
+    }
+
+    companion object {
+        private val DATE_REGEX = Regex("""(\d{1,2})\s+(\p{L}+)\.?\s+(\d{4})""")
+        private val TIME_ZONE: ZoneId = ZoneId.of("Europe/Paris")
+    }
+}

--- a/src/fr/hentaiorigines/build.gradle.kts
+++ b/src/fr/hentaiorigines/build.gradle.kts
@@ -6,10 +6,10 @@ plugins {
 
 keiyoushi {
     name = "Hentai Origines"
-    versionCode = 1
+    versionCode = 54
     contentWarning = ContentWarning.NSFW
-    libVersion = "1.4"
-    theme = "madara"
+    libVersion = "1.6"
+    theme = "origines"
 
     source {
         lang = "fr"

--- a/src/fr/hentaiorigines/src/eu/kanade/tachiyomi/extension/fr/hentaiorigines/HentaiOrigines.kt
+++ b/src/fr/hentaiorigines/src/eu/kanade/tachiyomi/extension/fr/hentaiorigines/HentaiOrigines.kt
@@ -1,30 +1,81 @@
 package eu.kanade.tachiyomi.extension.fr.hentaiorigines
 
-import eu.kanade.tachiyomi.multisrc.madara.Madara
-import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.multisrc.origines.Origines
 import keiyoushi.annotation.Source
-import java.text.SimpleDateFormat
-import java.util.Locale
-import java.util.TimeZone
 
 @Source
-abstract class HentaiOrigines : Madara() {
-    override val dateFormat = SimpleDateFormat("d MMMM yyyy", Locale.FRENCH).apply {
-        timeZone = TimeZone.getTimeZone("Europe/Paris")
-    }
+abstract class HentaiOrigines : Origines() {
 
-    override val useLoadMoreRequest = LoadMoreStrategy.Never
-    override val useNewChapterEndpoint = true
+    override val mangaPath = "manga"
 
-    override val mangaDetailsSelectorAuthor = "div.author-content > a"
-    override val mangaDetailsSelectorDescription = "div.summary__content > p"
-    override val seriesTypeSelector = "span.manga-title-badges > span"
+    override val origins = listOf(
+        "Doujinshi" to "doujinshi",
+        "Pornhwa" to "pornhwa",
+        "Pornhua" to "pornhua",
+        "Hentai" to "hentai",
+    )
 
-    override fun getFilterList(): FilterList {
-        val filters = super.getFilterList().list.filterNot {
-            it.name.lowercase().contains("adult content")
-        }
-
-        return FilterList(filters)
-    }
+    override val genres = listOf(
+        "Action" to "action",
+        "Alien" to "alien",
+        "Alpha" to "alpha",
+        "Amitié" to "amitie",
+        "Art martiaux" to "art-martiaux",
+        "Aventure" to "aventure",
+        "Belle-mère" to "belle-mere",
+        "Boy's Love" to "yaoi",
+        "Campus" to "campus",
+        "Comédie" to "comedie",
+        "Domination" to "domination",
+        "Drame" to "drame",
+        "Démon" to "demon",
+        "Ecchi" to "ecchi",
+        "Fantasy" to "fantasy",
+        "Futanari" to "futanari",
+        "Furry" to "furry",
+        "Fétichisme" to "fetichisme",
+        "Gallerie" to "gallerie",
+        "Gangster" to "gangster",
+        "Gofast" to "gofast",
+        "Gore" to "gore",
+        "Guideverse" to "guideverse",
+        "Hardcore" to "hardcore",
+        "Harem" to "harem",
+        "Historique" to "historique",
+        "Horreur" to "horreur",
+        "Humiliation" to "humiliation",
+        "Inceste" to "inceste",
+        "Isekai" to "isekai",
+        "Josei" to "josei",
+        "Loli" to "loli",
+        "Love" to "love",
+        "Magie" to "magie",
+        "Mature" to "mature",
+        "Milf" to "milf",
+        "Mini-série" to "mini-serie",
+        "Monsters girls" to "monsters-girls",
+        "Ntr" to "ntr",
+        "Office" to "office",
+        "Omégaverse" to "omegaverse",
+        "Oneshot" to "oneshot",
+        "Parodie" to "parodie",
+        "Professeur" to "professeur",
+        "Psychologie" to "psychologie",
+        "Rape" to "rape",
+        "Romance" to "romance",
+        "Réincarnation" to "reincarnation",
+        "School life" to "school-life",
+        "Sci-fi" to "sci-fi",
+        "Shonen-ai" to "shonen-ai",
+        "Slice of life" to "slice-of-life",
+        "Smut" to "smut",
+        "Soft" to "soft",
+        "Sport" to "sport",
+        "Surnaturel" to "surnaturel",
+        "Tomgirl" to "tomgirl",
+        "Tragédie" to "tragedie",
+        "Triangle amoureux" to "triangle-amoureux",
+        "Uncensored" to "uncensored",
+        "Yuri" to "yuri",
+    )
 }

--- a/src/fr/mangasoriginesfr/build.gradle.kts
+++ b/src/fr/mangasoriginesfr/build.gradle.kts
@@ -6,10 +6,10 @@ plugins {
 
 keiyoushi {
     name = "Mangas-Origines.fr"
-    versionCode = 4
+    versionCode = 57
     contentWarning = ContentWarning.SAFE
-    libVersion = "1.4"
-    theme = "madara"
+    libVersion = "1.6"
+    theme = "origines"
 
     source {
         lang = "fr"

--- a/src/fr/mangasoriginesfr/src/eu/kanade/tachiyomi/extension/fr/mangasoriginesfr/MangasOriginesFr.kt
+++ b/src/fr/mangasoriginesfr/src/eu/kanade/tachiyomi/extension/fr/mangasoriginesfr/MangasOriginesFr.kt
@@ -1,20 +1,82 @@
 package eu.kanade.tachiyomi.extension.fr.mangasoriginesfr
 
-import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.multisrc.origines.Origines
 import keiyoushi.annotation.Source
-import java.text.SimpleDateFormat
-import java.util.Locale
-import java.util.TimeZone
 
 @Source
-abstract class MangasOriginesFr : Madara() {
-    override val dateFormat = SimpleDateFormat("d MMMM yyyy", Locale("fr")).apply {
-        timeZone = TimeZone.getTimeZone("Europe/Paris")
-    }
-    override val mangaSubString = "catalogues"
-    override val useNewChapterEndpoint = true
-    override val useLoadMoreRequest = LoadMoreStrategy.Never
+abstract class MangasOriginesFr : Origines() {
 
-    override val mangaDetailsSelectorAuthor = "div.author-content > a"
-    override val mangaDetailsSelectorDescription = "div.summary__content > p"
+    override val mangaPath = "oeuvre"
+
+    override val legacyMangaPaths = setOf("catalogues")
+
+    override val origins = listOf(
+        "Manhwa" to "manhwa",
+        "Manhua" to "manhua",
+        "Manga" to "manga",
+    )
+
+    override val genres = listOf(
+        "Action" to "action",
+        "Adventure" to "adventure",
+        "Amitié" to "amitie",
+        "Amour" to "amour",
+        "Art Martiaux" to "art-martiaux",
+        "Aventure" to "aventure",
+        "BL" to "bl",
+        "Boys" to "boys",
+        "Combat" to "combat",
+        "Comedy" to "comedy",
+        "Comédie" to "comedie",
+        "Dark Fantasy" to "dark-fantasy",
+        "Drama" to "drama",
+        "Drame" to "drame",
+        "Dystopie" to "dystopie",
+        "Démon" to "demon",
+        "Ecchi" to "ecchi",
+        "Erotique" to "erotique",
+        "Fantastique" to "fantastique",
+        "Fantasy" to "fantasy",
+        "Guerre" to "guerre",
+        "Harem" to "harem",
+        "Historique" to "historique",
+        "Horreur" to "horreur",
+        "Isekai" to "isekai",
+        "Jeu" to "jeu",
+        "Josei" to "josei",
+        "Magie" to "magie",
+        "Malédiction" to "malediction",
+        "Mature" to "mature",
+        "Moderne" to "moderne",
+        "Mort" to "mort",
+        "Murim" to "murim",
+        "Musique" to "musique",
+        "Mystère" to "mystere",
+        "Novel" to "novel",
+        "Post-Apo" to "post-apo",
+        "Prison" to "prison",
+        "Psychologique" to "psychologique",
+        "Religion" to "religion",
+        "Returner" to "returner",
+        "Romance" to "romance",
+        "Réincarnation" to "reincarnation",
+        "Régression" to "regression",
+        "School life" to "school-life",
+        "Sci-fi" to "sci-fi",
+        "Seinen" to "seinen",
+        "Shojo" to "shojo",
+        "Shonen" to "shonen",
+        "Slice of Life" to "slice-of-life",
+        "Société" to "societe",
+        "Sorcellerie" to "sorcellerie",
+        "Sport" to "sport",
+        "Steampunk" to "steampunk",
+        "Supernaturel" to "supernaturel",
+        "Surnaturel" to "surnaturel",
+        "Tragédie" to "tragedie",
+        "Vengeance" to "vengeance",
+        "Webcomic" to "webcomic",
+        "Yuri" to "yuri",
+        "École" to "ecole",
+    )
 }


### PR DESCRIPTION
Some enhancements:
- Keep old manga url sheme working
- Full search/filter support
- ext bump to 1.6
- multisrc
- hentai-origines also fixed

Closes #18236

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
