### PR TITLE
Art Lapsa, RitharScans: default paid chapters on

### DIFF
--- a/lib-multisrc/keyoapp/src/eu/kanade/tachiyomi/multisrc/keyoapp/Keyoapp.kt
+++ b/lib-multisrc/keyoapp/src/eu/kanade/tachiyomi/multisrc/keyoapp/Keyoapp.kt
@@ -35,6 +35,8 @@ abstract class Keyoapp :
 
     protected val preferences = getPreferences()
 
+    protected open val showPaidChaptersDefault = false
+
     open val dateFormat = DateTimeFormatter.ofPattern("MMM d, yyyy", Locale.ENGLISH)
 
     protected val intl = Intl(
@@ -394,12 +396,12 @@ abstract class Keyoapp :
             title = intl["pref_show_paid_chapter_title"]
             summaryOn = intl["pref_show_paid_chapter_summary_on"]
             summaryOff = intl["pref_show_paid_chapter_summary_off"]
-            setDefaultValue(false)
+            setDefaultValue(showPaidChaptersDefault)
         }.also(screen::addPreference)
     }
 
     protected val showPaidChapters
-        get() = preferences.getBoolean(SHOW_PAID_CHAPTERS_PREF, false)
+        get() = preferences.getBoolean(SHOW_PAID_CHAPTERS_PREF, showPaidChaptersDefault)
 
     companion object {
         private const val SHOW_PAID_CHAPTERS_PREF = "pref_show_paid_chap"

--- a/src/en/artlapsa/build.gradle.kts
+++ b/src/en/artlapsa/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Art Lapsa"
-    versionCode = 5
+    versionCode = 6
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
     theme = "keyoapp"

--- a/src/en/artlapsa/src/eu/kanade/tachiyomi/extension/en/artlapsa/ArtLapsa.kt
+++ b/src/en/artlapsa/src/eu/kanade/tachiyomi/extension/en/artlapsa/ArtLapsa.kt
@@ -14,6 +14,7 @@ import org.jsoup.nodes.Document
 
 @Source
 abstract class ArtLapsa : Keyoapp() {
+    override val showPaidChaptersDefault = true
 
     override suspend fun requestGeneres() = client.get("$baseUrl/search")
 

--- a/src/en/ritharscans/build.gradle.kts
+++ b/src/en/ritharscans/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "RitharScans"
-    versionCode = 3
+    versionCode = 4
     contentWarning = ContentWarning.SAFE
     libVersion = "1.6"
     theme = "keyoapp"

--- a/src/en/ritharscans/src/eu/kanade/tachiyomi/extension/en/ritharscans/RitharScans.kt
+++ b/src/en/ritharscans/src/eu/kanade/tachiyomi/extension/en/ritharscans/RitharScans.kt
@@ -12,6 +12,7 @@ import org.jsoup.nodes.Element
 
 @Source
 abstract class RitharScans : Keyoapp() {
+    override val showPaidChaptersDefault = true
 
     override suspend fun requestGeneres() = client.get("$baseUrl/search")
 


### PR DESCRIPTION
Change default settings for paid chapters to on for Art Lapsa and RitharScans

Paid chapters load normally regardless of payment and login status, so it doesn't make sense for the show paid chapters setting to default to off.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
