### PR TITLE
KuroMangas: fix expired credentials error

### DIFF
--- a/src/pt/kuromangas/build.gradle.kts
+++ b/src/pt/kuromangas/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "KuroMangas"
-    versionCode = 9
+    versionCode = 10
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/pt/kuromangas/src/eu/kanade/tachiyomi/extension/pt/kuromangas/KuroMangas.kt
+++ b/src/pt/kuromangas/src/eu/kanade/tachiyomi/extension/pt/kuromangas/KuroMangas.kt
@@ -49,7 +49,7 @@ abstract class KuroMangas :
         network.client.newBuilder()
             .apply {
                 addInterceptor { chain ->
-                    checkLogin() ?: throw IOException(LOGIN_REQUIRED_MESSAGE)
+                    if (!checkLogin()) throw IOException(LOGIN_REQUIRED_MESSAGE)
                     return@addInterceptor chain.proceed(chain.request())
                 }
 
@@ -205,20 +205,20 @@ abstract class KuroMangas :
 
     // ============================= Auth ===================================
 
-    private fun checkLogin(): Boolean? {
-        client.getCookie(baseUrl, "kuro_session")?.also { return true }
+    private fun checkLogin(): Boolean {
+        if (client.getCookie(baseUrl, SESSION_COOKIE) != null) return true
 
         val email = preferences.getString(PREF_EMAIL, "") ?: ""
         val password = preferences.getString(PREF_PASSWORD, "") ?: ""
         if (email.isEmpty() || password.isEmpty()) {
-            return null
+            return false
         }
         login(email, password)
 
-        return client.getCookie(baseUrl, "kuro_session").let { true }
+        return client.getCookie(baseUrl, SESSION_COOKIE) != null
     }
 
-    // Implicit set-cookie: kuro_session + kuro_csrf
+    // Implicit set-cookie: kuro_session + kuro_x
     private fun login(email: String, password: String) {
         val payload = buildJsonObject {
             put("email", email)
@@ -226,7 +226,7 @@ abstract class KuroMangas :
         }.toString()
         val requestBody = payload.toRequestBody(JSON_MEDIA_TYPE)
         val request = POST("$apiUrl/auth/login", headers, requestBody)
-        val response = network.client.newCall(request).execute()
+        network.client.newCall(request).execute().close()
     }
 
     // ============================= Preferences ============================
@@ -265,6 +265,7 @@ abstract class KuroMangas :
         private const val API_HOST = "beta.kuromangas.com"
         private const val PREF_EMAIL = "kuromangas_email"
         private const val PREF_PASSWORD = "kuromangas_password"
+        private const val SESSION_COOKIE = "kuro_session"
         private const val LOGIN_REQUIRED_MESSAGE = "Faça login no WebView ou insira email e senha nas configurações e tente novamente."
         private val JSON_MEDIA_TYPE = "application/json".toMediaType()
     }

--- a/src/pt/kuromangas/src/eu/kanade/tachiyomi/extension/pt/kuromangas/KuroMangasDecryptor.kt
+++ b/src/pt/kuromangas/src/eu/kanade/tachiyomi/extension/pt/kuromangas/KuroMangasDecryptor.kt
@@ -20,28 +20,30 @@ import java.time.ZoneOffset
 
 const val HOSTNAME_PART = "kuromangas.com::v2"
 const val ANTIBOT = "x9_4v2_b"
-const val DEFAULT_ENC_KEY = "5ato8l674shksfE2oMmieshonuYTusF4jKdqEwhUEft9787147sadr32s"
+const val DEFAULT_ENC_KEY = "2i3ato8l674shksfE2oMmieshonuYTusF4jKdqEwhUEft9dsadcxzde3"
+const val VERIFY_COOKIE = "kuro_x"
+const val VERIFY_HEADER = "X-Kuro-Verify"
 
 private val encKeyRegex = Regex("""ENCRYPTION_KEY\s*[:=]\s*["']([^"']+)["']""")
-private val anyAssignRegex = Regex("""[:=]\s*["']([^"']+)["']""")
 
 class KuroMangasDecryptor(val baseUrl: String, val client: OkHttpClient) {
     private var viteApiEncKey: String? = DEFAULT_ENC_KEY
-    private var headerCookie: Pair<String, String?>? = "X-Kuro-Verify" to client.getCookie(baseUrl, "kuro_v")
-    private var hasErrored: Boolean = false
 
     fun vSecureInterceptor() = Interceptor { chain ->
 
-        fun newRequest() = chain.request().newBuilder().apply {
-            headerCookie?.let { (name, value) -> header(name, value ?: "") }
-        }.build()
+        fun newRequest(): Request {
+            val verifyToken = client.getCookie(baseUrl, VERIFY_COOKIE) ?: return chain.request()
+            return chain.request().newBuilder()
+                .header(VERIFY_HEADER, verifyToken)
+                .build()
+        }
 
         fun execute(request: Request, retried: Boolean): Response {
             val response = chain.proceed(request)
 
             if (response.code == 401 || response.code == 403) {
                 response.close()
-                if (retried) throw IOException("Credentials expired, open webivew and retry")
+                if (retried) throw IOException("Credentials expired, open webview and retry")
                 reloadCredentials()
                 return execute(newRequest(), true)
             }
@@ -72,29 +74,11 @@ class KuroMangasDecryptor(val baseUrl: String, val client: OkHttpClient) {
         val indexJsUrl = client.newCall(GET(baseUrl)).execute()
             .asJsoup()
             .selectFirst("script[src*=index]")
-            ?.absUrl("src")
+            ?.absUrl("src") ?: return
 
-        if (indexJsUrl != null) {
-            val js = client.newCall(GET(indexJsUrl)).execute().body.string()
+        val js = client.newCall(GET(indexJsUrl)).execute().body.string()
 
-            viteApiEncKey = encKeyRegex.find(js)?.groupValues?.get(1)
-
-            for (cookie in client.getCookies(baseUrl)) {
-                val key = getHeaderKey(js, cookie.name) ?: continue
-                headerCookie = key to cookie.value
-                return
-            }
-        }
-    }
-
-    private fun getHeaderKey(js: String, cookieName: String): String? {
-        val match = Regex("""\b\w+\s*[:=]\s*["']$cookieName["']""")
-            .find(js) ?: return null
-
-        return anyAssignRegex
-            .find(js, match.range.last + 1)
-            ?.groupValues
-            ?.get(1)
+        encKeyRegex.find(js)?.groupValues?.get(1)?.let { viteApiEncKey = it }
     }
 
     // index-*.js: Ik2() + Hk2()


### PR DESCRIPTION
The source always failed with `Credentials expired, open webivew and retry`, even for logged in users.

Three separate causes:

- The verification cookie was renamed to `kuro_x` (was `kuro_v`), so the `X-Kuro-Verify` header was never filled and the API answered `403`.
- Its value was resolved once, in the field initializer, i.e. when the source was instantiated — before the user had any session. Even after a successful login the request kept sending an empty header. It is now read from the cookie jar on every request.
- `VITE_API_ENCRYPTION_KEY` changed on the site (`VITE_API_VERSION` is now `v4.7`), so the stale default could not decrypt `_v_secure`.

Also dropped the header name lookup in `reloadCredentials()`: the site now builds the cookie and header names from char code arrays, so the regex could never match them again and the recovery path did nothing. The encryption key refresh still works and is kept.

While here, `checkLogin()` returned `true` even when the login failed (`.let { true }`), which turned a wrong password into the confusing decryption error, and the login response was never closed.

Closes #17309

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
