### PR TITLE
WitchScans: migrate to standalone source for witchtoons.net

### DIFF
--- a/src/en/witchscans/build.gradle.kts
+++ b/src/en/witchscans/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "WitchScans"
-    versionCode = 1
+    versionCode = 33
     contentWarning = ContentWarning.SAFE
     libVersion = "1.6"
 

--- a/src/en/witchscans/build.gradle.kts
+++ b/src/en/witchscans/build.gradle.kts
@@ -6,13 +6,12 @@ plugins {
 
 keiyoushi {
     name = "WitchScans"
-    versionCode = 0
+    versionCode = 1
     contentWarning = ContentWarning.SAFE
-    libVersion = "1.4"
-    theme = "mangathemesia"
+    libVersion = "1.6"
 
     source {
         lang = "en"
-        baseUrl = "https://witchscans.com"
+        baseUrl = "https://witchtoons.net"
     }
 }

--- a/src/en/witchscans/src/eu/kanade/tachiyomi/extension/en/witchscans/Dto.kt
+++ b/src/en/witchscans/src/eu/kanade/tachiyomi/extension/en/witchscans/Dto.kt
@@ -3,11 +3,12 @@ package eu.kanade.tachiyomi.extension.en.witchscans
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import keiyoushi.utils.string
+import keiyoushi.utils.tryParse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
-import java.time.Instant
+import kotlin.time.Instant
 
 @Serializable
 class BrowseDto(
@@ -60,9 +61,8 @@ class MangaDto(
     fun toSManga(baseUrl: String, manga: SManga): SManga = manga.apply {
         title = this@MangaDto.title
         thumbnail_url = coverUrl?.let { it.toAbsoluteUrl(baseUrl) }
-        url = "comic/$slug"
+        url = id
         memo = buildJsonObject {
-            put("type", "comic")
             put("slug", slug)
         }
         status = this@MangaDto.status.toSMangaStatus()
@@ -107,13 +107,11 @@ class ChapterDto(
     fun toSChapter(manga: SManga): SChapter = SChapter.create().apply {
         name = if (title.isNullOrBlank() || title == number.toString()) "Chapter $number" else title
         if (isLocked) name = "\uD83D\uDD12 $name"
-        date_upload = publishedAt?.let { runCatching { Instant.parse(it).toEpochMilli() }.getOrDefault(0L) } ?: 0L
+        date_upload = publishedAt?.let { Instant.tryParse(it) } ?: 0L
         chapter_number = number.toFloat()
-        url = id
+        val mangaSlug = manga.memo["slug"]?.string.orEmpty()
+        url = "comic/$mangaSlug/chapter/$number"
         memo = buildJsonObject {
-            put("type", manga.memo["type"]?.string ?: "comic")
-            put("slug", manga.memo["slug"]?.string ?: "")
-            put("number", number.toString())
             put("isLocked", isLocked)
         }
     }

--- a/src/en/witchscans/src/eu/kanade/tachiyomi/extension/en/witchscans/Dto.kt
+++ b/src/en/witchscans/src/eu/kanade/tachiyomi/extension/en/witchscans/Dto.kt
@@ -1,0 +1,132 @@
+package eu.kanade.tachiyomi.extension.en.witchscans
+
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import keiyoushi.utils.string
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.time.Instant
+
+@Serializable
+class BrowseDto(
+    val initialSeries: List<MangaDto>,
+    val initialHasMore: Boolean = false,
+)
+
+@Serializable
+class GenreListDto(
+    val genres: List<GenreDto> = emptyList(),
+)
+
+@Serializable
+class DetailDto(
+    val series: MangaDto,
+    val chapters: List<ChapterDto> = emptyList(),
+    val totalPages: Int = 1,
+)
+
+@Serializable
+class ChapterDetailDto(
+    val chapter: ChapterPagesDto,
+)
+
+@Serializable
+class ChapterPagesDto(
+    val pages: List<PageDto> = emptyList(),
+)
+
+@Serializable
+class PageDto(
+    val imageUrl: String? = null,
+    val kind: String = "CONTENT",
+)
+
+@Serializable
+class MangaDto(
+    val id: String,
+    val title: String,
+    @SerialName("coverImage")
+    val coverUrl: String? = null,
+    val slug: String = "",
+    val status: String = "",
+    val description: String? = null,
+    val genres: List<GenreDto> = emptyList(),
+    val team: TeamDto? = null,
+) {
+    fun toSManga(baseUrl: String): SManga = toSManga(baseUrl, SManga.create())
+
+    fun toSManga(baseUrl: String, manga: SManga): SManga = manga.apply {
+        title = this@MangaDto.title
+        thumbnail_url = coverUrl?.let { it.toAbsoluteUrl(baseUrl) }
+        url = "comic/$slug"
+        memo = buildJsonObject {
+            put("type", "comic")
+            put("slug", slug)
+        }
+        status = this@MangaDto.status.toSMangaStatus()
+        author = team?.name
+        genre = genres.joinToString { it.displayName }
+        description = this@MangaDto.description
+    }
+}
+
+@Serializable
+class GenreDto(
+    val name: String = "",
+    val slug: String = "",
+    val genre: GenreSlugDto? = null,
+) {
+    val displayName: String
+        get() = (if (name.isNotBlank()) name else genre?.slug.orEmpty()).stripEmoji()
+
+    val genreSlug: String
+        get() = slug.ifBlank { genre?.slug.orEmpty() }
+}
+
+@Serializable
+class GenreSlugDto(
+    val slug: String = "",
+)
+
+@Serializable
+class TeamDto(
+    val name: String? = null,
+)
+
+@Serializable
+class ChapterDto(
+    val id: String,
+    val number: Int,
+    val title: String? = null,
+    val publishedAt: String? = null,
+    @SerialName("isLocked")
+    val isLocked: Boolean = false,
+) {
+    fun toSChapter(manga: SManga): SChapter = SChapter.create().apply {
+        name = if (title.isNullOrBlank() || title == number.toString()) "Chapter $number" else title
+        if (isLocked) name = "\uD83D\uDD12 $name"
+        date_upload = publishedAt?.let { runCatching { Instant.parse(it).toEpochMilli() }.getOrDefault(0L) } ?: 0L
+        chapter_number = number.toFloat()
+        url = id
+        memo = buildJsonObject {
+            put("type", manga.memo["type"]?.string ?: "comic")
+            put("slug", manga.memo["slug"]?.string ?: "")
+            put("number", number.toString())
+            put("isLocked", isLocked)
+        }
+    }
+}
+
+fun String.toSMangaStatus(): Int = when (this) {
+    "ONGOING" -> SManga.ONGOING
+    "COMPLETED" -> SManga.COMPLETED
+    "HIATUS" -> SManga.ON_HIATUS
+    "CANCELLED" -> SManga.CANCELLED
+    else -> SManga.UNKNOWN
+}
+
+fun String.stripEmoji(): String = replace(Regex("[^\\p{ASCII}\\p{L}0-9\\- ]+")) { "" }.trim()
+
+fun String.toAbsoluteUrl(baseUrl: String): String = if (startsWith("http")) this else "$baseUrl$this"

--- a/src/en/witchscans/src/eu/kanade/tachiyomi/extension/en/witchscans/Dto.kt
+++ b/src/en/witchscans/src/eu/kanade/tachiyomi/extension/en/witchscans/Dto.kt
@@ -109,9 +109,10 @@ class ChapterDto(
         if (isLocked) name = "\uD83D\uDD12 $name"
         date_upload = publishedAt?.let { Instant.tryParse(it) } ?: 0L
         chapter_number = number.toFloat()
-        val mangaSlug = manga.memo["slug"]?.string.orEmpty()
-        url = "comic/$mangaSlug/chapter/$number"
+        url = id
         memo = buildJsonObject {
+            put("slug", manga.memo["slug"]!!.string)
+            put("number", number.toString())
             put("isLocked", isLocked)
         }
     }

--- a/src/en/witchscans/src/eu/kanade/tachiyomi/extension/en/witchscans/Filters.kt
+++ b/src/en/witchscans/src/eu/kanade/tachiyomi/extension/en/witchscans/Filters.kt
@@ -1,0 +1,99 @@
+package eu.kanade.tachiyomi.extension.en.witchscans
+
+import eu.kanade.tachiyomi.source.model.Filter
+import okhttp3.HttpUrl
+
+interface UriQueryFilter {
+    fun addToQuery(builder: HttpUrl.Builder)
+}
+
+open class UriPartFilter(
+    name: String,
+    private val field: String,
+    private val vals: Array<Pair<String, String>>,
+    private val default: String = "",
+) : Filter.Select<String>(
+    name,
+    vals.map { it.first }.toTypedArray(),
+    vals.indexOfFirst { it.second == default }.takeIf { it != -1 } ?: 0,
+),
+    UriQueryFilter {
+    override fun addToQuery(builder: HttpUrl.Builder) {
+        val selected = vals[state].second
+        if (selected.isNotEmpty()) {
+            builder.addQueryParameter(field, selected)
+        }
+    }
+}
+
+class SortFilter :
+    UriPartFilter(
+        "Sort",
+        "sort",
+        arrayOf(
+            Pair("Latest", "updated"),
+            Pair("Popular", "popular"),
+            Pair("Trending", "trending"),
+            Pair("Views", "views"),
+            Pair("Rating", "rating"),
+            Pair("Longest", "longest"),
+            Pair("Newest", "newest"),
+        ),
+        default = "updated",
+    )
+
+class StatusFilter :
+    UriPartFilter(
+        "Status",
+        "status",
+        arrayOf(
+            Pair("All", ""),
+            Pair("Ongoing", "Ongoing"),
+            Pair("Completed", "Completed"),
+            Pair("Hiatus", "Hiatus"),
+            Pair("Dropped", "Dropped"),
+            Pair("Discontinued", "Discontinued"),
+            Pair("Upcoming", "Upcoming"),
+        ),
+    )
+
+class TypeFilter :
+    UriPartFilter(
+        "Type",
+        "type",
+        arrayOf(
+            Pair("All", ""),
+            Pair("Manhwa", "MANHWA"),
+            Pair("Manhua", "MANHUA"),
+            Pair("Manga", "MANGA"),
+        ),
+    )
+
+class OriginFilter :
+    UriPartFilter(
+        "Origin",
+        "origin",
+        arrayOf(
+            Pair("All", ""),
+            Pair("Korean", "KOREAN"),
+            Pair("Japanese", "JAPANESE"),
+            Pair("Chinese", "CHINESE"),
+            Pair("Other", "OTHER"),
+        ),
+    )
+
+class GenreFilter(genres: Array<Pair<String, String>>) :
+    Filter.Group<GenreFilter.GenreCheckBox>(
+        "Genre",
+        genres.map { GenreCheckBox(it.first, it.second) },
+    ),
+    UriQueryFilter {
+    class GenreCheckBox(name: String, val value: String) : Filter.CheckBox(name)
+
+    override fun addToQuery(builder: HttpUrl.Builder) {
+        val selected = state.filter { it.state }.map { it.value }
+        if (selected.isNotEmpty()) {
+            builder.addQueryParameter("genre", selected.joinToString(","))
+        }
+    }
+}

--- a/src/en/witchscans/src/eu/kanade/tachiyomi/extension/en/witchscans/WitchScans.kt
+++ b/src/en/witchscans/src/eu/kanade/tachiyomi/extension/en/witchscans/WitchScans.kt
@@ -20,6 +20,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Response
 
@@ -29,6 +30,8 @@ abstract class WitchScans :
     ConfigurableSource {
 
     private val preferences by getPreferencesLazy()
+
+    private val rscHeaders: Headers get() = headersBuilder().set("rsc", "1").build()
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         SwitchPreferenceCompat(screen.context).apply {
@@ -45,11 +48,11 @@ abstract class WitchScans :
 
     // ------------------------- Browse (Popular) -------------------------
 
-    override suspend fun getPopularManga(page: Int): MangasPage = getMangasPage(client.get("$baseUrl/series?sort=popular&page=$page"))
+    override suspend fun getPopularManga(page: Int): MangasPage = getMangasPage(client.get("$baseUrl/series?sort=popular&page=$page", headers = rscHeaders))
 
     // ------------------------- Latest -------------------------
 
-    override suspend fun getLatestUpdates(page: Int): MangasPage = getMangasPage(client.get("$baseUrl/series?page=$page"))
+    override suspend fun getLatestUpdates(page: Int): MangasPage = getMangasPage(client.get("$baseUrl/series?page=$page", headers = rscHeaders))
 
     private suspend fun getMangasPage(response: Response): MangasPage {
         val dto = response.extractNextJs<BrowseDto> { it is JsonObject && "initialSeries" in it }
@@ -69,7 +72,7 @@ abstract class WitchScans :
                 addQueryParameter("page", page.toString())
             }
             .build()
-        return getMangasPage(client.get(url))
+        return getMangasPage(client.get(url, headers = rscHeaders))
     }
 
     // ------------------------- Filter -------------------------
@@ -101,7 +104,7 @@ abstract class WitchScans :
         fetchDetails: Boolean,
         fetchChapters: Boolean,
     ): SMangaUpdate {
-        val document = client.get(getMangaUrl(manga)).extractNextJs<DetailDto> { it is JsonObject && "series" in it && "chapters" in it }
+        val document = client.get(getMangaUrl(manga), headers = rscHeaders).extractNextJs<DetailDto> { it is JsonObject && "series" in it && "chapters" in it }
 
         val updatedManga = if (fetchDetails) document?.series?.toSManga(baseUrl, manga) ?: manga else manga
         val updatedChapters = if (fetchChapters) fetchAllChapters(manga, document) else chapters
@@ -109,18 +112,20 @@ abstract class WitchScans :
         return SMangaUpdate(updatedManga, updatedChapters)
     }
 
-    // ponytail: detail page cuma serve 100 chapters per page (totalPages dari response),
-    // jadi loop semua halaman chapter & gabung. Kalau totalPages nggak ada, ambil 1 halaman.
     private suspend fun fetchAllChapters(manga: SManga, document: DetailDto?): List<SChapter> {
         if (document == null) return emptyList()
         val hideLocked = preferences.getBoolean(HIDE_LOCKED_PREF, false)
         val totalPages = document.totalPages.coerceAtLeast(1)
-        val pages = (1..totalPages).map { page ->
-            val dto = client.get("${getMangaUrl(manga)}?page=$page")
-                .extractNextJs<DetailDto> { it is JsonObject && "series" in it && "chapters" in it }
-            dto?.chapters.orEmpty()
+        val extraChapters = if (totalPages > 1) {
+            (2..totalPages).map { page ->
+                client.get("${getMangaUrl(manga)}?page=$page", headers = rscHeaders)
+                    .extractNextJs<DetailDto> { it is JsonObject && "series" in it && "chapters" in it }
+                    ?.chapters.orEmpty()
+            }.flatten()
+        } else {
+            emptyList()
         }
-        return pages.flatten()
+        return (document.chapters + extraChapters)
             .filter { !(it.isLocked && hideLocked) }
             .map { it.toSChapter(manga) }
             .sortedByDescending { it.chapter_number }
@@ -132,7 +137,7 @@ abstract class WitchScans :
         if (chapter.memo["isLocked"]?.jsonPrimitive?.booleanOrNull == true) {
             throw Exception("This chapter is locked and requires coins to read")
         }
-        val response = client.get(getChapterUrl(chapter))
+        val response = client.get(getChapterUrl(chapter), headers = rscHeaders)
         val dto = response.extractNextJs<ChapterDetailDto> { it is JsonObject && "chapter" in it }
         return dto?.chapter?.pages.orEmpty().mapIndexedNotNull { index, pageDto ->
             pageDto.imageUrl?.let { Page(index, imageUrl = it.toAbsoluteUrl(baseUrl)) }
@@ -142,15 +147,13 @@ abstract class WitchScans :
     // ------------------------- URL helpers -------------------------
 
     override fun getMangaUrl(manga: SManga): String {
-        val slug = manga.memo["slug"]?.string ?: manga.url.substringAfterLast('/')
+        val slug = manga.memo["slug"]?.string.orEmpty()
         return "$baseUrl/series/comic/$slug"
     }
 
     override fun getChapterUrl(chapter: SChapter): String {
-        val memo = chapter.memo
-        val type = memo["type"]?.string ?: "comic"
-        val slug = memo["slug"]?.string ?: ""
-        val number = memo["number"]?.string ?: ""
-        return "$baseUrl/series/$type/$slug/chapter/$number"
+        val path = chapter.url.substringBeforeLast("/chapter/")
+        val number = chapter.url.substringAfterLast("/")
+        return "$baseUrl/series/$path/chapter/$number"
     }
 }

--- a/src/en/witchscans/src/eu/kanade/tachiyomi/extension/en/witchscans/WitchScans.kt
+++ b/src/en/witchscans/src/eu/kanade/tachiyomi/extension/en/witchscans/WitchScans.kt
@@ -48,11 +48,11 @@ abstract class WitchScans :
 
     // ------------------------- Browse (Popular) -------------------------
 
-    override suspend fun getPopularManga(page: Int): MangasPage = getMangasPage(client.get("$baseUrl/series?sort=popular&page=$page", headers = rscHeaders))
+    override suspend fun getPopularManga(page: Int): MangasPage = getMangasPage(client.get("$baseUrl/series?sort=popular&page=$page", rscHeaders))
 
     // ------------------------- Latest -------------------------
 
-    override suspend fun getLatestUpdates(page: Int): MangasPage = getMangasPage(client.get("$baseUrl/series?page=$page", headers = rscHeaders))
+    override suspend fun getLatestUpdates(page: Int): MangasPage = getMangasPage(client.get("$baseUrl/series?page=$page", rscHeaders))
 
     private suspend fun getMangasPage(response: Response): MangasPage {
         val dto = response.extractNextJs<BrowseDto> { it is JsonObject && "initialSeries" in it }
@@ -72,7 +72,7 @@ abstract class WitchScans :
                 addQueryParameter("page", page.toString())
             }
             .build()
-        return getMangasPage(client.get(url, headers = rscHeaders))
+        return getMangasPage(client.get(url, rscHeaders))
     }
 
     // ------------------------- Filter -------------------------
@@ -104,7 +104,7 @@ abstract class WitchScans :
         fetchDetails: Boolean,
         fetchChapters: Boolean,
     ): SMangaUpdate {
-        val document = client.get(getMangaUrl(manga), headers = rscHeaders).extractNextJs<DetailDto> { it is JsonObject && "series" in it && "chapters" in it }
+        val document = client.get(getMangaUrl(manga), rscHeaders).extractNextJs<DetailDto> { it is JsonObject && "series" in it && "chapters" in it }
 
         val updatedManga = if (fetchDetails) document?.series?.toSManga(baseUrl, manga) ?: manga else manga
         val updatedChapters = if (fetchChapters) fetchAllChapters(manga, document) else chapters
@@ -118,7 +118,7 @@ abstract class WitchScans :
         val totalPages = document.totalPages.coerceAtLeast(1)
         val extraChapters = if (totalPages > 1) {
             (2..totalPages).map { page ->
-                client.get("${getMangaUrl(manga)}?page=$page", headers = rscHeaders)
+                client.get("${getMangaUrl(manga)}?page=$page", rscHeaders)
                     .extractNextJs<DetailDto> { it is JsonObject && "series" in it && "chapters" in it }
                     ?.chapters.orEmpty()
             }.flatten()
@@ -137,7 +137,7 @@ abstract class WitchScans :
         if (chapter.memo["isLocked"]?.jsonPrimitive?.booleanOrNull == true) {
             throw Exception("This chapter is locked and requires coins to read")
         }
-        val response = client.get(getChapterUrl(chapter), headers = rscHeaders)
+        val response = client.get(getChapterUrl(chapter), rscHeaders)
         val dto = response.extractNextJs<ChapterDetailDto> { it is JsonObject && "chapter" in it }
         return dto?.chapter?.pages.orEmpty().mapIndexedNotNull { index, pageDto ->
             pageDto.imageUrl?.let { Page(index, imageUrl = it.toAbsoluteUrl(baseUrl)) }
@@ -147,13 +147,13 @@ abstract class WitchScans :
     // ------------------------- URL helpers -------------------------
 
     override fun getMangaUrl(manga: SManga): String {
-        val slug = manga.memo["slug"]?.string.orEmpty()
+        val slug = manga.memo["slug"]!!.string
         return "$baseUrl/series/comic/$slug"
     }
 
     override fun getChapterUrl(chapter: SChapter): String {
-        val path = chapter.url.substringBeforeLast("/chapter/")
-        val number = chapter.url.substringAfterLast("/")
-        return "$baseUrl/series/$path/chapter/$number"
+        val slug = chapter.memo["slug"]!!.string
+        val number = chapter.memo["number"]!!.string
+        return "$baseUrl/series/comic/$slug/chapter/$number"
     }
 }

--- a/src/en/witchscans/src/eu/kanade/tachiyomi/extension/en/witchscans/WitchScans.kt
+++ b/src/en/witchscans/src/eu/kanade/tachiyomi/extension/en/witchscans/WitchScans.kt
@@ -1,15 +1,156 @@
 package eu.kanade.tachiyomi.extension.en.witchscans
 
-import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import androidx.preference.PreferenceScreen
+import androidx.preference.SwitchPreferenceCompat
+import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import keiyoushi.annotation.Source
+import keiyoushi.network.get
+import keiyoushi.source.KeiSource
+import keiyoushi.utils.extractNextJs
+import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
+import keiyoushi.utils.string
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Response
 
 @Source
-abstract class WitchScans : MangaThemesia() {
-    override fun chapterListSelector() = "div.eplister ul li:has(div.chbox):has(div.eph-num):has(a[href])"
+abstract class WitchScans :
+    KeiSource(),
+    ConfigurableSource {
 
-    override fun getFilterList(): FilterList {
-        val filters = super.getFilterList().filterNot { it is AuthorFilter || it is YearFilter }
-        return FilterList(filters)
+    private val preferences by getPreferencesLazy()
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        SwitchPreferenceCompat(screen.context).apply {
+            key = HIDE_LOCKED_PREF
+            title = "Hide locked chapters"
+            summary = "Hide chapters that require coins to read"
+            setDefaultValue(false)
+        }.also(screen::addPreference)
+    }
+
+    companion object {
+        private const val HIDE_LOCKED_PREF = "pref_hide_locked_chapters"
+    }
+
+    // ------------------------- Browse (Popular) -------------------------
+
+    override suspend fun getPopularManga(page: Int): MangasPage = getMangasPage(client.get("$baseUrl/series?sort=popular&page=$page"))
+
+    // ------------------------- Latest -------------------------
+
+    override suspend fun getLatestUpdates(page: Int): MangasPage = getMangasPage(client.get("$baseUrl/series?page=$page"))
+
+    private suspend fun getMangasPage(response: Response): MangasPage {
+        val dto = response.extractNextJs<BrowseDto> { it is JsonObject && "initialSeries" in it }
+        val mangas = dto?.initialSeries?.map { it.toSManga(baseUrl) } ?: emptyList()
+        return MangasPage(mangas, dto?.initialHasMore == true)
+    }
+
+    // ------------------------- Search -------------------------
+
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
+        val url = "$baseUrl/series".toHttpUrl().newBuilder()
+            .apply {
+                if (query.isNotEmpty()) {
+                    addQueryParameter("q", query)
+                }
+                filters.filterIsInstance<UriQueryFilter>().forEach { it.addToQuery(this) }
+                addQueryParameter("page", page.toString())
+            }
+            .build()
+        return getMangasPage(client.get(url))
+    }
+
+    // ------------------------- Filter -------------------------
+
+    override val supportsFilterFetching: Boolean get() = true
+
+    override suspend fun fetchFilterData(): JsonElement = client.get("$baseUrl/api/genres").parseAs()
+
+    override fun getFilterList(data: JsonElement?): FilterList {
+        val genres = data?.parseAs<GenreListDto>()?.genres
+        return FilterList(
+            buildList {
+                add(SortFilter())
+                add(StatusFilter())
+                add(TypeFilter())
+                add(OriginFilter())
+                if (!genres.isNullOrEmpty()) {
+                    add(GenreFilter(genres.map { it.name.stripEmoji() to it.genreSlug }.toTypedArray()))
+                }
+            },
+        )
+    }
+
+    // ------------------------- Details + Chapters -------------------------
+
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        val document = client.get(getMangaUrl(manga)).extractNextJs<DetailDto> { it is JsonObject && "series" in it && "chapters" in it }
+
+        val updatedManga = if (fetchDetails) document?.series?.toSManga(baseUrl, manga) ?: manga else manga
+        val updatedChapters = if (fetchChapters) fetchAllChapters(manga, document) else chapters
+
+        return SMangaUpdate(updatedManga, updatedChapters)
+    }
+
+    // ponytail: detail page cuma serve 100 chapters per page (totalPages dari response),
+    // jadi loop semua halaman chapter & gabung. Kalau totalPages nggak ada, ambil 1 halaman.
+    private suspend fun fetchAllChapters(manga: SManga, document: DetailDto?): List<SChapter> {
+        if (document == null) return emptyList()
+        val hideLocked = preferences.getBoolean(HIDE_LOCKED_PREF, false)
+        val totalPages = document.totalPages.coerceAtLeast(1)
+        val pages = (1..totalPages).map { page ->
+            val dto = client.get("${getMangaUrl(manga)}?page=$page")
+                .extractNextJs<DetailDto> { it is JsonObject && "series" in it && "chapters" in it }
+            dto?.chapters.orEmpty()
+        }
+        return pages.flatten()
+            .filter { !(it.isLocked && hideLocked) }
+            .map { it.toSChapter(manga) }
+            .sortedByDescending { it.chapter_number }
+    }
+
+    // ------------------------- Pages -------------------------
+
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        if (chapter.memo["isLocked"]?.jsonPrimitive?.booleanOrNull == true) {
+            throw Exception("This chapter is locked and requires coins to read")
+        }
+        val response = client.get(getChapterUrl(chapter))
+        val dto = response.extractNextJs<ChapterDetailDto> { it is JsonObject && "chapter" in it }
+        return dto?.chapter?.pages.orEmpty().mapIndexedNotNull { index, pageDto ->
+            pageDto.imageUrl?.let { Page(index, imageUrl = it.toAbsoluteUrl(baseUrl)) }
+        }
+    }
+
+    // ------------------------- URL helpers -------------------------
+
+    override fun getMangaUrl(manga: SManga): String {
+        val slug = manga.memo["slug"]?.string ?: manga.url.substringAfterLast('/')
+        return "$baseUrl/series/comic/$slug"
+    }
+
+    override fun getChapterUrl(chapter: SChapter): String {
+        val memo = chapter.memo
+        val type = memo["type"]?.string ?: "comic"
+        val slug = memo["slug"]?.string ?: ""
+        val number = memo["number"]?.string ?: ""
+        return "$baseUrl/series/$type/$slug/chapter/$number"
     }
 }


### PR DESCRIPTION
WitchScans moved from WordPress (MangaThemesia) to a Next.js site at witchtoons.net. The old MangaThemesia theme no longer matches the new site structure, so this rewrites it as a standalone KeiSource extension.

Fixes #18365

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
