### PR TITLE
KivaraToons: fix latest updates and show adult content

### DIFF
--- a/src/pt/kivaratoons/build.gradle.kts
+++ b/src/pt/kivaratoons/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "KivaraToons"
-    versionCode = 1
+    versionCode = 2
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
 

--- a/src/pt/kivaratoons/src/eu/kanade/tachiyomi/extension/pt/kivaratoons/Dto.kt
+++ b/src/pt/kivaratoons/src/eu/kanade/tachiyomi/extension/pt/kivaratoons/Dto.kt
@@ -20,6 +20,29 @@ class MangaListDto(
 }
 
 @Serializable
+class LatestUpdatesDto(
+    private val updates: List<ChapterUpdateDto>,
+    @SerialName("pagina") private val page: Int = 1,
+    @SerialName("total_paginas") private val totalPages: Int = 1,
+) {
+    val mangas get() = updates.distinctBy(ChapterUpdateDto::mangaId)
+    val hasNextPage get() = page < totalPages
+}
+
+@Serializable
+class ChapterUpdateDto(
+    @SerialName("obra_id") val mangaId: Int,
+    @SerialName("obra_nome") private val mangaName: String,
+    @SerialName("obra_capa") private val mangaCover: String? = null,
+) {
+    fun toSManga(siteUrl: HttpUrl) = SManga.create().apply {
+        url = mangaId.toString()
+        title = mangaName
+        thumbnail_url = mangaCover?.takeIf(String::isNotBlank)?.let { siteUrl.resolve(it)?.toString() }
+    }
+}
+
+@Serializable
 class MangaDto(
     private val id: Int,
     @SerialName("nome") private val name: String,

--- a/src/pt/kivaratoons/src/eu/kanade/tachiyomi/extension/pt/kivaratoons/KivaraToons.kt
+++ b/src/pt/kivaratoons/src/eu/kanade/tachiyomi/extension/pt/kivaratoons/KivaraToons.kt
@@ -30,7 +30,15 @@ abstract class KivaraToons : KeiSource() {
 
     override suspend fun getPopularManga(page: Int): MangasPage = getMangaList(page, defaultSort = "views")
 
-    override suspend fun getLatestUpdates(page: Int): MangasPage = getMangaList(page, defaultSort = "recentes")
+    override suspend fun getLatestUpdates(page: Int): MangasPage {
+        val url = "$baseUrl/api/leitores/ultimas-atualizacoes".toHttpUrl().newBuilder()
+            .addQueryParameter("pagina", page.toString())
+            .addQueryParameter("limite", UPDATES_PAGE_SIZE.toString())
+            .build()
+
+        val result = client.get(url).parseAs<LatestUpdatesDto>()
+        return MangasPage(result.mangas.map { it.toSManga(siteUrl) }, result.hasNextPage)
+    }
 
     override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage = getMangaList(page, query, filters, defaultSort = "recentes")
 
@@ -119,6 +127,7 @@ abstract class KivaraToons : KeiSource() {
 
     companion object {
         private const val MANGA_PAGE_SIZE = 24
+        private const val UPDATES_PAGE_SIZE = MANGA_PAGE_SIZE * 2
         private val MANGA_PATH_SEGMENTS = listOf("obra", "manhwa", "reader")
     }
 }

--- a/src/pt/kivaratoons/src/eu/kanade/tachiyomi/extension/pt/kivaratoons/KivaraToons.kt
+++ b/src/pt/kivaratoons/src/eu/kanade/tachiyomi/extension/pt/kivaratoons/KivaraToons.kt
@@ -31,7 +31,7 @@ abstract class KivaraToons : KeiSource() {
     override suspend fun getPopularManga(page: Int): MangasPage = getMangaList(page, defaultSort = "views")
 
     override suspend fun getLatestUpdates(page: Int): MangasPage {
-        val url = "$baseUrl/api/leitores/ultimas-atualizacoes".toHttpUrl().newBuilder()
+        val url = "$baseUrl/api/leitores/ultimas-atualizacoes?$SHOW_ADULT_CONTENT".toHttpUrl().newBuilder()
             .addQueryParameter("pagina", page.toString())
             .addQueryParameter("limite", UPDATES_PAGE_SIZE.toString())
             .build()
@@ -48,7 +48,7 @@ abstract class KivaraToons : KeiSource() {
         filters: FilterList = FilterList(),
         defaultSort: String,
     ): MangasPage {
-        val url = "$baseUrl/api/obras".toHttpUrl().newBuilder()
+        val url = "$baseUrl/api/obras?$SHOW_ADULT_CONTENT".toHttpUrl().newBuilder()
             .addQueryParameter("pagina", page.toString())
             .addQueryParameter("limite", MANGA_PAGE_SIZE.toString())
             .addQueryParameter("ordem", filters.firstInstanceOrNull<SortFilter>()?.selectedValue ?: defaultSort)
@@ -82,7 +82,7 @@ abstract class KivaraToons : KeiSource() {
         fetchDetails: Boolean,
         fetchChapters: Boolean,
     ): SMangaUpdate {
-        val details = client.get("$baseUrl/api/obras/${manga.url}").parseAs<MangaDto>()
+        val details = client.get("$baseUrl/api/obras/${manga.url}?$SHOW_ADULT_CONTENT").parseAs<MangaDto>()
 
         return SMangaUpdate(
             manga = details.toSManga(siteUrl),
@@ -90,7 +90,7 @@ abstract class KivaraToons : KeiSource() {
         )
     }
 
-    override suspend fun getPageList(chapter: SChapter): List<Page> = client.get("$baseUrl/api/capitulos/${chapter.url}")
+    override suspend fun getPageList(chapter: SChapter): List<Page> = client.get("$baseUrl/api/capitulos/${chapter.url}?$SHOW_ADULT_CONTENT")
         .parseAs<ChapterPagesDto>()
         .toPageList(siteUrl)
 
@@ -128,6 +128,7 @@ abstract class KivaraToons : KeiSource() {
     companion object {
         private const val MANGA_PAGE_SIZE = 24
         private const val UPDATES_PAGE_SIZE = MANGA_PAGE_SIZE * 2
+        private const val SHOW_ADULT_CONTENT = "mostrar_conteudo_adulto=true"
         private val MANGA_PATH_SEGMENTS = listOf("obra", "manhwa", "reader")
     }
 }


### PR DESCRIPTION
Closes #18292

The "Latest" tab was hitting `/api/obras?ordem=recentes`, which sorts entries by when they were added to the site, so it listed new series instead of new chapters. The site's own "Atualizações" page (`/recentes`) uses `/api/leitores/ultimas-atualizacoes`, so the extension uses that now. That endpoint returns one row per chapter (up to two per entry), so rows are deduplicated by entry and `limite` is doubled to keep 24 entries per page.

While testing I also ran into the +18 gate. The site hides restricted content unless `mostrar_conteudo_adulto=true` is sent: without it the catalogue drops from ~13k to ~3k entries, details come back with an empty chapter list, and page requests fail with `{"erro":"Conteudo restrito +18"}`. The parameter is now sent on every API call. It's a no-op for regular entries, and the source is already flagged as `MIXED`.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
