### PR TITLE
[Atsumaru] Exclude genre

### DIFF
--- a/src/en/atsumaru/build.gradle.kts
+++ b/src/en/atsumaru/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Atsumaru"
-    versionCode = 22
+    versionCode = 23
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
 

--- a/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/Atsumaru.kt
+++ b/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/Atsumaru.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.extension.en.atsumaru
 
+import androidx.preference.MultiSelectListPreference
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.network.GET
@@ -15,6 +16,7 @@ import keiyoushi.annotation.Source
 import keiyoushi.network.get
 import keiyoushi.network.rateLimit
 import keiyoushi.source.KeiSource
+import keiyoushi.utils.firstInstanceOrNull
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.toJsonElement
@@ -49,7 +51,7 @@ abstract class Atsumaru :
         val offset = (page - 1) * BROWSE_LIMIT
         val data = client.get(
             "$baseUrl/api/home2/popular?offset=$offset&limit=$BROWSE_LIMIT" +
-                "&types=Manga,Manwha,Manhua,OEL&mediums=Comic&timeframe=daily${get18Mode()}",
+                "&types=Manga,Manwha,Manhua,OEL&mediums=Comic&timeframe=daily${get18Mode()}${excludedGenresQuery()}",
         ).parseAs<BrowseMangaDto>()
 
         return MangasPage(data.items.map { it.toSManga(baseUrl) }, true)
@@ -61,7 +63,7 @@ abstract class Atsumaru :
         val offset = (page - 1) * BROWSE_LIMIT
         val data = client.get(
             "$baseUrl/api/home2/recentlyUpdated?offset=$offset&limit=$BROWSE_LIMIT" +
-                "&types=Manga,Manwha,Manhua,OEL&mediums=Comic${get18Mode()}",
+                "&types=Manga,Manwha,Manhua,OEL&mediums=Comic${get18Mode()}${excludedGenresQuery()}",
         ).parseAs<BrowseMangaDto>()
 
         return MangasPage(data.items.map { it.toSManga(baseUrl) }, true)
@@ -243,7 +245,8 @@ abstract class Atsumaru :
     }
 
     override fun getFilterList(data: JsonElement?): FilterList {
-        val filters = data?.parseAs<FilterData>()?.getFilterList().orEmpty()
+        val excludedGenres = prefs.getStringSet(PREF_EXCLUDE_GENRES, emptySet()).orEmpty()
+        val filters = data?.parseAs<FilterData>()?.getFilterList(excludedGenres).orEmpty()
 
         return FilterList(
             filters + listOf(
@@ -355,6 +358,12 @@ abstract class Atsumaru :
         return if (isEnabled) "&adult=1" else ""
     }
 
+    private fun excludedGenresQuery(): String {
+        val ids = prefs.getStringSet(PREF_EXCLUDE_GENRES, emptySet()).orEmpty()
+        if (ids.isEmpty()) return ""
+        return "&excludedTags=${ids.joinToString(",")}"
+    }
+
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         SwitchPreferenceCompat(screen.context).apply {
             key = PREF_SHOW_18
@@ -362,10 +371,46 @@ abstract class Atsumaru :
             summaryOff = "Safe (default)"
             summaryOn = "+18"
         }.let(screen::addPreference)
+
+        val genreFilter = getFilterList().firstInstanceOrNull<GenreFilter>()
+        val genres = genreFilter?.state.orEmpty()
+        val genreIds = genreFilter?.genreIds.orEmpty()
+
+        MultiSelectListPreference(screen.context).apply {
+            key = PREF_EXCLUDE_GENRES
+            title = "Exclude Genres from Browse"
+            entries = genres.map { it.name }.toTypedArray()
+            entryValues = genreIds.toTypedArray()
+            setDefaultValue(emptySet<String>())
+            setEnabled(genres.isNotEmpty())
+
+            fun updateSummary(pref: MultiSelectListPreference, selected: Set<String>?) {
+                pref.summary = if (selected.isNullOrEmpty()) {
+                    "None"
+                } else {
+                    val entryMap = pref.entryValues.zip(pref.entries).toMap()
+                    selected.joinToString { entryMap[it] ?: it }
+                }
+            }
+
+            updateSummary(this, prefs.getStringSet(PREF_EXCLUDE_GENRES, emptySet()))
+
+            setOnPreferenceChangeListener { pref, newValue ->
+                @Suppress("UNCHECKED_CAST")
+                val updated = pref as MultiSelectListPreference
+
+                @Suppress("UNCHECKED_CAST")
+                val newSet = newValue as Set<String>
+
+                updateSummary(updated, newSet)
+                true
+            }
+        }.let(screen::addPreference)
     }
 
     companion object {
         private const val PREF_SHOW_18 = "pref_18_mode"
+        private const val PREF_EXCLUDE_GENRES = "pref_exclude_genres"
         private const val BROWSE_LIMIT = 40
 
         private val PROTOCOL_REGEX = Regex("^https?:?//")

--- a/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/Dto.kt
+++ b/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/Dto.kt
@@ -232,8 +232,8 @@ class FilterData(
     val types: List<Filter>?,
     val statuses: List<Filter>?,
 ) {
-    fun getFilterList() = buildList {
-        genres?.let { add(GenreFilter(it.map { Genre(it.name, it.id) })) }
+    fun getFilterList(excludedGenreIds: Set<String> = emptySet()) = buildList {
+        genres?.let { add(GenreFilter(it.map { Genre(it.name, it.id) }, excludedGenreIds)) }
         tags?.let { add(TagFilters(it.map { Tag(it.name, it.id) })) }
         types?.let { add(TypeFilter(it.map { Type(it.name, it.id) })) }
         statuses?.let { add(StatusFilter(it.map { Status(it.name, it.id) })) }

--- a/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/Filters.kt
+++ b/src/en/atsumaru/src/eu/kanade/tachiyomi/extension/en/atsumaru/Filters.kt
@@ -2,11 +2,16 @@ package eu.kanade.tachiyomi.extension.en.atsumaru
 
 import eu.kanade.tachiyomi.source.model.Filter
 
-internal class GenreFilter(genres: List<Genre>) :
+internal class GenreFilter(genres: List<Genre>, excludedIds: Set<String> = emptySet()) :
     Filter.Group<Filter.TriState>(
         "Genres",
         genres.map { genre ->
-            object : Filter.TriState(genre.name) {}
+            val state = if (genre.id in excludedIds) {
+                Filter.TriState.STATE_EXCLUDE
+            } else {
+                Filter.TriState.STATE_IGNORE
+            }
+            object : Filter.TriState(genre.name, state) {}
         },
     ) {
     val genreIds = genres.map { it.id }


### PR DESCRIPTION
Added a preference to exclude selected genres in browsing. There are too many tags so I limited it only to genre.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
