### PR TITLE
Komiku.com: rebuild to new /api/v2 REST API

### DIFF
--- a/src/id/komikucom/build.gradle.kts
+++ b/src/id/komikucom/build.gradle.kts
@@ -6,10 +6,9 @@ plugins {
 
 keiyoushi {
     name = "Komiku.com"
-    versionCode = 2
+    versionCode = 35
     contentWarning = ContentWarning.SAFE
-    libVersion = "1.4"
-    theme = "mangathemesia"
+    libVersion = "1.6"
 
     source {
         lang = "id"

--- a/src/id/komikucom/src/eu/kanade/tachiyomi/extension/id/komikucom/Dto.kt
+++ b/src/id/komikucom/src/eu/kanade/tachiyomi/extension/id/komikucom/Dto.kt
@@ -1,0 +1,136 @@
+package eu.kanade.tachiyomi.extension.id.komikucom
+
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+@Serializable
+class ComicListResponse(
+    val items: List<ComicDto>? = null,
+    val page: Int? = null,
+    val totalPages: Int? = null,
+)
+
+@Serializable
+class ComicDto(
+    private val id: Int,
+    private val slug: String,
+    private val title: String,
+    private val genres: List<String>? = null,
+    private val comicStatus: String? = null,
+    private val author: String? = null,
+    private val artist: String? = null,
+    private val synopsis: String? = null,
+    private val coverUrl: String? = null,
+) {
+    fun toSManga(): SManga {
+        val comicTitle = title
+        val comicThumbnail = coverUrl
+        val comicAuthor = author
+        val comicArtist = artist
+        val comicSynopsis = synopsis
+        val comicGenres = genres
+        val comicId = id
+        val comicUrl = "/manga/$slug"
+        val lowerStatus = comicStatus?.lowercase()
+        return SManga.create().apply {
+            url = comicUrl
+            this.title = comicTitle
+            thumbnail_url = comicThumbnail
+            author = listOfNotNull(comicAuthor, comicArtist).filter { it.isNotBlank() }.joinToString()
+            description = comicSynopsis
+            genre = comicGenres?.joinToString()
+            status = when (lowerStatus) {
+                "ongoing" -> SManga.ONGOING
+                "completed" -> SManga.COMPLETED
+                "hiatus" -> SManga.ON_HIATUS
+                "cancelled", "canceled" -> SManga.CANCELLED
+                else -> SManga.UNKNOWN
+            }
+            memo = buildJsonObject {
+                put("id", comicId)
+            }
+            initialized = true
+        }
+    }
+}
+
+@Serializable
+class ChapterDto(
+    private val id: Int,
+    private val n: Float? = null,
+    private val title: String? = null,
+    private val releasedLabel: String? = null,
+) {
+    fun toSChapter(comicId: Int): SChapter = SChapter.create().apply {
+        url = "/$comicId/$id"
+        name = title ?: "Chapter ${n?.let { if (it % 1f == 0f) it.toInt().toString() else it.toString() }}"
+        date_upload = parseRelativeLabel(releasedLabel)
+        chapter_number = n ?: 0F
+    }
+}
+
+@Serializable
+class ChapterDetailDto(
+    private val id: Int,
+    private val pages: List<PageDto>? = null,
+) {
+    fun toPageList(): List<Page> = pages?.mapIndexed { index, page ->
+        Page(index, "", page.imageUrl())
+    } ?: emptyList()
+}
+
+@Serializable
+class PageDto(
+    private val url: String,
+) {
+    fun imageUrl(): String = url
+}
+
+@Serializable
+class FilterResponse(
+    val genres: List<String>? = null,
+    val statuses: List<String>? = null,
+    val types: List<String>? = null,
+    val sorts: List<SortDto>? = null,
+)
+
+@Serializable
+class SortDto(
+    private val key: String? = null,
+    private val label: String? = null,
+) {
+    fun toPair(): Pair<String, String> = (label ?: key ?: "") to (key ?: "")
+}
+
+fun parseRelativeLabel(label: String?): Long {
+    if (label.isNullOrBlank()) return 0L
+    val now = System.currentTimeMillis()
+    when {
+        "baru saja" in label -> return now
+        "menit" in label -> return now - (label.filter { it.isDigit() }.toLongOrNull() ?: 0L) * 60_000L
+        "jam" in label -> return now - (label.filter { it.isDigit() }.toLongOrNull() ?: 0L) * 3_600_000L
+        "hari" in label -> return now - (label.filter { it.isDigit() }.toLongOrNull() ?: 0L) * 86_400_000L
+    }
+    // absolute date like "9 Feb 2022" / "28 Agu 2022" (mixed EN/ID month abbreviations)
+    val parts = label.split(" ")
+    if (parts.size == 3) {
+        val day = parts[0].toIntOrNull() ?: return 0L
+        val month = MONTH_ABBREVIATIONS[parts[1].lowercase()] ?: return 0L
+        val year = parts[2].toIntOrNull() ?: return 0L
+        return java.time.LocalDate.of(year, month, day)
+            .atStartOfDay(java.time.ZoneId.systemDefault())
+            .toInstant()
+            .toEpochMilli()
+    }
+    return 0L
+}
+
+private val MONTH_ABBREVIATIONS = mapOf(
+    "jan" to 1, "feb" to 2, "mar" to 3, "apr" to 4, "mei" to 5, "may" to 5,
+    "jun" to 6, "jul" to 7, "agu" to 8, "aug" to 8, "sep" to 9, "okt" to 10,
+    "oct" to 10, "nov" to 11, "des" to 12, "dec" to 12,
+)

--- a/src/id/komikucom/src/eu/kanade/tachiyomi/extension/id/komikucom/Filters.kt
+++ b/src/id/komikucom/src/eu/kanade/tachiyomi/extension/id/komikucom/Filters.kt
@@ -1,0 +1,75 @@
+package eu.kanade.tachiyomi.extension.id.komikucom
+
+import eu.kanade.tachiyomi.source.model.Filter
+import okhttp3.HttpUrl
+
+interface UriQueryFilter {
+    fun addToQuery(builder: HttpUrl.Builder)
+}
+
+open class UriPartFilter(
+    name: String,
+    private val field: String,
+    private val vals: Array<Pair<String, String>>,
+    private val default: String = "",
+) : Filter.Select<String>(
+    name,
+    vals.map { it.first }.toTypedArray(),
+    vals.indexOfFirst { it.second == default }.takeIf { it != -1 } ?: 0,
+),
+    UriQueryFilter {
+    override fun addToQuery(builder: HttpUrl.Builder) {
+        if (vals.isEmpty()) return
+        val selected = vals[state].second
+        if (selected.isNotEmpty()) {
+            builder.addQueryParameter(field, selected)
+        }
+    }
+}
+
+open class UriMultiSelectOption(name: String, val value: String) : Filter.CheckBox(name)
+
+open class UriMultiSelectFilter(
+    name: String,
+    private val field: String,
+    private val options: Array<Pair<String, String>>,
+) : Filter.Group<UriMultiSelectOption>(
+    name,
+    options.map { UriMultiSelectOption(it.first, it.second) },
+),
+    UriQueryFilter {
+    override fun addToQuery(builder: HttpUrl.Builder) {
+        state.filter { it.state }.forEach {
+            builder.addQueryParameter(field, it.value)
+        }
+    }
+}
+
+class SortFilter(sorts: Array<Pair<String, String>>) :
+    UriPartFilter(
+        "Sort",
+        "sort",
+        sorts,
+        default = "update",
+    )
+
+class GenreFilter(genres: Array<Pair<String, String>>) :
+    UriMultiSelectFilter(
+        "Genre",
+        "genres",
+        genres,
+    )
+
+class StatusFilter(statuses: Array<Pair<String, String>>) :
+    UriPartFilter(
+        "Status",
+        "status",
+        statuses,
+    )
+
+class TypeFilter(types: Array<Pair<String, String>>) :
+    UriPartFilter(
+        "Type",
+        "type",
+        types,
+    )

--- a/src/id/komikucom/src/eu/kanade/tachiyomi/extension/id/komikucom/KomikuCom.kt
+++ b/src/id/komikucom/src/eu/kanade/tachiyomi/extension/id/komikucom/KomikuCom.kt
@@ -110,7 +110,7 @@ abstract class KomikuCom : KeiSource() {
         fetchDetails: Boolean,
         fetchChapters: Boolean,
     ): SMangaUpdate = coroutineScope {
-        val comicId = manga.memo["id"]!!.string.toInt()
+        val comicId = manga.memo["id"]!!.string
         val slug = manga.url.substringAfter("/manga/")
         val details = if (fetchDetails) async { client.get("$apiUrl/comics/$slug") } else null
         val chapterList = if (fetchChapters) async { client.get("$apiUrl/comics/$comicId/chapters") } else null
@@ -119,7 +119,7 @@ abstract class KomikuCom : KeiSource() {
         val chapterDtos = chapterList?.await()?.parseAs<List<ChapterDto>>()
         SMangaUpdate(
             manga = comicDto?.toSManga() ?: manga,
-            chapters = chapterDtos?.map { it.toSChapter(comicId) } ?: chapters,
+            chapters = chapterDtos?.map { it.toSChapter(comicId.toInt()) } ?: chapters,
         )
     }
 

--- a/src/id/komikucom/src/eu/kanade/tachiyomi/extension/id/komikucom/KomikuCom.kt
+++ b/src/id/komikucom/src/eu/kanade/tachiyomi/extension/id/komikucom/KomikuCom.kt
@@ -1,11 +1,144 @@
 package eu.kanade.tachiyomi.extension.id.komikucom
 
-import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import keiyoushi.annotation.Source
-import java.text.SimpleDateFormat
-import java.util.Locale
+import keiyoushi.network.get
+import keiyoushi.source.KeiSource
+import keiyoushi.utils.parseAs
+import keiyoushi.utils.string
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.json.JsonElement
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Response
 
 @Source
-abstract class KomikuCom : MangaThemesia() {
-    override val dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale("id"))
+abstract class KomikuCom : KeiSource() {
+
+    private val apiUrl = "https://01.komiku.asia/api/v2"
+
+    override fun Headers.Builder.configureHeaders(): Headers.Builder = apply {
+        add("Accept", "application/json, text/plain, */*")
+        add("Accept-Language", "id-ID,id;q=0.9,en-US;q=0.8")
+        add("Sec-Fetch-Dest", "empty")
+        add("Sec-Fetch-Mode", "cors")
+        add("Sec-Fetch-Site", "same-origin")
+    }
+
+    // ------------------------- Browse (Popular) -------------------------
+
+    override suspend fun getPopularManga(page: Int): MangasPage = parseComicListResponse(
+        client.get(
+            "$apiUrl/comics".toHttpUrl().newBuilder()
+                .addQueryParameter("sort", "popular")
+                .addQueryParameter("page", page.toString())
+                .build(),
+        ),
+    )
+
+    // ------------------------- Latest -------------------------
+
+    override suspend fun getLatestUpdates(page: Int): MangasPage = parseComicListResponse(
+        client.get(
+            "$apiUrl/comics".toHttpUrl().newBuilder()
+                .addQueryParameter("sort", "update")
+                .addQueryParameter("page", page.toString())
+                .build(),
+        ),
+    )
+
+    private fun parseComicListResponse(response: Response): MangasPage {
+        val result = response.parseAs<ComicListResponse>()
+        val mangas = result.items?.map { it.toSManga() } ?: emptyList()
+        val hasNextPage = (result.page ?: 0) < (result.totalPages ?: 0)
+        return MangasPage(mangas, hasNextPage)
+    }
+
+    // ------------------------- Search -------------------------
+
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
+        // /comics/search requires `q`; when browsing without a query, use /comics with filters instead
+        val endpoint = if (query.isEmpty()) "$apiUrl/comics" else "$apiUrl/comics/search"
+        val url = endpoint.toHttpUrl().newBuilder()
+            .apply {
+                if (query.isNotEmpty()) {
+                    addQueryParameter("q", query)
+                }
+                filters.filterIsInstance<UriQueryFilter>().forEach { it.addToQuery(this) }
+                addQueryParameter("page", page.toString())
+            }
+            .build()
+        val response = client.get(url)
+        return if (query.isEmpty()) {
+            parseComicListResponse(response)
+        } else {
+            val mangas = response.parseAs<List<ComicDto>>().map { it.toSManga() }
+            MangasPage(mangas, mangas.isNotEmpty())
+        }
+    }
+
+    // ------------------------- Filters -------------------------
+
+    override val supportsFilterFetching: Boolean get() = true
+
+    override suspend fun fetchFilterData(): JsonElement = client.get("$apiUrl/comics/filters").parseAs()
+
+    override fun getFilterList(data: JsonElement?): FilterList {
+        val dto = data?.parseAs<FilterResponse>() ?: return FilterList()
+        return FilterList(
+            buildList {
+                add(SortFilter(dto.sorts?.map { it.toPair() }?.toTypedArray() ?: emptyArray()))
+                add(StatusFilter(dto.statuses?.filter { it != "ngoing" }?.map { if (it == "Semua") "Semua" to "" else it to it }?.toTypedArray() ?: emptyArray()))
+                add(TypeFilter(dto.types?.map { if (it == "Semua") "Semua" to "" else it to it }?.toTypedArray() ?: emptyArray()))
+                add(GenreFilter(dto.genres?.map { it to it }?.toTypedArray() ?: emptyArray()))
+            },
+        )
+    }
+
+    // ------------------------- Detail + Chapters -------------------------
+
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate = coroutineScope {
+        val comicId = manga.memo["id"]!!.string.toInt()
+        val slug = manga.url.substringAfter("/manga/")
+        val details = if (fetchDetails) async { client.get("$apiUrl/comics/$slug") } else null
+        val chapterList = if (fetchChapters) async { client.get("$apiUrl/comics/$comicId/chapters") } else null
+
+        val comicDto = details?.await()?.parseAs<ComicDto>()
+        val chapterDtos = chapterList?.await()?.parseAs<List<ChapterDto>>()
+        SMangaUpdate(
+            manga = comicDto?.toSManga() ?: manga,
+            chapters = chapterDtos?.map { it.toSChapter(comicId) } ?: chapters,
+        )
+    }
+
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+        if (url.host != baseUrl.toHttpUrl().host) return null
+        val slug = url.pathSegments.getOrNull(1) ?: return null
+        return try {
+            client.get("$apiUrl/comics/$slug").parseAs<ComicDto>().toSManga()
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        val segments = chapter.url.split("/").filter { it.isNotEmpty() }
+        val comicId = segments.getOrNull(0)
+        val chapterId = segments.getOrNull(1)
+        return client.get("$apiUrl/comics/$comicId/chapters/id/$chapterId")
+            .parseAs<ChapterDetailDto>()
+            .toPageList()
+    }
 }


### PR DESCRIPTION
Closes #18530

Komiku.com moved from WordPress (MangaThemesia) to a Next.js app backed by a clean REST API (`/api/v2`). The old theme-based extension no longer works, so this rebuilds it as a standalone `KeiSource`:

- Browse (popular/latest) via `GET /api/v2/comics?sort=popular|update&page=N`
- Search + filters (sort/status/type/genre) via `/comics` and `/comics/search` (search requires `q`, so browsing without a query uses `/comics`)
- Details via `/comics/{slug}`, chapter list via `/comics/{id}/chapters`, pages via `/comics/{id}/chapters/id/{id}`
- Filter options fetched from `/comics/filters` (sort, status, type, genre)
- Chapter dates handle both relative labels ("3 jam lalu") and absolute dates with mixed EN/ID month abbreviations ("9 Feb 2022", "28 Agu 2022")
- versionCode 35 (> old theme final 32 + 2 = 34, so Mihon accepts the update)

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
