### PR TITLE
MangaFire (Multi): Trim query space

### DIFF
--- a/src/all/mangafire/build.gradle.kts
+++ b/src/all/mangafire/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "MangaFire"
-    versionCode = 28
+    versionCode = 29
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
 

--- a/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/MangaFire.kt
+++ b/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/MangaFire.kt
@@ -92,7 +92,7 @@ abstract class MangaFire :
     }
 
     override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
-        val authorQuery = filters.firstInstanceOrNull<AuthorFilter>()?.state.orEmpty()
+        val authorQuery = filters.firstInstanceOrNull<AuthorFilter>()?.state.orEmpty().trim()
         var authorId: String? = null
 
         if (authorQuery.isNotBlank()) {
@@ -111,7 +111,7 @@ abstract class MangaFire :
 
         val url = "$baseUrl/api/titles".toHttpUrl().newBuilder().apply {
             if (query.isNotBlank()) {
-                addQueryParameter("keyword", query)
+                addQueryParameter("keyword", query.trim())
             }
             addQueryParameter("page", page.toString())
             addQueryParameter("limit", "50")


### PR DESCRIPTION
Closes #18320

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

