### PR TITLE
MangaLivre.org: fix 404 when opening chapters

### DIFF
--- a/src/pt/mangalivreorg/build.gradle.kts
+++ b/src/pt/mangalivreorg/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "MangaLivre.org"
-    versionCode = 2
+    versionCode = 3
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
 

--- a/src/pt/mangalivreorg/src/eu/kanade/tachiyomi/extension/pt/mangalivreorg/MangaLivreOrg.kt
+++ b/src/pt/mangalivreorg/src/eu/kanade/tachiyomi/extension/pt/mangalivreorg/MangaLivreOrg.kt
@@ -31,8 +31,9 @@ abstract class MangaLivreOrg : KeiSource() {
 
     override fun Headers.Builder.configureHeaders(): Headers.Builder = this
         .add("Accept-Language", "pt-BR,pt;q=0.9,en;q=0.8")
-        // The chapter endpoint answers 404 unless this header is present, with any value.
         .add("Sec-Fetch-Site", "same-origin")
+        // Constant in the site's bundle. The chapter endpoint answers 404 without it.
+        .add("X-ML-Nonce", "7854d8e036b53cddefc539b61aa95e35")
 
     override suspend fun getPopularManga(page: Int): MangasPage = getMangaList(page, "views", period = "ever")
 


### PR DESCRIPTION
Opening any chapter failed with HTTP 404. The API now rejects requests that do not carry the `X-ML-Nonce` header — `/api/v1/chapters/{id}` answers `{"error":"not found"}` without it.

The site sets it from a constant baked into its bundle, applied by an axios request interceptor on every call:

```js
K = G.create({ baseURL: `https://api.mangalivre.org/api/v1` }), fo = `7854d8e036b53cddefc539b61aa95e35`;
K.interceptors.request.use(e => { ...; e.headers[`X-ML-Nonce`] = fo, e });
```

Note that the `reader-v3` flow described in #18152 is gone: `/api/reader/bootstrap`, `/api/reader/runtime` and `/api/reader/proof/verify` all return the Express 404 for unknown routes. There is no proof of work and no per-request obfuscated runtime involved anymore, so only the header was missing.

Verified with the header: manga list, details, chapter pages (both by UUID and by `legacyId`), genres, search, categories and the page images all answer 200, and the payload still matches the existing DTOs. `baseUrl` and the DTOs are unchanged.

Closes #18369
Closes #18152

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
