### PR TITLE
[Eva Scans] Fix synopsis

### DIFF
--- a/src/en/evascans/build.gradle.kts
+++ b/src/en/evascans/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Eva Scans"
-    versionCode = 2
+    versionCode = 3
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
     theme = "mangathemesia"

--- a/src/en/evascans/src/eu/kanade/tachiyomi/extension/en/evascans/EvaScans.kt
+++ b/src/en/evascans/src/eu/kanade/tachiyomi/extension/en/evascans/EvaScans.kt
@@ -33,10 +33,14 @@ abstract class EvaScans : MangaThemesia() {
     // Fix page reading - site uses custom reader with camelCase ID
     override val pageSelector = "div#readerArea img"
 
-    override fun mangaDetailsParse(document: Document): SManga = SManga.create().apply {
-        title = document.selectFirst(".series-title-main, h1.entry-title")?.text().orEmpty()
-        thumbnail_url = document.selectFirst(".series-poster-premium img, .poster-box img")?.imgAttr()
+    override val seriesDetailsSelector = ".series-premium-header"
+    override val seriesTitleSelector = ".series-title-main"
+    override val seriesThumbnailSelector = ".series-poster-premium img, .poster-box img"
+    override val seriesGenreSelector = ".series-genres-wrap .gen-tag"
+    override val seriesTypeSelector = ".stat-v-box:has(.stat-v-label:containsOwn(Type)) .stat-v-value"
+    override val seriesStatusSelector = ".stat-v-box:has(.stat-v-label:containsOwn(Status)) .stat-v-value"
 
+    override fun mangaDetailsParse(document: Document): SManga = super.mangaDetailsParse(document).apply {
         val stats = document.select(".stat-v-box").associate { box ->
             box.selectFirst(".stat-v-label")?.text().orEmpty() to
                 box.selectFirst(".stat-v-value")?.text()?.trim().orEmpty()
@@ -67,12 +71,5 @@ abstract class EvaScans : MangaThemesia() {
                 add("Alternative Names:\n" + altNames.joinToString("\n") { "- $it" })
             }
         }.joinToString("\n\n")
-
-        genre = buildList {
-            stats["Type"]?.takeIf { it.isNotBlank() }?.let { add(it) }
-            addAll(document.select(".series-genres-wrap .gen-tag").map { it.text() })
-        }.joinToString()
-
-        status = stats["Status"]?.parseStatus() ?: SManga.UNKNOWN
     }
 }

--- a/src/en/evascans/src/eu/kanade/tachiyomi/extension/en/evascans/EvaScans.kt
+++ b/src/en/evascans/src/eu/kanade/tachiyomi/extension/en/evascans/EvaScans.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.extension.en.evascans
 import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
 import eu.kanade.tachiyomi.source.model.SManga
 import keiyoushi.annotation.Source
+import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -31,4 +32,47 @@ abstract class EvaScans : MangaThemesia() {
 
     // Fix page reading - site uses custom reader with camelCase ID
     override val pageSelector = "div#readerArea img"
+
+    override fun mangaDetailsParse(document: Document): SManga = SManga.create().apply {
+        title = document.selectFirst(".series-title-main, h1.entry-title")?.text().orEmpty()
+        thumbnail_url = document.selectFirst(".series-poster-premium img, .poster-box img")?.imgAttr()
+
+        val stats = document.select(".stat-v-box").associate { box ->
+            box.selectFirst(".stat-v-label")?.text().orEmpty() to
+                box.selectFirst(".stat-v-value")?.text()?.trim().orEmpty()
+        }
+
+        val rating = stats["Rating"]?.toFloatOrNull()
+        val views = stats["Views"]?.takeIf { it.isNotBlank() }
+        val synopsis = document.selectFirst(".synopsis-full")
+            ?.select("p")
+            ?.joinToString("\n\n") { it.text() }
+            ?.takeIf { it.isNotBlank() }
+            ?: document.selectFirst(".synopsis-short p")?.text()
+            ?: document.selectFirst("meta[name=description]")?.attr("content")?.trim()
+
+        val altNames = document.selectFirst(".series-title-alt")?.text()
+            ?.split(",")
+            ?.map { it.trim() }
+            ?.filter { it.isNotEmpty() }
+            .orEmpty()
+
+        description = buildList {
+            rating?.takeIf { it > 0 }?.let {
+                add("Rating: %.2f/10".format(Locale.ENGLISH, it))
+            }
+            views?.let { add("Views: $it") }
+            synopsis?.let { add("Synopsis: $it") }
+            if (altNames.isNotEmpty()) {
+                add("Alternative Names:\n" + altNames.joinToString("\n") { "- $it" })
+            }
+        }.joinToString("\n\n")
+
+        genre = buildList {
+            stats["Type"]?.takeIf { it.isNotBlank() }?.let { add(it) }
+            addAll(document.select(".series-genres-wrap .gen-tag").map { it.text() })
+        }.joinToString()
+
+        status = stats["Status"]?.parseStatus() ?: SManga.UNKNOWN
+    }
 }


### PR DESCRIPTION
Eva Scans uses a custom template. This adds the synopsis correctly, along with other information.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
