### PR TITLE
Hiperdex: Allow title refresh when opening manga with custom removal settings

### DIFF
--- a/src/en/hiperdex/build.gradle.kts
+++ b/src/en/hiperdex/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Hiperdex"
-    versionCode = 80
+    versionCode = 81
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
     theme = "hiper"

--- a/src/en/hiperdex/src/eu/kanade/tachiyomi/extension/en/hiperdex/Hiperdex.kt
+++ b/src/en/hiperdex/src/eu/kanade/tachiyomi/extension/en/hiperdex/Hiperdex.kt
@@ -101,6 +101,9 @@ abstract class Hiperdex : Hiper() {
             mangaUpdate.mangas.map {
                 if (!noCleanTitlesWhileBrowsing()) {
                     it.title = it.title.cleanTitleIfNeeded()
+                } else if (isRemoveTitleVersion() || customRemoveTitle().isNotEmpty()) {
+                    // Allow it to refresh the cleaning title when manga is opened
+                    it.initialized = false
                 }
                 it
             },


### PR DESCRIPTION
Checklist:

- [X] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
