### PR TITLE
Mangas-Origines.fr: fix field to parse for date

### DIFF
--- a/lib-multisrc/origines/build.gradle.kts
+++ b/lib-multisrc/origines/build.gradle.kts
@@ -3,6 +3,6 @@ plugins {
 }
 
 keiyoushi {
-    baseVersionCode = 2
+    baseVersionCode = 3
     libVersion = "1.6"
 }

--- a/lib-multisrc/origines/src/eu/kanade/tachiyomi/multisrc/origines/Origines.kt
+++ b/lib-multisrc/origines/src/eu/kanade/tachiyomi/multisrc/origines/Origines.kt
@@ -223,7 +223,7 @@ abstract class Origines : KeiSource() {
             SChapter.create().apply {
                 url = link.attr("href").toChapterSlug()
                 name = element.selectFirst("span.ori-chl-nom")?.text() ?: link.text()
-                date_upload = parseChapterDate(element.selectFirst("span.ori-chl-date")?.text())
+                date_upload = parseChapterDate(element.selectFirst("span.ori-chl-date")?.attr("title"))
             }
         }
     }


### PR DESCRIPTION
Closes #18665

Checked both extensions depending on the theme

Checklist:

- [ ] Updated `versionCode` value in `build.gradle.kts`
- [X] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [X] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
