### PR TITLE
Publish verified Tachiyomi 0.15.x extensions

### DIFF
--- a/.github/workflows/legacy-015x-pages.yml
+++ b/.github/workflows/legacy-015x-pages.yml
@@ -1,0 +1,66 @@
+name: Publish Tachiyomi 0.15.x catalog
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/legacy-015x-pages.yml
+      - gradle/**
+      - gradle.properties
+      - legacy-modules.txt
+      - scripts/build_legacy_repo.py
+      - scripts/list_legacy_modules.py
+      - settings.gradle.kts
+      - src/**
+  schedule:
+    - cron: "27 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+  pages: write
+
+concurrency:
+  group: legacy-015x-pages
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+
+      - name: Build verified legacy extensions
+        run: |
+          mapfile -t tasks < <(python scripts/list_legacy_modules.py --source-root .)
+          ./gradlew "${tasks[@]}"
+
+      - name: Build static catalog
+        run: |
+          metadata=()
+          while IFS= read -r task; do
+            module="${task#:src:}"
+            module="${module%:assembleRelease}"
+            metadata+=("src/${module//:/\/}/build/keiyoushi-source-info.json")
+          done < <(python scripts/list_legacy_modules.py --source-root .)
+          python scripts/build_legacy_repo.py --source-root . --output public "${metadata[@]}"
+
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: public
+
+      - id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,10 @@ build/
 .idea/
 *.iml
 repo/
+.repo.*
 apk/
 gen
 generated-src/
 .kotlin
 *.jks
+__pycache__/

--- a/gradle/build-logic/src/main/kotlin/ExtensionPlugin.kt
+++ b/gradle/build-logic/src/main/kotlin/ExtensionPlugin.kt
@@ -26,6 +26,7 @@ import io.github.keiyoushi.gradle.tasks.GenerateKeepRulesTask
 import io.github.keiyoushi.gradle.tasks.GenerateManifestTask
 import io.github.keiyoushi.gradle.tasks.GenerateSourceInfoTask
 import io.github.keiyoushi.gradle.tasks.SignExtensionJarTask
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -267,7 +268,7 @@ class ExtensionPlugin : Plugin<Project> {
             }
             val translationsFile = project(":core").projectDir.resolve("translations/strings.json")
             extensions.configure<KspExtension> {
-                arg("kei_sources", Json.encodeToString<List<ResolvedSource>>(resolvedSources))
+                arg("kei_sources", Json.encodeToString(ListSerializer(ResolvedSource.serializer()), resolvedSources))
                 arg("kei_translations", translationsFile.absolutePath)
             }
             tasks.matching { it.name.startsWith("ksp") }.configureEach {
@@ -290,6 +291,7 @@ class ExtensionPlugin : Plugin<Project> {
 
             val sourceInfoJsonProvider = versionCodeProvider.zip(versionNameProvider) { code, name ->
                 Json.encodeToString(
+                    ExtensionMetadata.serializer(),
                     ExtensionMetadata(
                         module = applicationIdSuffix,
                         theme = keiyoushi.theme.orNull,

--- a/gradle/kei.versions.toml
+++ b/gradle/kei.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 # Used in [/gradle/build-logic/src/main/kotlin/AndroidBasePlugin.kt]
 android-sdk-min = "26"
-android-sdk-compile = "37"
-android-sdk-target = "37"
+android-sdk-compile = "36"
+android-sdk-target = "36"
 java = "11"
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 android-gradle = "9.3.1"
-coroutines = "1.11.0"
-serialization = "1.11.0"
+coroutines = "1.7.3"
+serialization = "1.6.2"
 junit = "4.13.2"
 kotlin-gradle = "2.4.10"
 ksp = "2.3.9"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ coroutines = "1.7.3"
 serialization = "1.6.2"
 junit = "4.13.2"
 kotlin-gradle = "2.4.10"
+kotlin-runtime = "1.9.22"
 ksp = "2.3.9"
 kotlinpoet = "2.3.0"
 ktlint = "1.8.0"
@@ -31,7 +32,7 @@ jsoup = { module = "org.jsoup:jsoup", version = "1.22.2" }
 kotlin-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 kotlin-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf", version.ref = "serialization" }
 kotlin-json-okio = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json-okio", version.ref = "serialization" }
-kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin-gradle" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin-runtime" }
 okhttp-core = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-brotli = { module = "com.squareup.okhttp3:okhttp-brotli", version.ref = "okhttp" }
 okhttp-zstd = { module = "com.squareup.okhttp3:okhttp-zstd", version.ref = "okhttp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
-networkTimeout=10000
-retries=0
+networkTimeout=60000
+retries=2
 retryBackOffMs=500
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/legacy-modules.txt
+++ b/legacy-modules.txt
@@ -1,0 +1,8 @@
+all/comicklive
+all/manhwa18cc
+all/stashapp
+all/webtoons
+en/allporncomic
+en/manhwa18
+en/mangahere
+en/novelcrow

--- a/scripts/build_legacy_repo.py
+++ b/scripts/build_legacy_repo.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import argparse
+import ctypes
+import fcntl
 import hashlib
 import json
 import os
@@ -15,8 +17,10 @@ from pathlib import Path
 from typing import Any
 
 
-LEGACY_LIBRARIES = frozenset({"1.4", "1.5"})
+LEGACY_LIBRARIES = frozenset({"1.4"})
 MODULE_PATTERN = re.compile(r"^[a-z0-9]+(?:\.[a-z0-9]+)+$")
+AT_FDCWD = -100
+RENAME_EXCHANGE = 0x2
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -36,7 +40,7 @@ def required_string(metadata: dict[str, Any], field: str, source: Path) -> str:
 
 def required_integer(metadata: dict[str, Any], field: str, source: Path) -> int:
     value = metadata.get(field)
-    if not isinstance(value, int):
+    if type(value) is not int:
         raise ValueError(f"{source}: {field} must be an integer")
     return value
 
@@ -58,8 +62,12 @@ def load_extension(metadata_path: Path, source_root: Path) -> tuple[dict[str, An
     if not MODULE_PATTERN.fullmatch(module):
         raise ValueError(f"{metadata_path}: module {module!r} is invalid")
     package_name = required_string(metadata, "packageName", metadata_path)
+    if package_name != f"eu.kanade.tachiyomi.extension.{module}":
+        raise ValueError(f"{metadata_path}: packageName must match module")
     name = required_string(metadata, "name", metadata_path)
     version_name = required_string(metadata, "versionName", metadata_path)
+    if "/" in version_name or "\\" in version_name:
+        raise ValueError(f"{metadata_path}: versionName must not contain a path separator")
     version_code = required_integer(metadata, "versionCode", metadata_path)
     content_warning = required_integer(metadata, "contentWarning", metadata_path)
     sources = metadata.get("sources")
@@ -71,7 +79,7 @@ def load_extension(metadata_path: Path, source_root: Path) -> tuple[dict[str, An
         if not isinstance(source, dict):
             raise ValueError(f"{metadata_path}: sources[{position}] must be an object")
         source_id = source.get("id")
-        if not isinstance(source_id, int):
+        if type(source_id) is not int:
             raise ValueError(f"{metadata_path}: sources[{position}].id must be an integer")
         legacy_sources.append(
             {
@@ -83,28 +91,32 @@ def load_extension(metadata_path: Path, source_root: Path) -> tuple[dict[str, An
         )
 
     apk_directory = metadata_path.parent / "outputs" / "apk" / "release"
-    apks = sorted(apk_directory.glob("*.apk"))
-    if len(apks) != 1:
-        raise ValueError(f"{metadata_path}: expected one release APK in {apk_directory}, found {len(apks)}")
+    apk_name = f"tachiyomi-{module}-v{version_name}.apk"
+    apk = apk_directory / apk_name
+    if not apk.is_file():
+        raise ValueError(f"{metadata_path}: expected release APK {apk_name}")
 
     module_path = Path(*module.split("."))
     icon = source_root / "src" / module_path / "res" / "mipmap-xhdpi" / "ic_launcher.png"
+    theme = metadata.get("theme")
+    if not icon.is_file() and theme is not None:
+        if not isinstance(theme, str) or not theme or "/" in theme or "\\" in theme:
+            raise ValueError(f"{metadata_path}: theme must be a simple non-empty string or null")
+        icon = source_root / "lib-multisrc" / theme / "res" / "mipmap-xhdpi" / "ic_launcher.png"
     if not icon.is_file():
         icon = source_root / "core" / "src" / "main" / "res" / "mipmap-xhdpi" / "ic_launcher.png"
-    if not icon.is_file():
-        raise ValueError(f"{metadata_path}: no icon found for {module}")
 
     legacy_entry = {
         "name": f"Tachiyomi: {name}",
         "pkg": package_name,
-        "apk": apks[0].name,
+        "apk": apk.name,
         "lang": module.split(".", maxsplit=1)[0],
         "code": version_code,
         "version": version_name,
         "nsfw": int(content_warning > 1),
         "sources": legacy_sources,
     }
-    return legacy_entry, apks[0], icon
+    return legacy_entry, apk, icon
 
 
 def sha256(path: Path) -> str:
@@ -113,6 +125,33 @@ def sha256(path: Path) -> str:
         for chunk in iter(lambda: file.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+def replace_output_directory(staging: Path, output: Path, backup: Path) -> None:
+    lock_path = output.with_name(f".{output.name}.lock")
+    with lock_path.open("w") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        if not output.exists():
+            os.replace(staging, output)
+            return
+
+        if backup.exists():
+            shutil.rmtree(backup)
+
+        libc = ctypes.CDLL(None, use_errno=True)
+        renameat2 = getattr(libc, "renameat2", None)
+        if renameat2 is None:
+            raise OSError("atomic directory replacement requires libc renameat2")
+        renameat2.argtypes = (ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_uint)
+        renameat2.restype = ctypes.c_int
+        if renameat2(AT_FDCWD, os.fsencode(staging), AT_FDCWD, os.fsencode(output), RENAME_EXCHANGE) != 0:
+            error = ctypes.get_errno()
+            raise OSError(error, os.strerror(error), output)
+
+        try:
+            os.replace(staging, backup)
+        except OSError:
+            # The exchange already published output. Keep the prior output in staging.
+            pass
 
 
 def build_repository(output: Path, source_root: Path, metadata_paths: list[Path]) -> int:
@@ -156,17 +195,10 @@ def build_repository(output: Path, source_root: Path, metadata_paths: list[Path]
             encoding="utf-8",
         )
 
-        if backup.exists():
-            shutil.rmtree(backup)
-        if output.exists():
-            os.replace(output, backup)
-        os.replace(staging, output)
-        if backup.exists():
-            shutil.rmtree(backup)
+        replace_output_directory(staging, output, backup)
     except Exception:
-        shutil.rmtree(staging, ignore_errors=True)
-        if backup.exists() and not output.exists():
-            os.replace(backup, output)
+        if staging.exists():
+            shutil.rmtree(staging, ignore_errors=True)
         raise
 
     print(f"Generated {len(extensions)} legacy extension entries in {output}")
@@ -177,7 +209,7 @@ def main() -> int:
     arguments = parse_arguments()
     try:
         return build_repository(arguments.output, arguments.source_root.resolve(), arguments.metadata)
-    except ValueError as error:
+    except (OSError, ValueError) as error:
         print(error, file=sys.stderr)
         return 1
 

--- a/scripts/build_legacy_repo.py
+++ b/scripts/build_legacy_repo.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Build a Tachiyomi 0.15.x-compatible static extension repository."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+LEGACY_LIBRARIES = frozenset({"1.4", "1.5"})
+MODULE_PATTERN = re.compile(r"^[a-z0-9]+(?:\.[a-z0-9]+)+$")
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-root", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("metadata", type=Path, nargs="+")
+    return parser.parse_args()
+
+
+def required_string(metadata: dict[str, Any], field: str, source: Path) -> str:
+    value = metadata.get(field)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{source}: {field} must be a non-empty string")
+    return value
+
+
+def required_integer(metadata: dict[str, Any], field: str, source: Path) -> int:
+    value = metadata.get(field)
+    if not isinstance(value, int):
+        raise ValueError(f"{source}: {field} must be an integer")
+    return value
+
+
+def load_extension(metadata_path: Path, source_root: Path) -> tuple[dict[str, Any], Path, Path]:
+    try:
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"{metadata_path}: cannot read extension metadata: {error}") from error
+    if not isinstance(metadata, dict):
+        raise ValueError(f"{metadata_path}: metadata root must be an object")
+
+    extension_lib = required_string(metadata, "extensionLib", metadata_path)
+    if extension_lib not in LEGACY_LIBRARIES:
+        accepted = ", ".join(sorted(LEGACY_LIBRARIES))
+        raise ValueError(f"{metadata_path}: extensionLib {extension_lib!r} is not one of {accepted}")
+
+    module = required_string(metadata, "module", metadata_path)
+    if not MODULE_PATTERN.fullmatch(module):
+        raise ValueError(f"{metadata_path}: module {module!r} is invalid")
+    package_name = required_string(metadata, "packageName", metadata_path)
+    name = required_string(metadata, "name", metadata_path)
+    version_name = required_string(metadata, "versionName", metadata_path)
+    version_code = required_integer(metadata, "versionCode", metadata_path)
+    content_warning = required_integer(metadata, "contentWarning", metadata_path)
+    sources = metadata.get("sources")
+    if not isinstance(sources, list) or not sources:
+        raise ValueError(f"{metadata_path}: sources must be a non-empty array")
+
+    legacy_sources = []
+    for position, source in enumerate(sources):
+        if not isinstance(source, dict):
+            raise ValueError(f"{metadata_path}: sources[{position}] must be an object")
+        source_id = source.get("id")
+        if not isinstance(source_id, int):
+            raise ValueError(f"{metadata_path}: sources[{position}].id must be an integer")
+        legacy_sources.append(
+            {
+                "id": source_id,
+                "name": required_string(source, "name", metadata_path),
+                "lang": required_string(source, "lang", metadata_path),
+                "baseUrl": required_string(source, "baseUrl", metadata_path),
+            },
+        )
+
+    apk_directory = metadata_path.parent / "outputs" / "apk" / "release"
+    apks = sorted(apk_directory.glob("*.apk"))
+    if len(apks) != 1:
+        raise ValueError(f"{metadata_path}: expected one release APK in {apk_directory}, found {len(apks)}")
+
+    module_path = Path(*module.split("."))
+    icon = source_root / "src" / module_path / "res" / "mipmap-xhdpi" / "ic_launcher.png"
+    if not icon.is_file():
+        icon = source_root / "core" / "src" / "main" / "res" / "mipmap-xhdpi" / "ic_launcher.png"
+    if not icon.is_file():
+        raise ValueError(f"{metadata_path}: no icon found for {module}")
+
+    legacy_entry = {
+        "name": f"Tachiyomi: {name}",
+        "pkg": package_name,
+        "apk": apks[0].name,
+        "lang": module.split(".", maxsplit=1)[0],
+        "code": version_code,
+        "version": version_name,
+        "nsfw": int(content_warning > 1),
+        "sources": legacy_sources,
+    }
+    return legacy_entry, apks[0], icon
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def build_repository(output: Path, source_root: Path, metadata_paths: list[Path]) -> int:
+    extensions = [load_extension(path, source_root) for path in metadata_paths]
+    extensions.sort(key=lambda extension: extension[0]["pkg"])
+    packages = [extension[0]["pkg"] for extension in extensions]
+    if len(packages) != len(set(packages)):
+        raise ValueError("duplicate package names in repository input")
+
+    output = output.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=f".{output.name}.", dir=output.parent))
+    backup = output.with_name(f".{output.name}.previous")
+    try:
+        apk_directory = staging / "apk"
+        icon_directory = staging / "icon"
+        apk_directory.mkdir()
+        icon_directory.mkdir()
+        asset_manifest = []
+        for entry, apk, icon in extensions:
+            destination_apk = apk_directory / entry["apk"]
+            destination_icon = icon_directory / f"{entry['pkg']}.png"
+            shutil.copyfile(apk, destination_apk)
+            shutil.copyfile(icon, destination_icon)
+            asset_manifest.append(
+                {
+                    "apk": f"apk/{destination_apk.name}",
+                    "apkSha256": sha256(destination_apk),
+                    "icon": f"icon/{destination_icon.name}",
+                    "iconSha256": sha256(destination_icon),
+                    "pkg": entry["pkg"],
+                },
+            )
+
+        (staging / "index.min.json").write_text(
+            json.dumps([entry for entry, _, _ in extensions], separators=(",", ":")),
+            encoding="utf-8",
+        )
+        (staging / "manifest.json").write_text(
+            json.dumps({"assets": asset_manifest}, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        if backup.exists():
+            shutil.rmtree(backup)
+        if output.exists():
+            os.replace(output, backup)
+        os.replace(staging, output)
+        if backup.exists():
+            shutil.rmtree(backup)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        if backup.exists() and not output.exists():
+            os.replace(backup, output)
+        raise
+
+    print(f"Generated {len(extensions)} legacy extension entries in {output}")
+    return 0
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    try:
+        return build_repository(arguments.output, arguments.source_root.resolve(), arguments.metadata)
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/list_legacy_modules.py
+++ b/scripts/list_legacy_modules.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""List Keiyoushi extension Gradle tasks compatible with Tachiyomi 0.15.x."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+LEGACY_LIBRARY_ASSIGNMENT = re.compile(r'^\s*libVersion\s*=\s*"1\.[45]"\s*$', re.MULTILINE)
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-root", type=Path, required=True)
+    return parser.parse_args()
+
+
+def list_tasks(source_root: Path) -> list[str]:
+    modules = []
+    for build_file in source_root.glob("src/*/*/build.gradle.kts"):
+        if LEGACY_LIBRARY_ASSIGNMENT.search(build_file.read_text(encoding="utf-8")) is None:
+            continue
+        module = build_file.parent.relative_to(source_root / "src")
+        if len(module.parts) != 2:
+            continue
+        modules.append(f":src:{module.parts[0]}:{module.parts[1]}:assembleRelease")
+    return sorted(modules)
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    for task in list_tasks(arguments.source_root.resolve()):
+        print(task)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/list_legacy_modules.py
+++ b/scripts/list_legacy_modules.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 
 import argparse
 import re
+import sys
 from pathlib import Path
 
 
-LEGACY_LIBRARY_ASSIGNMENT = re.compile(r'^\s*libVersion\s*=\s*"1\.[45]"\s*$', re.MULTILINE)
+LEGACY_LIBRARY_ASSIGNMENT = re.compile(r'^\s*libVersion\s*=\s*"1\.4"\s*$', re.MULTILINE)
+MODULE_PATTERN = re.compile(r"^[a-z][a-z0-9]*/[a-z][a-z0-9]*$")
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -18,20 +20,39 @@ def parse_arguments() -> argparse.Namespace:
 
 
 def list_tasks(source_root: Path) -> list[str]:
+    modules_path = source_root / "legacy-modules.txt"
+    if not modules_path.is_file():
+        raise ValueError(f"missing verified legacy module list: {modules_path}")
+
     modules = []
-    for build_file in source_root.glob("src/*/*/build.gradle.kts"):
+    for raw_module in modules_path.read_text(encoding="utf-8").splitlines():
+        module = raw_module.partition("#")[0].strip()
+        if not module:
+            continue
+        if MODULE_PATTERN.fullmatch(module) is None:
+            raise ValueError(f"invalid legacy module: {module}")
+
+        language, name = module.split("/")
+        build_file = source_root / "src" / language / name / "build.gradle.kts"
+        if not build_file.is_file():
+            raise ValueError(f"missing legacy module build file: {build_file}")
         if LEGACY_LIBRARY_ASSIGNMENT.search(build_file.read_text(encoding="utf-8")) is None:
