### PR TITLE
RawDEX: rewrite for new site design

### DIFF
--- a/src/ko/rawdex/build.gradle.kts
+++ b/src/ko/rawdex/build.gradle.kts
@@ -6,10 +6,9 @@ plugins {
 
 keiyoushi {
     name = "RawDEX"
-    versionCode = 3
+    versionCode = 4
     contentWarning = ContentWarning.NSFW
-    libVersion = "1.4"
-    theme = "madaralegacy"
+    libVersion = "1.6"
 
     source {
         lang = "ko"

--- a/src/ko/rawdex/build.gradle.kts
+++ b/src/ko/rawdex/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "RawDEX"
-    versionCode = 4
+    versionCode = 56
     contentWarning = ContentWarning.NSFW
     libVersion = "1.6"
 

--- a/src/ko/rawdex/src/eu/kanade/tachiyomi/extension/ko/rawdex/RawDEX.kt
+++ b/src/ko/rawdex/src/eu/kanade/tachiyomi/extension/ko/rawdex/RawDEX.kt
@@ -35,22 +35,22 @@ abstract class RawDEX : KeiSource() {
 
     private suspend fun fetchBrowsePage(url: String): MangasPage {
         val document = client.get(url, ensureSuccess = false).asJsoup()
-        val mangas = document.select(BROWSE_CARD_SELECTOR).mapNotNull(::browseMangaFromElement)
+        val mangas = document.select("article.rdx-library-card").mapNotNull(::browseMangaFromElement)
 
         // Pagination links claim more pages than actually exist near the end of the
         // archive; requesting them yields a 404 with zero cards, handled above.
-        val hasNextPage = mangas.isNotEmpty() && document.selectNextPageSelector() != null
+        val hasNextPage = mangas.isNotEmpty() && document.selectFirst("a.next.page-numbers") != null
         return MangasPage(mangas, hasNextPage)
     }
 
     private fun browseMangaFromElement(element: Element): SManga? {
-        val link = element.selectFirst(BROWSE_TITLE_LINK_SELECTOR) ?: return null
+        val link = element.selectFirst(".rdx-library-card__body h2 a") ?: return null
         val title = link.text().takeIf { it.isNotEmpty() } ?: return null
 
         return SManga.create().apply {
             setUrlWithoutDomain(link.absUrl("href"))
             this.title = title
-            thumbnail_url = element.selectFirst(BROWSE_COVER_SELECTOR)?.attr("abs:src")
+            thumbnail_url = element.selectFirst(".rdx-library-card__cover img")?.attr("abs:src")
         }
     }
 
@@ -65,16 +65,16 @@ abstract class RawDEX : KeiSource() {
     }
 
     private fun parseMangaDetails(document: Document): SManga = SManga.create().apply {
-        title = document.selectFirst(DETAILS_TITLE_SELECTOR)?.text()
+        title = document.selectFirst(".rdx-manga-heading h1")?.text()
             ?: error("Failed to parse title")
-        thumbnail_url = document.selectFirst(DETAILS_COVER_SELECTOR)?.attr("abs:src")
-        status = when (document.selectFirst(DETAILS_STATUS_SELECTOR)?.text()?.lowercase()) {
+        thumbnail_url = document.selectFirst("img.rdx-manga-cover")?.attr("abs:src")
+        status = when (document.selectFirst(".rdx-manga-status")?.text()?.lowercase()) {
             "on-going" -> SManga.ONGOING
             "end" -> SManga.COMPLETED
             else -> SManga.UNKNOWN
         }
 
-        document.select(DETAILS_META_SELECTOR).forEach { element ->
+        document.select("dl.rdx-manga-meta div").forEach { element ->
             val value = element.selectFirst("dd")?.text().orEmpty()
             when (element.selectFirst("dt")?.text()?.lowercase()) {
                 "author" -> author = value
@@ -82,18 +82,18 @@ abstract class RawDEX : KeiSource() {
             }
         }
 
-        genre = document.select(DETAILS_GENRE_SELECTOR)
+        genre = document.select(".rdx-manga-tags a")
             .joinToString { it.text() }
             .takeIf { it.isNotEmpty() }
 
-        val altNames = document.selectFirst(DETAILS_ALT_NAMES_SELECTOR)?.text()
+        val altNames = document.selectFirst(".rdx-manga-alternative")?.text()
             ?.split('/', ';')
             ?.map(String::trim)
             ?.filter(String::isNotEmpty)
             .orEmpty()
 
         description = buildString {
-            document.selectFirst(DETAILS_SUMMARY_SELECTOR)?.text()
+            document.selectFirst(".rdx-manga-summary")?.text()
                 ?.takeIf { it.isNotEmpty() }
                 ?.let(::append)
             if (altNames.isNotEmpty()) {
@@ -106,15 +106,15 @@ abstract class RawDEX : KeiSource() {
     }
 
     // Chapters render newest first, matching the descending order the app expects.
-    private fun parseChapterList(document: Document): List<SChapter> = document.select(CHAPTER_LIST_SELECTOR).mapNotNull { element ->
-        val name = element.selectFirst(CHAPTER_NAME_SELECTOR)?.text()
+    private fun parseChapterList(document: Document): List<SChapter> = document.select(".rdx-chapter-list > a.rdx-chapter-row").mapNotNull { element ->
+        val name = element.selectFirst(".rdx-chapter-row__label")?.text()
             ?.takeIf { it.isNotEmpty() }
             ?: return@mapNotNull null
 
         SChapter.create().apply {
             setUrlWithoutDomain(element.absUrl("href"))
             this.name = name
-            date_upload = element.selectFirst(CHAPTER_DATE_SELECTOR)?.text()
+            date_upload = element.selectFirst(".rdx-chapter-row__date")?.text()
                 ?.let(::parseRelativeDate)
                 ?: 0L
             chapter_number = CHAPTER_NUMBER_REGEX.find(name)
@@ -127,7 +127,7 @@ abstract class RawDEX : KeiSource() {
 
     override suspend fun getPageList(chapter: SChapter): List<Page> {
         val document = client.get(getChapterUrl(chapter)).asJsoup()
-        return document.select(PAGE_IMAGE_SELECTOR).mapIndexed { index, img ->
+        return document.select(".rdx-reader-page img").mapIndexed { index, img ->
             Page(index, imageUrl = img.attr("abs:src"))
         }.ifEmpty { error("No pages found") }
     }
@@ -149,24 +149,7 @@ abstract class RawDEX : KeiSource() {
     }
 }
 
-private const val BROWSE_CARD_SELECTOR = "article.rdx-library-card"
-private const val BROWSE_TITLE_LINK_SELECTOR = ".rdx-library-card__body h2 a"
-private const val BROWSE_COVER_SELECTOR = ".rdx-library-card__cover img"
-private const val DETAILS_TITLE_SELECTOR = ".rdx-manga-heading h1"
-private const val DETAILS_COVER_SELECTOR = "img.rdx-manga-cover"
-private const val DETAILS_STATUS_SELECTOR = ".rdx-manga-status"
-private const val DETAILS_META_SELECTOR = "dl.rdx-manga-meta div"
-private const val DETAILS_GENRE_SELECTOR = ".rdx-manga-tags a"
-private const val DETAILS_SUMMARY_SELECTOR = ".rdx-manga-summary"
-private const val DETAILS_ALT_NAMES_SELECTOR = ".rdx-manga-alternative"
-private const val CHAPTER_LIST_SELECTOR = ".rdx-chapter-list > a.rdx-chapter-row"
-private const val CHAPTER_NAME_SELECTOR = ".rdx-chapter-row__label"
-private const val CHAPTER_DATE_SELECTOR = ".rdx-chapter-row__date"
-private const val PAGE_IMAGE_SELECTOR = ".rdx-reader-page img"
-
 private const val ALT_NAME_PREFIX = "Alternative Names:"
-
-private fun Document.selectNextPageSelector() = selectFirst("a.next.page-numbers")
 
 private val CHAPTER_NUMBER_REGEX = Regex("""(\d+(?:\.\d+)?)""")
 private val RELATIVE_DATE_REGEX = Regex("""(\d+)\s+(second|minute|hour|day|week|month|year)s?\s+ago""")

--- a/src/ko/rawdex/src/eu/kanade/tachiyomi/extension/ko/rawdex/RawDEX.kt
+++ b/src/ko/rawdex/src/eu/kanade/tachiyomi/extension/ko/rawdex/RawDEX.kt
@@ -1,15 +1,175 @@
 package eu.kanade.tachiyomi.extension.ko.rawdex
 
-import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
+import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.annotation.Source
-import java.text.SimpleDateFormat
-import java.util.Locale
+import keiyoushi.network.get
+import keiyoushi.source.KeiSource
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
 
+// The site used to run a Madara theme but moved to custom markup (rdx-* classes),
+// so this source cannot live on the madaralegacy theme anymore.
 @Source
-abstract class RawDEX : Madara() {
-    override val dateFormat = SimpleDateFormat("dd.MM.yyyy", Locale.ROOT)
+abstract class RawDEX : KeiSource() {
 
-    override val mangaDetailsSelectorStatus = "div.summary-heading:has(h5:contains(Status)) + div"
-    override val chapterUrlSuffix = ""
-    override fun searchMangaSelector() = "div.page-item-detail.manga"
+    override suspend fun getPopularManga(page: Int): MangasPage =
+        fetchBrowsePage("$baseUrl/manga/page/$page/?m_orderby=views")
+
+    override suspend fun getLatestUpdates(page: Int): MangasPage =
+        fetchBrowsePage("$baseUrl/manga/page/$page/?m_orderby=latest")
+
+    // The site ignores m_orderby=popular, views is its de facto most-read ordering.
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
+        val url = "$baseUrl/".toHttpUrl().newBuilder()
+            .addQueryParameter("s", query)
+            .apply { if (page > 1) addQueryParameter("spage", page.toString()) }
+            .build()
+
+        return fetchBrowsePage(url.toString())
+    }
+
+    private suspend fun fetchBrowsePage(url: String): MangasPage {
+        val document = client.get(url, ensureSuccess = false).asJsoup()
+        val mangas = document.select(BROWSE_CARD_SELECTOR).mapNotNull(::browseMangaFromElement)
+
+        // Pagination links claim more pages than actually exist near the end of the
+        // archive; requesting them yields a 404 with zero cards, handled above.
+        val hasNextPage = mangas.isNotEmpty() && document.selectNextPageSelector() != null
+        return MangasPage(mangas, hasNextPage)
+    }
+
+    private fun browseMangaFromElement(element: Element): SManga? {
+        val link = element.selectFirst(BROWSE_TITLE_LINK_SELECTOR) ?: return null
+        val title = link.text().takeIf { it.isNotEmpty() } ?: return null
+
+        return SManga.create().apply {
+            setUrlWithoutDomain(link.absUrl("href"))
+            this.title = title
+            thumbnail_url = element.selectFirst(BROWSE_COVER_SELECTOR)?.attr("abs:src")
+        }
+    }
+
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        val document = client.get(getMangaUrl(manga)).asJsoup()
+        return SMangaUpdate(parseMangaDetails(document), parseChapterList(document))
+    }
+
+    private fun parseMangaDetails(document: Document): SManga = SManga.create().apply {
+        title = document.selectFirst(DETAILS_TITLE_SELECTOR)?.text()
+            ?: error("Failed to parse title")
+        thumbnail_url = document.selectFirst(DETAILS_COVER_SELECTOR)?.attr("abs:src")
+        status = when (document.selectFirst(DETAILS_STATUS_SELECTOR)?.text()?.lowercase()) {
+            "on-going" -> SManga.ONGOING
+            "end" -> SManga.COMPLETED
+            else -> SManga.UNKNOWN
+        }
+
+        document.select(DETAILS_META_SELECTOR).forEach { element ->
+            val value = element.selectFirst("dd")?.text().orEmpty()
+            when (element.selectFirst("dt")?.text()?.lowercase()) {
+                "author" -> author = value
+                "artist" -> artist = value
+            }
+        }
+
+        genre = document.select(DETAILS_GENRE_SELECTOR)
+            .joinToString { it.text() }
+            .takeIf { it.isNotEmpty() }
+
+        val altNames = document.selectFirst(DETAILS_ALT_NAMES_SELECTOR)?.text()
+            ?.split('/', ';')
+            ?.map(String::trim)
+            ?.filter(String::isNotEmpty)
+            .orEmpty()
+
+        description = buildString {
+            document.selectFirst(DETAILS_SUMMARY_SELECTOR)?.text()
+                ?.takeIf { it.isNotEmpty() }
+                ?.let(::append)
+            if (altNames.isNotEmpty()) {
+                if (isNotEmpty()) append("\n\n")
+                append(ALT_NAME_PREFIX)
+                append("\n")
+                altNames.joinTo(this, "\n") { "- $it" }
+            }
+        }.takeIf(String::isNotEmpty)
+    }
+
+    // Chapters render newest first, matching the descending order the app expects.
+    private fun parseChapterList(document: Document): List<SChapter> =
+        document.select(CHAPTER_LIST_SELECTOR).mapNotNull { element ->
+            val name = element.selectFirst(CHAPTER_NAME_SELECTOR)?.text()
+                ?.takeIf { it.isNotEmpty() }
+                ?: return@mapNotNull null
+
+            SChapter.create().apply {
+                setUrlWithoutDomain(element.absUrl("href"))
+                this.name = name
+                date_upload = element.selectFirst(CHAPTER_DATE_SELECTOR)?.text()
+                    ?.let(::parseRelativeDate)
+                    ?: 0L
+                chapter_number = CHAPTER_NUMBER_REGEX.find(name)
+                    ?.groupValues
+                    ?.get(1)
+                    ?.toFloatOrNull()
+                    ?: -1f
+            }
+        }
+
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        val document = client.get(getChapterUrl(chapter)).asJsoup()
+        return document.select(PAGE_IMAGE_SELECTOR).mapIndexed { index, img ->
+            Page(index, imageUrl = img.attr("abs:src"))
+        }.ifEmpty { error("No pages found") }
+    }
+
+    private fun parseRelativeDate(date: String): Long {
+        val match = RELATIVE_DATE_REGEX.find(date.trim()) ?: return 0L
+        val amount = match.groupValues[1].toLong()
+        val unitMillis = when (match.groupValues[2]) {
+            "second" -> 1_000L
+            "minute" -> 60_000L
+            "hour" -> 3_600_000L
+            "day" -> 86_400_000L
+            "week" -> 604_800_000L
+            "month" -> 2_592_000_000L
+            "year" -> 31_536_000_000L
+            else -> return 0L
+        }
+        return System.currentTimeMillis() - amount * unitMillis
+    }
 }
+
+private const val BROWSE_CARD_SELECTOR = "article.rdx-library-card"
+private const val BROWSE_TITLE_LINK_SELECTOR = ".rdx-library-card__body h2 a"
+private const val BROWSE_COVER_SELECTOR = ".rdx-library-card__cover img"
+private const val DETAILS_TITLE_SELECTOR = ".rdx-manga-heading h1"
+private const val DETAILS_COVER_SELECTOR = "img.rdx-manga-cover"
+private const val DETAILS_STATUS_SELECTOR = ".rdx-manga-status"
+private const val DETAILS_META_SELECTOR = "dl.rdx-manga-meta div"
+private const val DETAILS_GENRE_SELECTOR = ".rdx-manga-tags a"
+private const val DETAILS_SUMMARY_SELECTOR = ".rdx-manga-summary"
+private const val DETAILS_ALT_NAMES_SELECTOR = ".rdx-manga-alternative"
+private const val CHAPTER_LIST_SELECTOR = ".rdx-chapter-list > a.rdx-chapter-row"
+private const val CHAPTER_NAME_SELECTOR = ".rdx-chapter-row__label"
+private const val CHAPTER_DATE_SELECTOR = ".rdx-chapter-row__date"
+private const val PAGE_IMAGE_SELECTOR = ".rdx-reader-page img"
+
+private const val ALT_NAME_PREFIX = "Alternative Names:"
+
+private fun Document.selectNextPageSelector() = selectFirst("a.next.page-numbers")
+
+private val CHAPTER_NUMBER_REGEX = Regex("""(\d+(?:\.\d+)?)""")
+private val RELATIVE_DATE_REGEX = Regex("""(\d+)\s+(second|minute|hour|day|week|month|year)s?\s+ago""")

--- a/src/ko/rawdex/src/eu/kanade/tachiyomi/extension/ko/rawdex/RawDEX.kt
+++ b/src/ko/rawdex/src/eu/kanade/tachiyomi/extension/ko/rawdex/RawDEX.kt
@@ -19,11 +19,9 @@ import org.jsoup.nodes.Element
 @Source
 abstract class RawDEX : KeiSource() {
 
-    override suspend fun getPopularManga(page: Int): MangasPage =
-        fetchBrowsePage("$baseUrl/manga/page/$page/?m_orderby=views")
+    override suspend fun getPopularManga(page: Int): MangasPage = fetchBrowsePage("$baseUrl/manga/page/$page/?m_orderby=views")
 
-    override suspend fun getLatestUpdates(page: Int): MangasPage =
-        fetchBrowsePage("$baseUrl/manga/page/$page/?m_orderby=latest")
+    override suspend fun getLatestUpdates(page: Int): MangasPage = fetchBrowsePage("$baseUrl/manga/page/$page/?m_orderby=latest")
 
     // The site ignores m_orderby=popular, views is its de facto most-read ordering.
     override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
@@ -108,25 +106,24 @@ abstract class RawDEX : KeiSource() {
     }
 
     // Chapters render newest first, matching the descending order the app expects.
-    private fun parseChapterList(document: Document): List<SChapter> =
-        document.select(CHAPTER_LIST_SELECTOR).mapNotNull { element ->
-            val name = element.selectFirst(CHAPTER_NAME_SELECTOR)?.text()
-                ?.takeIf { it.isNotEmpty() }
-                ?: return@mapNotNull null
+    private fun parseChapterList(document: Document): List<SChapter> = document.select(CHAPTER_LIST_SELECTOR).mapNotNull { element ->
+        val name = element.selectFirst(CHAPTER_NAME_SELECTOR)?.text()
+            ?.takeIf { it.isNotEmpty() }
+            ?: return@mapNotNull null
 
-            SChapter.create().apply {
-                setUrlWithoutDomain(element.absUrl("href"))
-                this.name = name
-                date_upload = element.selectFirst(CHAPTER_DATE_SELECTOR)?.text()
-                    ?.let(::parseRelativeDate)
-                    ?: 0L
-                chapter_number = CHAPTER_NUMBER_REGEX.find(name)
-                    ?.groupValues
-                    ?.get(1)
-                    ?.toFloatOrNull()
-                    ?: -1f
-            }
+        SChapter.create().apply {
+            setUrlWithoutDomain(element.absUrl("href"))
+            this.name = name
+            date_upload = element.selectFirst(CHAPTER_DATE_SELECTOR)?.text()
+                ?.let(::parseRelativeDate)
+                ?: 0L
+            chapter_number = CHAPTER_NUMBER_REGEX.find(name)
+                ?.groupValues
+                ?.get(1)
+                ?.toFloatOrNull()
+                ?: -1f
         }
+    }
 
     override suspend fun getPageList(chapter: SChapter): List<Page> {
         val document = client.get(getChapterUrl(chapter)).asJsoup()


### PR DESCRIPTION
Closes #18519

rawdex.net dropped its Madara theme for a fully custom design (rdx-* classes), so every selector in the madaralegacy theme went dead: browse returned nothing ("No results found") and opening a saved entry crashed with the NullPointerException from the report. There was nothing left to patch selector by selector, so this rewrites RawDEX as a standalone KeiSource source instead of staying on the madaralegacy theme, same as the Manga18fx migration.

What it does now:

- popular uses /manga/?m_orderby=views (the site ignores m_orderby=popular), latest uses m_orderby=latest, search hits /?s=query with spage= pagination
- details parse title, cover, status, summary, genres and author/artist straight off the new markup, alternative names get appended to the description
- chapter list is server rendered now (newest first), dates are relative strings ("2 weeks ago") which get converted to timestamps
- reader pages come straight out of figure.rdx-reader-page img, no ajax involved

Some site quirks handled along the way: img.rawdex.net 403s without a rawdex referer (default source headers already send one), pagination links claim more pages than exist near the end of the archive so those requests just resolve to an empty page instead of an error, and bare slugs 301 to hash suffixed ones which does not matter since all urls are taken from scraped hrefs.

libVersion moves 1.4 -> 1.6 with the theme gone, versionCode bumped to 4, name/lang/contentWarning untouched so existing libraries carry over.

Verified every flow against the live site and ran :src:ko:rawdex:lintRelease + assembleRelease through GitHub Actions, both green (https://github.com/sleepy-snowflake/extensions-source/actions/runs/32661599507).

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

🤖 AI-agent disclosure: this PR was opened by an AI agent (opencode) working with the human contributor who brought the issue over. The agent traced the bug, checked the site behaviour end to end and wrote the rewrite; the contributor tested the built extension on their device, reviewed the diff and handled the rest.


