### PR TITLE
Picacomic: Fix category filtering

### DIFF
--- a/src/zh/picacomic/build.gradle.kts
+++ b/src/zh/picacomic/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Picacomic"
-    versionCode = 9
+    versionCode = 10
     contentWarning = ContentWarning.NSFW
     libVersion = "1.6"
 

--- a/src/zh/picacomic/src/eu/kanade/tachiyomi/extension/zh/picacomic/Filters.kt
+++ b/src/zh/picacomic/src/eu/kanade/tachiyomi/extension/zh/picacomic/Filters.kt
@@ -21,12 +21,10 @@ internal class SortFilter :
         ),
     )
 
-internal class Category(name: String) : Filter.CheckBox(name)
-
 internal class CategoryFilter :
-    Filter.Group<Filter.CheckBox>(
+    UriPartFilter(
         "类型",
-        listOf(
+        listOf("全部" to "") + listOf(
             "大家都在看", "牛牛不哭", "那年今天", "官方都在看",
             "嗶咔漢化", "全彩", "長篇", "同人", "短篇", "圓神領域",
             "碧藍幻想", "CG雜圖", "純愛", "百合花園", "後宮閃光", "單行本", "姐姐系",
@@ -35,7 +33,7 @@ internal class CategoryFilter :
             "東方", "禁書目錄", "Cosplay",
             "英語 ENG", "生肉", "性轉換", "足の恋", "非人類",
             "耽美花園", "偽娘哲學", "扶他樂園", "重口地帶", "歐美", "WEBTOON",
-        ).map { Category(it) },
+        ).map { it to it },
     )
 
 internal class RankFilter :

--- a/src/zh/picacomic/src/eu/kanade/tachiyomi/extension/zh/picacomic/Picacomic.kt
+++ b/src/zh/picacomic/src/eu/kanade/tachiyomi/extension/zh/picacomic/Picacomic.kt
@@ -111,14 +111,14 @@ abstract class Picacomic :
     // Search
     override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
         var sort: String? = null
-        var categories: List<String>? = null
+        var category: String? = null
         var rankPath: String? = null
 
         // parse filters
         for (filter in filters) {
             when (filter) {
                 is SortFilter -> sort = filter.toUriPart()
-                is CategoryFilter -> categories = filter.state.filter { it.state }.map { it.name }
+                is CategoryFilter -> category = filter.toUriPart()
                 is RankFilter -> rankPath = filter.toUriPart()
                 else -> {}
             }
@@ -129,10 +129,22 @@ abstract class Picacomic :
             return singlePageParse(client.get("$apiUrl$rankPath"))
         }
 
+        if (query.isEmpty()) {
+            val url = "$apiUrl/comics".toHttpUrl().newBuilder()
+                .addQueryParameter("page", page.toString())
+                .addQueryParameter("s", sort ?: "dd")
+                .apply {
+                    category?.takeIf(String::isNotEmpty)?.let { addQueryParameter("c", it) }
+                }
+                .build()
+
+            return parseSearchManga(client.get(url))
+        }
+
         // return comics from some search
         val url = "$apiUrl/comics/advanced-search?page=$page"
 
-        val body = PicaSearchPayload(query, sort ?: "dd", categories).toJsonString().toRequestBody()
+        val body = PicaSearchPayload(query, sort ?: "dd").toJsonString().toRequestBody()
 
         return parseSearchManga(client.post(url, body))
     }
@@ -360,6 +372,7 @@ abstract class Picacomic :
     }
 
     private suspend fun OkHttpClient.get(url: String) = get(url, picaHeaders(url))
+    private suspend fun OkHttpClient.get(url: HttpUrl) = get(url, picaHeaders(url.toString()))
     private suspend fun OkHttpClient.post(url: String, body: RequestBody) = post(url, picaHeaders(url, "POST"), body)
 
     private fun Request.applyToken() = newBuilder().header("Authorization", token).build()


### PR DESCRIPTION
Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

## Issue

  After the 1.6 migration, applying a category with an empty search query used
  `POST /comics/advanced-search`. The API returned HTTP 200 but no results.

## Fix

  - Restore category browsing through `GET /comics` with the `c` query parameter.
  - Restore the category filter to a single-select control, matching the API's
    single-category parameter.
  - Bump Picacomic's version code to 10.

## Testing

  - Verified in redroid with a valid logged-in account:
    - “大家都在看” with default sorting now loads results.
  - `./gradlew :src:zh:picacomic:assembleDebug`
  - `./gradlew :src:zh:picacomic:lintRelease`
    - 0 errors; 2 existing generated-manifest warnings.