### PR TITLE
Mangas-Origines.fr: fix chapter dates without year

### DIFF
--- a/lib-multisrc/origines/build.gradle.kts
+++ b/lib-multisrc/origines/build.gradle.kts
@@ -3,6 +3,6 @@ plugins {
 }
 
 keiyoushi {
-    baseVersionCode = 1
+    baseVersionCode = 2
     libVersion = "1.6"
 }

--- a/lib-multisrc/origines/src/eu/kanade/tachiyomi/multisrc/origines/Origines.kt
+++ b/lib-multisrc/origines/src/eu/kanade/tachiyomi/multisrc/origines/Origines.kt
@@ -229,14 +229,21 @@ abstract class Origines : KeiSource() {
     }
 
     /**
-     * Dates read `8 Août 2026`: capitalized, shortened month names no locale pattern parses.
+     * Dates can read `8 Août 2026` or `8 Août`. The latter uses the most recent matching year.
      */
     private fun parseChapterDate(date: String?): Long {
         val (day, month, year) = DATE_REGEX.find(date.orEmpty())?.destructured ?: return 0L
         val monthNumber = monthNumber(month) ?: return 0L
+        val today = LocalDate.now(TIME_ZONE)
 
         return runCatching {
-            LocalDate.of(year.toInt(), monthNumber, day.toInt())
+            var chapterDate = LocalDate.of(year.toIntOrNull() ?: today.year, monthNumber, day.toInt())
+
+            if (year.isBlank() && chapterDate.isAfter(today)) {
+                chapterDate = chapterDate.minusYears(1)
+            }
+
+            chapterDate
                 .atStartOfDay(TIME_ZONE)
                 .toInstant()
                 .toEpochMilli()
@@ -278,7 +285,7 @@ abstract class Origines : KeiSource() {
     }
 
     companion object {
-        private val DATE_REGEX = Regex("""(\d{1,2})\s+(\p{L}+)\.?\s+(\d{4})""")
+        private val DATE_REGEX = Regex("""(\d{1,2})\s+(\p{L}+)\.?(?:\s+(\d{4}))?""")
         private val TIME_ZONE: ZoneId = ZoneId.of("Europe/Paris")
     }
 }


### PR DESCRIPTION
Fix chapter date parsing for Mangas-Origines.fr.

The site now returns some chapter dates without a year, for example:

- `3 Août`
- `31 Juil`
- `28 Juil`

The current parser expects dates containing an explicit year, such as `8 Août 2026`.

Because the year is missing, `parseChapterDate()` fails to match those dates and returns `0L`, causing chapter dates to not appear in the app.

### Changes

- Support both chapter date formats:
  - `8 Août 2026`
  - `8 Août`
- Preserve the existing parsing behavior for dates that already contain a year.
- For dates without a year, use the current year.
- If that inferred date would be in the future, use the previous year instead. This handles the December/January transition correctly.
- Keep the existing French abbreviated month handling.
- Bump the Origines multisrc `baseVersionCode` from `1` to `2`.

### Examples

With the current date in August 2026:

- `8 Août 2026` → `2026-08-08`
- `3 Août` → `2026-08-03`
- `31 Juil` → `2026-07-31`
- `31 Déc` → `2025-12-31` when parsed in January

The change is limited to the Origines multisrc date parser and its version bump.

Related context:
- #18299 introduced the current Origines multisrc implementation after the site rework.
- #18559 recently updated the same Origines multisrc for the page list.

Checklist:

- [ ] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop