### PR TITLE
Yubikiri [id]: Update domain and endpoint fix

### DIFF
--- a/src/id/yubikiri/build.gradle.kts
+++ b/src/id/yubikiri/build.gradle.kts
@@ -6,14 +6,14 @@ plugins {
 
 keiyoushi {
     name = "Kaguya"
-    versionCode = 3
+    versionCode = 4
     contentWarning = ContentWarning.NSFW // or MIXED, please confirm
     libVersion = "1.4"
     theme = "madara"
 
     source {
         lang = "id"
-        baseUrl = "https://v1.kaguya.pro"
+        baseUrl = "https://02.kaguya.pro"
         id = 1557304490417397104L
     }
 }

--- a/src/id/yubikiri/src/eu/kanade/tachiyomi/extension/id/yubikiri/Kaguya.kt
+++ b/src/id/yubikiri/src/eu/kanade/tachiyomi/extension/id/yubikiri/Kaguya.kt
@@ -23,11 +23,12 @@ abstract class Kaguya : Madara() {
         .readTimeout(1.minutes)
         .build()
 
-    override val mangaSubString = "all-series"
+    // Fixed: Set to "series" to match https://02.kaguya.pro/series/...
+    override val mangaSubString = "series"
 
     override val mangaDetailsSelectorTitle = "h1.post-title"
     override val mangaDetailsSelectorStatus = "div.summary-heading:contains(Status) + div"
-    override val mangaDetailsSelectorThumbnail = "head meta[property='og:image']" // Same as browse
+    override val mangaDetailsSelectorThumbnail = "head meta[property='og:image']"
 
     override fun imageFromElement(element: Element): String? {
         if (element.hasAttr("data-aesir")) {
@@ -37,7 +38,7 @@ abstract class Kaguya : Madara() {
 
         return super.imageFromElement(element)
             ?.takeIf { it.isNotEmpty() }
-            ?: element.attr("content") // Thumbnail from <head>
+            ?: element.attr("content")
     }
 
     // ============================== Chapters ==============================


### PR DESCRIPTION
Checklist:

- [X] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [X] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

Closes #14781 
<img width="752" height="1600" alt="WhatsApp Image 2026-08-13 at 07 12 10" src="https://github.com/user-attachments/assets/d602a73c-b2d3-41f9-8b89-73cc461c7f31" />