### PR TITLE
Jmanga: update domain to jmanga.land

### DIFF
--- a/src/ja/jmanga/build.gradle.kts
+++ b/src/ja/jmanga/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Jmanga"
-    versionCode = 3
+    versionCode = 4
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
     theme = "mangareader"
@@ -14,7 +14,7 @@ keiyoushi {
     source {
         lang = "ja"
         baseUrl {
-            custom("https://jmanga.loan")
+            custom("https://jmanga.land")
         }
     }
 }


### PR DESCRIPTION
Jmanga moved to a new domain. The old domain (`jmanga.loan`) now redirects to `jmanga.land`.

Fixes #18306

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
