### PR TITLE
Mangafreak: update domain to ww3.mangafreak.me

### DIFF
--- a/src/en/mangafreak/build.gradle.kts
+++ b/src/en/mangafreak/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 
 keiyoushi {
     name = "Mangafreak"
-    versionCode = 14
+    versionCode = 15
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 
     source {
         lang = "en"
-        baseUrl = "https://ww2.mangafreak.me"
+        baseUrl = "https://ww3.mangafreak.me"
     }
 }


### PR DESCRIPTION
Mangafreak moved to a new domain. The old domain (`ww2.mangafreak.me`) now redirects to `ww3.mangafreak.me`.

Fixes #18542

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

