### PR TITLE
Kuro Manga: fix domain and chapter dates

### DIFF
--- a/src/id/kuromanga/build.gradle.kts
+++ b/src/id/kuromanga/build.gradle.kts
@@ -6,13 +6,13 @@ plugins {
 
 keiyoushi {
     name = "Kuro Manga"
-    versionCode = 0
+    versionCode = 1
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
     theme = "mangathemesia"
 
     source {
         lang = "id"
-        baseUrl = "https://kuromanga.me"
+        baseUrl = "https://kuromanga.id"
     }
 }

--- a/src/id/kuromanga/src/eu/kanade/tachiyomi/extension/kuromanga/KuroManga.kt
+++ b/src/id/kuromanga/src/eu/kanade/tachiyomi/extension/kuromanga/KuroManga.kt
@@ -12,6 +12,8 @@ import java.util.TimeZone
 @Source
 abstract class KuroManga : MangaThemesia() {
 
+    override val dateFormat: SimpleDateFormat = KMdateFormat
+
     override fun popularMangaParse(response: Response): MangasPage = searchMangaParse(response)
 
     override fun latestUpdatesParse(response: Response): MangasPage = searchMangaParse(response)


### PR DESCRIPTION
Closes #18484

## Changes
- Updated `baseUrl` to `https://kuromanga.id` (old domain redirects to new one)
- Fixed chapter dates showing "Today" for everything: the `dateFormat` override (Indonesian locale) was lost during the multisrc migration, causing all dates to parse as 0 → mihon assigned `nowMillis`
- Bumped `versionCode` 0 → 1

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop