### PR TITLE
KivaraToons: make adult content optional and fix ids in latest

### DIFF
--- a/src/pt/kivaratoons/build.gradle.kts
+++ b/src/pt/kivaratoons/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "KivaraToons"
-    versionCode = 2
+    versionCode = 3
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
 

--- a/src/pt/kivaratoons/src/eu/kanade/tachiyomi/extension/pt/kivaratoons/Dto.kt
+++ b/src/pt/kivaratoons/src/eu/kanade/tachiyomi/extension/pt/kivaratoons/Dto.kt
@@ -1,10 +1,12 @@
 package eu.kanade.tachiyomi.extension.pt.kivaratoons
 
+import android.util.Base64
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import okhttp3.HttpUrl
@@ -31,12 +33,14 @@ class LatestUpdatesDto(
 
 @Serializable
 class ChapterUpdateDto(
-    @SerialName("obra_id") val mangaId: Int,
+    @SerialName("obra_id") private val id: JsonPrimitive,
     @SerialName("obra_nome") private val mangaName: String,
     @SerialName("obra_capa") private val mangaCover: String? = null,
 ) {
+    val mangaId get() = id.content.decodeMangaId()
+
     fun toSManga(siteUrl: HttpUrl) = SManga.create().apply {
-        url = mangaId.toString()
+        url = mangaId
         title = mangaName
         thumbnail_url = mangaCover?.takeIf(String::isNotBlank)?.let { siteUrl.resolve(it)?.toString() }
     }
@@ -82,7 +86,7 @@ class MangaDto(
 @Serializable
 class ChapterDto(
     private val id: String,
-    @SerialName("obra_id") private val mangaId: Int,
+    @SerialName("obra_id") private val mangaId: JsonPrimitive,
     @SerialName("numero") private val number: Float,
     @SerialName("data_publicacao") private val publishedAt: String? = null,
 ) {
@@ -91,7 +95,7 @@ class ChapterDto(
         name = "Capítulo ${number.formatted()}"
         chapter_number = number
         date_upload = publishedAt?.let(Instant::parseOrNull)?.toEpochMilliseconds() ?: 0L
-        memo = buildJsonObject { put("mangaId", mangaId) }
+        memo = buildJsonObject { put("mangaId", mangaId.content.decodeMangaId()) }
     }
 
     private fun Float.formatted(): String = if (this % 1 == 0f) toInt().toString() else toString()
@@ -139,3 +143,17 @@ class FilterData(
     val statuses: List<FilterOptionDto>,
     val tags: List<String>,
 )
+
+private const val MANGA_ID_KEY = "4b7e8"
+
+/** Newer entries expose the manga id base64 encoded and XORed, while the listings use the plain numeric id. */
+fun String.decodeMangaId(): String {
+    if (isEmpty() || all(Char::isDigit)) return this
+
+    val bytes = runCatching { Base64.decode(this, Base64.DEFAULT) }.getOrNull() ?: return this
+    val decoded = String(
+        ByteArray(bytes.size) { (bytes[it].toInt() xor MANGA_ID_KEY[it % MANGA_ID_KEY.length].code).toByte() },
+    )
+
+    return decoded.takeIf { it.isNotEmpty() && it.all(Char::isDigit) } ?: this
+}

--- a/src/pt/kivaratoons/src/eu/kanade/tachiyomi/extension/pt/kivaratoons/KivaraToons.kt
+++ b/src/pt/kivaratoons/src/eu/kanade/tachiyomi/extension/pt/kivaratoons/KivaraToons.kt
@@ -1,5 +1,8 @@
 package eu.kanade.tachiyomi.extension.pt.kivaratoons
 
+import androidx.preference.PreferenceScreen
+import androidx.preference.SwitchPreferenceCompat
+import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
@@ -11,8 +14,9 @@ import keiyoushi.network.get
 import keiyoushi.network.rateLimit
 import keiyoushi.source.KeiSource
 import keiyoushi.utils.firstInstanceOrNull
-import keiyoushi.utils.int
+import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
+import keiyoushi.utils.string
 import keiyoushi.utils.toJsonElement
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -22,18 +26,34 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 
 @Source
-abstract class KivaraToons : KeiSource() {
+abstract class KivaraToons :
+    KeiSource(),
+    ConfigurableSource {
+
+    private val preferences by getPreferencesLazy()
+
+    private val showAdultContent get() = preferences.getBoolean(ADULT_CONTENT_PREF, false)
 
     override fun OkHttpClient.Builder.configureClient(): OkHttpClient.Builder = rateLimit(2)
 
     private val siteUrl get() = baseUrl.toHttpUrl()
 
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        SwitchPreferenceCompat(screen.context).apply {
+            key = ADULT_CONTENT_PREF
+            title = "Mostrar conteúdo adulto"
+            summary = "Inclui obras +18 nos populares, nas últimas atualizações e na busca."
+            setDefaultValue(false)
+        }.also(screen::addPreference)
+    }
+
     override suspend fun getPopularManga(page: Int): MangasPage = getMangaList(page, defaultSort = "views")
 
     override suspend fun getLatestUpdates(page: Int): MangasPage {
-        val url = "$baseUrl/api/leitores/ultimas-atualizacoes?$SHOW_ADULT_CONTENT".toHttpUrl().newBuilder()
+        val url = "$baseUrl/api/leitores/ultimas-atualizacoes".toHttpUrl().newBuilder()
             .addQueryParameter("pagina", page.toString())
             .addQueryParameter("limite", UPDATES_PAGE_SIZE.toString())
+            .addAdultContentParameter()
             .build()
 
         val result = client.get(url).parseAs<LatestUpdatesDto>()
@@ -48,10 +68,11 @@ abstract class KivaraToons : KeiSource() {
         filters: FilterList = FilterList(),
         defaultSort: String,
     ): MangasPage {
-        val url = "$baseUrl/api/obras?$SHOW_ADULT_CONTENT".toHttpUrl().newBuilder()
+        val url = "$baseUrl/api/obras".toHttpUrl().newBuilder()
             .addQueryParameter("pagina", page.toString())
             .addQueryParameter("limite", MANGA_PAGE_SIZE.toString())
             .addQueryParameter("ordem", filters.firstInstanceOrNull<SortFilter>()?.selectedValue ?: defaultSort)
+            .addAdultContentParameter()
             .apply {
                 if (query.isNotBlank()) {
                     addQueryParameter("busca", query)
@@ -66,23 +87,28 @@ abstract class KivaraToons : KeiSource() {
         return MangasPage(result.mangas.map { it.toSManga(siteUrl) }, result.hasNextPage)
     }
 
+    private fun HttpUrl.Builder.addAdultContentParameter() = apply {
+        if (showAdultContent) addQueryParameter(ADULT_CONTENT_PARAM, "true")
+    }
+
     override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
         if (url.host != siteUrl.host || url.pathSegments.firstOrNull() !in MANGA_PATH_SEGMENTS) return null
-        val mangaId = url.pathSegments.getOrNull(1)?.toIntOrNull() ?: return null
-        val manga = SManga.create().apply { this.url = mangaId.toString() }
+        val mangaId = url.pathSegments.getOrNull(1)?.takeIf(String::isNotEmpty)?.decodeMangaId() ?: return null
+        val manga = SManga.create().apply { this.url = mangaId }
 
         return fetchMangaUpdate(manga, emptyList(), fetchDetails = true, fetchChapters = false)
             .manga
             .apply { initialized = true }
     }
 
+    // Details and pages always ask for adult content, otherwise entries already saved by the user stop working.
     override suspend fun fetchMangaUpdate(
         manga: SManga,
         chapters: List<SChapter>,
         fetchDetails: Boolean,
         fetchChapters: Boolean,
     ): SMangaUpdate {
-        val details = client.get("$baseUrl/api/obras/${manga.url}?$SHOW_ADULT_CONTENT").parseAs<MangaDto>()
+        val details = client.get("$baseUrl/api/obras/${manga.url}?$ADULT_CONTENT_QUERY").parseAs<MangaDto>()
 
         return SMangaUpdate(
             manga = details.toSManga(siteUrl),
@@ -90,7 +116,7 @@ abstract class KivaraToons : KeiSource() {
         )
     }
 
-    override suspend fun getPageList(chapter: SChapter): List<Page> = client.get("$baseUrl/api/capitulos/${chapter.url}?$SHOW_ADULT_CONTENT")
+    override suspend fun getPageList(chapter: SChapter): List<Page> = client.get("$baseUrl/api/capitulos/${chapter.url}?$ADULT_CONTENT_QUERY")
         .parseAs<ChapterPagesDto>()
         .toPageList(siteUrl)
 
@@ -123,12 +149,14 @@ abstract class KivaraToons : KeiSource() {
 
     override fun getMangaUrl(manga: SManga): String = "$baseUrl/obra/${manga.url}"
 
-    override fun getChapterUrl(chapter: SChapter): String = "$baseUrl/reader/${chapter.memo["mangaId"]!!.int}/${chapter.url}"
+    override fun getChapterUrl(chapter: SChapter): String = "$baseUrl/reader/${chapter.memo["mangaId"]!!.string}/${chapter.url}"
 
     companion object {
         private const val MANGA_PAGE_SIZE = 24
         private const val UPDATES_PAGE_SIZE = MANGA_PAGE_SIZE * 2
-        private const val SHOW_ADULT_CONTENT = "mostrar_conteudo_adulto=true"
+        private const val ADULT_CONTENT_PREF = "pref_show_adult_content"
+        private const val ADULT_CONTENT_PARAM = "mostrar_conteudo_adulto"
+        private const val ADULT_CONTENT_QUERY = "$ADULT_CONTENT_PARAM=true"
         private val MANGA_PATH_SEGMENTS = listOf("obra", "manhwa", "reader")
     }
 }


### PR DESCRIPTION
Follow-up to #18331.

- Adult content was requested on every call, so +18 entries flooded popular, latest and search. It is now a preference (off by default) applied to the listings only; details and page lists keep sending it so entries already in the library don't break.
- `obra_id` comes back either as a number or as an obfuscated string, which made latest fail with `JsonDecodingException`. Both forms are accepted now, and the obfuscated one is decoded so an entry keeps the same id across every listing.
- `getMangaByUrl` no longer requires a numeric id, so `/manhwa/<obfuscated-id>` links resolve.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
