### PR TITLE
Read Solo Leveling Manga Manhwa Online: update baseUrl to ww4.readsololeveling.org

### DIFF
--- a/src/en/readsololevelingmangamanhwaonline/build.gradle.kts
+++ b/src/en/readsololevelingmangamanhwaonline/build.gradle.kts
@@ -6,13 +6,13 @@ plugins {
 
 keiyoushi {
     name = "Read Solo Leveling Manga Manhwa Online"
-    versionCode = 3
+    versionCode = 4
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
     theme = "mangacatalog"
 
     source {
         lang = "en"
-        baseUrl = "https://ww3.readsololeveling.org"
+        baseUrl = "https://ww4.readsololeveling.org"
     }
 }


### PR DESCRIPTION
Closes #18097

Website pindah ke https://ww4.readsololeveling.org

- baseUrl: ww3.readsololeveling.org -> ww4.readsololeveling.org
- versionCode: 3 -> 4

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop