### PR TITLE
DrakeScans & WitchScans: bump version

### DIFF
--- a/src/en/drakescans/build.gradle.kts
+++ b/src/en/drakescans/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Drake Scans"
-    versionCode = 16
+    versionCode = 48
     contentWarning = ContentWarning.SAFE
     libVersion = "1.6"
     theme = "vinetheme"

--- a/src/en/witchscans/build.gradle.kts
+++ b/src/en/witchscans/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "WitchScans"
-    versionCode = 0
+    versionCode = 32
     contentWarning = ContentWarning.SAFE
     libVersion = "1.6"
     theme = "vinetheme"

--- a/src/en/witchscans/build.gradle.kts
+++ b/src/en/witchscans/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "WitchScans"
-    versionCode = 32
+    versionCode = 0
     contentWarning = ContentWarning.SAFE
     libVersion = "1.6"
     theme = "vinetheme"


### PR DESCRIPTION
Checklist:

<details>
  <summary>DrakeScans info</summary>
<img width="1128" height="517" alt="Screenshot 2026-08-28 at 22-45-56 Update extensions repo · keiyoushi_extensions@b5a5c74" src="https://github.com/user-attachments/assets/d57f87c6-c3e7-42de-8899-80affb29db69" />
</details>

48 + 1 (from multisrc) = 49

<details>
  <summary>WitchScans info</summary>
<img width="754" height="213" alt="1" src="https://github.com/user-attachments/assets/f2e3c778-1473-46bb-9806-574b3a108a38" />
<img width="1037" height="577" alt="Screenshot 2026-08-29 at 01-36-35 Update extensions repo · keiyoushi_extensions@b5a5c74" src="https://github.com/user-attachments/assets/3112d3e2-9250-4504-8e35-fcf65a9dbee5" />
</details>

32 + 1 (from multisrc) = 33

> New Version code is less that previous one so android doesn't let it "downgrade"

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
