### PR TITLE
MangaStarz: update domain

### DIFF
--- a/src/ar/mangastarz/build.gradle.kts
+++ b/src/ar/mangastarz/build.gradle.kts
@@ -6,13 +6,13 @@ plugins {
 
 keiyoushi {
     name = "Manga Starz"
-    versionCode = 9
+    versionCode = 10
     contentWarning = ContentWarning.SAFE
     libVersion = "1.6"
     theme = "madara"
 
     source {
         lang = "ar"
-        baseUrl = "https://manga-starz.net"
+        baseUrl = "https://starzmanga.com"
     }
 }

--- a/src/ar/mangastarz/src/eu/kanade/tachiyomi/extension/ar/mangastarz/MangaStarz.kt
+++ b/src/ar/mangastarz/src/eu/kanade/tachiyomi/extension/ar/mangastarz/MangaStarz.kt
@@ -8,5 +8,4 @@ import java.util.Locale
 @Source
 abstract class MangaStarz : Madara() {
     override val chapterDateFormat = DateTimeFormatter.ofPattern("d MMMM، yyyy", Locale.forLanguageTag("ar"))
-    override val chapterMode = ChapterMode.AdminAjax
 }


### PR DESCRIPTION
closes #18617

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
