### PR TITLE
Fix '18+' prefix on titles for MangaForFree.net and ManhwaClub.net

### DIFF
--- a/src/all/mangaforfree/build.gradle.kts
+++ b/src/all/mangaforfree/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "MangaForFree.net"
-    versionCode = 2
+    versionCode = 3
     contentWarning = ContentWarning.NSFW
     libVersion = "1.6"
     theme = "madara"

--- a/src/all/mangaforfree/src/eu/kanade/tachiyomi/extension/all/mangaforfree/MangaForFree.kt
+++ b/src/all/mangaforfree/src/eu/kanade/tachiyomi/extension/all/mangaforfree/MangaForFree.kt
@@ -1,14 +1,21 @@
 package eu.kanade.tachiyomi.extension.all.mangaforfree
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.source.model.SManga
 import keiyoushi.annotation.Source
 import keiyoushi.network.rateLimit
 import okhttp3.OkHttpClient
+import org.jsoup.nodes.Document
 import kotlin.time.Duration.Companion.seconds
 
 @Source
 abstract class MangaForFree : Madara() {
     override val chapterMode = ChapterMode.AdminAjax
+
+    override fun parseDetails(document: Document, id: String, preserveUrl: String?): SManga {
+        document.select("span.manga-title-badges").remove()
+        return super.parseDetails(document, id, preserveUrl)
+    }
 
     override fun OkHttpClient.Builder.configureClient() = rateLimit(1, 1.seconds) { !it.encodedPath.startsWith("/wp-content/uploads/") }
 

--- a/src/all/manhwaclubnet/build.gradle.kts
+++ b/src/all/manhwaclubnet/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "ManhwaClub.net"
-    versionCode = 0
+    versionCode = 1
     contentWarning = ContentWarning.NSFW
     libVersion = "1.6"
     theme = "madara"

--- a/src/all/manhwaclubnet/src/eu/kanade/tachiyomi/extension/all/manhwaclubnet/ManhwaClubNet.kt
+++ b/src/all/manhwaclubnet/src/eu/kanade/tachiyomi/extension/all/manhwaclubnet/ManhwaClubNet.kt
@@ -3,12 +3,18 @@ package eu.kanade.tachiyomi.extension.all.manhwaclubnet
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.multisrc.madara.MadaraBase.ChapterMode
 import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
 import keiyoushi.annotation.Source
 import org.jsoup.nodes.Document
 
 @Source
 abstract class ManhwaClubNet : Madara() {
     override val chapterMode = ChapterMode.AdminAjax
+
+    override fun parseDetails(document: Document, id: String, preserveUrl: String?): SManga {
+        document.select("span.manga-title-badges").remove()
+        return super.parseDetails(document, id, preserveUrl)
+    }
 
     override suspend fun fetchChapters(mangaPath: String, id: String, mangaPage: Document?): List<SChapter> = super.fetchChapters(mangaPath, id, mangaPage).let { chapters ->
         when (lang) {


### PR DESCRIPTION
Closes #18655

Both sources render an adult badge (`<span class="manga-title-badges">18+</span>`) inside the title element of the manga detail page. The default Madara `parseDetails` grabs `.text()` on the whole element, so the badge text gets prepended to the title.

Strip the badge element from the detail document before delegating to the theme's `parseDetails`. Localized to each source, so no change to the shared Madara theme.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop