### PR TITLE
Guazimanhua: parse authors

### DIFF
--- a/src/zh/guazimanhua/build.gradle.kts
+++ b/src/zh/guazimanhua/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Guazimanhua"
-    versionCode = 5
+    versionCode = 6
     contentWarning = ContentWarning.SAFE
     libVersion = "1.6"
 

--- a/src/zh/guazimanhua/src/eu/kanade/tachiyomi/extension/zh/guazimanhua/Guazimanhua.kt
+++ b/src/zh/guazimanhua/src/eu/kanade/tachiyomi/extension/zh/guazimanhua/Guazimanhua.kt
@@ -66,6 +66,9 @@ abstract class Guazimanhua : KeiSource() {
                 title = element.selectFirst("h3 a")!!.text()
                 setUrlWithoutDomain(element.selectFirst("a.cover-wrap")!!.attr("href"))
                 thumbnail_url = element.selectFirst("img.cover")?.attr("src")
+                author = element.selectFirst("div.meta")?.ownText()
+                    ?.substringBefore(" · ")
+                    ?.takeIf { it.isNotEmpty() }
             }
         }
         val hasNextPage = document.select("nav.pager a").any { it.text() == ">" }
@@ -91,6 +94,12 @@ abstract class Guazimanhua : KeiSource() {
             document.selectFirst("img.mobile-comic-cover")?.absUrl("src")?.let { thumbnail_url = it }
             document.selectFirst("p.mobile-comic-desc")?.text()?.let { description = it }
             document.selectFirst("p.mobile-comic-tags")?.text()?.let { genre = it }
+            document.select("div.cinema-strip > div")
+                .firstOrNull { it.selectFirst("span")?.text() == "作者" }
+                ?.selectFirst("b")
+                ?.text()
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { author = it }
             val meta = document.selectFirst("p.mobile-comic-meta")?.text().orEmpty()
             status = when {
                 meta.contains("完结") -> SManga.COMPLETED


### PR DESCRIPTION
## Summary

- Parse the author from the list card metadata and manga detail page.
- Bump the extension `versionCode` from 5 to 6.

## Root Cause

The source populated titles, URLs, thumbnails, genres, and status, but never assigned `SManga.author`. Mihon therefore displayed its default unknown-author value.

## Review Notes

- Keeps the mandatory list title selector as a non-null assertion, following the review feedback from PR #18500.
- Keeps the manga URL host check against the configured `baseUrl`.
- Treats author data as optional and uses stable structural selectors, so missing author markup does not break list or detail parsing.

## Validation

- `./gradlew :src:zh:guazimanhua:lintRelease :src:zh:guazimanhua:assembleRelease --no-daemon`
- `git diff --check`
- Verified the current site markup returns author values in both list and detail pages.

The release build and lint completed successfully. Lint reported 0 errors and the standard generated-manifest warnings. Runtime testing inside Mihon was not performed in this environment.

## Checklist

- [x] Updated `versionCode`.
- [x] Preserved the existing source name, language, and source ID behavior.
- [x] `assembleRelease` and `lintRelease` pass.
- [x] This PR is AI-assisted; the changes and validation were reviewed manually.