-            continue
-        module = build_file.parent.relative_to(source_root / "src")
-        if len(module.parts) != 2:
-            continue
-        modules.append(f":src:{module.parts[0]}:{module.parts[1]}:assembleRelease")
+            raise ValueError(f"legacy module does not use extension library 1.4: {module}")
+        modules.append(f":src:{language}:{name}:assembleRelease")
+
+    if len(modules) != len(set(modules)):
+        raise ValueError("duplicate module in verified legacy module list")
     return sorted(modules)
 
 
 def main() -> int:
     arguments = parse_arguments()
-    for task in list_tasks(arguments.source_root.resolve()):
+    try:
+        tasks = list_tasks(arguments.source_root.resolve())
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 1
+    for task in tasks:
         print(task)
     return 0
 

--- a/src/all/comicklive/build.gradle.kts
+++ b/src/all/comicklive/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Comick (Unoriginal)"
-    versionCode = 5
+    versionCode = 6
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 

--- a/src/all/manhwa18cc/build.gradle.kts
+++ b/src/all/manhwa18cc/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Manhwa18.cc"
-    versionCode = 7
+    versionCode = 8
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
     theme = "madara"

--- a/src/all/stashapp/build.gradle.kts
+++ b/src/all/stashapp/build.gradle.kts
@@ -17,3 +17,19 @@ keiyoushi {
         }
     }
 }
+
+android {
+    sourceSets.named("test") {
+        java.directories.add("test")
+        kotlin.directories.add("test")
+    }
+}
+
+dependencies {
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlin.stdlib)
+}
+
+tasks.matching { it.name == "kspDebugUnitTestKotlin" }.configureEach {
+    enabled = false
+}

--- a/src/all/stashapp/src/eu/kanade/tachiyomi/extension/all/stashapp/StashApp.kt
+++ b/src/all/stashapp/src/eu/kanade/tachiyomi/extension/all/stashapp/StashApp.kt
@@ -19,7 +19,12 @@ import keiyoushi.utils.parseGraphQLAs
 import okhttp3.Headers
 import okhttp3.Request
 import okhttp3.Response
-import kotlin.time.Instant
+import java.time.Instant
+
+fun parseRFC3339Millis(value: String): Long {
+    // ISO 8601 covers RFC3339.
+    return runCatching { Instant.parse(value).toEpochMilli() }.getOrDefault(0L)
+}
 
 @Source
 abstract class StashApp :
@@ -180,10 +185,5 @@ abstract class StashApp :
             mangas = mangas,
             hasNextPage = mangas.size >= MANGA_BRIEF_PER_PAGE,
         )
-    }
-
-    private fun parseRFC3339Millis(value: String): Long {
-        // ISO 8601 covers RFC3339
-        return Instant.parseOrNull(value)?.toEpochMilliseconds() ?: 0L
     }
 }

--- a/src/all/stashapp/test/eu/kanade/tachiyomi/extension/all/stashapp/StashAppDateTest.java
+++ b/src/all/stashapp/test/eu/kanade/tachiyomi/extension/all/stashapp/StashAppDateTest.java
@@ -1,0 +1,18 @@
+package eu.kanade.tachiyomi.extension.all.stashapp;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public final class StashAppDateTest {
+    @Test
+    public void parsesUtcAndOffsetRfc3339Timestamps() {
+        assertEquals(1_704_067_200_000L, StashAppKt.parseRFC3339Millis("2024-01-01T00:00:00Z"));
+        assertEquals(1_704_067_200_000L, StashAppKt.parseRFC3339Millis("2024-01-01T02:00:00+02:00"));
+    }
+
+    @Test
+    public void returnsZeroForMalformedTimestamp() {
+        assertEquals(0L, StashAppKt.parseRFC3339Millis("not-a-timestamp"));
+    }
+}

--- a/src/all/webtoons/build.gradle.kts
+++ b/src/all/webtoons/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Webtoons.com"
-    versionCode = 57
+    versionCode = 58
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/en/allporncomic/build.gradle.kts
+++ b/src/en/allporncomic/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "AllPornComic"
-    versionCode = 2
+    versionCode = 3
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
     theme = "madara"

--- a/src/en/mangahere/build.gradle.kts
+++ b/src/en/mangahere/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Mangahere"
-    versionCode = 24
+    versionCode = 25
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 

--- a/src/en/manhwa18/build.gradle.kts
+++ b/src/en/manhwa18/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Manhwa18"
-    versionCode = 14
+    versionCode = 15
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
 

