### PR TITLE
Argos Comics: update Next.js actions

### DIFF
--- a/src/pt/argoscomics/build.gradle.kts
+++ b/src/pt/argoscomics/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Argos Comics"
-    versionCode = 57
+    versionCode = 58
     contentWarning = ContentWarning.SAFE
     libVersion = "1.6"
 

--- a/src/pt/argoscomics/src/eu/kanade/tachiyomi/extension/pt/argoscomics/ArgosComics.kt
+++ b/src/pt/argoscomics/src/eu/kanade/tachiyomi/extension/pt/argoscomics/ArgosComics.kt
@@ -112,9 +112,9 @@ abstract class ArgosComics : KeiSource() {
     }
 
     companion object {
-        private const val SEARCH_TOKEN = "401563018947bb5e0823b4295c6f5fbbbb27c7c8a7"
-        private const val CHAPTERS_TOKEN = "606716f5913c027ff3c3054981361be598857cefe2"
-        private const val DETAILS_TOKEN = "601ce7e470cca09f45d7d39f2668924e80b1c3df0c"
-        private const val PAGES_TOKEN = "609b98cc48cafaf9f9eb7a2ef652330137d7198d8f"
+        private const val SEARCH_TOKEN = "409ae74984efeccf922164e02e3bcd60d8b0107638"
+        private const val CHAPTERS_TOKEN = "606c13e60309ce062fade63ac2f1cc68bbc5dc25f4"
+        private const val DETAILS_TOKEN = "60e89cb5963d6bb1b61383872fbfb4cc2726925dd8"
+        private const val PAGES_TOKEN = "6062e8559136ee33cc337e5520fb09950c3dced65e"
     }
 }


### PR DESCRIPTION
## Summary

- Update the stale Next.js Server Action identifiers used by Argos Comics for search, manga details, chapter listings, and reader pages.
- Bump the extension version code from 57 to 58.

## Cause

Aniargos deployed a new frontend build, which regenerated the identifiers sent through the `Next-Action` request header. The extension was still sending the previous identifiers, so the server returned HTTP 404 for its API requests even though the same content continued to work in WebView.

## Testing

- Built the release APK successfully with GitHub Actions.
- Installed and tested the APK on Mihon 0.20.4.
- Confirmed that Popular and Recent listings load.
- Confirmed that manga details and chapter lists load and update correctly.
- Confirmed that chapter pages open successfully in the native reader.

### Test evidence

<img width="576" height="1280" alt="Imagem do Codex 30 de ago  de 2026, 23_59_06" src="https://github.com/user-attachments/assets/07a56547-32e4-47ce-be6a-c052be41b97b" />

<img width="576" height="1280" alt="Imagem do Codex 31 de ago  de 2026, 00_01_14" src="https://github.com/user-attachments/assets/8c404215-703c-404e-a018-24ef76a2972a" />

<img width="576" height="1280" alt="image" src="https://github.com/user-attachments/assets/0246d8c0-5e46-4cc7-aca8-18f52a57420d" />


<img width="576" height="1280" alt="image" src="https://github.com/user-attachments/assets/0b7024a5-8001-4299-9e5b-90cf6230023f" />


Closes #18706

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop