### PR TITLE
Mangago: fix summary not displaying

### DIFF
--- a/src/en/mangago/build.gradle.kts
+++ b/src/en/mangago/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Mangago"
-    versionCode = 39
+    versionCode = 40
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
 

--- a/src/en/mangago/src/eu/kanade/tachiyomi/extension/en/mangago/Mangago.kt
+++ b/src/en/mangago/src/eu/kanade/tachiyomi/extension/en/mangago/Mangago.kt
@@ -175,7 +175,7 @@ abstract class Mangago :
         document.getElementById("information")?.let { info ->
             thumbnail_url = info.selectFirst("img")?.attr("abs:src")
             description = info.selectFirst(".manga_summary")
-                ?.ownText()
+                ?.text()
                 ?.takeIf { it.isNotEmpty() && !it.equals("not found...", ignoreCase = true) }
 
             info.select(".manga_info li, .manga_right tr").forEach { element ->


### PR DESCRIPTION
Closes #18576

The site now wraps the summary text in a `<p>` element inside `.manga_summary`, like this:

    <div class="manga_summary">
        <p>...</p>
    </div>

`ownText()` only reads text nodes sitting directly in the element, ignoring children, so it came back empty and the description ended up dropped. This switches it to `text()`, which picks up descendant text too. The existing guards for empty summaries and the "not found..." placeholder still apply afterwards.

`versionCode` bumped 39 -> 40, no other changes.

Confirmed against a live details page that the summary renders inside a `<p>` now, and ran `:src:en:mangago:lintRelease` + `assembleRelease` through GitHub Actions on my fork, both green (https://github.com/sleepy-snowflake/extensions-source/actions/runs/32657901347).

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
