### PR TITLE
Com-X (ru): fix things

### DIFF
--- a/src/ru/comx/build.gradle.kts
+++ b/src/ru/comx/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Com-X"
-    versionCode = 39
+    versionCode = 40
     contentWarning = ContentWarning.SAFE
     libVersion = "1.6"
 

--- a/src/ru/comx/src/eu/kanade/tachiyomi/extension/ru/comx/ComX.kt
+++ b/src/ru/comx/src/eu/kanade/tachiyomi/extension/ru/comx/ComX.kt
@@ -22,6 +22,7 @@ import keiyoushi.source.KeiSource
 import keiyoushi.utils.getPreferences
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.toJsonElement
+import keiyoushi.utils.tryParseDate
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.buildJsonObject
 import okhttp3.FormBody
@@ -31,8 +32,6 @@ import okhttp3.OkHttpClient
 import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
-import java.time.LocalDate
-import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Calendar
 import java.util.Locale
@@ -181,7 +180,7 @@ abstract class ComX :
         fetchDetails: Boolean,
         fetchChapters: Boolean,
     ): SMangaUpdate {
-        val doc = client.get("$baseUrl/${manga.url}", ensureSuccess = false).use { response ->
+        val doc = client.get(baseUrl + manga.url, ensureSuccess = false).use { response ->
             if (!response.isSuccessful) {
                 if (response.code == 403) {
                     throw Exception("Контент не доступен. Возможно может помочь авторизация через WebView")
@@ -254,9 +253,10 @@ abstract class ComX :
     }
 
     // ============================== Manga Utilities ===============================
-    private fun Document.getPageListItem(label: String): String? = selectFirst(".page__list > li:has(> div:contains($label))")
-        ?.ownText()
-        ?.takeIf { it.isNotBlank() }
+    private fun Document.getPageListItem(label: String): String? = selectFirst(".page__list > li:has(> div:contains($label))")?.let { element ->
+        element.selectFirst("a")?.text() ?: element.ownText()
+    }?.takeIf { it.isNotBlank() }
+
     private fun parseStatus(element: String?): Int = when {
         element.isNullOrBlank() -> SManga.UNKNOWN
         element.contains("Продолжается") || element.contains(" из ") || element.contains("Онгоинг") -> SManga.ONGOING
@@ -291,9 +291,7 @@ abstract class ComX :
         return data.chapters.asReversed().map { chap ->
             SChapter.create().apply {
                 url = "/reader/${data.comicId}/${chap.id}"
-                date_upload = runCatching {
-                    LocalDate.parse(chap.date, dateFormat).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
-                }.getOrDefault(0L)
+                date_upload = dateFormat.tryParseDate(chap.date)
 
                 val matchNumber = chapterNumberRegex.find(chap.title)?.groupValues[1]?.toFloatOrNull()
                 val anyNumber = chapterAnyNumberRegex.find(chap.title)?.groupValues[1]?.toFloatOrNull()


### PR DESCRIPTION
Checklist:

Fixes:
- As mentioned in #18654  `fetchMangaUpdate` had double slash in request url
- updated `getPageListItem` to properly get Author/Artist when it was inside url element
- parse upload date for chapter with `tryParseDate` (wasn't available at the time of migration to 1.6)

.

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
