### PR TITLE
MangaFire: add a solver for shape-selecting captcha

### DIFF
--- a/src/all/mangafire/assets/solver.html
+++ b/src/all/mangafire/assets/solver.html
@@ -1,0 +1,909 @@
+<!DOCTYPE html>
+<html lang="en-US">
+    <head>
+        <title>MangaFire Challenge Solver</title>
+        <script src="https://docs.opencv.org/5.0/opencv.js"></script>
+        <script>
+const SCALE_FACTOR = 1.5;
+const ANGULAR_BINS = 72;
+const RADIAL_BINS = 24;
+const MIN_HOLE_AREA_RATIO = 0.03;
+
+function contourCenter(c) {
+  const m = cv.moments(c, false);
+
+  if (Math.abs(m.m00) > 1e-8) {
+    return {
+      x: m.m10 / m.m00,
+      y: m.m01 / m.m00
+    };
+  }
+
+  const r = cv.boundingRect(c);
+
+  return {
+    x: r.x + r.width / 2,
+    y: r.y + r.height / 2
+  };
+}
+
+function releaseShape(shape) {
+  shape.outer.delete();
+
+  for (const h of shape.holes) {
+    h.delete();
+  }
+}
+
+function contourDepth(index, hierarchyData) {
+  let depth = 0;
+  let p = hierarchyData[index * 4 + 3];
+
+  while (p >= 0) {
+    depth++;
+    p = hierarchyData[p * 4 + 3];
+  }
+
+  return depth;
+}
+
+function shapeFeatures(shape) {
+  const outerArea = Math.abs(cv.contourArea(shape.outer, false));
+
+  let holeArea = 0;
+  const holeRatios = [];
+
+  for (const h of shape.holes) {
+    const a = Math.abs(cv.contourArea(h, false));
+
+    holeArea += a;
+    holeRatios.push(
+      outerArea > 0 ? a / outerArea : 0
+    );
+  }
+
+  holeRatios.sort((a, b) => b - a);
+
+  const perimeter = cv.arcLength(shape.outer, true);
+
+  const circularity = perimeter > 0 ? (4 * Math.PI * outerArea) / (perimeter * perimeter) : 0;
+
+  const hull = new cv.Mat();
+  cv.convexHull(shape.outer, hull, false, true);
+
+  const hullArea = Math.abs(cv.contourArea(hull, false));
+
+  hull.delete();
+
+  const solidity = hullArea > 0 ? outerArea / hullArea : 0;
+
+  const rr = cv.minAreaRect(shape.outer);
+  const rw = rr.size.width;
+  const rh = rr.size.height;
+
+  const aspect = Math.max(rw, rh) > 0 ? Math.min(rw, rh) / Math.max(rw, rh) : 0;
+
+  return {
+    outerArea,
+    netArea: Math.max(0, outerArea - holeArea),
+    holeArea,
+    holeAreaRatio: outerArea > 0 ? holeArea / outerArea : 0,
+    holeCount: shape.holes.length,
+    holeRatios,
+    circularity,
+    solidity,
+    aspect
+  };
+}
+
+function extractHierarchyShapes(binary) {
+  const input = binary.clone();
+
+  const contours = new cv.MatVector();
+  const hierarchy = new cv.Mat();
+
+  cv.findContours(
+    input,
+    contours,
+    hierarchy,
+    cv.RETR_TREE,
+    cv.CHAIN_APPROX_NONE
+  );
+
+  input.delete();
+
+  if (hierarchy.empty()) {
+    contours.delete();
+    hierarchy.delete();
+    return [];
+  }
+
+  const hd = hierarchy.data32S;
+  const result = [];
+
+  for (let i = 0; i < contours.size(); i++) {
+    if ((contourDepth(i, hd) & 1) !== 0) {
+      continue;
+    }
+
+    const outerSrc = contours.get(i);
+
+    const outerArea = Math.abs(cv.contourArea(outerSrc, false));
+
+    if (outerArea < 1) {
+      outerSrc.delete();
+      continue;
+    }
+
+    const outer = outerSrc.clone();
+    outerSrc.delete();
+
+    const holes = [];
+
+    let child = hd[i * 4 + 2];
+
+    while (child >= 0) {
+      const holeSrc = contours.get(child);
+
+      const holeArea = Math.abs(cv.contourArea(holeSrc, false));
+
+      if (holeArea >= Math.max(2, outerArea * MIN_HOLE_AREA_RATIO)) {
+        holes.push(holeSrc.clone());
+      }
+
+      holeSrc.delete();
+
+      child = hd[child * 4];
+    }
+
+    const shape = {
+      outer,
+      holes,
+      center: contourCenter(outer),
+      box: cv.boundingRect(outer)
+    };
+
+    shape.features = shapeFeatures(shape);
+
+    result.push(shape);
+  }
+
+  contours.delete();
+  hierarchy.delete();
+
+  return result;
+}
+
+function polarSignature(shape) {
+  const center = shape.center;
+
+  let maxRadius = 0;
+
+  const d = shape.outer.data32S;
+
+  for (let i = 0; i + 1 < d.length; i += 2) {
+    const dx = d[i] - center.x;
+    const dy = d[i + 1] - center.y;
+
+    maxRadius = Math.max(maxRadius, Math.sqrt(dx * dx + dy * dy));
+  }
+
+  if (maxRadius < 1e-6) {
+    return new Float32Array(ANGULAR_BINS * RADIAL_BINS);
+  }
+
+  const raw = new Float32Array(ANGULAR_BINS * RADIAL_BINS);
+
+  for (let a = 0; a < ANGULAR_BINS; a++) {
+    const angle = (a * Math.PI * 2) / ANGULAR_BINS;
+
+    const cos = Math.cos(angle);
+    const sin = Math.sin(angle);
+
+    for (let r = 0; r < RADIAL_BINS; r++) {
+      const radius = ((r + 0.5) / RADIAL_BINS) * maxRadius;
+
+      const p = new cv.Point(
+        center.x + cos * radius,
+        center.y + sin * radius
+      );
+
+      let inside = cv.pointPolygonTest(shape.outer, p, false) >= 0;
+
+      if (inside) {
+        for (const hole of shape.holes) {
+          if (cv.pointPolygonTest(hole, p, false) >= 0) {
+            inside = false;
+            break;
+          }
+        }
+      }
+
+      raw[a * RADIAL_BINS + r] = inside ? 1 : 0;
+    }
+  }
+
+  const smooth = new Float32Array(raw.length);
+
+  function value(a, r) {
+    a = (a + ANGULAR_BINS) % ANGULAR_BINS;
+
+    if (r < 0 || r >= RADIAL_BINS) {
+      return 0;
+    }
+
+    return raw[a * RADIAL_BINS + r];
+  }
+
+  for (let a = 0; a < ANGULAR_BINS; a++) {
+    for (let r = 0; r < RADIAL_BINS; r++) {
+      let sum = 4 * value(a, r);
+
+      let weight = 4;
+
+      sum += value(a - 1, r);
+      sum += value(a + 1, r);
+      weight += 2;
+
+      sum += value(a, r - 1);
+      sum += value(a, r + 1);
+      weight += 2;
+
+      smooth[a * RADIAL_BINS + r] = sum / weight;
+    }
+  }
+
+  return smooth;
+}
+
+function polarDistance(a, b) {
+  let best = Infinity;
+
+  for (let shift = 0; shift < ANGULAR_BINS; shift++) {
+    let sum = 0;
+
+    for (let angle = 0; angle < ANGULAR_BINS; angle++) {
+      const otherAngle = (angle + shift) % ANGULAR_BINS;
+
+      const baseA = angle * RADIAL_BINS;
+
+      const baseB = otherAngle * RADIAL_BINS;
+
+      for (let r = 0; r < RADIAL_BINS;r++) {
+        const d = a[baseA + r] - b[baseB + r];
+
+        sum += d * d;
+      }
+    }
+
+    const rms = Math.sqrt(sum / (ANGULAR_BINS * RADIAL_BINS));
+
+    if (rms < best) {
+      best = rms;
+    }
+  }
+
+  return best;
+}
+
+function prepareShape(shape) {
+  shape.signature = polarSignature(shape);
+
+  if (!shape.features) {
+    shape.features = shapeFeatures(shape);
+  }
+
+  return shape;
+}
+
+function referenceForeground(src) {
+  const mask = cv.Mat.zeros(src.rows, src.cols, cv.CV_8UC1);
+
+  const channels = src.channels();
+
+  if (channels === 4) {
+    const planes = new cv.MatVector();
+
+    cv.split(src, planes);
+
+    const alpha = planes.get(3);
+    const alphaMask = new cv.Mat();
+
+    cv.threshold(alpha, alphaMask, 20, 255, cv.THRESH_BINARY);
+
+    const foregroundPixels = cv.countNonZero(alphaMask);
+
+    const useAlpha = foregroundPixels < src.rows * src.cols * 0.98;
+
+    if (useAlpha) {
+      alphaMask.copyTo(mask);
+    }
+
+    alpha.delete();
+    alphaMask.delete();
+    planes.delete();
+
+    if (useAlpha) {
+      return mask;
+    }
+  }
+
+  const data = src.data;
+  const ch = channels;
+
+  const corners = [
+    [0, 0],
+    [src.cols - 1, 0],
+    [0, src.rows - 1],
+    [src.cols - 1, src.rows - 1]
+  ];
+
+  const bg = [0, 0, 0];
+
+  function pixel(x, y, k) {
+    return data[(y * src.cols + x) * ch +k];
+  }
+
+  if (ch === 1) {
+    for (const [x, y] of corners) {
+      bg[0] += pixel(x, y, 0);
+    }
+
+    bg[0] /= corners.length;
+  } else {
+    for (let k = 0; k < 3; ++k) {
+      for (
+        const [x, y] of corners
+      ) {
+        bg[k] += pixel(x, y, k);
+      }
+
+      bg[k] /= corners.length;
+    }
+  }
+
+  const out = mask.data;
+
+  for (let y = 0; y < src.rows; y++) {
+    for (let x = 0; x < src.cols; x++) {
+      const p = (y * src.cols + x) * ch;
+
+      let dist2 = 0;
+
+      if (ch === 1) {
+        const d = data[p] - bg[0];
+
+        dist2 = d * d;
+      } else {
+        for (let k = 0; k < 3;k++) {
+          const d = data[p + k] - bg[k];
+
+          dist2 += d * d;
+        }
+      }
+
+      out[y * src.cols + x] = dist2 > 20 * 20 ? 255 : 0;
+    }
+  }
+
+  return mask;
+}
+
+function getReferenceShapes(src, count) {
+  const foreground = referenceForeground(src);
+
+  let result = null;
+
+  const maxKernel = Math.max(3, Math.min(15, Math.floor(Math.min(src.rows, src.cols) / 4) | 1));
+
+  for (let k = 3; k <= maxKernel; k += 2) {
+    const opened = new cv.Mat();
+
+    const kernel = cv.getStructuringElement(cv.MORPH_ELLIPSE, new cv.Size(k, k));
+
+    cv.morphologyEx(foreground, opened, cv.MORPH_OPEN, kernel);
+
+    kernel.delete();
+
+    let shapes = extractHierarchyShapes(opened);
+
+    opened.delete();
+
+    shapes = shapes.filter(s => {
+      const b = s.box;
+
+      const valid = s.features.outerArea >= 8 && b.width >= 4 && b.height >= 4;
+
+      if (!valid) {
+        releaseShape(s);
+      }
+
+      return valid;
+    });
+
+    shapes.sort((a, b) => b.features.outerArea - a.features.outerArea);
+
+    if (shapes.length >= count) {
+      result = shapes.slice(0, count);
+
+      for (let i = count; i < shapes.length; i++) {
+        releaseShape(shapes[i]);
+      }
+
+      break;
+    }
+
+    for (const s of shapes) {
+      releaseShape(s);
+    }
+  }
+
+  foreground.delete();
+
+  if (!result || result.length !== count) {
+    if (result) {
+      for (const s of result) {
+        releaseShape(s);
+      }
+    }
+
+    throw new Error(`Could not separate ${count} reference shapes.`);
+  }
+
+  result.sort((a, b) => {
+    const dx = a.center.x - b.center.x;
+
+    if (Math.abs(dx) > 1) {
+      return dx;
+    }
+
+    return a.center.y - b.center.y;
+  });
+
+  for (const s of result) {
+    prepareShape(s);
+  }
+
+  return result;
+}
+
+function getSceneCandidates(src, refs) {
+  const channels = new cv.MatVector();
+
+  cv.split(src, channels);
+
+  const edges = cv.Mat.zeros(src.rows, src.cols, cv.CV_8UC1);
+
+  const n = src.channels() === 1 ? 1 : Math.min(3, src.channels());
+
+  for (let i = 0; i < n; ++i) {
+    const channel = channels.get(i);
+
+    const e = new cv.Mat();
+
+    cv.Canny(channel, e, 20, 60, 3, false);
+
+    cv.bitwise_or(edges, e, edges);
+
+    channel.delete();
+    e.delete();
+  }
+
+  channels.delete();
+
+  const k3 = cv.getStructuringElement(cv.MORPH_ELLIPSE, new cv.Size(3, 3));
+
+  cv.morphologyEx(edges, edges, cv.MORPH_CLOSE, k3);
+
+  cv.dilate(edges, edges, k3);
+
+  k3.delete();
+
+  const regions = new cv.Mat();
+
+  cv.bitwise_not(edges, regions);
+
+  edges.delete();
+
+  let candidates = extractHierarchyShapes(regions);
+
+  regions.delete();
+
+  let minOuterArea = Infinity;
+  let maxOuterArea = 0;
+
+  let minSide = Infinity;
+  let maxSide = 0;
+
+  for (const ref of refs) {
+    minOuterArea = Math.min(minOuterArea, ref.features.outerArea);
+
+    maxOuterArea = Math.max(maxOuterArea, ref.features.outerArea);
+
+    minSide = Math.min(minSide, ref.box.width, ref.box.height);
+
+    maxSide = Math.max(maxSide, ref.box.width, ref.box.height);
+  }
+
+  const scaleArea = SCALE_FACTOR * SCALE_FACTOR;
+
+  const minAllowedArea = minOuterArea * scaleArea * 0.18;
+
+  const maxAllowedArea = maxOuterArea * scaleArea * 5.0;
+
+  const minAllowedSide = minSide * SCALE_FACTOR * 0.30;
+
+  const maxAllowedSide = maxSide * SCALE_FACTOR * 3.0;
+
+  candidates = candidates.filter(s => {
+    const f = s.features;
+    const b = s.box;
+
+    const ok =
+          f.outerArea >= minAllowedArea &&
+          f.outerArea <= maxAllowedArea &&
+          b.width >= minAllowedSide &&
+          b.height >= minAllowedSide &&
+          b.width <= maxAllowedSide &&
+          b.height <= maxAllowedSide;
+
+    if (!ok) {
+      releaseShape(s);
+    }
+
+    return ok;
+  });
+
+  for (const s of candidates) {
+    prepareShape(s);
+  }
+
+  return candidates;
+}
+
+function shapeCost(ref, cand) {
+  const polar = polarDistance(ref.signature, cand.signature);
+
+  const holeAreaPenalty = Math.abs(ref.features.holeAreaRatio - cand.features.holeAreaRatio);
+
+  const holeCountPenalty = Math.min(3, Math.abs(ref.features.holeCount - cand.features.holeCount));
+
+  let holeSizePenalty = 0;
+
+  for (let i = 0; i < 3; ++i) {
+    const a = ref.features.holeRatios[i] || 0;
+
+    const b = cand.features.holeRatios[i] || 0;
+
+    holeSizePenalty += Math.abs(a - b);
+  }
+
+  const dc = (ref.features.circularity - cand.features.circularity) / 0.4;
+
+  const ds = (ref.features.solidity - cand.features.solidity) / 0.3;
+
+  const da = (ref.features.aspect - cand.features.aspect) / 0.3;
+
+  const outerPenalty = Math.sqrt(dc * dc + ds * ds + da * da);
+
+  const measuredScale = Math.sqrt(cand.features.outerArea / Math.max(ref.features.outerArea, 1e-6));
+
+  const scalePenalty = Math.abs(Math.log(Math.max(measuredScale, 1e-6) / SCALE_FACTOR));
+
+  return polar + 0.30 * holeAreaPenalty + 0.07 * holeCountPenalty + 0.12 * holeSizePenalty + 0.08 * outerPenalty + 0.03 * scalePenalty;
+}
+
+function groupCandidates(candidates) {
+  const sorted = candidates.slice().sort((a, b) => b.features.outerArea - a.features.outerArea);
+
+  const groups = [];
+
+  for (const candidate of sorted) {
+    let matchedGroup = null;
+
+    for (const group of groups) {
+      const anchor = group.members[0];
+
+      const dx = anchor.center.x - candidate.center.x;
+
+      const dy = anchor.center.y - candidate.center.y;
+
+      const dist = Math.sqrt(dx * dx + dy * dy);
+
+      const size = Math.max(
+        anchor.box.width,
+        anchor.box.height,
+        candidate.box.width,
+        candidate.box.height
+      );
+
+      if (dist > size * 0.25) {
+        continue;
+      }
+
+      const candidateInAnchor = cv.pointPolygonTest(
+        anchor.outer,
+        new cv.Point(candidate.center.x, candidate.center.y),
+        false
+      ) >= 0;
+
+      const anchorInCandidate = cv.pointPolygonTest(
+        candidate.outer,
+        new cv.Point(anchor.center.x, anchor.center.y),
+        false
+      ) >= 0;
+
+      if (candidateInAnchor || anchorInCandidate) {
+        matchedGroup = group;
+        break;
+      }
+    }
+
+    if (matchedGroup) {
+      matchedGroup.members.push(candidate);
+    } else {
+      groups.push({
+        members: [candidate]
+      });
+    }
+  }
+
+  return groups;
+}
+
+function hungarian(cost) {
+  const n = cost.length;
+  const m = cost[0].length;
+
+  const u = new Array(n + 1).fill(0);
+
+  const v = new Array(m + 1).fill(0);
+
+  const p = new Array(m + 1).fill(0);
+
+  const way = new Array(m + 1).fill(0);
+
+  for (let i = 1; i <= n; ++i) {
+    p[0] = i;
+
+    let j0 = 0;
+
+    const minv = new Array(m + 1).fill(Infinity);
+
+    const used = new Array(m + 1).fill(false);
+
+    do {
+      used[j0] = true;
+
+      const i0 = p[j0];
+
+      let delta = Infinity;
+      let j1 = 0;
+
+      for (let j = 1; j <= m;j++) {
+        if (used[j]) {
+          continue;
+        }
+
+        const cur = cost[i0 - 1][j - 1] - u[i0] - v[j];
+
+        if (cur < minv[j]) {
+          minv[j] = cur;
+          way[j] = j0;
+        }
+
+        if (minv[j] < delta) {
+          delta = minv[j];
+          j1 = j;
+        }
+      }
+
+      for (let j = 0; j <= m; j++) {
+        if (used[j]) {
+          u[p[j]] += delta;
+          v[j] -= delta;
+        } else {
+          minv[j] -= delta;
+        }
+      }
+
+      j0 = j1;
+    } while (p[j0] !== 0);
+
+    do {
+      const j1 = way[j0];
+
+      p[j0] = p[j1];
+      j0 = j1;
+    } while (j0 !== 0);
+  }
+
+  const assignment = new Array(n).fill(-1);
+
+  for (let j = 1; j <= m; j++) {
+    if (p[j] > 0 && p[j] <= n) {
+      assignment[p[j] - 1] = j - 1;
+    }
+  }
+
+  return assignment;
+}
+
+function findShapes(referenceMat, sceneMat, count) {
+  const refs = getReferenceShapes(referenceMat, count);
+
+  const candidates = getSceneCandidates(sceneMat, refs);
+
+  try {
+    if (candidates.length < count) {
+      throw new Error(`Only ${candidates.length} scene candidates found; ${count} are required.`);
+    }
+
+    let groups = groupCandidates(candidates);
+
+    if (groups.length < count) {
+      groups = candidates.map(c => ({
+        members: [c]
+      }));
+    }
+
+    const costs = [];
+
+    const bestMember = [];
+
+    for (let r = 0; r < refs.length; r++) {
+      const row = [];
+      const memberRow = [];
+
+      for (let g = 0; g < groups.length; g++) {
+        let bestCost = Infinity;
+        let bestIndex = -1;
+
+        for (let k = 0; k < groups[g].members.length; k++) {
+          const score = shapeCost(refs[r], groups[g].members[k]);
+
+          if (score < bestCost) {
+            bestCost = score;
+            bestIndex = k;
+          }
+        }
+
+        row.push(bestCost);
+        memberRow.push(bestIndex);
+      }
+
+      costs.push(row);
+      bestMember.push(memberRow);
+    }
+
+    const assignment = hungarian(costs);
+
+    const dots = assignment.flatMap((groupIndex, refIndex) => {
+      if (groupIndex < 0) {
+        throw new Error(
+          "Could not assign all reference shapes."
+        );
+      }
+
+      const memberIndex = bestMember[refIndex][groupIndex];
+
+      const shape = groups[groupIndex].members[memberIndex];
+
+      return [Math.round(shape.center.x), Math.round(shape.center.y)];
+    });
+
+    return dots;
+  } finally {
+    for (const r of refs) {
+      releaseShape(r);
+    }
+
+    for (const c of candidates) {
+      releaseShape(c);
+    }
+  }
+}
+
+function read(url) {
+  return new Promise((resolve, reject) => Object.assign(new Image(), {
+    onload() {
+      const canvas = Object.assign(document.createElement("canvas"), {
+        width: this.width,
+        height: this.height
+      });
+      const ctx = canvas.getContext("2d");
+      ctx.drawImage(this, 0, 0);
+      resolve(cv.imread(canvas));
+      canvas.remove();
+    },
+    onerror: reject,
+    src: url
+  }));
+}
+
+function toCanvas(mat) {
+  const canvas = Object.assign(document.createElement("canvas"), {
+    width: mat.rows,
+    height: mat.cols
+  });
+  cv.imshow(canvas, mat);
+  return canvas;
+}
+
+async function generate() {
+  const response = await fetch("generate");
+  return response.json();
+}
+
+async function verify(captcha_id, dots) {
+  const response = await fetch("verify", {
+    method: "POST",
+    body: JSON.stringify({
+      captcha_id,
+      dots: dots.join(",")
+    })
+  });
+  return response.json();
+}
+
+async function solve(abortIfDone) {
+  abortIfDone();
+
+  const {captcha_id, count, image_base64, thumb_base64} = await generate();
+
+  if (count > 2) {
+    throw "Too many shapes, skipping due to low success rate";
+  }
+
+  abortIfDone();
+
+  const [thumb_mat, image_mat] = await Promise.all([read(thumb_base64), read(image_base64)]);
+
+  try {
+    abortIfDone();
+
+    const dots = findShapes(thumb_mat, image_mat, count);
+
+    const {success} = await verify(captcha_id, dots);
+
+    if (!success) {
+      throw "Failed";
+    }
+  } finally {
+    thumb_mat.delete();
+    image_mat.delete();
+  }
+}
+
+let complete = false;
+
+function setComplete() {
+  complete = true;
+  return true;
+}
+
+function abortIfDone() {
+  if (complete) {
+    throw "Aborted";
+  }
+}
+
+function task() {
+  return solve(abortIfDone);
+}
+
+(async () => {
+  try {
+    for (let i = 0; i < 10; i++) {
+      if (await Promise.any(Array.from({length: 10}, task)).then(setComplete, () => false)) {
+        return;
+      }
+    }
+  } finally {
+    latch.countDown();
+  }
+})();
+        </script>
+    </head>
+    <body></body>
+</html>

--- a/src/all/mangafire/assets/solver.html
+++ b/src/all/mangafire/assets/solver.html
@@ -1,909 +1,905 @@
 <!DOCTYPE html>
 <html lang="en-US">
-    <head>
-        <title>MangaFire Challenge Solver</title>
-        <script src="https://docs.opencv.org/5.0/opencv.js"></script>
-        <script>
-const SCALE_FACTOR = 1.5;
-const ANGULAR_BINS = 72;
-const RADIAL_BINS = 24;
-const MIN_HOLE_AREA_RATIO = 0.03;
+<head>
+    <title>MangaFire Challenge Solver</title>
+    <script src="https://docs.opencv.org/5.0/opencv.js"></script>
+    <script>
+        const SCALE_FACTOR = 1.5;
+        const ANGULAR_BINS = 72;
+        const RADIAL_BINS = 24;
+        const MIN_HOLE_AREA_RATIO = 0.03;
 
-function contourCenter(c) {
-  const m = cv.moments(c, false);
+        function contourCenter(c) {
+          const m = cv.moments(c, false);
 
-  if (Math.abs(m.m00) > 1e-8) {
-    return {
-      x: m.m10 / m.m00,
-      y: m.m01 / m.m00
-    };
-  }
-
-  const r = cv.boundingRect(c);
-
-  return {
-    x: r.x + r.width / 2,
-    y: r.y + r.height / 2
-  };
-}
-
-function releaseShape(shape) {
-  shape.outer.delete();
-
-  for (const h of shape.holes) {
-    h.delete();
-  }
-}
-
-function contourDepth(index, hierarchyData) {
-  let depth = 0;
-  let p = hierarchyData[index * 4 + 3];
-
-  while (p >= 0) {
-    depth++;
-    p = hierarchyData[p * 4 + 3];
-  }
-
-  return depth;
-}
-
-function shapeFeatures(shape) {
-  const outerArea = Math.abs(cv.contourArea(shape.outer, false));
-
-  let holeArea = 0;
-  const holeRatios = [];
-
-  for (const h of shape.holes) {
-    const a = Math.abs(cv.contourArea(h, false));
-
-    holeArea += a;
-    holeRatios.push(
-      outerArea > 0 ? a / outerArea : 0
-    );
-  }
-
-  holeRatios.sort((a, b) => b - a);
-
-  const perimeter = cv.arcLength(shape.outer, true);
-
-  const circularity = perimeter > 0 ? (4 * Math.PI * outerArea) / (perimeter * perimeter) : 0;
-
-  const hull = new cv.Mat();
-  cv.convexHull(shape.outer, hull, false, true);
-
-  const hullArea = Math.abs(cv.contourArea(hull, false));
-
-  hull.delete();
-
-  const solidity = hullArea > 0 ? outerArea / hullArea : 0;
-
-  const rr = cv.minAreaRect(shape.outer);
-  const rw = rr.size.width;
-  const rh = rr.size.height;
-
-  const aspect = Math.max(rw, rh) > 0 ? Math.min(rw, rh) / Math.max(rw, rh) : 0;
-
-  return {
-    outerArea,
-    netArea: Math.max(0, outerArea - holeArea),
-    holeArea,
-    holeAreaRatio: outerArea > 0 ? holeArea / outerArea : 0,
-    holeCount: shape.holes.length,
-    holeRatios,
-    circularity,
-    solidity,
-    aspect
-  };
-}
-
-function extractHierarchyShapes(binary) {
-  const input = binary.clone();
-
-  const contours = new cv.MatVector();
-  const hierarchy = new cv.Mat();
-
-  cv.findContours(
-    input,
-    contours,
-    hierarchy,
-    cv.RETR_TREE,
-    cv.CHAIN_APPROX_NONE
-  );
-
-  input.delete();
-
-  if (hierarchy.empty()) {
-    contours.delete();
-    hierarchy.delete();
-    return [];
-  }
-
-  const hd = hierarchy.data32S;
-  const result = [];
-
-  for (let i = 0; i < contours.size(); i++) {
-    if ((contourDepth(i, hd) & 1) !== 0) {
-      continue;
-    }
-
-    const outerSrc = contours.get(i);
-
-    const outerArea = Math.abs(cv.contourArea(outerSrc, false));
-
-    if (outerArea < 1) {
-      outerSrc.delete();
-      continue;
-    }
-
-    const outer = outerSrc.clone();
-    outerSrc.delete();
-
-    const holes = [];
-
-    let child = hd[i * 4 + 2];
-
-    while (child >= 0) {
-      const holeSrc = contours.get(child);
-
-      const holeArea = Math.abs(cv.contourArea(holeSrc, false));
-
-      if (holeArea >= Math.max(2, outerArea * MIN_HOLE_AREA_RATIO)) {
-        holes.push(holeSrc.clone());
-      }
-
-      holeSrc.delete();
-
-      child = hd[child * 4];
-    }
-
-    const shape = {
-      outer,
-      holes,
-      center: contourCenter(outer),
-      box: cv.boundingRect(outer)
-    };
-
-    shape.features = shapeFeatures(shape);
-
-    result.push(shape);
-  }
-
-  contours.delete();
-  hierarchy.delete();
-
-  return result;
-}
-
-function polarSignature(shape) {
-  const center = shape.center;
-
-  let maxRadius = 0;
-
-  const d = shape.outer.data32S;
-
-  for (let i = 0; i + 1 < d.length; i += 2) {
-    const dx = d[i] - center.x;
-    const dy = d[i + 1] - center.y;
-
-    maxRadius = Math.max(maxRadius, Math.sqrt(dx * dx + dy * dy));
-  }
-
-  if (maxRadius < 1e-6) {
-    return new Float32Array(ANGULAR_BINS * RADIAL_BINS);
-  }
-
-  const raw = new Float32Array(ANGULAR_BINS * RADIAL_BINS);
-
-  for (let a = 0; a < ANGULAR_BINS; a++) {
-    const angle = (a * Math.PI * 2) / ANGULAR_BINS;
-
-    const cos = Math.cos(angle);
-    const sin = Math.sin(angle);
-
-    for (let r = 0; r < RADIAL_BINS; r++) {
-      const radius = ((r + 0.5) / RADIAL_BINS) * maxRadius;
-
-      const p = new cv.Point(
-        center.x + cos * radius,
-        center.y + sin * radius
-      );
-
-      let inside = cv.pointPolygonTest(shape.outer, p, false) >= 0;
-
-      if (inside) {
-        for (const hole of shape.holes) {
-          if (cv.pointPolygonTest(hole, p, false) >= 0) {
-            inside = false;
-            break;
+          if (Math.abs(m.m00) > 1e-8) {
+            return {
+              x: m.m10 / m.m00,
+              y: m.m01 / m.m00
+            };
           }
-        }
-      }
 
-      raw[a * RADIAL_BINS + r] = inside ? 1 : 0;
-    }
-  }
+          const r = cv.boundingRect(c);
 
-  const smooth = new Float32Array(raw.length);
-
-  function value(a, r) {
-    a = (a + ANGULAR_BINS) % ANGULAR_BINS;
-
-    if (r < 0 || r >= RADIAL_BINS) {
-      return 0;
-    }
-
-    return raw[a * RADIAL_BINS + r];
-  }
-
-  for (let a = 0; a < ANGULAR_BINS; a++) {
-    for (let r = 0; r < RADIAL_BINS; r++) {
-      let sum = 4 * value(a, r);
-
-      let weight = 4;
-
-      sum += value(a - 1, r);
-      sum += value(a + 1, r);
-      weight += 2;
-
-      sum += value(a, r - 1);
-      sum += value(a, r + 1);
-      weight += 2;
-
-      smooth[a * RADIAL_BINS + r] = sum / weight;
-    }
-  }
-
-  return smooth;
-}
-
-function polarDistance(a, b) {
-  let best = Infinity;
-
-  for (let shift = 0; shift < ANGULAR_BINS; shift++) {
-    let sum = 0;
-
-    for (let angle = 0; angle < ANGULAR_BINS; angle++) {
-      const otherAngle = (angle + shift) % ANGULAR_BINS;
-
-      const baseA = angle * RADIAL_BINS;
-
-      const baseB = otherAngle * RADIAL_BINS;
-
-      for (let r = 0; r < RADIAL_BINS;r++) {
-        const d = a[baseA + r] - b[baseB + r];
-
-        sum += d * d;
-      }
-    }
-
-    const rms = Math.sqrt(sum / (ANGULAR_BINS * RADIAL_BINS));
-
-    if (rms < best) {
-      best = rms;
-    }
-  }
-
-  return best;
-}
-
-function prepareShape(shape) {
-  shape.signature = polarSignature(shape);
-
-  if (!shape.features) {
-    shape.features = shapeFeatures(shape);
-  }
-
-  return shape;
-}
-
-function referenceForeground(src) {
-  const mask = cv.Mat.zeros(src.rows, src.cols, cv.CV_8UC1);
-
-  const channels = src.channels();
-
-  if (channels === 4) {
-    const planes = new cv.MatVector();
-
-    cv.split(src, planes);
-
-    const alpha = planes.get(3);
-    const alphaMask = new cv.Mat();
-
-    cv.threshold(alpha, alphaMask, 20, 255, cv.THRESH_BINARY);
-
-    const foregroundPixels = cv.countNonZero(alphaMask);
-
-    const useAlpha = foregroundPixels < src.rows * src.cols * 0.98;
-
-    if (useAlpha) {
-      alphaMask.copyTo(mask);
-    }
-
-    alpha.delete();
-    alphaMask.delete();
-    planes.delete();
-
-    if (useAlpha) {
-      return mask;
-    }
-  }
-
-  const data = src.data;
-  const ch = channels;
-
-  const corners = [
-    [0, 0],
-    [src.cols - 1, 0],
-    [0, src.rows - 1],
-    [src.cols - 1, src.rows - 1]
-  ];
-
-  const bg = [0, 0, 0];
-
-  function pixel(x, y, k) {
-    return data[(y * src.cols + x) * ch +k];
-  }
-
-  if (ch === 1) {
-    for (const [x, y] of corners) {
-      bg[0] += pixel(x, y, 0);
-    }
-
-    bg[0] /= corners.length;
-  } else {
-    for (let k = 0; k < 3; ++k) {
-      for (
-        const [x, y] of corners
-      ) {
-        bg[k] += pixel(x, y, k);
-      }
-
-      bg[k] /= corners.length;
-    }
-  }
-
-  const out = mask.data;
-
-  for (let y = 0; y < src.rows; y++) {
-    for (let x = 0; x < src.cols; x++) {
-      const p = (y * src.cols + x) * ch;
-
-      let dist2 = 0;
-
-      if (ch === 1) {
-        const d = data[p] - bg[0];
-
-        dist2 = d * d;
-      } else {
-        for (let k = 0; k < 3;k++) {
-          const d = data[p + k] - bg[k];
-
-          dist2 += d * d;
-        }
-      }
-
-      out[y * src.cols + x] = dist2 > 20 * 20 ? 255 : 0;
-    }
-  }
-
-  return mask;
-}
-
-function getReferenceShapes(src, count) {
-  const foreground = referenceForeground(src);
-
-  let result = null;
-
-  const maxKernel = Math.max(3, Math.min(15, Math.floor(Math.min(src.rows, src.cols) / 4) | 1));
-
-  for (let k = 3; k <= maxKernel; k += 2) {
-    const opened = new cv.Mat();
-
-    const kernel = cv.getStructuringElement(cv.MORPH_ELLIPSE, new cv.Size(k, k));
-
-    cv.morphologyEx(foreground, opened, cv.MORPH_OPEN, kernel);
-
-    kernel.delete();
-
-    let shapes = extractHierarchyShapes(opened);
-
-    opened.delete();
-
-    shapes = shapes.filter(s => {
-      const b = s.box;
-
-      const valid = s.features.outerArea >= 8 && b.width >= 4 && b.height >= 4;
-
-      if (!valid) {
-        releaseShape(s);
-      }
-
-      return valid;
-    });
-
-    shapes.sort((a, b) => b.features.outerArea - a.features.outerArea);
-
-    if (shapes.length >= count) {
-      result = shapes.slice(0, count);
-
-      for (let i = count; i < shapes.length; i++) {
-        releaseShape(shapes[i]);
-      }
-
-      break;
-    }
-
-    for (const s of shapes) {
-      releaseShape(s);
-    }
-  }
-
-  foreground.delete();
-
-  if (!result || result.length !== count) {
-    if (result) {
-      for (const s of result) {
-        releaseShape(s);
-      }
-    }
-
-    throw new Error(`Could not separate ${count} reference shapes.`);
-  }
-
-  result.sort((a, b) => {
-    const dx = a.center.x - b.center.x;
-
-    if (Math.abs(dx) > 1) {
-      return dx;
-    }
-
-    return a.center.y - b.center.y;
-  });
-
-  for (const s of result) {
-    prepareShape(s);
-  }
-
-  return result;
-}
-
-function getSceneCandidates(src, refs) {
-  const channels = new cv.MatVector();
-
-  cv.split(src, channels);
-
-  const edges = cv.Mat.zeros(src.rows, src.cols, cv.CV_8UC1);
-
-  const n = src.channels() === 1 ? 1 : Math.min(3, src.channels());
-
-  for (let i = 0; i < n; ++i) {
-    const channel = channels.get(i);
-
-    const e = new cv.Mat();
-
-    cv.Canny(channel, e, 20, 60, 3, false);
-
-    cv.bitwise_or(edges, e, edges);
-
-    channel.delete();
-    e.delete();
-  }
-
-  channels.delete();
-
-  const k3 = cv.getStructuringElement(cv.MORPH_ELLIPSE, new cv.Size(3, 3));
-
-  cv.morphologyEx(edges, edges, cv.MORPH_CLOSE, k3);
-
-  cv.dilate(edges, edges, k3);
-
-  k3.delete();
-
-  const regions = new cv.Mat();
-
-  cv.bitwise_not(edges, regions);
-
-  edges.delete();
-
-  let candidates = extractHierarchyShapes(regions);
-
-  regions.delete();
-
-  let minOuterArea = Infinity;
-  let maxOuterArea = 0;
-
-  let minSide = Infinity;
-  let maxSide = 0;
-
-  for (const ref of refs) {
-    minOuterArea = Math.min(minOuterArea, ref.features.outerArea);
-
-    maxOuterArea = Math.max(maxOuterArea, ref.features.outerArea);
-
-    minSide = Math.min(minSide, ref.box.width, ref.box.height);
-
-    maxSide = Math.max(maxSide, ref.box.width, ref.box.height);
-  }
-
-  const scaleArea = SCALE_FACTOR * SCALE_FACTOR;
-
-  const minAllowedArea = minOuterArea * scaleArea * 0.18;
-
-  const maxAllowedArea = maxOuterArea * scaleArea * 5.0;
-
-  const minAllowedSide = minSide * SCALE_FACTOR * 0.30;
-
-  const maxAllowedSide = maxSide * SCALE_FACTOR * 3.0;
-
-  candidates = candidates.filter(s => {
-    const f = s.features;
-    const b = s.box;
-
-    const ok =
-          f.outerArea >= minAllowedArea &&
-          f.outerArea <= maxAllowedArea &&
-          b.width >= minAllowedSide &&
-          b.height >= minAllowedSide &&
-          b.width <= maxAllowedSide &&
-          b.height <= maxAllowedSide;
-
-    if (!ok) {
-      releaseShape(s);
-    }
-
-    return ok;
-  });
-
-  for (const s of candidates) {
-    prepareShape(s);
-  }
-
-  return candidates;
-}
-
-function shapeCost(ref, cand) {
-  const polar = polarDistance(ref.signature, cand.signature);
-
-  const holeAreaPenalty = Math.abs(ref.features.holeAreaRatio - cand.features.holeAreaRatio);
-
-  const holeCountPenalty = Math.min(3, Math.abs(ref.features.holeCount - cand.features.holeCount));
-
-  let holeSizePenalty = 0;
-
-  for (let i = 0; i < 3; ++i) {
-    const a = ref.features.holeRatios[i] || 0;
-
-    const b = cand.features.holeRatios[i] || 0;
-
-    holeSizePenalty += Math.abs(a - b);
-  }
-
-  const dc = (ref.features.circularity - cand.features.circularity) / 0.4;
-
-  const ds = (ref.features.solidity - cand.features.solidity) / 0.3;
-
-  const da = (ref.features.aspect - cand.features.aspect) / 0.3;
-
-  const outerPenalty = Math.sqrt(dc * dc + ds * ds + da * da);
-
-  const measuredScale = Math.sqrt(cand.features.outerArea / Math.max(ref.features.outerArea, 1e-6));
-
-  const scalePenalty = Math.abs(Math.log(Math.max(measuredScale, 1e-6) / SCALE_FACTOR));
-
-  return polar + 0.30 * holeAreaPenalty + 0.07 * holeCountPenalty + 0.12 * holeSizePenalty + 0.08 * outerPenalty + 0.03 * scalePenalty;
-}
-
-function groupCandidates(candidates) {
-  const sorted = candidates.slice().sort((a, b) => b.features.outerArea - a.features.outerArea);
-
-  const groups = [];
-
-  for (const candidate of sorted) {
-    let matchedGroup = null;
-
-    for (const group of groups) {
-      const anchor = group.members[0];
-
-      const dx = anchor.center.x - candidate.center.x;
-
-      const dy = anchor.center.y - candidate.center.y;
-
-      const dist = Math.sqrt(dx * dx + dy * dy);
-
-      const size = Math.max(
-        anchor.box.width,
-        anchor.box.height,
-        candidate.box.width,
-        candidate.box.height
-      );
-
-      if (dist > size * 0.25) {
-        continue;
-      }
-
-      const candidateInAnchor = cv.pointPolygonTest(
-        anchor.outer,
-        new cv.Point(candidate.center.x, candidate.center.y),
-        false
-      ) >= 0;
-
-      const anchorInCandidate = cv.pointPolygonTest(
-        candidate.outer,
-        new cv.Point(anchor.center.x, anchor.center.y),
-        false
-      ) >= 0;
-
-      if (candidateInAnchor || anchorInCandidate) {
-        matchedGroup = group;
-        break;
-      }
-    }
-
-    if (matchedGroup) {
-      matchedGroup.members.push(candidate);
-    } else {
-      groups.push({
-        members: [candidate]
-      });
-    }
-  }
-
-  return groups;
-}
-
-function hungarian(cost) {
-  const n = cost.length;
-  const m = cost[0].length;
-
-  const u = new Array(n + 1).fill(0);
-
-  const v = new Array(m + 1).fill(0);
-
-  const p = new Array(m + 1).fill(0);
-
-  const way = new Array(m + 1).fill(0);
-
-  for (let i = 1; i <= n; ++i) {
-    p[0] = i;
-
-    let j0 = 0;
-
-    const minv = new Array(m + 1).fill(Infinity);
-
-    const used = new Array(m + 1).fill(false);
-
-    do {
-      used[j0] = true;
-
-      const i0 = p[j0];
-
-      let delta = Infinity;
-      let j1 = 0;
-
-      for (let j = 1; j <= m;j++) {
-        if (used[j]) {
-          continue;
+          return {
+            x: r.x + r.width / 2,
+            y: r.y + r.height / 2
+          };
         }
 
-        const cur = cost[i0 - 1][j - 1] - u[i0] - v[j];
+        function releaseShape(shape) {
+          shape.outer.delete();
 
-        if (cur < minv[j]) {
-          minv[j] = cur;
-          way[j] = j0;
-        }
-
-        if (minv[j] < delta) {
-          delta = minv[j];
-          j1 = j;
-        }
-      }
-
-      for (let j = 0; j <= m; j++) {
-        if (used[j]) {
-          u[p[j]] += delta;
-          v[j] -= delta;
-        } else {
-          minv[j] -= delta;
-        }
-      }
-
-      j0 = j1;
-    } while (p[j0] !== 0);
-
-    do {
-      const j1 = way[j0];
-
-      p[j0] = p[j1];
-      j0 = j1;
-    } while (j0 !== 0);
-  }
-
-  const assignment = new Array(n).fill(-1);
-
-  for (let j = 1; j <= m; j++) {
-    if (p[j] > 0 && p[j] <= n) {
-      assignment[p[j] - 1] = j - 1;
-    }
-  }
-
-  return assignment;
-}
-
-function findShapes(referenceMat, sceneMat, count) {
-  const refs = getReferenceShapes(referenceMat, count);
-
-  const candidates = getSceneCandidates(sceneMat, refs);
-
-  try {
-    if (candidates.length < count) {
-      throw new Error(`Only ${candidates.length} scene candidates found; ${count} are required.`);
-    }
-
-    let groups = groupCandidates(candidates);
-
-    if (groups.length < count) {
-      groups = candidates.map(c => ({
-        members: [c]
-      }));
-    }
-
-    const costs = [];
-
-    const bestMember = [];
-
-    for (let r = 0; r < refs.length; r++) {
-      const row = [];
-      const memberRow = [];
-
-      for (let g = 0; g < groups.length; g++) {
-        let bestCost = Infinity;
-        let bestIndex = -1;
-
-        for (let k = 0; k < groups[g].members.length; k++) {
-          const score = shapeCost(refs[r], groups[g].members[k]);
-
-          if (score < bestCost) {
-            bestCost = score;
-            bestIndex = k;
+          for (const h of shape.holes) {
+            h.delete();
           }
         }
 
-        row.push(bestCost);
-        memberRow.push(bestIndex);
-      }
+        function contourDepth(index, hierarchyData) {
+          let depth = 0;
+          let p = hierarchyData[index * 4 + 3];
 
-      costs.push(row);
-      bestMember.push(memberRow);
-    }
+          while (p >= 0) {
+            depth++;
+            p = hierarchyData[p * 4 + 3];
+          }
 
-    const assignment = hungarian(costs);
+          return depth;
+        }
 
-    const dots = assignment.flatMap((groupIndex, refIndex) => {
-      if (groupIndex < 0) {
-        throw new Error(
-          "Could not assign all reference shapes."
-        );
-      }
+        function shapeFeatures(shape) {
+          const outerArea = Math.abs(cv.contourArea(shape.outer, false));
 
-      const memberIndex = bestMember[refIndex][groupIndex];
+          let holeArea = 0;
+          const holeRatios = [];
 
-      const shape = groups[groupIndex].members[memberIndex];
+          for (const h of shape.holes) {
+            const a = Math.abs(cv.contourArea(h, false));
 
-      return [Math.round(shape.center.x), Math.round(shape.center.y)];
-    });
+            holeArea += a;
+            holeRatios.push(
+              outerArea > 0 ? a / outerArea : 0
+            );
+          }
 
-    return dots;
-  } finally {
-    for (const r of refs) {
-      releaseShape(r);
-    }
+          holeRatios.sort((a, b) => b - a);
 
-    for (const c of candidates) {
-      releaseShape(c);
-    }
-  }
-}
+          const perimeter = cv.arcLength(shape.outer, true);
 
-function read(url) {
-  return new Promise((resolve, reject) => Object.assign(new Image(), {
-    onload() {
-      const canvas = Object.assign(document.createElement("canvas"), {
-        width: this.width,
-        height: this.height
-      });
-      const ctx = canvas.getContext("2d");
-      ctx.drawImage(this, 0, 0);
-      resolve(cv.imread(canvas));
-      canvas.remove();
-    },
-    onerror: reject,
-    src: url
-  }));
-}
+          const circularity = perimeter > 0 ? (4 * Math.PI * outerArea) / (perimeter * perimeter) : 0;
 
-function toCanvas(mat) {
-  const canvas = Object.assign(document.createElement("canvas"), {
-    width: mat.rows,
-    height: mat.cols
-  });
-  cv.imshow(canvas, mat);
-  return canvas;
-}
+          const hull = new cv.Mat();
+          cv.convexHull(shape.outer, hull, false, true);
 
-async function generate() {
-  const response = await fetch("generate");
-  return response.json();
-}
+          const hullArea = Math.abs(cv.contourArea(hull, false));
 
-async function verify(captcha_id, dots) {
-  const response = await fetch("verify", {
-    method: "POST",
-    body: JSON.stringify({
-      captcha_id,
-      dots: dots.join(",")
-    })
-  });
-  return response.json();
-}
+          hull.delete();
 
-async function solve(abortIfDone) {
-  abortIfDone();
+          const solidity = hullArea > 0 ? outerArea / hullArea : 0;
 
-  const {captcha_id, count, image_base64, thumb_base64} = await generate();
+          const rr = cv.minAreaRect(shape.outer);
+          const rw = rr.size.width;
+          const rh = rr.size.height;
 
-  if (count > 2) {
-    throw "Too many shapes, skipping due to low success rate";
-  }
+          const aspect = Math.max(rw, rh) > 0 ? Math.min(rw, rh) / Math.max(rw, rh) : 0;
 
-  abortIfDone();
+          return {
+            outerArea,
+            netArea: Math.max(0, outerArea - holeArea),
+            holeArea,
+            holeAreaRatio: outerArea > 0 ? holeArea / outerArea : 0,
+            holeCount: shape.holes.length,
+            holeRatios,
+            circularity,
+            solidity,
+            aspect
+          };
+        }
 
-  const [thumb_mat, image_mat] = await Promise.all([read(thumb_base64), read(image_base64)]);
+        function extractHierarchyShapes(binary) {
+          const input = binary.clone();
 
-  try {
-    abortIfDone();
+          const contours = new cv.MatVector();
+          const hierarchy = new cv.Mat();
 
-    const dots = findShapes(thumb_mat, image_mat, count);
+          cv.findContours(
+            input,
+            contours,
+            hierarchy,
+            cv.RETR_TREE,
+            cv.CHAIN_APPROX_NONE
+          );
 
-    const {success} = await verify(captcha_id, dots);
+          input.delete();
 
-    if (!success) {
-      throw "Failed";
-    }
-  } finally {
-    thumb_mat.delete();
-    image_mat.delete();
-  }
-}
+          if (hierarchy.empty()) {
+            contours.delete();
+            hierarchy.delete();
+            return [];
+          }
 
-let complete = false;
+          const hd = hierarchy.data32S;
+          const result = [];
 
-function setComplete() {
-  complete = true;
-  return true;
-}
+          for (let i = 0; i < contours.size(); i++) {
+            if ((contourDepth(i, hd) & 1) !== 0) {
+              continue;
+            }
 
-function abortIfDone() {
-  if (complete) {
-    throw "Aborted";
-  }
-}
+            const outerSrc = contours.get(i);
 
-function task() {
-  return solve(abortIfDone);
-}
+            const outerArea = Math.abs(cv.contourArea(outerSrc, false));
 
-(async () => {
-  try {
-    for (let i = 0; i < 10; i++) {
-      if (await Promise.any(Array.from({length: 10}, task)).then(setComplete, () => false)) {
-        return;
-      }
-    }
-  } finally {
-    latch.countDown();
-  }
-})();
-        </script>
-    </head>
-    <body></body>
+            if (outerArea < 1) {
+              outerSrc.delete();
+              continue;
+            }
+
+            const outer = outerSrc.clone();
+            outerSrc.delete();
+
+            const holes = [];
+
+            let child = hd[i * 4 + 2];
+
+            while (child >= 0) {
+              const holeSrc = contours.get(child);
+
+              const holeArea = Math.abs(cv.contourArea(holeSrc, false));
+
+              if (holeArea >= Math.max(2, outerArea * MIN_HOLE_AREA_RATIO)) {
+                holes.push(holeSrc.clone());
+              }
+
+              holeSrc.delete();
+
+              child = hd[child * 4];
+            }
+
+            const shape = {
+              outer,
+              holes,
+              center: contourCenter(outer),
+              box: cv.boundingRect(outer)
+            };
+
+            shape.features = shapeFeatures(shape);
+
+            result.push(shape);
+          }
+
+          contours.delete();
+          hierarchy.delete();
+
+          return result;
+        }
+
+        function polarSignature(shape) {
+          const center = shape.center;
+
+          let maxRadius = 0;
+
+          const d = shape.outer.data32S;
+
+          for (let i = 0; i + 1 < d.length; i += 2) {
+            const dx = d[i] - center.x;
+            const dy = d[i + 1] - center.y;
+
+            maxRadius = Math.max(maxRadius, Math.sqrt(dx * dx + dy * dy));
+          }
+
+          if (maxRadius < 1e-6) {
+            return new Float32Array(ANGULAR_BINS * RADIAL_BINS);
+          }
+
+          const raw = new Float32Array(ANGULAR_BINS * RADIAL_BINS);
+
+          for (let a = 0; a < ANGULAR_BINS; a++) {
+            const angle = (a * Math.PI * 2) / ANGULAR_BINS;
+
+            const cos = Math.cos(angle);
+            const sin = Math.sin(angle);
+
+            for (let r = 0; r < RADIAL_BINS; r++) {
+              const radius = ((r + 0.5) / RADIAL_BINS) * maxRadius;
+
+              const p = new cv.Point(
+                center.x + cos * radius,
+                center.y + sin * radius
+              );
+
+              let inside = cv.pointPolygonTest(shape.outer, p, false) >= 0;
+
+              if (inside) {
+                for (const hole of shape.holes) {
+                  if (cv.pointPolygonTest(hole, p, false) >= 0) {
+                    inside = false;
+                    break;
+                  }
+                }
+              }
+
+              raw[a * RADIAL_BINS + r] = inside ? 1 : 0;
+            }
+          }
+
+          const smooth = new Float32Array(raw.length);
+
+          function value(a, r) {
+            a = (a + ANGULAR_BINS) % ANGULAR_BINS;
+
+            if (r < 0 || r >= RADIAL_BINS) {
+              return 0;
+            }
+
+            return raw[a * RADIAL_BINS + r];
+          }
+
+          for (let a = 0; a < ANGULAR_BINS; a++) {
+            for (let r = 0; r < RADIAL_BINS; r++) {
+              let sum = 4 * value(a, r);
+
+              let weight = 4;
+
+              sum += value(a - 1, r);
+              sum += value(a + 1, r);
+              weight += 2;
+
+              sum += value(a, r - 1);
+              sum += value(a, r + 1);
+              weight += 2;
+
+              smooth[a * RADIAL_BINS + r] = sum / weight;
+            }
+          }
+
+          return smooth;
+        }
+
+        function polarDistance(a, b) {
+          let best = Infinity;
+
+          for (let shift = 0; shift < ANGULAR_BINS; shift++) {
+            let sum = 0;
+
+            for (let angle = 0; angle < ANGULAR_BINS; angle++) {
+              const otherAngle = (angle + shift) % ANGULAR_BINS;
+
+              const baseA = angle * RADIAL_BINS;
+
+              const baseB = otherAngle * RADIAL_BINS;
+
+              for (let r = 0; r < RADIAL_BINS;r++) {
+                const d = a[baseA + r] - b[baseB + r];
+
+                sum += d * d;
+              }
+            }
+
+            const rms = Math.sqrt(sum / (ANGULAR_BINS * RADIAL_BINS));
+
+            if (rms < best) {
+              best = rms;
+            }
+          }
+
+          return best;
+        }
+
+        function prepareShape(shape) {
+          shape.signature = polarSignature(shape);
+
+          if (!shape.features) {
+            shape.features = shapeFeatures(shape);
+          }
+
+          return shape;
+        }
+
+        function referenceForeground(src) {
+          const mask = cv.Mat.zeros(src.rows, src.cols, cv.CV_8UC1);
+
+          const channels = src.channels();
+
+          if (channels === 4) {
+            const planes = new cv.MatVector();
+
+            cv.split(src, planes);
+
+            const alpha = planes.get(3);
+            const alphaMask = new cv.Mat();
+
+            cv.threshold(alpha, alphaMask, 20, 255, cv.THRESH_BINARY);
+
+            const foregroundPixels = cv.countNonZero(alphaMask);
+
+            const useAlpha = foregroundPixels < src.rows * src.cols * 0.98;
+
+            if (useAlpha) {
+              alphaMask.copyTo(mask);
+            }
+
+            alpha.delete();
+            alphaMask.delete();
+            planes.delete();
+
+            if (useAlpha) {
+              return mask;
+            }
+          }
+
+          const data = src.data;
+          const ch = channels;
+
+          const corners = [
+            [0, 0],
+            [src.cols - 1, 0],
+            [0, src.rows - 1],
+            [src.cols - 1, src.rows - 1]
+          ];
+
+          const bg = [0, 0, 0];
+
+          function pixel(x, y, k) {
+            return data[(y * src.cols + x) * ch +k];
+          }
+
+          if (ch === 1) {
+            for (const [x, y] of corners) {
+              bg[0] += pixel(x, y, 0);
+            }
+
+            bg[0] /= corners.length;
+          } else {
+            for (let k = 0; k < 3; ++k) {
+              for (
+                const [x, y] of corners
+              ) {
+                bg[k] += pixel(x, y, k);
+              }
+
+              bg[k] /= corners.length;
+            }
+          }
+
+          const out = mask.data;
+
+          for (let y = 0; y < src.rows; y++) {
+            for (let x = 0; x < src.cols; x++) {
+              const p = (y * src.cols + x) * ch;
+
+              let dist2 = 0;
+
+              if (ch === 1) {
+                const d = data[p] - bg[0];
+
+                dist2 = d * d;
+              } else {
+                for (let k = 0; k < 3;k++) {
+                  const d = data[p + k] - bg[k];
+
+                  dist2 += d * d;
+                }
+              }
+
+              out[y * src.cols + x] = dist2 > 20 * 20 ? 255 : 0;
+            }
+          }
+
+          return mask;
+        }
+
+        function getReferenceShapes(src, count) {
+          const foreground = referenceForeground(src);
+
+          let result = null;
+
+          const maxKernel = Math.max(3, Math.min(15, Math.floor(Math.min(src.rows, src.cols) / 4) | 1));
+
+          for (let k = 3; k <= maxKernel; k += 2) {
+            const opened = new cv.Mat();
+
+            const kernel = cv.getStructuringElement(cv.MORPH_ELLIPSE, new cv.Size(k, k));
+
+            cv.morphologyEx(foreground, opened, cv.MORPH_OPEN, kernel);
+
+            kernel.delete();
+
+            let shapes = extractHierarchyShapes(opened);
+
+            opened.delete();
+
+            shapes = shapes.filter(s => {
+              const b = s.box;
+
+              const valid = s.features.outerArea >= 8 && b.width >= 4 && b.height >= 4;
+
+              if (!valid) {
+                releaseShape(s);
+              }
+
+              return valid;
+            });
+
+            shapes.sort((a, b) => b.features.outerArea - a.features.outerArea);
+
+            if (shapes.length >= count) {
+              result = shapes.slice(0, count);
+
+              for (let i = count; i < shapes.length; i++) {
+                releaseShape(shapes[i]);
+              }
+
+              break;
+            }
+
+            for (const s of shapes) {
+              releaseShape(s);
+            }
+          }
+
+          foreground.delete();
+
+          if (!result || result.length !== count) {
+            if (result) {
+              for (const s of result) {
+                releaseShape(s);
+              }
+            }
+
+            throw new Error(`Could not separate ${count} reference shapes.`);
+          }
+
+          result.sort((a, b) => {
+            const dx = a.center.x - b.center.x;
+
+            if (Math.abs(dx) > 1) {
+              return dx;
+            }
+
+            return a.center.y - b.center.y;
+          });
+
+          for (const s of result) {
+            prepareShape(s);
+          }
+
+          return result;
+        }
+
+        function getSceneCandidates(src, refs) {
+          const channels = new cv.MatVector();
+
+          cv.split(src, channels);
+
+          const edges = cv.Mat.zeros(src.rows, src.cols, cv.CV_8UC1);
+
+          const n = src.channels() === 1 ? 1 : Math.min(3, src.channels());
+
+          for (let i = 0; i < n; ++i) {
+            const channel = channels.get(i);
+
+            const e = new cv.Mat();
+
+            cv.Canny(channel, e, 20, 60, 3, false);
+
+            cv.bitwise_or(edges, e, edges);
+
+            channel.delete();
+            e.delete();
+          }
+
+          channels.delete();
+
+          const k3 = cv.getStructuringElement(cv.MORPH_ELLIPSE, new cv.Size(3, 3));
+
+          cv.morphologyEx(edges, edges, cv.MORPH_CLOSE, k3);
+
+          cv.dilate(edges, edges, k3);
+
+          k3.delete();
+
+          const regions = new cv.Mat();
+
+          cv.bitwise_not(edges, regions);
+
+          edges.delete();
+
+          let candidates = extractHierarchyShapes(regions);
+
+          regions.delete();
+
+          let minOuterArea = Infinity;
+          let maxOuterArea = 0;
+
+          let minSide = Infinity;
+          let maxSide = 0;
+
+          for (const ref of refs) {
+            minOuterArea = Math.min(minOuterArea, ref.features.outerArea);
+
+            maxOuterArea = Math.max(maxOuterArea, ref.features.outerArea);
+
+            minSide = Math.min(minSide, ref.box.width, ref.box.height);
+
+            maxSide = Math.max(maxSide, ref.box.width, ref.box.height);
+          }
+
+          const scaleArea = SCALE_FACTOR * SCALE_FACTOR;
+
+          const minAllowedArea = minOuterArea * scaleArea * 0.18;
+
+          const maxAllowedArea = maxOuterArea * scaleArea * 5.0;
+
+          const minAllowedSide = minSide * SCALE_FACTOR * 0.30;
+
+          const maxAllowedSide = maxSide * SCALE_FACTOR * 3.0;
+
+          candidates = candidates.filter(s => {
+            const f = s.features;
+            const b = s.box;
+
+            const ok =
+                  f.outerArea >= minAllowedArea &&
+                  f.outerArea <= maxAllowedArea &&
+                  b.width >= minAllowedSide &&
+                  b.height >= minAllowedSide &&
+                  b.width <= maxAllowedSide &&
+                  b.height <= maxAllowedSide;
+
+            if (!ok) {
+              releaseShape(s);
+            }
+
+            return ok;
+          });
+
+          for (const s of candidates) {
+            prepareShape(s);
+          }
+
+          return candidates;
+        }
+
+        function shapeCost(ref, cand) {
+          const polar = polarDistance(ref.signature, cand.signature);
+
+          const holeAreaPenalty = Math.abs(ref.features.holeAreaRatio - cand.features.holeAreaRatio);
+
+          const holeCountPenalty = Math.min(3, Math.abs(ref.features.holeCount - cand.features.holeCount));
+
+          let holeSizePenalty = 0;
+
+          for (let i = 0; i < 3; ++i) {
+            const a = ref.features.holeRatios[i] || 0;
+
+            const b = cand.features.holeRatios[i] || 0;
+
+            holeSizePenalty += Math.abs(a - b);
+          }
+
+          const dc = (ref.features.circularity - cand.features.circularity) / 0.4;
+
+          const ds = (ref.features.solidity - cand.features.solidity) / 0.3;
+
+          const da = (ref.features.aspect - cand.features.aspect) / 0.3;
+
+          const outerPenalty = Math.sqrt(dc * dc + ds * ds + da * da);
+
+          const measuredScale = Math.sqrt(cand.features.outerArea / Math.max(ref.features.outerArea, 1e-6));
+
+          const scalePenalty = Math.abs(Math.log(Math.max(measuredScale, 1e-6) / SCALE_FACTOR));
+
+          return polar + 0.30 * holeAreaPenalty + 0.07 * holeCountPenalty + 0.12 * holeSizePenalty + 0.08 * outerPenalty + 0.03 * scalePenalty;
+        }
+
+        function groupCandidates(candidates) {
+          const sorted = candidates.slice().sort((a, b) => b.features.outerArea - a.features.outerArea);
+
+          const groups = [];
+
+          for (const candidate of sorted) {
+            let matchedGroup = null;
+
+            for (const group of groups) {
+              const anchor = group.members[0];
+
+              const dx = anchor.center.x - candidate.center.x;
+
+              const dy = anchor.center.y - candidate.center.y;
+
+              const dist = Math.sqrt(dx * dx + dy * dy);
+
+              const size = Math.max(
+                anchor.box.width,
+                anchor.box.height,
+                candidate.box.width,
+                candidate.box.height
+              );
+
+              if (dist > size * 0.25) {
+                continue;
+              }
+
+              const candidateInAnchor = cv.pointPolygonTest(
+                anchor.outer,
+                new cv.Point(candidate.center.x, candidate.center.y),
+                false
+              ) >= 0;
+
+              const anchorInCandidate = cv.pointPolygonTest(
+                candidate.outer,
+                new cv.Point(anchor.center.x, anchor.center.y),
+                false
+              ) >= 0;
+
+              if (candidateInAnchor || anchorInCandidate) {
+                matchedGroup = group;
+                break;
+              }
+            }
+
+            if (matchedGroup) {
+              matchedGroup.members.push(candidate);
+            } else {
+              groups.push({
+                members: [candidate]
+              });
+            }
+          }
+
+          return groups;
+        }
+
+        function hungarian(cost) {
+          const n = cost.length;
+          const m = cost[0].length;
+
+          const u = new Array(n + 1).fill(0);
+
+          const v = new Array(m + 1).fill(0);
+
+          const p = new Array(m + 1).fill(0);
+
+          const way = new Array(m + 1).fill(0);
+
+          for (let i = 1; i <= n; ++i) {
+            p[0] = i;
+
+            let j0 = 0;
+
+            const minv = new Array(m + 1).fill(Infinity);
+
+            const used = new Array(m + 1).fill(false);
+
+            do {
+              used[j0] = true;
+
+              const i0 = p[j0];
+
+              let delta = Infinity;
+              let j1 = 0;
+
+              for (let j = 1; j <= m;j++) {
+                if (used[j]) {
+                  continue;
+                }
+
+                const cur = cost[i0 - 1][j - 1] - u[i0] - v[j];
+
+                if (cur < minv[j]) {
+                  minv[j] = cur;
+                  way[j] = j0;
+                }
+
+                if (minv[j] < delta) {
+                  delta = minv[j];
+                  j1 = j;
+                }
+              }
+
+              for (let j = 0; j <= m; j++) {
+                if (used[j]) {
+                  u[p[j]] += delta;
+                  v[j] -= delta;
+                } else {
+                  minv[j] -= delta;
+                }
+              }
+
+              j0 = j1;
+            } while (p[j0] !== 0);
+
+            do {
+              const j1 = way[j0];
+
+              p[j0] = p[j1];
+              j0 = j1;
+            } while (j0 !== 0);
+          }
+
+          const assignment = new Array(n).fill(-1);
+
+          for (let j = 1; j <= m; j++) {
+            if (p[j] > 0 && p[j] <= n) {
+              assignment[p[j] - 1] = j - 1;
+            }
+          }
+
+          return assignment;
+        }
+
+        function findShapes(referenceMat, sceneMat, count) {
+          const refs = getReferenceShapes(referenceMat, count);
+
+          const candidates = getSceneCandidates(sceneMat, refs);
+
+          try {
+            if (candidates.length < count) {
+              throw new Error(`Only ${candidates.length} scene candidates found; ${count} are required.`);
+            }
+
+            let groups = groupCandidates(candidates);
+
+            if (groups.length < count) {
+              groups = candidates.map(c => ({
+                members: [c]
+              }));
+            }
+
+            const costs = [];
+
+            const bestMember = [];
+
+            for (let r = 0; r < refs.length; r++) {
+              const row = [];
+              const memberRow = [];
+
+              for (let g = 0; g < groups.length; g++) {
+                let bestCost = Infinity;
+                let bestIndex = -1;
+
+                for (let k = 0; k < groups[g].members.length; k++) {
+                  const score = shapeCost(refs[r], groups[g].members[k]);
+
+                  if (score < bestCost) {
+                    bestCost = score;
+                    bestIndex = k;
+                  }
+                }
+
+                row.push(bestCost);
+                memberRow.push(bestIndex);
+              }
+
+              costs.push(row);
+              bestMember.push(memberRow);
+            }
+
+            const assignment = hungarian(costs);
+
+            const dots = assignment.flatMap((groupIndex, refIndex) => {
+              if (groupIndex < 0) {
+                throw new Error(
+                  "Could not assign all reference shapes."
+                );
+              }
+
+              const memberIndex = bestMember[refIndex][groupIndex];
+
+              const shape = groups[groupIndex].members[memberIndex];
+
+              return [Math.round(shape.center.x), Math.round(shape.center.y)];
+            });
+
+            return dots;
+          } finally {
+            for (const r of refs) {
+              releaseShape(r);
+            }
+
+            for (const c of candidates) {
+              releaseShape(c);
+            }
+          }
+        }
+
+        function read(url) {
+          return new Promise((resolve, reject) => Object.assign(new Image(), {
+            onload() {
+              const canvas = Object.assign(document.createElement("canvas"), {
+                width: this.width,
+                height: this.height
+              });
+              const ctx = canvas.getContext("2d");
+              ctx.drawImage(this, 0, 0);
+              resolve(cv.imread(canvas));
+              canvas.remove();
+            },
+            onerror: reject,
+            src: url
+          }));
+        }
+
+        function toCanvas(mat) {
+          const canvas = Object.assign(document.createElement("canvas"), {
+            width: mat.rows,
+            height: mat.cols
+          });
+          cv.imshow(canvas, mat);
+          return canvas;
+        }
+
+        async function generate() {
+          const response = await fetch("generate");
+          return response.json();
+        }
+
+        async function verify(captcha_id, dots) {
+          const response = await fetch("verify", {
+            method: "POST",
+            body: JSON.stringify({
+              captcha_id,
+              dots: dots.join(",")
+            })
+          });
+          return response.json();
+        }
+
+        let complete = false;
+
+        function setComplete() {
+          complete = true;
+          return true;
+        }
+
+        function abortIfDone() {
+          if (complete) {
+            throw "Aborted";
+          }
+        }
+
+        async function solve() {
+          abortIfDone();
+
+          const {captcha_id, count, image_base64, thumb_base64} = await generate();
+
+          if (count > 2) {
+            throw "Too many shapes, skipping due to low success rate";
+          }
+
+          abortIfDone();
+
+          const [thumb_mat, image_mat] = await Promise.all([read(thumb_base64), read(image_base64)]);
+
+          try {
+            abortIfDone();
+
+            const dots = findShapes(thumb_mat, image_mat, count);
+
+            const {success} = await verify(captcha_id, dots);
+
+            if (!success) {
+              throw "Failed";
+            }
+          } finally {
+            thumb_mat.delete();
+            image_mat.delete();
+          }
+        }
+
+        (async () => {
+          try {
+            for (let i = 0; i < 10; i++) {
+              if (await Promise.any(Array.from({length: 10}, solve)).then(setComplete, () => false)) {
+                return;
+              }
+            }
+          } finally {
+            jsInterface.resolve(complete);
+          }
+        })();
+    </script>
+</head>
+<body></body>
 </html>

--- a/src/all/mangafire/build.gradle.kts
+++ b/src/all/mangafire/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "MangaFire"
-    versionCode = 30
+    versionCode = 31
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
 

--- a/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/ChallengeSolverInterceptor.kt
+++ b/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/ChallengeSolverInterceptor.kt
@@ -32,7 +32,6 @@ class ChallengeSolverInterceptor(
         val error: String?,
     )
 
-    @SuppressLint("SetJavaScriptEnabled")
     override fun intercept(chain: Interceptor.Chain): Response {
         val call = chain.call()
         val request = chain.request()

--- a/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/ChallengeSolverInterceptor.kt
+++ b/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/ChallengeSolverInterceptor.kt
@@ -1,28 +1,27 @@
 package eu.kanade.tachiyomi.extension.all.mangafire
 
-import eu.kanade.tachiyomi.network.NetworkHelper
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.runWebViewBlocking
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
+import okhttp3.CookieJar
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.Response
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
 import java.io.IOException
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.withLock
 import kotlin.getValue
 
 class ChallengeSolverInterceptor(
+    getCookieJar: () -> CookieJar,
     private val doSolve: () -> Boolean,
 ) : Interceptor {
     private val html by lazy { javaClass.getResource("/assets/solver.html")!!.readText() }
 
     private val lock = ReentrantReadWriteLock()
 
-    private val cookieJar by lazy { Injekt.get<NetworkHelper>().client.cookieJar }
+    private val cookieJar by lazy { getCookieJar() }
 
     private fun clearance(url: HttpUrl) = cookieJar.loadForRequest(url).find { it.name == "waf_pass" }?.value
 

--- a/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/ChallengeSolverInterceptor.kt
+++ b/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/ChallengeSolverInterceptor.kt
@@ -1,0 +1,108 @@
+package eu.kanade.tachiyomi.extension.all.mangafire
+
+import android.annotation.SuppressLint
+import android.app.Application
+import android.os.Handler
+import android.os.Looper
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import android.widget.Toast
+import keiyoushi.utils.parseAs
+import kotlinx.serialization.Serializable
+import okhttp3.Interceptor
+import okhttp3.Response
+import uy.kohesive.injekt.injectLazy
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.getValue
+
+object ChallengeSolverInterceptor : Interceptor {
+    private val application by injectLazy<Application>()
+    private val html by lazy { javaClass.getResource("/assets/solver.html")!!.readText() }
+
+    @Serializable
+    private data class ErrorResponse(
+        val error: String?,
+    )
+
+    @SuppressLint("SetJavaScriptEnabled")
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val response = chain.proceed(request)
+
+        if (
+            response.code != 403 ||
+            response.peekBody(Long.MAX_VALUE).byteStream().parseAs<ErrorResponse>().error != "captcha_required"
+        ) {
+            return response
+        }
+
+        response.close()
+
+        // We are solving the challenge in a WebView instead of directly in Kotlin because the solver depends on OpenCV, which is >100 MB
+        // as a Kotlin dependency. Also, the OpenCV binaries would be in the storage of the extension app, making them inaccessible to the
+        // reader app.
+        // Using a WebView instead makes it possible to dynamically request OpenCV.js, keeping the app size small.
+
+        val handler = Handler(Looper.getMainLooper())
+        val latch = object : CountDownLatch(1) {
+            @JavascriptInterface
+            override fun countDown() {
+                super.countDown()
+            }
+        }
+        var webView: WebView? = null
+
+        handler.post {
+            Toast.makeText(application, "Attempting to solve MangaFire challenge", Toast.LENGTH_SHORT).show()
+
+            val view = WebView(application)
+            webView = view
+
+            with(view.settings) {
+                javaScriptEnabled = true
+                domStorageEnabled = true
+                databaseEnabled = true
+                loadWithOverviewMode = true
+                useWideViewPort = true
+                blockNetworkImage = false
+                userAgentString = request.header("User-Agent")
+            }
+
+            // Somewhat useful if you need to debug WebView issues. Don't delete.
+            /*view.webChromeClient = object : WebChromeClient() {
+                override fun onConsoleMessage(consoleMessage: ConsoleMessage?): Boolean {
+                    if (consoleMessage == null) {
+                        return false
+                    }
+                    val logContent = "wv: ${consoleMessage.message()} (${consoleMessage.sourceId()}, line ${consoleMessage.lineNumber()})"
+                    when (consoleMessage.messageLevel()) {
+                        ConsoleMessage.MessageLevel.DEBUG -> Log.d("mangafire", logContent)
+                        ConsoleMessage.MessageLevel.ERROR -> Log.e("mangafire", logContent)
+                        ConsoleMessage.MessageLevel.LOG -> Log.i("mangafire", logContent)
+                        ConsoleMessage.MessageLevel.TIP -> Log.i("mangafire", logContent)
+                        ConsoleMessage.MessageLevel.WARNING -> Log.w("mangafire", logContent)
+                        else -> Log.d("mangafire", logContent)
+                    }
+
+                    return true
+                }
+            }*/
+
+            view.addJavascriptInterface(latch, "latch")
+
+            view.loadDataWithBaseURL(
+                "https://mangafire.to/@waf/solver",
+                html,
+                "text/html",
+                "UTF-8",
+                null,
+            )
+        }
+
+        latch.await(30, TimeUnit.SECONDS)
+        handler.post { webView?.destroy() }
+
+        return chain.proceed(request)
+    }
+}

--- a/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/ChallengeSolverInterceptor.kt
+++ b/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/ChallengeSolverInterceptor.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.extension.all.mangafire
 
-import android.annotation.SuppressLint
 import eu.kanade.tachiyomi.network.NetworkHelper
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.runWebViewBlocking

--- a/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/ChallengeSolverInterceptor.kt
+++ b/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/ChallengeSolverInterceptor.kt
@@ -55,7 +55,7 @@ class ChallengeSolverInterceptor(
         response.close()
 
         if (!doSolve()) {
-            throw IOException("Shape-selecting captcha detected. Open in WebView to solve or turn on the setting to solve automatically.")
+            throw IOException("Shape-selecting captcha detected. Open in WebView to solve manually or turn on the setting to solve automatically.")
         }
 
         // We are solving the challenge in a WebView instead of directly in Kotlin because the solver depends on OpenCV, which is >100 MB

--- a/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/ChallengeSolverInterceptor.kt
+++ b/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/ChallengeSolverInterceptor.kt
@@ -12,11 +12,14 @@ import kotlinx.serialization.Serializable
 import okhttp3.Interceptor
 import okhttp3.Response
 import uy.kohesive.injekt.injectLazy
+import java.io.IOException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.getValue
 
-object ChallengeSolverInterceptor : Interceptor {
+class ChallengeSolverInterceptor(
+    private val doSolve: () -> Boolean,
+) : Interceptor {
     private val application by injectLazy<Application>()
     private val html by lazy { javaClass.getResource("/assets/solver.html")!!.readText() }
 
@@ -24,6 +27,18 @@ object ChallengeSolverInterceptor : Interceptor {
     private data class ErrorResponse(
         val error: String?,
     )
+
+    private class JsInterface {
+        val latch = CountDownLatch(1)
+        var solved: Boolean = false
+
+        @Suppress("unused")
+        @JavascriptInterface
+        fun resolve(solved: Boolean) {
+            this.solved = solved
+            latch.countDown()
+        }
+    }
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun intercept(chain: Interceptor.Chain): Response {
@@ -39,18 +54,17 @@ object ChallengeSolverInterceptor : Interceptor {
 
         response.close()
 
+        if (!doSolve()) {
+            throw IOException("Shape-selecting captcha detected. Open in WebView to solve or turn on the setting to solve automatically.")
+        }
+
         // We are solving the challenge in a WebView instead of directly in Kotlin because the solver depends on OpenCV, which is >100 MB
         // as a Kotlin dependency. Also, the OpenCV binaries would be in the storage of the extension app, making them inaccessible to the
         // reader app.
         // Using a WebView instead makes it possible to dynamically request OpenCV.js, keeping the app size small.
 
         val handler = Handler(Looper.getMainLooper())
-        val latch = object : CountDownLatch(1) {
-            @JavascriptInterface
-            override fun countDown() {
-                super.countDown()
-            }
-        }
+        val jsInterface = JsInterface()
         var webView: WebView? = null
 
         handler.post {
@@ -89,7 +103,7 @@ object ChallengeSolverInterceptor : Interceptor {
                 }
             }*/
 
-            view.addJavascriptInterface(latch, "latch")
+            view.addJavascriptInterface(jsInterface, "jsInterface")
 
             view.loadDataWithBaseURL(
                 "https://mangafire.to/@waf/solver",
@@ -100,8 +114,12 @@ object ChallengeSolverInterceptor : Interceptor {
             )
         }
 
-        latch.await(30, TimeUnit.SECONDS)
+        jsInterface.latch.await(30, TimeUnit.SECONDS)
         handler.post { webView?.destroy() }
+
+        if (!jsInterface.solved) {
+            throw IOException("Failed to solve shape-selecting captcha. Open in WebView to solve manually.")
+        }
 
         return chain.proceed(request)
     }

--- a/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/ChallengeSolverInterceptor.kt
+++ b/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/ChallengeSolverInterceptor.kt
@@ -1,123 +1,90 @@
 package eu.kanade.tachiyomi.extension.all.mangafire
 
 import android.annotation.SuppressLint
-import android.app.Application
-import android.os.Handler
-import android.os.Looper
-import android.webkit.JavascriptInterface
-import android.webkit.WebView
-import android.widget.Toast
+import eu.kanade.tachiyomi.network.NetworkHelper
 import keiyoushi.utils.parseAs
+import keiyoushi.utils.runWebViewBlocking
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.Response
-import uy.kohesive.injekt.injectLazy
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import java.io.IOException
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.withLock
 import kotlin.getValue
 
 class ChallengeSolverInterceptor(
     private val doSolve: () -> Boolean,
 ) : Interceptor {
-    private val application by injectLazy<Application>()
     private val html by lazy { javaClass.getResource("/assets/solver.html")!!.readText() }
+
+    private val lock = ReentrantReadWriteLock()
+
+    private val cookieJar by lazy { Injekt.get<NetworkHelper>().client.cookieJar }
+
+    private fun clearance(url: HttpUrl) = cookieJar.loadForRequest(url).find { it.name == "waf_pass" }?.value
 
     @Serializable
     private data class ErrorResponse(
         val error: String?,
     )
 
-    private class JsInterface {
-        val latch = CountDownLatch(1)
-        var solved: Boolean = false
-
-        @Suppress("unused")
-        @JavascriptInterface
-        fun resolve(solved: Boolean) {
-            this.solved = solved
-            latch.countDown()
-        }
-    }
-
     @SuppressLint("SetJavaScriptEnabled")
     override fun intercept(chain: Interceptor.Chain): Response {
+        val call = chain.call()
         val request = chain.request()
-        val response = chain.proceed(request)
+        val url = request.url
 
-        if (
-            response.code != 403 ||
-            response.peekBody(Long.MAX_VALUE).byteStream().parseAs<ErrorResponse>().error != "captcha_required"
-        ) {
-            return response
+        val oldClearance = lock.readLock().withLock {
+            // We can't just check cookies first because we might need to bypass Cloudflare
+            val response = chain.proceed(request)
+            if (
+                response.code != 403 ||
+                try {
+                    response.peekBody(Long.MAX_VALUE).byteStream().parseAs<ErrorResponse>().error != "captcha_required"
+                } catch (_: SerializationException) {
+                    true
+                }
+            ) {
+                return response
+            }
+            response.close()
+
+            if (!doSolve()) {
+                throw IOException("Shape-selecting captcha detected. Open in WebView to solve manually or turn on the setting to solve automatically.")
+            }
+
+            clearance(url)
         }
 
-        response.close()
-
-        if (!doSolve()) {
-            throw IOException("Shape-selecting captcha detected. Open in WebView to solve manually or turn on the setting to solve automatically.")
+        if (call.isCanceled()) {
+            throw IOException("Canceled")
         }
 
         // We are solving the challenge in a WebView instead of directly in Kotlin because the solver depends on OpenCV, which is >100 MB
         // as a Kotlin dependency. Also, the OpenCV binaries would be in the storage of the extension app, making them inaccessible to the
         // reader app.
         // Using a WebView instead makes it possible to dynamically request OpenCV.js, keeping the app size small.
-
-        val handler = Handler(Looper.getMainLooper())
-        val jsInterface = JsInterface()
-        var webView: WebView? = null
-
-        handler.post {
-            Toast.makeText(application, "Attempting to solve MangaFire challenge", Toast.LENGTH_SHORT).show()
-
-            val view = WebView(application)
-            webView = view
-
-            with(view.settings) {
-                javaScriptEnabled = true
-                domStorageEnabled = true
-                databaseEnabled = true
-                loadWithOverviewMode = true
-                useWideViewPort = true
-                blockNetworkImage = false
-                userAgentString = request.header("User-Agent")
+        val solved = lock.writeLock().withLock {
+            if (call.isCanceled()) {
+                throw IOException("Canceled")
             }
 
-            // Somewhat useful if you need to debug WebView issues. Don't delete.
-            /*view.webChromeClient = object : WebChromeClient() {
-                override fun onConsoleMessage(consoleMessage: ConsoleMessage?): Boolean {
-                    if (consoleMessage == null) {
-                        return false
-                    }
-                    val logContent = "wv: ${consoleMessage.message()} (${consoleMessage.sourceId()}, line ${consoleMessage.lineNumber()})"
-                    when (consoleMessage.messageLevel()) {
-                        ConsoleMessage.MessageLevel.DEBUG -> Log.d("mangafire", logContent)
-                        ConsoleMessage.MessageLevel.ERROR -> Log.e("mangafire", logContent)
-                        ConsoleMessage.MessageLevel.LOG -> Log.i("mangafire", logContent)
-                        ConsoleMessage.MessageLevel.TIP -> Log.i("mangafire", logContent)
-                        ConsoleMessage.MessageLevel.WARNING -> Log.w("mangafire", logContent)
-                        else -> Log.d("mangafire", logContent)
-                    }
+            if (clearance(url).let { it != oldClearance && !it.isNullOrBlank() }) {
+                // Captcha solved in another call, skip
+                return@withLock true
+            }
 
-                    return true
-                }
-            }*/
-
-            view.addJavascriptInterface(jsInterface, "jsInterface")
-
-            view.loadDataWithBaseURL(
-                "https://mangafire.to/@waf/solver",
-                html,
-                "text/html",
-                "UTF-8",
-                null,
-            )
+            runWebViewBlocking(call) {
+                jsBridge("bridge") { resolve(it == "true") }
+                loadData("https://${request.url.host}/@waf/solver", html)
+            }
         }
 
-        jsInterface.latch.await(30, TimeUnit.SECONDS)
-        handler.post { webView?.destroy() }
-
-        if (!jsInterface.solved) {
+        if (!solved) {
             throw IOException("Failed to solve shape-selecting captcha. Open in WebView to solve manually.")
         }
 

--- a/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/ChallengeSolverInterceptor.kt
+++ b/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/ChallengeSolverInterceptor.kt
@@ -77,7 +77,7 @@ class ChallengeSolverInterceptor(
 
             runWebViewBlocking(call) {
                 jsBridge("bridge") { resolve(it == "true") }
-                loadData("https://${request.url.host}/@waf/solver", html)
+                loadData("https://${url.host}/@waf/solver", html)
             }
         }
 

--- a/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/ChallengeSolverInterceptor.kt
+++ b/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/ChallengeSolverInterceptor.kt
@@ -21,7 +21,7 @@ class ChallengeSolverInterceptor(
 
     private val lock = ReentrantReadWriteLock()
 
-    private val cookieJar by lazy { getCookieJar() }
+    private val cookieJar by lazy(getCookieJar)
 
     private fun clearance(url: HttpUrl) = cookieJar.loadForRequest(url).find { it.name == "waf_pass" }?.value
 

--- a/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/MangaFire.kt
+++ b/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/MangaFire.kt
@@ -43,6 +43,7 @@ abstract class MangaFire :
     override fun OkHttpClient.Builder.configureClient() = apply {
         rateLimit(2)
         addInterceptor(VrfSigner().interceptor())
+        addInterceptor(ChallengeSolverInterceptor)
     }
 
     override fun Headers.Builder.configureHeaders() = apply {

--- a/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/MangaFire.kt
+++ b/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/MangaFire.kt
@@ -43,7 +43,7 @@ abstract class MangaFire :
     override fun OkHttpClient.Builder.configureClient() = apply {
         rateLimit(2)
         addInterceptor(VrfSigner().interceptor())
-        addInterceptor(ChallengeSolverInterceptor { solveCaptcha })
+        addInterceptor(ChallengeSolverInterceptor({ client.cookieJar }, { solveCaptcha }))
     }
 
     override fun Headers.Builder.configureHeaders() = apply {

--- a/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/MangaFire.kt
+++ b/src/all/mangafire/src/eu/kanade/tachiyomi/extension/all/mangafire/MangaFire.kt
@@ -43,7 +43,7 @@ abstract class MangaFire :
     override fun OkHttpClient.Builder.configureClient() = apply {
         rateLimit(2)
         addInterceptor(VrfSigner().interceptor())
-        addInterceptor(ChallengeSolverInterceptor)
+        addInterceptor(ChallengeSolverInterceptor { solveCaptcha })
     }
 
     override fun Headers.Builder.configureHeaders() = apply {
@@ -291,6 +291,9 @@ abstract class MangaFire :
     private val preferOfficial: Boolean
         get() = preferences.getBoolean(PREF_PREFER_OFFICIAL, true)
 
+    private val solveCaptcha: Boolean
+        get() = preferences.getBoolean(PREF_SOLVE_CAPTCHA, false)
+
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         MultiSelectListPreference(screen.context).apply {
             key = CONTENT_RATING_PREF
@@ -332,6 +335,12 @@ abstract class MangaFire :
             preferOfficialPref.setEnabled(newValue as Boolean)
             true
         }
+
+        SwitchPreferenceCompat(screen.context).apply {
+            key = PREF_SOLVE_CAPTCHA
+            title = "Automatically solve shape-selecting captcha"
+            setDefaultValue(false)
+        }.also(screen::addPreference)
     }
 
     companion object {
@@ -339,6 +348,7 @@ abstract class MangaFire :
         private const val PREF_SHOW_AS_VOLUMES = "show_as_volumes"
         private const val PREF_MERGE_CHAPTERS = "merge_chapters"
         private const val PREF_PREFER_OFFICIAL = "prefer_official"
+        private const val PREF_SOLVE_CAPTCHA = "solve_captcha"
         private const val SUMMARY_MSG = "Requires Chapter List Refresh to Apply"
     }
 }


### PR DESCRIPTION
MangaFire's shape-selecting captcha still shows up for certain IP addresses despite them switching over to Cloudflare challenge.

This change adds a solver for MangaFire's captcha via a WebView using OpenCV.js.

Since the success rate of the solver is around 10% to 20%, the solver is run in batches of 10, up to a total of 100 attempts. The captcha APIs apparently don't need rate limiting.

There are two main reasons I did not implement the solver in Kotlin:
1. The OpenCV dependency (org.opencv:opencv:5.0.0.1) is bloated (145.9 MB aar file) compared to v5.0 OpenCV.js (4321 KB over the network).
2. The .so files would be under the extension's app-specific directory instead of the reader's app-specific directory, which means we would need to store the .so files as assets and write them to temp files before manually loading them.

I used ChatGPT to help debug and improve the accuracy of the OpenCV magic, hence the AI-assisted checkbox.

<details>
  <summary>Example captcha</summary>

![image](https://github.com/user-attachments/assets/8bca01de-b3f0-4772-9edb-516c02e8d7d1)

</details>

<details>
  <summary>Video of solver in action in Komikku</summary>

https://github.com/user-attachments/assets/e5a97ed7-2449-484f-87d7-c51decc22a62

</details>

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
