### PR TITLE
[Reimanga] Fix for chapter updates in library

### DIFF
--- a/src/en/reimanga/build.gradle.kts
+++ b/src/en/reimanga/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "ReiManga"
-    versionCode = 4
+    versionCode = 5
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
 

--- a/src/en/reimanga/src/eu/kanade/tachiyomi/extension/en/reimanga/Dto.kt
+++ b/src/en/reimanga/src/eu/kanade/tachiyomi/extension/en/reimanga/Dto.kt
@@ -68,7 +68,7 @@ class MangaPage(
         @SerialName("main_name_url")
         private val mainNameUrl: String? = null,
     ) {
-        val resolvedId: Long get() = mainMangaId ?: id
+        val resolvedId: Long get() = mainMangaId?.takeIf { it > 0 } ?: id
 
         fun toSManga(baseUrl: String) = SManga.create().apply {
             url = "$slug-$id"
@@ -111,7 +111,7 @@ class MangaPage(
         fun chapterPageUrl(baseUrl: String): String {
             val mainId = mainMangaId
             val mainSlug = mainNameUrl
-            return if (mainId != null && !mainSlug.isNullOrBlank()) {
+            return if (mainId != null && mainId > 0 && !mainSlug.isNullOrBlank()) {
                 "$baseUrl/manga/$mainSlug-$mainId"
             } else {
                 "$baseUrl/manga/$slug-$id"


### PR DESCRIPTION
It incorrectly followed a `main_manga_id: 0` (no parent) resulting in a 404 when refreshing the entry in your library.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
