### PR TITLE
Com-X (RU): fix WebView antibot bypass in Tachimanga

### DIFF
--- a/src/ru/comx/build.gradle.kts
+++ b/src/ru/comx/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Com-X"
-    versionCode = 39
+    versionCode = 40
     contentWarning = ContentWarning.SAFE
     libVersion = "1.6"
 

--- a/src/ru/comx/src/eu/kanade/tachiyomi/extension/ru/comx/ComX.kt
+++ b/src/ru/comx/src/eu/kanade/tachiyomi/extension/ru/comx/ComX.kt
@@ -181,7 +181,7 @@ abstract class ComX :
         fetchDetails: Boolean,
         fetchChapters: Boolean,
     ): SMangaUpdate {
-        val doc = client.get("$baseUrl/${manga.url}", ensureSuccess = false).use { response ->
+        val doc = client.get(getMangaUrl(manga), ensureSuccess = false).use { response ->
             if (!response.isSuccessful) {
                 if (response.code == 403) {
                     throw Exception("Контент не доступен. Возможно может помочь авторизация через WebView")

--- a/src/ru/comx/src/eu/kanade/tachiyomi/extension/ru/comx/DleGuardResolver.kt
+++ b/src/ru/comx/src/eu/kanade/tachiyomi/extension/ru/comx/DleGuardResolver.kt
@@ -1,25 +1,61 @@
 package eu.kanade.tachiyomi.extension.ru.comx
 
-import android.webkit.CookieManager
-import keiyoushi.utils.runWebViewBlocking
+import android.annotation.SuppressLint
+import android.os.Handler
+import android.os.Looper
+import android.webkit.WebView
+import keiyoushi.utils.applicationContext
+import keiyoushi.utils.parseAs
+import kotlinx.serialization.Serializable
 import okhttp3.Call
 import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
 import java.io.IOException
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 object DleGuardResolver {
 
     private const val TIMEOUT_SECONDS = 30L
     private const val POLL_INTERVAL_MS = 250L
-    private const val PARALLEL_TRUST_WINDOW_MS = 5_000L
-    private const val TRUST_COOKIE = "__guard_trust"
+    private const val FAILURE_RETRY_DELAY_MS = 5_000L
 
-    @Volatile
-    private var failedOnce = false
+    private val htmlMediaType = "text/html; charset=UTF-8".toMediaType()
 
-    @Volatile
-    private var lastSolveAt = 0L
+    // The guard briefly renders a 404 /_c page before replacing it with the target document.
+    private val pageResponseScript = """
+        (() => {
+            const root = document.documentElement;
+            const isGuardPage = /^\/_c(?:\/|$)/.test(location.pathname);
+            const errorMessage =
+                document.querySelector(".message-info__content")?.textContent || "";
+            const isNotFound =
+                /\/404\.html\/?$/.test(location.pathname) ||
+                errorMessage.includes("изменен её адрес или она была удалена");
+            const hasPageContent =
+                document.querySelector("#dle-content") ||
+                root?.innerHTML.includes("window.__DATA__") ||
+                root?.innerHTML.includes("window.__XFILTER__");
+            if (
+                !root ||
+                document.readyState === "loading" ||
+                !/^https?:$/.test(location.protocol) ||
+                isGuardPage ||
+                (!hasPageContent && !isNotFound)
+            ) return null;
+
+            return JSON.stringify({
+                url: location.href,
+                code: isNotFound ? 404 : 200,
+                message: isNotFound ? "Not Found" : "OK",
+                html: root.outerHTML,
+            });
+        })()
+    """.trimIndent()
+
+    // Avoid launching another WebView for requests queued behind a failed solve.
+    private var lastFailureAtNanos = 0L
 
     fun interceptor(baseUrl: String): Interceptor = Interceptor { chain ->
         val originalRequest = chain.request()
@@ -27,55 +63,157 @@ object DleGuardResolver {
         if (response.request.url.pathSegments.firstOrNull() != "_c") {
             return@Interceptor response
         }
+        val responseBuilder = response.newBuilder()
         response.close()
+
         val url = if (originalRequest.method == "GET") {
             originalRequest.url.toString()
         } else {
             "$baseUrl/"
         }
-        if (!solve(url, originalRequest.header("User-Agent"), chain.call())) {
+        val pageResponse = solve(url, originalRequest.header("User-Agent"), chain.call())
+        if (pageResponse == null) {
             throw IOException("Open in WebView to bypass site protection")
         }
-        chain.proceed(originalRequest)
+
+        if (originalRequest.method != "GET") {
+            return@Interceptor chain.proceed(originalRequest)
+        }
+
+        val finalRequest = originalRequest.newBuilder()
+            .url(pageResponse.url)
+            .build()
+
+        responseBuilder
+            .request(finalRequest)
+            .code(pageResponse.code)
+            .message(pageResponse.message)
+            .removeHeader("Content-Encoding")
+            .removeHeader("Content-Length")
+            .removeHeader("Location")
+            .header("Content-Type", "text/html; charset=UTF-8")
+            .body(pageResponse.html.toResponseBody(htmlMediaType))
+            .build()
     }
 
     @Synchronized
-    private fun solve(siteUrl: String, userAgent: String?, call: Call): Boolean {
-        if (failedOnce) return false
-        if (System.currentTimeMillis() - lastSolveAt < PARALLEL_TRUST_WINDOW_MS) return true
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun solve(siteUrl: String, userAgent: String?, call: Call): PageResponse? {
+        val now = System.nanoTime()
+        val retryDelayNanos = TimeUnit.MILLISECONDS.toNanos(FAILURE_RETRY_DELAY_MS)
+        if (lastFailureAtNanos != 0L && now - lastFailureAtNanos < retryDelayNanos) return null
 
-        val cookieManager = CookieManager.getInstance()
-        cookieManager.setCookie(siteUrl, "$TRUST_COOKIE=; Max-Age=0; Path=/")
+        val handler = Handler(Looper.getMainLooper())
+        val latch = CountDownLatch(1)
+        var webView: WebView? = null
+        var poll: Runnable? = null
+        var failure: Throwable? = null
+        var pageResponse: PageResponse? = null
 
-        return try {
-            runWebViewBlocking<Unit>(call, timeout = TIMEOUT_SECONDS.seconds) {
-                this.userAgent = userAgent!!
-                blockImages = true
+        handler.post {
+            try {
+                if (call.isCanceled()) {
+                    latch.countDown()
+                    return@post
+                }
 
-                onPageFinished { url ->
-                    poll(POLL_INTERVAL_MS.milliseconds) {
-                        if (hasTrust(cookieManager, url)) {
-                            resolve(Unit)
+                val wv = WebView(applicationContext)
+                webView = wv
+                with(wv.settings) {
+                    javaScriptEnabled = true
+                    domStorageEnabled = true
+                    blockNetworkImage = true
+                    if (!userAgent.isNullOrBlank()) userAgentString = userAgent
+                }
+
+                // runWebViewBlocking assigns a WebViewClient, which makes Tachimanga intercept
+                // the challenge requests instead of letting the WebView handle them.
+                val pollTask = object : Runnable {
+                    override fun run() {
+                        if (latch.count == 0L || call.isCanceled()) {
+                            latch.countDown()
+                            return
+                        }
+                        try {
+                            wv.evaluateJavascript(pageResponseScript) { value ->
+                                try {
+                                    if (latch.count == 0L || call.isCanceled()) {
+                                        latch.countDown()
+                                        return@evaluateJavascript
+                                    }
+                                    val result = decodePageResponse(value)
+                                    when {
+                                        result == null -> handler.postDelayed(this, POLL_INTERVAL_MS)
+                                        result.code == 0 -> {
+                                            failure = IOException(result.message)
+                                            latch.countDown()
+                                        }
+                                        else -> {
+                                            pageResponse = result
+                                            latch.countDown()
+                                        }
+                                    }
+                                } catch (t: Throwable) {
+                                    failure = t
+                                    latch.countDown()
+                                }
+                            }
+                        } catch (t: Throwable) {
+                            failure = t
+                            latch.countDown()
                         }
                     }
                 }
-                loadUrl(siteUrl)
+                poll = pollTask
+
+                wv.loadUrl(siteUrl)
+                handler.postDelayed(pollTask, POLL_INTERVAL_MS)
+            } catch (t: Throwable) {
+                failure = t
+                latch.countDown()
             }
-            val solved = hasTrust(cookieManager, siteUrl)
-            if (solved) {
-                lastSolveAt = System.currentTimeMillis()
-            } else {
-                failedOnce = true
-            }
-            solved
-        } catch (e: Exception) {
-            failedOnce = true
-            false
         }
+
+        try {
+            val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS)
+            while (latch.count != 0L && !call.isCanceled()) {
+                val remainingMs = TimeUnit.NANOSECONDS.toMillis(deadline - System.nanoTime())
+                if (remainingMs <= 0L) break
+                latch.await(minOf(POLL_INTERVAL_MS, remainingMs), TimeUnit.MILLISECONDS)
+            }
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw IOException("Interrupted while solving WebView challenge", e)
+        } finally {
+            latch.countDown()
+            handler.post {
+                poll?.let(handler::removeCallbacks)
+                webView?.stopLoading()
+                webView?.destroy()
+            }
+        }
+
+        if (call.isCanceled()) throw IOException("Canceled")
+        failure?.let {
+            lastFailureAtNanos = System.nanoTime()
+            throw IOException("WebView challenge failed", it)
+        }
+
+        lastFailureAtNanos = if (pageResponse == null) System.nanoTime() else 0L
+        return pageResponse
     }
 
-    private fun hasTrust(cookieManager: CookieManager, url: String): Boolean {
-        val cookies = cookieManager.getCookie(url) ?: return false
-        return cookies.split(';').any { it.trim().startsWith("$TRUST_COOKIE=") }
+    private fun decodePageResponse(value: String?): PageResponse? {
+        if (value == null || value == "null") return null
+        val json = if (value.startsWith('"')) value.parseAs<String>() else value
+        return json.parseAs()
     }
+
+    @Serializable
+    private class PageResponse(
+        val url: String,
+        val code: Int,
+        val message: String,
+        val html: String,
+    )
 }

--- a/src/ru/comx/src/eu/kanade/tachiyomi/extension/ru/comx/DleGuardResolver.kt
+++ b/src/ru/comx/src/eu/kanade/tachiyomi/extension/ru/comx/DleGuardResolver.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.os.Handler
 import android.os.Looper
 import android.webkit.WebView
+import android.webkit.WebViewClient
 import keiyoushi.utils.applicationContext
 import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
@@ -20,6 +21,7 @@ object DleGuardResolver {
     private const val TIMEOUT_SECONDS = 30L
     private const val POLL_INTERVAL_MS = 250L
     private const val FAILURE_RETRY_DELAY_MS = 5_000L
+    private const val TACHIMANGA_PACKAGE = "app.tachimanga"
 
     private val htmlMediaType = "text/html; charset=UTF-8".toMediaType()
 
@@ -126,8 +128,12 @@ object DleGuardResolver {
                     if (!userAgent.isNullOrBlank()) userAgentString = userAgent
                 }
 
-                // runWebViewBlocking assigns a WebViewClient, which makes Tachimanga intercept
-                // the challenge requests instead of letting the WebView handle them.
+                // Android needs a client to keep guard redirects inside the WebView. Tachimanga
+                // intercepts the challenge requests whenever one is assigned.
+                if (applicationContext.packageName != TACHIMANGA_PACKAGE) {
+                    wv.webViewClient = WebViewClient()
+                }
+
                 val pollTask = object : Runnable {
                     override fun run() {
                         if (latch.count == 0L || call.isCanceled()) {


### PR DESCRIPTION
`runWebViewBlocking` installs a `WebViewClient` that Tachimanga intercepts as custom URL-scheme
tasks, causing guarded detail requests to time out. Use a client-free WebView to wait for the final
page DOM, preserve real 404 responses, and use `getMangaUrl(manga)` to avoid a double slash.

Related to #18144.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop