### PR TITLE
Ortega Scans: parse categories as a list of strings

### DIFF
--- a/src/fr/ortegascans/build.gradle.kts
+++ b/src/fr/ortegascans/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Ortega Scans"
-    versionCode = 1
+    versionCode = 2
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
 

--- a/src/fr/ortegascans/src/eu/kanade/tachiyomi/extension/fr/ortegascans/Dto.kt
+++ b/src/fr/ortegascans/src/eu/kanade/tachiyomi/extension/fr/ortegascans/Dto.kt
@@ -58,7 +58,7 @@ class MangaDto(
     val author: String? = null,
     val artist: String? = null,
     val alternativeNames: String? = null,
-    val categories: List<CategoryDto> = emptyList(),
+    val categories: List<String> = emptyList(),
 ) {
     fun toSManga(baseUrl: String) = SManga.create().apply {
         url = MangaUrl(slug, id).toJsonString()
@@ -71,14 +71,9 @@ class MangaDto(
         author = this@MangaDto.author
         artist = this@MangaDto.artist
         status = parseStatus(this@MangaDto.status)
-        genre = categories.joinToString { it.name }
+        genre = categories.joinToString()
     }
 }
-
-@Serializable
-class CategoryDto(
-    val name: String,
-)
 
 @Serializable
 class ChapterListDataDto(


### PR DESCRIPTION
Closes #18639

The `/serie/{slug}?_rsc` API now returns `categories` as a plain array of strings (e.g. `["Mature","Drame","Harem"]`) instead of an array of objects. The old `List<CategoryDto>` caused a kotlinx `JsonDecodingException` when loading a chapter list (`Expected JsonObject, but had JsonLiteral ... at path: $.0`).

Use `List<String>` and join them directly for the `genre` field.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop