### PR TITLE
Mangas-Origines.fr: fix page list

### DIFF
--- a/lib-multisrc/origines/build.gradle.kts
+++ b/lib-multisrc/origines/build.gradle.kts
@@ -3,6 +3,6 @@ plugins {
 }
 
 keiyoushi {
-    baseVersionCode = 0
+    baseVersionCode = 1
     libVersion = "1.6"
 }

--- a/lib-multisrc/origines/src/eu/kanade/tachiyomi/multisrc/origines/Origines.kt
+++ b/lib-multisrc/origines/src/eu/kanade/tachiyomi/multisrc/origines/Origines.kt
@@ -268,8 +268,12 @@ abstract class Origines : KeiSource() {
     override suspend fun getPageList(chapter: SChapter): List<Page> {
         val document = client.get("$baseUrl/$mangaPath/${chapter.url.toChapterSlug()}/").asJsoup()
 
-        return document.select("div.reading-content img.wp-manga-chapter-img").mapIndexed { index, image ->
-            Page(index, imageUrl = image.attr("src").trim())
+        return document.select("div.reading-content img.wp-manga-chapter-img").mapIndexed { index, img ->
+            val image = when {
+                img.hasAttr("data-src") -> img.absUrl("data-src").trim()
+                else -> img.absUrl("src").trim()
+            }
+            Page(index, imageUrl = image)
         }
     }
 


### PR DESCRIPTION
closes https://github.com/keiyoushi/extensions-source/issues/18555

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
