### PR TITLE
NoyAcg: Add automatic account login

### DIFF
--- a/src/zh/noyacg/build.gradle.kts
+++ b/src/zh/noyacg/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "NoyAcg"
-    versionCode = 6
+    versionCode = 7
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
 
@@ -23,6 +23,7 @@ keiyoushi {
 
     deeplink {
         host("beta.noyteam.online")
+        host("noymanga.com")
         path("/manga/..*")
     }
 }

--- a/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/Dto.kt
+++ b/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/Dto.kt
@@ -10,6 +10,9 @@ import java.util.Locale
 const val LISTING_PAGE_SIZE = 20
 val DATE_FORMAT = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH)
 
+@Serializable
+class LoginResponseDto(val status: String)
+
 fun String.formatAuthors() = split(" ").joinToString { name ->
     name.split("-").joinToString(" ") { word -> word.replaceFirstChar { it.uppercaseChar() } }
 }

--- a/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/NoyAcg.kt
+++ b/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/NoyAcg.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.extension.zh.noyacg
 
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
@@ -39,11 +40,15 @@ abstract class NoyAcg :
 
     private val pref by getPreferencesLazy()
     private val imgBaseUrl get() = baseUrl.replace("api", "img")
+    private val loginLock = Any()
 
-    override fun getHomeUrl() = "https://beta.noyteam.online"
+    @Volatile
+    private var sessionGeneration = 0
+
+    override fun getHomeUrl() = WEB_BASE_URL
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        getPreferencesInternal(screen.context).forEach(screen::addPreference)
+        getPreferencesInternal(screen.context, pref).forEach(screen::addPreference)
     }
 
     override fun Headers.Builder.configureHeaders() = apply {
@@ -53,11 +58,55 @@ abstract class NoyAcg :
 
     override fun OkHttpClient.Builder.configureClient() = apply {
         cookieJar(SessionCookieJar(getHomeUrl().toHttpUrl(), network.client.cookieJar))
-        addNetworkInterceptor { chain ->
-            val resp = chain.proceed(chain.request())
-            resp.takeUnless {
-                it.header("Content-Type")?.contains("application/json") == true && it.header("Content-Length") == "18"
-            } ?: resp.use { throw IOException("請在 WebView 中登入") }
+        addInterceptor { chain ->
+            val requestGeneration = sessionGeneration
+            val response = chain.proceed(chain.request())
+            if (!response.isLoginRequired()) return@addInterceptor response
+
+            response.close()
+            synchronized(loginLock) {
+                if (requestGeneration == sessionGeneration) {
+                    login()
+                    sessionGeneration++
+                }
+            }
+            chain.proceed(chain.request()).also {
+                if (it.isLoginRequired()) {
+                    it.close()
+                    throw IOException("登入失敗，請檢查帳號與密碼")
+                }
+            }
+        }
+    }
+
+    private fun Response.isLoginRequired(): Boolean = header("Content-Type")?.contains("application/json") == true &&
+        runCatching {
+            peekBody(LOGIN_RESPONSE_SIZE).string().parseAs<LoginResponseDto>().status == "login"
+        }.getOrDefault(false)
+
+    private fun login() {
+        val username = pref.getString(USERNAME_PREF, "").orEmpty()
+        val password = pref.getString(PASSWORD_PREF, "").orEmpty()
+        if (username.isEmpty() || password.isEmpty()) {
+            throw IOException("請在擴充套件設定中輸入帳號與密碼，或在 WebView 中登入")
+        }
+
+        val body = FormBody.Builder()
+            .add("user", username)
+            .add("pass", password)
+            .build()
+        val loginHeaders = headers.newBuilder()
+            .set("Origin", WEB_BASE_URL)
+            .set("Referer", "$WEB_BASE_URL/")
+            .build()
+        val request = POST("$WEB_BASE_URL/api/login", loginHeaders, body)
+        network.client.newCall(request).execute().use { response ->
+            val status = response.parseAs<LoginResponseDto>().status
+            when (status) {
+                "error" -> throw IOException("帳號或密碼錯誤")
+                "danger" -> throw IOException("帳號或密碼包含不允許的字元")
+                else -> Unit
+            }
         }
     }
 
@@ -175,4 +224,9 @@ abstract class NoyAcg :
     }
 
     override fun imageRequest(page: Page) = GET(imgBaseUrl + page.imageUrl, headers)
+
+    companion object {
+        const val WEB_BASE_URL = "https://noymanga.com"
+        const val LOGIN_RESPONSE_SIZE = 64L
+    }
 }

--- a/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/Preferences.kt
+++ b/src/zh/noyacg/src/eu/kanade/tachiyomi/extension/zh/noyacg/Preferences.kt
@@ -1,12 +1,40 @@
 package eu.kanade.tachiyomi.extension.zh.noyacg
 
 import android.content.Context
+import android.content.SharedPreferences
+import android.text.InputType
+import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 
 const val POPULAR_MANGAS_PREF = "POPULAR_MANGAS"
 const val ADULT_PREF = "ADULT"
+const val USERNAME_PREF = "USERNAME"
+const val PASSWORD_PREF = "PASSWORD"
 
-fun getPreferencesInternal(context: Context) = arrayOf(
+fun getPreferencesInternal(context: Context, preferences: SharedPreferences) = arrayOf(
+    EditTextPreference(context).apply {
+        key = USERNAME_PREF
+        title = "用戶名稱 / 電郵"
+        summary = preferences.getString(key, "")?.takeIf(String::isNotEmpty) ?: "未設定"
+        dialogTitle = title
+        setOnPreferenceChangeListener { _, newValue ->
+            summary = (newValue as String).takeIf(String::isNotEmpty) ?: "未設定"
+            true
+        }
+    },
+    EditTextPreference(context).apply {
+        key = PASSWORD_PREF
+        title = "密碼"
+        summary = if (preferences.getString(key, "").isNullOrEmpty()) "未設定" else "********"
+        dialogTitle = title
+        setOnBindEditTextListener {
+            it.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
+        }
+        setOnPreferenceChangeListener { _, newValue ->
+            summary = if ((newValue as String).isEmpty()) "未設定" else "********"
+            true
+        }
+    },
     ListPreference(context).apply {
         key = POPULAR_MANGAS_PREF
         title = "熱門漫畫顯示內容"


### PR DESCRIPTION
## Summary

- Add username/email and password preferences.
- Automatically log in and retry requests when the session expires.
- Prevent duplicate login attempts from concurrent requests.
- Update the web URL and support the current domain in deeplinks.
- Keep WebView login as a fallback when credentials are not configured.

## Testing

- `CI=true ./gradlew :src:zh:noyacg:assembleRelease`
- Installed and tested the generated APK on a physical device.
- Verified account login and authenticated source access.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (not applicable)
- [ ] Referenced all related issues in the PR body (no related issue)
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed (not applicable)
- [x] Have tested the modifications by compiling and running the extension
- [x] Have removed `web_hi_res_512.png` when adding a new extension (not applicable)
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

🤖 I was asked to add account-based automatic login for NoyAcg to avoid frequent WebView cookie expiration. The resulting APK was tested by the user on a physical device, and this PR was opened by an AI agent.