### PR TITLE
Update some domains

### DIFF
--- a/src/vi/doctruyen3q/build.gradle.kts
+++ b/src/vi/doctruyen3q/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "DocTruyen3Q"
-    versionCode = 29
+    versionCode = 30
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
     theme = "wpcomics"
@@ -14,7 +14,7 @@ keiyoushi {
     source {
         lang = "vi"
         baseUrl {
-            custom("https://doctruyen3qhub4.com")
+            custom("https://doctruyen3qhub.vip")
         }
     }
 }

--- a/src/vi/truyentuoitho/build.gradle.kts
+++ b/src/vi/truyentuoitho/build.gradle.kts
@@ -6,13 +6,13 @@ plugins {
 
 keiyoushi {
     name = "TruyenTuoiTho"
-    versionCode = 3
+    versionCode = 4
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
     theme = "madara"
 
     source {
         lang = "vi"
-        baseUrl = "https://truyentuoitho.online"
+        baseUrl = "https://truyentuoitho.com"
     }
 }

--- a/src/vi/vinahentai/build.gradle.kts
+++ b/src/vi/vinahentai/build.gradle.kts
@@ -6,14 +6,14 @@ plugins {
 
 keiyoushi {
     name = "VinaHentai"
-    versionCode = 13
+    versionCode = 14
     contentWarning = ContentWarning.NSFW
     libVersion = "1.6"
 
     source {
         lang = "vi"
         baseUrl {
-            custom("https://vinahentai.blog")
+            custom("https://vinahentai.wiki")
         }
     }
 


### PR DESCRIPTION
Closed https://github.com/keiyoushi/extensions-source/issues/18397

## Changed Domains
- **doctruyen3q**: `doctruyen3qhub4.com` => `doctruyen3qhub.vip`
- **truyentuoitho**: `truyentuoitho.online` => `truyentuoitho.com`
- **vinahentai**: `vinahentai.blog` => `vinahentai.wiki`

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop