### PR TITLE
Roxinha: add login support

### DIFF
--- a/src/pt/roxinha/build.gradle.kts
+++ b/src/pt/roxinha/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Roxinha"
-    versionCode = 2
+    versionCode = 3
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 

--- a/src/pt/roxinha/src/eu/kanade/tachiyomi/extension/pt/roxinha/Dto.kt
+++ b/src/pt/roxinha/src/eu/kanade/tachiyomi/extension/pt/roxinha/Dto.kt
@@ -14,6 +14,23 @@ private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale
 }
 
 @Serializable
+class LoginRequestDto(
+    private val email: String,
+    private val password: String,
+    private val rememberMe: Boolean = true,
+)
+
+@Serializable
+class LoginResponseDto(
+    val token: String,
+)
+
+@Serializable
+class ErrorDto(
+    val error: String,
+)
+
+@Serializable
 class SearchResponseDto(
     private val mangas: List<MangaDto> = emptyList(),
     val hasMore: Boolean = false,

--- a/src/pt/roxinha/src/eu/kanade/tachiyomi/extension/pt/roxinha/Roxinha.kt
+++ b/src/pt/roxinha/src/eu/kanade/tachiyomi/extension/pt/roxinha/Roxinha.kt
@@ -1,6 +1,11 @@
 package eu.kanade.tachiyomi.extension.pt.roxinha
 
+import android.text.InputType
+import androidx.preference.EditTextPreference
+import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
@@ -9,18 +14,34 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.annotation.Source
 import keiyoushi.utils.firstInstanceOrNull
+import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
+import keiyoushi.utils.toJsonRequestBody
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
 import rx.Observable
+import java.io.IOException
 
 @Source
-abstract class Roxinha : HttpSource() {
+abstract class Roxinha :
+    HttpSource(),
+    ConfigurableSource {
 
     override val supportsLatest = true
 
     private val apiUrl = "$baseUrl/api"
+
+    private val preferences by getPreferencesLazy()
+
+    private var token: String? = null
+
+    override val client by lazy {
+        network.client.newBuilder()
+            .addInterceptor(::authIntercept)
+            .build()
+    }
 
     override fun headersBuilder() = super.headersBuilder()
         .add("Referer", "$baseUrl/")
@@ -104,9 +125,12 @@ abstract class Roxinha : HttpSource() {
 
     override fun fetchPageList(chapter: SChapter): Observable<List<Page>> {
         val chapterUrl = "$apiUrl/manga/chapter/${chapter.url}"
-        val accessUrl = chapterUrl + "/access"
 
-        val accessRes = client.newCall(GET(accessUrl, headers)).execute()
+        val accessRes = client.newCall(GET("$chapterUrl/access", headers)).execute()
+        if (!accessRes.isSuccessful) {
+            val message = accessRes.errorMessage()
+            throw Exception(if (accessRes.code == 401) "$message. $LOGIN_HINT" else message)
+        }
         val accessDto = accessRes.parseAs<TicketDto>()
         val accessHeaders = headersBuilder().set("x-chapter-access", accessDto.ticket).build()
 
@@ -126,4 +150,84 @@ abstract class Roxinha : HttpSource() {
         StatusFilter(),
         TypeFilter(),
     )
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        EditTextPreference(screen.context).apply {
+            key = EMAIL_PREF
+            title = "E-mail"
+            summary = LOGIN_HINT
+            setDefaultValue("")
+            setOnPreferenceChangeListener { _, _ ->
+                token = null
+                true
+            }
+        }.also(screen::addPreference)
+
+        EditTextPreference(screen.context).apply {
+            key = PASSWORD_PREF
+            title = "Senha"
+            summary = LOGIN_HINT
+            setDefaultValue("")
+            setOnBindEditTextListener {
+                it.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
+            }
+            setOnPreferenceChangeListener { _, _ ->
+                token = null
+                true
+            }
+        }.also(screen::addPreference)
+    }
+
+    private fun authIntercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        if (!request.url.encodedPath.startsWith("/api/")) {
+            return chain.proceed(request)
+        }
+
+        val token = getToken() ?: return chain.proceed(request)
+        val response = chain.proceed(request.withToken(token))
+
+        if (response.code != 401) {
+            return response
+        }
+
+        response.close()
+        this.token = null
+        val newToken = getToken() ?: return chain.proceed(request)
+        return chain.proceed(request.withToken(newToken))
+    }
+
+    private fun Request.withToken(token: String) = newBuilder()
+        .header("Authorization", "Bearer $token")
+        .build()
+
+    @Synchronized
+    private fun getToken(): String? {
+        token?.let { return it }
+
+        val email = preferences.getString(EMAIL_PREF, "").orEmpty()
+        val password = preferences.getString(PASSWORD_PREF, "").orEmpty()
+        if (email.isEmpty() || password.isEmpty()) {
+            return null
+        }
+
+        val body = LoginRequestDto(email.trim(), password).toJsonRequestBody()
+        val response = network.client.newCall(POST("$apiUrl/auth/login", headers, body)).execute()
+
+        if (!response.isSuccessful) {
+            throw IOException(response.errorMessage())
+        }
+
+        return response.parseAs<LoginResponseDto>().token.also { token = it }
+    }
+
+    private fun Response.errorMessage(): String = use {
+        runCatching { it.parseAs<ErrorDto>().error }.getOrDefault("Erro HTTP ${it.code}")
+    }
+
+    companion object {
+        private const val EMAIL_PREF = "email"
+        private const val PASSWORD_PREF = "password"
+        private const val LOGIN_HINT = "Informe o e-mail e a senha da sua conta da Roxinha para ler os capítulos"
+    }
 }


### PR DESCRIPTION
Chapters on Roxinha are gated behind an account (`GET /api/manga/chapter/{id}/access` answers `401 {"error":"Você precisa estar logado para acessar este conteúdo","requiresLogin":true,"reason":"public_chapter_lock"}`), so `TicketDto` could never be parsed and the reader failed with `Field 'ticket' is required for type with serial name`.

Adds a simple login:

- `ConfigurableSource` with email/password preferences (password field masked, cached token cleared when either changes).
- Token from `POST /api/auth/login`, cached in memory and sent as `Authorization: Bearer` on `/api/` requests, refreshed once on `401`.
- Readable error when a chapter requires login instead of the serialization failure.

Closes #18160

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
