### PR TITLE
Updated Search Endpoint for MangaCloud[en]

### DIFF
--- a/src/en/mangacloud/build.gradle.kts
+++ b/src/en/mangacloud/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "MangaCloud"
-    versionCode = 7
+    versionCode = 8
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/en/mangacloud/src/eu/kanade/tachiyomi/extension/en/mangacloud/MangaCloud.kt
+++ b/src/en/mangacloud/src/eu/kanade/tachiyomi/extension/en/mangacloud/MangaCloud.kt
@@ -62,7 +62,7 @@ abstract class MangaCloud : HttpSource() {
         }
     }
 
-    override fun popularMangaParse(response: Response): MangasPage = if (response.request.url.pathSegments.last() == "browse") {
+    override fun popularMangaParse(response: Response): MangasPage = if (response.request.url.pathSegments.last() == "library") {
         searchMangaParse(response)
     } else {
         val data = response.parseAs<Data<DataList<BrowseManga>>>()

--- a/src/en/mangacloud/src/eu/kanade/tachiyomi/extension/en/mangacloud/MangaCloud.kt
+++ b/src/en/mangacloud/src/eu/kanade/tachiyomi/extension/en/mangacloud/MangaCloud.kt
@@ -187,7 +187,7 @@ abstract class MangaCloud : HttpSource() {
     }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        val url = "$API_URL/comic/browse"
+        val url = "$API_URL/comic/library"
 
         if (query.isNotBlank() && query.length < 3) {
             throw Exception("Search query must be more than 3 characters!")

--- a/src/en/mangacloud/src/eu/kanade/tachiyomi/extension/en/mangacloud/MangaCloud.kt
+++ b/src/en/mangacloud/src/eu/kanade/tachiyomi/extension/en/mangacloud/MangaCloud.kt
@@ -270,7 +270,7 @@ abstract class MangaCloud : HttpSource() {
     override fun pageListRequest(chapter: SChapter): Request {
         val chapterId = chapter.url.parseAs<ChapterUrl>().chapterId
 
-        return GET("$API_URL/chapter5/$chapterId", headers)
+        return GET("$API_URL/chapters/$chapterId", headers)
     }
 
     override fun getChapterUrl(chapter: SChapter): String {


### PR DESCRIPTION
closes #18563

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