--- a/src/en/novelcrow/build.gradle.kts
+++ b/src/en/novelcrow/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "NovelCrow"
-    versionCode = 1
+    versionCode = 2
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
     theme = "madara"

--- a/tests/test_build_legacy_repo.py
+++ b/tests/test_build_legacy_repo.py
@@ -1,0 +1,125 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+GENERATOR = PROJECT_ROOT / "scripts" / "build_legacy_repo.py"
+
+
+class BuildLegacyRepoTests(unittest.TestCase):
+    def write_extension(
+        self,
+        root: Path,
+        *,
+        package_name: str = "eu.kanade.tachiyomi.extension.all.example",
+        extension_lib: str = "1.4",
+        content_warning: int = 1,
+    ) -> Path:
+        build_dir = root / "build"
+        release_dir = build_dir / "outputs" / "apk" / "release"
+        release_dir.mkdir(parents=True)
+        (release_dir / "tachiyomi-all.example-v1.4.7.apk").write_bytes(b"apk")
+        metadata = {
+            "module": "all.example",
+            "theme": None,
+            "packageName": package_name,
+            "name": "Example",
+            "versionCode": 7,
+            "versionName": "1.4.7",
+            "extensionLib": extension_lib,
+            "contentWarning": content_warning,
+            "sources": [
+                {
+                    "id": 42,
+                    "name": "Example",
+                    "lang": "en",
+                    "baseUrl": "https://example.invalid",
+                    "mirrorUrls": [],
+                },
+            ],
+        }
+        metadata_path = build_dir / "keiyoushi-source-info.json"
+        metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+        return metadata_path
+
+    def run_generator(self, source_root: Path, output: Path, *metadata: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(GENERATOR),
+                "--source-root",
+                str(source_root),
+                "--output",
+                str(output),
+                *map(str, metadata),
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_generates_legacy_catalog_apk_and_icon_layout(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_root = root / "source"
+            icon = source_root / "src" / "all" / "example" / "res" / "mipmap-xhdpi" / "ic_launcher.png"
+            icon.parent.mkdir(parents=True)
+            icon.write_bytes(b"icon")
+            metadata_path = self.write_extension(root)
+            output = root / "repository"
+
+            result = self.run_generator(source_root, output, metadata_path)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            catalog = json.loads((output / "index.min.json").read_text(encoding="utf-8"))
+            self.assertEqual(
+                catalog,
+                [
+                    {
+                        "name": "Tachiyomi: Example",
+                        "pkg": "eu.kanade.tachiyomi.extension.all.example",
+                        "apk": "tachiyomi-all.example-v1.4.7.apk",
+                        "lang": "all",
+                        "code": 7,
+                        "version": "1.4.7",
+                        "nsfw": 0,
+                        "sources": [
+                            {
+                                "id": 42,
+                                "name": "Example",
+                                "lang": "en",
+                                "baseUrl": "https://example.invalid",
+                            },
+                        ],
+                    },
+                ],
+            )
+            self.assertEqual(
+                (output / "apk" / "tachiyomi-all.example-v1.4.7.apk").read_bytes(),
+                b"apk",
+            )
+            self.assertEqual(
+                (output / "icon" / "eu.kanade.tachiyomi.extension.all.example.png").read_bytes(),
+                b"icon",
+            )
+
+    def test_rejects_metadata_outside_legacy_library_band(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_root = root / "source"
+            metadata_path = self.write_extension(root, extension_lib="1.6")
+            output = root / "repository"
+
+            result = self.run_generator(source_root, output, metadata_path)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("extensionLib", result.stderr)
+            self.assertFalse((output / "index.min.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_build_legacy_repo.py
+++ b/tests/test_build_legacy_repo.py
@@ -2,6 +2,7 @@ import json
 import subprocess
 import sys
 import tempfile
+import threading
 import unittest
 from pathlib import Path
 
@@ -21,7 +22,7 @@ class BuildLegacyRepoTests(unittest.TestCase):
     ) -> Path:
         build_dir = root / "build"
         release_dir = build_dir / "outputs" / "apk" / "release"
-        release_dir.mkdir(parents=True)
+        release_dir.mkdir(parents=True, exist_ok=True)
         (release_dir / "tachiyomi-all.example-v1.4.7.apk").write_bytes(b"apk")
         metadata = {
             "module": "all.example",
@@ -107,18 +108,165 @@ class BuildLegacyRepoTests(unittest.TestCase):
                 b"icon",
             )
 
-    def test_rejects_metadata_outside_legacy_library_band(self) -> None:
+    def test_replaces_existing_catalog_without_removing_output(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
             source_root = root / "source"
-            metadata_path = self.write_extension(root, extension_lib="1.6")
+            icon = source_root / "src" / "all" / "example" / "res" / "mipmap-xhdpi" / "ic_launcher.png"
+            icon.parent.mkdir(parents=True)
+            icon.write_bytes(b"icon")
+            metadata_path = self.write_extension(root)
+            output = root / "repository"
+
+            first_result = self.run_generator(source_root, output, metadata_path)
+            self.assertEqual(first_result.returncode, 0, first_result.stderr)
+            first_catalog = (output / "index.min.json").read_text(encoding="utf-8")
+
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            metadata["versionCode"] = 8
+            metadata["versionName"] = "1.4.8"
+            metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+            release_directory = metadata_path.parent / "outputs" / "apk" / "release"
+            (release_directory / "tachiyomi-all.example-v1.4.7.apk").unlink()
+            (release_directory / "tachiyomi-all.example-v1.4.8.apk").write_bytes(b"updated apk")
+
+            second_result = self.run_generator(source_root, output, metadata_path)
+
+            self.assertEqual(second_result.returncode, 0, second_result.stderr)
+            self.assertEqual(json.loads((output / "index.min.json").read_text(encoding="utf-8"))[0]["code"], 8)
+            self.assertEqual((root / ".repository.previous" / "index.min.json").read_text(encoding="utf-8"), first_catalog)
+
+    def test_preserves_existing_catalog_when_preparation_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_root = root / "source"
+            icon = source_root / "src" / "all" / "example" / "res" / "mipmap-xhdpi" / "ic_launcher.png"
+            icon.parent.mkdir(parents=True)
+            icon.write_bytes(b"icon")
+            metadata_path = self.write_extension(root)
+            output = root / "repository"
+
+            first_result = self.run_generator(source_root, output, metadata_path)
+            self.assertEqual(first_result.returncode, 0, first_result.stderr)
+            first_catalog = (output / "index.min.json").read_text(encoding="utf-8")
+
+            release_directory = metadata_path.parent / "outputs" / "apk" / "release"
+            (release_directory / "tachiyomi-all.example-v1.4.7.apk").unlink()
+            failed_result = self.run_generator(source_root, output, metadata_path)
+
+            self.assertNotEqual(failed_result.returncode, 0)
+            self.assertEqual((output / "index.min.json").read_text(encoding="utf-8"), first_catalog)
+
+    def test_keeps_catalog_available_to_concurrent_readers(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_root = root / "source"
+            icon = source_root / "src" / "all" / "example" / "res" / "mipmap-xhdpi" / "ic_launcher.png"
+            icon.parent.mkdir(parents=True)
+            icon.write_bytes(b"icon")
+            metadata_path = self.write_extension(root)
+            output = root / "repository"
+
+            initial_result = self.run_generator(source_root, output, metadata_path)
+            self.assertEqual(initial_result.returncode, 0, initial_result.stderr)
+            errors = []
+
+            def publish_repeatedly() -> None:
+                for _ in range(32):
+                    result = self.run_generator(source_root, output, metadata_path)
+                    if result.returncode != 0:
+                        errors.append(result.stderr)
+
+            publisher = threading.Thread(target=publish_repeatedly)
+            publisher.start()
+            while publisher.is_alive():
+                try:
+                    catalog = json.loads((output / "index.min.json").read_text(encoding="utf-8"))
+                    if catalog[0]["pkg"] != "eu.kanade.tachiyomi.extension.all.example":
+                        errors.append("reader received an incomplete catalog")
+                except (IndexError, OSError, json.JSONDecodeError) as error:
+                    errors.append(str(error))
+            publisher.join()
+
+            self.assertEqual(errors, [])
+
+    def test_rejects_package_names_that_escape_catalog_assets(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            output = root / "repository"
+
+            for package_name in ("../../outside", "/tmp/outside", "eu.kanade.tachiyomi.extension.all.different"):
+                metadata_path = self.write_extension(root, package_name=package_name)
+                result = self.run_generator(root / "source", output, metadata_path)
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("packageName", result.stderr)
+                self.assertFalse((root / "outside").exists())
+
+    def test_rejects_extension_library_without_a_build_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_root = root / "source"
+            output = root / "repository"
+
+            for extension_lib in ("1.5", "1.6"):
+                metadata_path = self.write_extension(root, extension_lib=extension_lib)
+                result = self.run_generator(source_root, output, metadata_path)
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("extensionLib", result.stderr)
+                self.assertFalse((output / "index.min.json").exists())
+
+    def test_rejects_a_release_apk_that_does_not_match_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_root = root / "source"
+            icon = source_root / "src" / "all" / "example" / "res" / "mipmap-xhdpi" / "ic_launcher.png"
+            icon.parent.mkdir(parents=True)
+            icon.write_bytes(b"icon")
+            metadata_path = self.write_extension(root)
+            release_directory = metadata_path.parent / "outputs" / "apk" / "release"
+            (release_directory / "tachiyomi-all.example-v1.4.7.apk").unlink()
+            (release_directory / "stale.apk").write_bytes(b"stale")
+
+            result = self.run_generator(source_root, root / "repository", metadata_path)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("expected release APK", result.stderr)
+
+    def test_rejects_boolean_values_for_numeric_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            metadata_path = self.write_extension(root)
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            metadata["sources"][0]["id"] = True
+            metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+
+            result = self.run_generator(root / "source", root / "repository", metadata_path)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("must be an integer", result.stderr)
+
+    def test_uses_the_multisrc_theme_icon_when_module_icon_is_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_root = root / "source"
+            theme_icon = source_root / "lib-multisrc" / "example-theme" / "res" / "mipmap-xhdpi" / "ic_launcher.png"
+            theme_icon.parent.mkdir(parents=True)
+            theme_icon.write_bytes(b"theme icon")
+            metadata_path = self.write_extension(root)
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            metadata["theme"] = "example-theme"
+            metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
             output = root / "repository"
 
             result = self.run_generator(source_root, output, metadata_path)
 
-            self.assertNotEqual(result.returncode, 0)
-            self.assertIn("extensionLib", result.stderr)
-            self.assertFalse((output / "index.min.json").exists())
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                (output / "icon" / "eu.kanade.tachiyomi.extension.all.example.png").read_bytes(),
+                b"theme icon",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_list_legacy_modules.py
+++ b/tests/test_list_legacy_modules.py
@@ -1,0 +1,48 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SELECTOR = PROJECT_ROOT / "scripts" / "list_legacy_modules.py"
+
+
+class ListLegacyModulesTests(unittest.TestCase):
+    def write_module(self, source_root: Path, language: str, name: str, library_version: str) -> None:
+        module = source_root / "src" / language / name
+        module.mkdir(parents=True)
+        (module / "build.gradle.kts").write_text(
+            "keiyoushi {\n"
+            f'    libVersion = "{library_version}"\n'
+            "}\n",
+            encoding="utf-8",
+        )
+
+    def test_lists_only_extensions_in_legacy_library_band(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source_root = Path(temporary_directory)
+            self.write_module(source_root, "en", "legacy", "1.4")
+            self.write_module(source_root, "all", "shared", "1.5")
+            self.write_module(source_root, "en", "modern", "1.6")
+
+            result = subprocess.run(
+                [sys.executable, str(SELECTOR), "--source-root", str(source_root)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                result.stdout.splitlines(),
+                [
+                    ":src:all:shared:assembleRelease",
+                    ":src:en:legacy:assembleRelease",
+                ],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_list_legacy_modules.py
+++ b/tests/test_list_legacy_modules.py
@@ -20,12 +20,16 @@ class ListLegacyModulesTests(unittest.TestCase):
             encoding="utf-8",
         )
 
-    def test_lists_only_extensions_in_legacy_library_band(self) -> None:
+    def write_selection(self, source_root: Path, *modules: str) -> None:
+        (source_root / "legacy-modules.txt").write_text("\n".join(modules) + "\n", encoding="utf-8")
+
+    def test_lists_only_verified_runtime_checked_modules(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             source_root = Path(temporary_directory)
             self.write_module(source_root, "en", "legacy", "1.4")
-            self.write_module(source_root, "all", "shared", "1.5")
-            self.write_module(source_root, "en", "modern", "1.6")
+            self.write_module(source_root, "all", "unverified", "1.4")
+            self.write_module(source_root, "all", "unsupported", "1.5")
+            self.write_selection(source_root, "en/legacy")
 
             result = subprocess.run(
                 [sys.executable, str(SELECTOR), "--source-root", str(source_root)],
@@ -37,11 +41,69 @@ class ListLegacyModulesTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(
                 result.stdout.splitlines(),
-                [
-                    ":src:all:shared:assembleRelease",
-                    ":src:en:legacy:assembleRelease",
-                ],
+                [":src:en:legacy:assembleRelease"],
             )
+
+    def test_rejects_verified_module_without_legacy_library(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source_root = Path(temporary_directory)
+            self.write_module(source_root, "all", "unsupported", "1.5")
+            self.write_selection(source_root, "all/unsupported")
+
+            result = subprocess.run(
+                [sys.executable, str(SELECTOR), "--source-root", str(source_root)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("extension library 1.4", result.stderr)
+
+    def test_rejects_missing_module_selection(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source_root = Path(temporary_directory)
+
+            result = subprocess.run(
+                [sys.executable, str(SELECTOR), "--source-root", str(source_root)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("missing verified legacy module list", result.stderr)
+
+    def test_rejects_malformed_module_selection(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source_root = Path(temporary_directory)
+            self.write_selection(source_root, "en/not-valid")
+
+            result = subprocess.run(
+                [sys.executable, str(SELECTOR), "--source-root", str(source_root)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("invalid legacy module", result.stderr)
+
+    def test_rejects_duplicate_module_selection(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source_root = Path(temporary_directory)
+            self.write_module(source_root, "en", "legacy", "1.4")
+            self.write_selection(source_root, "en/legacy", "en/legacy")
+
+            result = subprocess.run(
+                [sys.executable, str(SELECTOR), "--source-root", str(source_root)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("duplicate module", result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Build eight runtime-checked extensions against the legacy host ABI and deploy the static catalog through GitHub Pages.