### PR TITLE
GreenShit: accept chapter pages sent as plain strings

### DIFF
--- a/lib-multisrc/greenshit/build.gradle.kts
+++ b/lib-multisrc/greenshit/build.gradle.kts
@@ -3,6 +3,6 @@ plugins {
 }
 
 keiyoushi {
-    baseVersionCode = 11
+    baseVersionCode = 12
     libVersion = "1.4"
 }

--- a/lib-multisrc/greenshit/src/eu/kanade/tachiyomi/multisrc/greenshit/Dto.kt
+++ b/lib-multisrc/greenshit/src/eu/kanade/tachiyomi/multisrc/greenshit/Dto.kt
@@ -6,7 +6,15 @@ import eu.kanade.tachiyomi.source.model.SManga
 import keiyoushi.utils.tryParse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNames
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.JsonTransformingSerializer
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.put
 import org.jsoup.Jsoup
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -109,12 +117,24 @@ class GreenShitPageSrcDto(
     val mime: String? = null,
 )
 
+private object PageListSerializer :
+    JsonTransformingSerializer<List<GreenShitPageSrcDto>>(ListSerializer(GreenShitPageSrcDto.serializer())) {
+    override fun transformDeserialize(element: JsonElement) = JsonArray(
+        element.jsonArray.map { page ->
+            when (page) {
+                is JsonPrimitive -> buildJsonObject { put("src", page.content) }
+                else -> page
+            }
+        },
+    )
+}
+
 @Serializable
 class GreenShitChapterDetailDto(
     @SerialName("cap_id") private val id: Int,
     @SerialName("cap_nome") private val name: String,
     @SerialName("cap_numero") private val number: Float? = null,
-    @SerialName("cap_paginas") private val pages: List<GreenShitPageSrcDto> = emptyList(),
+    @SerialName("cap_paginas") @Serializable(PageListSerializer::class) private val pages: List<GreenShitPageSrcDto> = emptyList(),
     @SerialName("obra") private val manga: GreenShitMangaDto? = null,
 ) {
     fun toPageList(cdnUrl: String): List<Page> {


### PR DESCRIPTION
Closes #18159
Closes #18237

`GET /capitulos/{id}` now returns `cap_paginas` as an array of absolute URLs instead of `{ src, mime }` objects, so every chapter blew up with `Unexpected JSON token at offset 163` — offset 163 is exactly where the first page string starts in the array.

The list is normalized before deserializing, so both shapes still parse. I kept the old one working because verdinha.wtf (Verdinha/MaidScan) is fully behind a VIP wall right now and I couldn't check which shape it serves.

Bumped `baseVersionCode` since this touches all three extensions on the theme.

Tested on Vegitoons: chapter list, reader and the 24 pages of the chapter all load.

Checklist:

- [ ] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
