### PR TITLE
MangaFire: fix chapter numbers

### DIFF
--- a/src/all/mangafire/build.gradle.kts
+++ b/src/all/mangafire/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "MangaFire"
-    versionCode = 29
+    versionCode = 30
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
 

--- a/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/Dto.kt
+++ b/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/Dto.kt
@@ -117,16 +117,19 @@ class ChapterDto(
     fun toSChapter(mangaUrl: String, langCode: String): SChapter = SChapter.create().apply {
         url = "$mangaUrl/$id-chapter-${number.toString().removeSuffix(".0")}-$langCode"
         chapter_number = number
-        name = buildString {
-            append("Ch. ")
-            append(number.toString().removeSuffix(".0"))
-            if (!this@ChapterDto.name.isNullOrBlank()) {
-                append(" - ")
-                append(this@ChapterDto.name)
-            }
+        name = if (this@ChapterDto.name.isNullOrBlank()) {
+            "Ch. ${number.toString().removeSuffix(".0")}"
+        } else if (this@ChapterDto.name.contains(chapterRegex)) {
+            this@ChapterDto.name
+        } else {
+            "Ch. ${number.toString().removeSuffix(".0")} - ${this@ChapterDto.name}"
         }
         scanlator = type ?: "Unknown"
         date_upload = createdAt?.times(1000L) ?: 0L
+    }
+
+    companion object {
+        private val chapterRegex = """(?:ch\.?|chapter)\s*\d+""".toRegex(RegexOption.IGNORE_CASE)
     }
 }
 

--- a/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/Dto.kt
+++ b/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/Dto.kt
@@ -116,20 +116,22 @@ class ChapterDto(
 ) {
     fun toSChapter(mangaUrl: String, langCode: String): SChapter = SChapter.create().apply {
         url = "$mangaUrl/$id-chapter-${number.toString().removeSuffix(".0")}-$langCode"
-        chapter_number = number
-        name = if (this@ChapterDto.name.isNullOrBlank()) {
-            "Ch. ${number.toString().removeSuffix(".0")}"
-        } else if (this@ChapterDto.name.contains(chapterRegex)) {
-            this@ChapterDto.name
-        } else {
-            "Ch. ${number.toString().removeSuffix(".0")} - ${this@ChapterDto.name}"
+        when {
+            this@ChapterDto.name.isNullOrBlank() -> number to "Ch. ${number.toString().removeSuffix(".0")}"
+            else -> when (val extractedNumber = chapterRegex.find(this@ChapterDto.name)?.value?.toFloatOrNull()) {
+                null -> number to "Ch. ${number.toString().removeSuffix(".0")} - ${this@ChapterDto.name}"
+                else -> extractedNumber to this@ChapterDto.name
+            }
+        }.let { (a, b) ->
+            chapter_number = a
+            name = b
         }
         scanlator = type ?: "Unknown"
         date_upload = createdAt?.times(1000L) ?: 0L
     }
 
     companion object {
-        private val chapterRegex = """\bch(?:\.|apter)?\s*\d""".toRegex(RegexOption.IGNORE_CASE)
+        private val chapterRegex = """(?<=\b(?:ch(?:\.|apter)?|ep(?:\.|isode)?)\s?)\d+(?:\.\d+)?""".toRegex(RegexOption.IGNORE_CASE)
     }
 }
 

--- a/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/Dto.kt
+++ b/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/Dto.kt
@@ -129,7 +129,7 @@ class ChapterDto(
     }
 
     companion object {
-        private val chapterRegex = """(?:ch\.?|chapter)\s*\d+""".toRegex(RegexOption.IGNORE_CASE)
+        private val chapterRegex = """\bch(?:\.|apter)?\s*\d""".toRegex(RegexOption.IGNORE_CASE)
     }
 }
 


### PR DESCRIPTION
Sometimes, chapter names contain the chapter number, and that number may differ from the number field. In such cases, the chapter number in the name is the correct one.

![image](https://github.com/user-attachments/assets/414a7149-0a05-4774-ac48-b5dbf8fdb48a)

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
