### PR TITLE
Manga-Scantrad: fix date parsing

### DIFF
--- a/src/fr/mangascantrad/build.gradle.kts
+++ b/src/fr/mangascantrad/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Manga-Scantrad"
-    versionCode = 3
+    versionCode = 4
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
     theme = "madara"

--- a/src/fr/mangascantrad/src/eu/kanade/tachiyomi/extension/fr/mangascantrad/MangaScantrad.kt
+++ b/src/fr/mangascantrad/src/eu/kanade/tachiyomi/extension/fr/mangascantrad/MangaScantrad.kt
@@ -9,5 +9,5 @@ import java.util.Locale
 @Source
 abstract class MangaScantrad : Madara() {
     override val chapterMode = ChapterMode.MangaAjax
-    override val chapterDateFormat = DateTimeFormatter.ofPattern("d MMM yyyy", Locale.FRANCE)
+    override val chapterDateFormat = DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.FRANCE)
 }


### PR DESCRIPTION
Closes #18587

Tested via `gradlew`.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
