### PR TITLE
MangaBuff (RU): add rate limit

### DIFF
--- a/src/ru/mangabuff/build.gradle.kts
+++ b/src/ru/mangabuff/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "MangaBuff"
-    versionCode = 6
+    versionCode = 7
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
 

--- a/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/MangaBuff.kt
+++ b/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/MangaBuff.kt
@@ -23,6 +23,7 @@ import keiyoushi.source.KeiSource
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.toJsonElement
+import keiyoushi.utils.tryParseDate
 import kotlinx.serialization.json.JsonElement
 import okhttp3.FormBody
 import okhttp3.HttpUrl
@@ -37,8 +38,6 @@ import okio.IOException
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
-import java.time.LocalDate
-import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
@@ -347,9 +346,7 @@ abstract class MangaBuff :
     private fun chapterFromElement(element: Element) = SChapter.create().apply {
         setUrlWithoutDomain(element.absUrl("href"))
         name = element.select(".chapters__volume, .chapters__value, .chapters__name").text()
-        date_upload = runCatching {
-            LocalDate.parse(element.selectFirst(".chapters__add-date")?.text(), dateFormat).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
-        }.getOrDefault(0L)
+        date_upload = dateFormat.tryParseDate(element.selectFirst(".chapters__add-date")?.text())
         chapter_number = element.select(".chapters__value").text()
             .substringAfter(" ").toFloatOrNull() ?: -1f
     }

--- a/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/MangaBuff.kt
+++ b/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/MangaBuff.kt
@@ -41,7 +41,6 @@ import java.time.LocalDate
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Locale
-import kotlin.time.Duration.Companion.seconds
 
 @Source
 abstract class MangaBuff :
@@ -51,7 +50,7 @@ abstract class MangaBuff :
     override fun OkHttpClient.Builder.configureClient() = apply {
         addInterceptor(::tokenInterceptor)
         addInterceptor(::gifToWebpInterceptor)
-        rateLimit(50, 30.seconds, 1.seconds)
+        rateLimit(1)
     }
 
     // From Akuma - CSRF token

--- a/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/MangaBuff.kt
+++ b/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/MangaBuff.kt
@@ -41,6 +41,7 @@ import java.time.LocalDate
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Locale
+import kotlin.time.Duration.Companion.seconds
 
 @Source
 abstract class MangaBuff :
@@ -50,7 +51,7 @@ abstract class MangaBuff :
     override fun OkHttpClient.Builder.configureClient() = apply {
         addInterceptor(::tokenInterceptor)
         addInterceptor(::gifToWebpInterceptor)
-        rateLimit(1)
+        rateLimit(50, 30.seconds, 1.seconds)
     }
 
     // From Akuma - CSRF token

--- a/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/MangaBuff.kt
+++ b/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/MangaBuff.kt
@@ -49,7 +49,7 @@ abstract class MangaBuff :
     override fun OkHttpClient.Builder.configureClient() = apply {
         addInterceptor(::tokenInterceptor)
         addInterceptor(::gifToWebpInterceptor)
-        rateLimit(1)
+        rateLimit(1) { it.encodedPath.startsWith("/manga/") || it.encodedPath.contains("chapters/load") }
     }
 
     // From Akuma - CSRF token

--- a/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/MangaBuff.kt
+++ b/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/MangaBuff.kt
@@ -212,7 +212,7 @@ abstract class MangaBuff :
 
     // =========================== Deeplink ============================
     override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
-        if (url.host == baseUrl.toHttpUrl().host && url.pathSegments[0] == "manga") {
+        if (url.host == baseUrl.toHttpUrl().host && url.pathSegments[0] == "manga" && url.pathSegments[1].length > 1) {
             val tmpManga = SManga.create().apply {
                 this.url = "/${url.pathSegments[0]}/${url.pathSegments[1]}"
             }

--- a/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/MangaBuff.kt
+++ b/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/MangaBuff.kt
@@ -214,7 +214,7 @@ abstract class MangaBuff :
     override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
         if (url.host == baseUrl.toHttpUrl().host && url.pathSegments[0] == "manga") {
             val tmpManga = SManga.create().apply {
-                this.url = url.encodedPath
+                this.url = "/${url.pathSegments[0]}/${url.pathSegments[1]}"
             }
             return getMangaUpdate(tmpManga, emptyList(), fetchDetails = true, fetchChapters = false).manga
         }

--- a/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/MangaBuff.kt
+++ b/src/ru/mangabuff/src/eu/kanade/tachiyomi/extension/ru/mangabuff/MangaBuff.kt
@@ -18,6 +18,7 @@ import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.annotation.Source
 import keiyoushi.network.get
 import keiyoushi.network.post
+import keiyoushi.network.rateLimit
 import keiyoushi.source.KeiSource
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
@@ -49,6 +50,7 @@ abstract class MangaBuff :
     override fun OkHttpClient.Builder.configureClient() = apply {
         addInterceptor(::tokenInterceptor)
         addInterceptor(::gifToWebpInterceptor)
+        rateLimit(1)
     }
 
     // From Akuma - CSRF token


### PR DESCRIPTION
Checklist:

Source applies rate limit based on amount of requests. 
While site allows ~50-60 requests initially without any rate limit, it's impossible to not get 429 error on a large library. Tested with 300 entries, and after ~150 requests even rateLimit(2) doesn't save from 429 error.

Also added use of `tryParseDate` and change to deeplink


- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
