### PR TITLE
Leslie&Victims: use /manga.json instead of broken /api/library

### DIFF
--- a/src/en/leslievictims/build.gradle.kts
+++ b/src/en/leslievictims/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Leslie&Victims"
-    versionCode = 1
+    versionCode = 2
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/en/leslievictims/src/eu/kanade/tachiyomi/extension/en/leslievictims/LeslieAndVictims.kt
+++ b/src/en/leslievictims/src/eu/kanade/tachiyomi/extension/en/leslievictims/LeslieAndVictims.kt
@@ -25,7 +25,7 @@ abstract class LeslieAndVictims : HttpSource() {
 
     // ============================== Popular ===============================
 
-    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/api/library", headers)
+    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/manga.json", headers)
 
     override fun popularMangaParse(response: Response): MangasPage {
         val mangas = response.parseAs<List<LibraryEntry>>().map { it.toSManga(baseUrl) }
@@ -40,7 +40,7 @@ abstract class LeslieAndVictims : HttpSource() {
 
     // =============================== Search ===============================
 
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request = GET("$baseUrl/api/library#$query", headers)
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request = GET("$baseUrl/manga.json#$query", headers)
 
     override fun searchMangaParse(response: Response): MangasPage {
         val query = response.request.url.fragment ?: ""
@@ -74,7 +74,7 @@ abstract class LeslieAndVictims : HttpSource() {
             ?: throw Exception("Missing series ID in chapter URL")
         val chId = url.queryParameter("ch")
             ?: throw Exception("Missing chapter ID in chapter URL")
-        return GET("$baseUrl/api/library#$seriesId|$chId", headers)
+        return GET("$baseUrl/manga.json#$seriesId|$chId", headers)
     }
 
     override fun pageListParse(response: Response): List<Page> {
@@ -147,7 +147,7 @@ abstract class LeslieAndVictims : HttpSource() {
     private fun libraryRequestForManga(manga: SManga): Request {
         val seriesId = (baseUrl + manga.url).toHttpUrl().queryParameter("series")
             ?: throw Exception("Invalid manga URL")
-        return GET("$baseUrl/api/library#$seriesId", headers)
+        return GET("$baseUrl/manga.json#$seriesId", headers)
     }
 
     private fun findEntry(response: Response): LibraryEntry {


### PR DESCRIPTION
Closes #18569

The `/api/library` endpoint now returns `503 {"error":"GitHub Error: 404"}` because the server-side GitHub fetch fails. The manga data actually lives in the static `/manga.json` file, which matches the existing `LibraryEntry` DTO (`id`, `title`, `cover`, `chapters`, `chapter_roots`).

Point all data requests at `/manga.json`. Chapter roots use R2 dev URLs with mode `count`/`list`, which the existing `pageListParse` already handles.

Note: `/novel.json` uses a different structure (markdown text chapters), which is out of scope for the manga reader.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop