### PR TITLE
MangaYi: fix after site changes, migrate to 1.6

### DIFF
--- a/core/src/main/kotlin/keiyoushi/utils/Date.kt
+++ b/core/src/main/kotlin/keiyoushi/utils/Date.kt
@@ -31,13 +31,13 @@ fun SimpleDateFormat.tryParse(date: String?): Long {
  */
 fun DateTimeFormatter.tryParseDate(
     date: String?,
-    zone: ZoneId = ZoneId.systemDefault(),
+    zone: ZoneId? = null,
 ): Long {
     date ?: return 0L
 
     return runCatching {
         LocalDate.parse(date, this)
-            .atStartOfDay(zone)
+            .atStartOfDay(zone ?: this.zone ?: ZoneId.systemDefault())
             .toInstant()
             .toEpochMilli()
     }.getOrDefault(0L)
@@ -58,13 +58,13 @@ fun DateTimeFormatter.tryParseDate(
  */
 fun DateTimeFormatter.tryParseDateTime(
     date: String?,
-    zone: ZoneId = ZoneId.systemDefault(),
+    zone: ZoneId? = null,
 ): Long {
     date ?: return 0L
 
     return runCatching {
         LocalDateTime.parse(date, this)
-            .atZone(zone)
+            .atZone(zone ?: this.zone ?: ZoneId.systemDefault())
             .toInstant()
             .toEpochMilli()
     }.getOrDefault(0L)

--- a/src/en/mangayi/build.gradle.kts
+++ b/src/en/mangayi/build.gradle.kts
@@ -6,9 +6,9 @@ plugins {
 
 keiyoushi {
     name = "MangaYi"
-    versionCode = 1
+    versionCode = 2
     contentWarning = ContentWarning.SAFE
-    libVersion = "1.4"
+    libVersion = "1.6"
 
     source {
         lang = "en"

--- a/src/en/mangayi/src/eu/kanade/tachiyomi/extension/en/mangayi/Dto.kt
+++ b/src/en/mangayi/src/eu/kanade/tachiyomi/extension/en/mangayi/Dto.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 class SearchRequestDto(
+    private val p: Int? = null,
     private val s: String? = null,
     private val t: Int? = null,
 )
@@ -13,6 +14,7 @@ class SearchRequestDto(
 @Serializable
 class SearchResponseDto(
     val results: List<MangaDto>,
+    val total: Int,
 )
 
 @Serializable

--- a/src/en/mangayi/src/eu/kanade/tachiyomi/extension/en/mangayi/Dto.kt
+++ b/src/en/mangayi/src/eu/kanade/tachiyomi/extension/en/mangayi/Dto.kt
@@ -11,6 +11,11 @@ class SearchRequestDto(
 )
 
 @Serializable
+class SearchResponseDto(
+    val results: List<MangaDto>,
+)
+
+@Serializable
 class MangaDto(
     @SerialName("i") private val slug: String,
     @SerialName("t") private val title: String,

--- a/src/en/mangayi/src/eu/kanade/tachiyomi/extension/en/mangayi/MangaYi.kt
+++ b/src/en/mangayi/src/eu/kanade/tachiyomi/extension/en/mangayi/MangaYi.kt
@@ -1,84 +1,57 @@
 package eu.kanade.tachiyomi.extension.en.mangayi
 
-import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.annotation.Source
+import keiyoushi.network.get
+import keiyoushi.network.post
 import keiyoushi.network.rateLimit
+import keiyoushi.source.KeiSource
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.toJsonRequestBody
-import keiyoushi.utils.tryParse
-import okhttp3.Headers
-import okhttp3.Request
-import okhttp3.Response
-import java.text.SimpleDateFormat
+import keiyoushi.utils.tryParseDate
+import okhttp3.OkHttpClient
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Locale
-import java.util.TimeZone
 
 @Source
-abstract class MangaYi : HttpSource() {
+abstract class MangaYi : KeiSource() {
 
     override val supportsLatest = false
 
-    override val client = network.client.newBuilder()
-        .rateLimit(2)
-        .build()
-
-    override fun headersBuilder(): Headers.Builder = super.headersBuilder()
-        .add("Referer", "$baseUrl/")
+    override fun OkHttpClient.Builder.configureClient() = rateLimit(2)
 
     // ============================== Popular ==============================
 
-    override fun popularMangaRequest(page: Int): Request {
+    override suspend fun getPopularManga(page: Int): MangasPage {
         val payload = SearchRequestDto(t = 1)
-        return POST(
-            url = "$baseUrl/api/search",
-            headers = headers.newBuilder()
-                .add("Accept", "application/json")
-                .build(),
-            body = payload.toJsonRequestBody(),
-        )
-    }
-
-    override fun popularMangaParse(response: Response): MangasPage {
         val mangas = response.parseAs<List<MangaDto>>().map { it.toSManga() }
         return MangasPage(mangas, false)
     }
 
     // ============================== Latest ===============================
 
-    override fun latestUpdatesRequest(page: Int): Request = throw UnsupportedOperationException()
-
-    override fun latestUpdatesParse(response: Response): MangasPage = throw UnsupportedOperationException()
+    override suspend fun getLatestUpdates(page: Int): MangasPage = throw UnsupportedOperationException()
 
     // ============================== Search ===============================
 
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
         val payload = SearchRequestDto(s = query)
-        return POST(
-            url = "$baseUrl/api/search",
-            headers = headers.newBuilder()
-                .add("Accept", "application/json")
-                .build(),
-            body = payload.toJsonRequestBody(),
-        )
+        val mangas = response.parseAs<List<MangaDto>>().map { it.toSManga() }
+        return MangasPage(mangas, false)
     }
 
-    override fun searchMangaParse(response: Response): MangasPage = popularMangaParse(response)
+    // ============================== Updates ==============================
 
-    // ============================== Details ==============================
-
-    override fun mangaDetailsRequest(manga: SManga): Request = GET("$baseUrl/read/${manga.url}/", headers)
-
-    override fun mangaDetailsParse(response: Response): SManga {
-        val document = response.asJsoup()
-        return SManga.create().apply {
+    override suspend fun fetchMangaUpdate(manga: SManga, chapters: List<SChapter>, fetchDetails: Boolean, fetchChapters: Boolean): SMangaUpdate {
+        val document = client.get("$baseUrl/read/${manga.url}/").asJsoup()
+        val manga2 = SManga.create().apply {
             title = document.selectFirst("h1.title")!!.text()
             author = document.selectFirst(".authors")?.text()
             description = document.select(".summary p").joinToString("\n") { it.text() }
@@ -86,6 +59,17 @@ abstract class MangaYi : HttpSource() {
             status = document.selectFirst(".stat:contains(Status) .value")?.text().parseStatus()
             thumbnail_url = document.selectFirst(".cover-wrapper img.cover-image")?.attr("abs:src")
         }
+
+        val chapters = document.select("div.chapters a.c:not(.unreleased)")
+        val chapters2 = chapters.map { element ->
+            SChapter.create().apply {
+                setUrlWithoutDomain(element.absUrl("href"))
+                name = element.selectFirst(".t")!!.text()
+                date_upload = dateFormat.tryParseDate(element.selectFirst(".chapter-date")?.text())
+            }
+        }
+
+        return SMangaUpdate(manga2, chapters2)
     }
 
     private fun String?.parseStatus(): Int = when (this?.lowercase()) {
@@ -96,41 +80,18 @@ abstract class MangaYi : HttpSource() {
         else -> SManga.UNKNOWN
     }
 
-    // ============================= Chapters ==============================
-
-    override fun chapterListRequest(manga: SManga): Request = mangaDetailsRequest(manga)
-
-    override fun chapterListParse(response: Response): List<SChapter> {
-        val document = response.asJsoup()
-        val chapters = document.select("div.chapters a.c:not(.unreleased)")
-
-        if (chapters.isEmpty()) return emptyList()
-
-        return chapters.map { element ->
-            SChapter.create().apply {
-                setUrlWithoutDomain(element.absUrl("href"))
-                name = element.selectFirst(".t")!!.text()
-                date_upload = dateFormat.tryParse(element.selectFirst(".chapter-date")?.text())
-            }
-        }
-    }
-
     // =============================== Pages ===============================
 
-    override fun pageListParse(response: Response): List<Page> {
-        val document = response.asJsoup()
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        val document = client.get(getChapterUrl(chapter)).asJsoup()
         return document.select("div.images img").mapIndexed { index, img ->
             Page(index, imageUrl = img.attr("abs:src"))
         }
     }
 
-    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
-
     // ============================= Utilities =============================
 
     companion object {
-        private val dateFormat = SimpleDateFormat("d MMMM yyyy", Locale.ENGLISH).apply {
-            timeZone = TimeZone.getTimeZone("UTC")
-        }
+        private val dateFormat = DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.ENGLISH).withZone(ZoneId.of("UTC"))
     }
 }

--- a/src/en/mangayi/src/eu/kanade/tachiyomi/extension/en/mangayi/MangaYi.kt
+++ b/src/en/mangayi/src/eu/kanade/tachiyomi/extension/en/mangayi/MangaYi.kt
@@ -30,10 +30,8 @@ abstract class MangaYi : KeiSource() {
     // ============================== Popular ==============================
 
     override suspend fun getPopularManga(page: Int): MangasPage {
-        val payload = SearchRequestDto(t = 1)
-        val response = client.post("$baseUrl/api/search", payload.toJsonRequestBody())
-        val mangas = response.parseAs<SearchResponseDto>().results.map { it.toSManga() }
-        return MangasPage(mangas, false)
+        val payload = SearchRequestDto(p = page, t = 1)
+        return fetchMangasPage(payload, page)
     }
 
     // ============================== Latest ===============================
@@ -43,10 +41,19 @@ abstract class MangaYi : KeiSource() {
     // ============================== Search ===============================
 
     override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
-        val payload = SearchRequestDto(s = query)
+        val payload = SearchRequestDto(p = page, s = query)
+        return fetchMangasPage(payload, page)
+    }
+
+    private suspend fun fetchMangasPage(payload: SearchRequestDto, page: Int): MangasPage {
         val response = client.post("$baseUrl/api/search", payload.toJsonRequestBody())
-        val mangas = response.parseAs<SearchResponseDto>().results.map { it.toSManga() }
-        return MangasPage(mangas, false)
+        val dto = response.parseAs<SearchResponseDto>()
+
+        pageSize = maxOf(pageSize, dto.results.size)
+
+        val mangas = dto.results.map { it.toSManga() }
+        val hasNextPage = page * pageSize < dto.total
+        return MangasPage(mangas, hasNextPage)
     }
 
     // ============================== Updates ==============================
@@ -92,6 +99,8 @@ abstract class MangaYi : KeiSource() {
     }
 
     // ============================= Utilities =============================
+
+    private var pageSize = 24
 
     companion object {
         private val dateFormat = DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.ENGLISH).withZone(ZoneId.of("UTC"))

--- a/src/en/mangayi/src/eu/kanade/tachiyomi/extension/en/mangayi/MangaYi.kt
+++ b/src/en/mangayi/src/eu/kanade/tachiyomi/extension/en/mangayi/MangaYi.kt
@@ -31,7 +31,8 @@ abstract class MangaYi : KeiSource() {
 
     override suspend fun getPopularManga(page: Int): MangasPage {
         val payload = SearchRequestDto(t = 1)
-        val mangas = response.parseAs<List<MangaDto>>().map { it.toSManga() }
+        val response = client.post("$baseUrl/api/search", payload.toJsonRequestBody())
+        val mangas = response.parseAs<SearchResponseDto>().results.map { it.toSManga() }
         return MangasPage(mangas, false)
     }
 
@@ -43,7 +44,8 @@ abstract class MangaYi : KeiSource() {
 
     override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
         val payload = SearchRequestDto(s = query)
-        val mangas = response.parseAs<List<MangaDto>>().map { it.toSManga() }
+        val response = client.post("$baseUrl/api/search", payload.toJsonRequestBody())
+        val mangas = response.parseAs<SearchResponseDto>().results.map { it.toSManga() }
         return MangasPage(mangas, false)
     }
 
@@ -52,20 +54,20 @@ abstract class MangaYi : KeiSource() {
     override suspend fun fetchMangaUpdate(manga: SManga, chapters: List<SChapter>, fetchDetails: Boolean, fetchChapters: Boolean): SMangaUpdate {
         val document = client.get("$baseUrl/read/${manga.url}/").asJsoup()
         val manga2 = SManga.create().apply {
-            title = document.selectFirst("h1.title")!!.text()
-            author = document.selectFirst(".authors")?.text()
-            description = document.select(".summary p").joinToString("\n") { it.text() }
-            genre = document.select(".genres .pill").joinToString { it.text() }
-            status = document.selectFirst(".stat:contains(Status) .value")?.text().parseStatus()
-            thumbnail_url = document.selectFirst(".cover-wrapper img.cover-image")?.attr("abs:src")
+            title = document.selectFirst("h1.m-title")!!.text()
+            author = document.selectFirst(".m-authors")?.text()
+            description = document.select(".m-summary p").joinToString("\n") { it.text() }
+            genre = document.select(".m-genres .pill").joinToString { it.text() }
+            status = document.selectFirst(".m-stat:contains(Status) .value")?.text().parseStatus()
+            thumbnail_url = document.selectFirst(".cover-wrap img.cover-image")?.attr("abs:src")
         }
 
-        val chapters = document.select("div.chapters a.c:not(.unreleased)")
+        val chapters = document.select("div.chapters-list a.c:not(.unreleased)")
         val chapters2 = chapters.map { element ->
             SChapter.create().apply {
                 setUrlWithoutDomain(element.absUrl("href"))
                 name = element.selectFirst(".t")!!.text()
-                date_upload = dateFormat.tryParseDate(element.selectFirst(".chapter-date")?.text())
+                date_upload = dateFormat.tryParseDate(element.selectFirst(".chapter-d")?.text())
             }
         }
 
@@ -84,7 +86,7 @@ abstract class MangaYi : KeiSource() {
 
     override suspend fun getPageList(chapter: SChapter): List<Page> {
         val document = client.get(getChapterUrl(chapter)).asJsoup()
-        return document.select("div.images img").mapIndexed { index, img ->
+        return document.select("div.c-images img").mapIndexed { index, img ->
             Page(index, imageUrl = img.attr("abs:src"))
         }
     }

--- a/src/en/mangayi/src/eu/kanade/tachiyomi/extension/en/mangayi/MangaYi.kt
+++ b/src/en/mangayi/src/eu/kanade/tachiyomi/extension/en/mangayi/MangaYi.kt
@@ -16,6 +16,7 @@ import keiyoushi.utils.parseAs
 import keiyoushi.utils.toJsonRequestBody
 import keiyoushi.utils.tryParseDate
 import okhttp3.OkHttpClient
+import org.jsoup.nodes.Document
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -60,25 +61,27 @@ abstract class MangaYi : KeiSource() {
 
     override suspend fun fetchMangaUpdate(manga: SManga, chapters: List<SChapter>, fetchDetails: Boolean, fetchChapters: Boolean): SMangaUpdate {
         val document = client.get("$baseUrl/read/${manga.url}/").asJsoup()
-        val manga2 = SManga.create().apply {
-            title = document.selectFirst("h1.m-title")!!.text()
-            author = document.selectFirst(".m-authors")?.text()
-            description = document.select(".m-summary p").joinToString("\n") { it.text() }
-            genre = document.select(".m-genres .pill").joinToString { it.text() }
-            status = document.selectFirst(".m-stat:contains(Status) .value")?.text().parseStatus()
-            thumbnail_url = document.selectFirst(".cover-wrap img.cover-image")?.attr("abs:src")
-        }
+        return SMangaUpdate(parseMangaDetails(document), parseChapterList(document))
+    }
 
+    private fun parseMangaDetails(document: Document): SManga = SManga.create().apply {
+        title = document.selectFirst("h1.m-title")!!.text()
+        author = document.selectFirst(".m-authors")?.text()
+        description = document.select(".m-summary p").joinToString("\n") { it.text() }
+        genre = document.select(".m-genres .pill").joinToString { it.text() }
+        status = document.selectFirst(".m-stat:contains(Status) .value")?.text().parseStatus()
+        thumbnail_url = document.selectFirst(".cover-wrap img.cover-image")?.attr("abs:src")
+    }
+
+    private fun parseChapterList(document: Document): List<SChapter> {
         val chapters = document.select("div.chapters-list a.c:not(.unreleased)")
-        val chapters2 = chapters.map { element ->
+        return chapters.map { element ->
             SChapter.create().apply {
                 setUrlWithoutDomain(element.absUrl("href"))
                 name = element.selectFirst(".t")!!.text()
                 date_upload = dateFormat.tryParseDate(element.selectFirst(".chapter-d")?.text())
             }
         }
-
-        return SMangaUpdate(manga2, chapters2)
     }
 
     private fun String?.parseStatus(): Int = when (this?.lowercase()) {


### PR DESCRIPTION
PR changes `core` package slightly to use `zone` from the DateTimeFormatter object itself as a fallback. Does not affect other extensions in this repository. IMO, this should be the preferred approach.

Closes #18490

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
