### PR TITLE
Read One-Punch Man Manga Online: update domain

### DIFF
--- a/src/en/readonepunchmanmangaonlinetwo/build.gradle.kts
+++ b/src/en/readonepunchmanmangaonlinetwo/build.gradle.kts
@@ -6,13 +6,13 @@ plugins {
 
 keiyoushi {
     name = "Read One-Punch Man Manga Online"
-    versionCode = 1
+    versionCode = 2
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
     theme = "mangacatalog"
 
     source {
         lang = "en"
-        baseUrl = "https://ww6.readopm.com"
+        baseUrl = "https://ww7.readopm.com"
     }
 }


### PR DESCRIPTION
Closes #18396

## Changes
- Updated `baseUrl` from `https://ww6.readopm.com` to `https://ww7.readopm.com` (old domain redirects to new one)
- Bumped `versionCode` 1 → 2

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop