### PR TITLE
fix: Pam (multi-src) search

### DIFF
--- a/lib-multisrc/pam/assets/i18n/messages_en.properties
+++ b/lib-multisrc/pam/assets/i18n/messages_en.properties
@@ -1,0 +1,3 @@
+release_year=Release Year
+alternative_names=Alternative Names
+pref_hide_premium_title=Hide Premium chapters

--- a/lib-multisrc/pam/assets/i18n/messages_fr.properties
+++ b/lib-multisrc/pam/assets/i18n/messages_fr.properties
@@ -1,3 +1,3 @@
 release_year=Sortie
 alternative_names=Noms alternatifs
-pref_hide_premium_title=Masquer les chapitres premium
+pref_hide_premium_title=Masquer les chapitres Premium

--- a/lib-multisrc/pam/assets/i18n/messages_fr.properties
+++ b/lib-multisrc/pam/assets/i18n/messages_fr.properties
@@ -1,0 +1,3 @@
+release_year=Sortie
+alternative_names=Noms alternatifs
+pref_hide_premium_title=Masquer les chapitres premium

--- a/lib-multisrc/pam/build.gradle.kts
+++ b/lib-multisrc/pam/build.gradle.kts
@@ -4,9 +4,10 @@ plugins {
 
 dependencies {
     api(project(":lib:secretstream"))
+    implementation(project(":ext-lib-i18n"))
 }
 
 keiyoushi {
-    baseVersionCode = 2
+    baseVersionCode = 3
     libVersion = "1.4"
 }

--- a/lib-multisrc/pam/build.gradle.kts
+++ b/lib-multisrc/pam/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     api(project(":lib:secretstream"))
-    implementation(project(":lib:i18n"))
+    api(project(":lib:i18n"))
 }
 
 keiyoushi {

--- a/lib-multisrc/pam/build.gradle.kts
+++ b/lib-multisrc/pam/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     api(project(":lib:secretstream"))
-    implementation(project(":ext-lib-i18n"))
+    implementation(project(":lib:i18n"))
 }
 
 keiyoushi {

--- a/lib-multisrc/pam/src/eu/kanade/tachiyomi/multisrc/pam/Dto.kt
+++ b/lib-multisrc/pam/src/eu/kanade/tachiyomi/multisrc/pam/Dto.kt
@@ -17,7 +17,7 @@ class LibraryResponse(
     @Serializable
     class Series(
         val data: List<BrowseManga>,
-        val meta: Meta,
+        val meta: Meta? = null,
     ) {
         @Serializable
         class Meta(
@@ -28,6 +28,11 @@ class LibraryResponse(
         )
     }
 }
+
+@Serializable
+class SearchResponse(
+    val data: List<BrowseManga>
+)
 
 @Serializable
 class BrowseManga(

--- a/lib-multisrc/pam/src/eu/kanade/tachiyomi/multisrc/pam/Dto.kt
+++ b/lib-multisrc/pam/src/eu/kanade/tachiyomi/multisrc/pam/Dto.kt
@@ -31,7 +31,7 @@ class LibraryResponse(
 
 @Serializable
 class SearchResponse(
-    val data: List<BrowseManga>
+    val data: List<BrowseManga>,
 )
 
 @Serializable

--- a/lib-multisrc/pam/src/eu/kanade/tachiyomi/multisrc/pam/Pam.kt
+++ b/lib-multisrc/pam/src/eu/kanade/tachiyomi/multisrc/pam/Pam.kt
@@ -193,7 +193,7 @@ abstract class Pam :
 
     override fun searchMangaParse(response: Response): MangasPage {
         if (response.request.url.queryParameter("q") != null) {
-            val data = response.parseAs<List<BrowseManga>>()
+            val data = response.parseAs<SearchResponse>().data
 
             return MangasPage(
                 mangas = data.map { it.toSManga(::createThumbnailUrl) },
@@ -204,7 +204,7 @@ abstract class Pam :
 
             return MangasPage(
                 mangas = data.data.map { it.toSManga(::createThumbnailUrl) },
-                hasNextPage = data.meta.current < data.meta.last,
+                hasNextPage = data.meta?.let { it.current < it.last } ?: false,
             )
         }
     }

--- a/lib-multisrc/pam/src/eu/kanade/tachiyomi/multisrc/pam/Pam.kt
+++ b/lib-multisrc/pam/src/eu/kanade/tachiyomi/multisrc/pam/Pam.kt
@@ -12,6 +12,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.lib.i18n.Intl
 import keiyoushi.lib.secretstream.SecretStream
 import keiyoushi.lib.secretstream.State
 import keiyoushi.lib.secretstream.X25519
@@ -53,7 +54,12 @@ abstract class Pam :
 
     private val preferences by getPreferencesLazy()
 
-    protected open val prefPremiumTitle = "Hide Premium chapters"
+    protected val intl = Intl(
+        language = lang,
+        baseLanguage = "en",
+        availableLanguages = setOf("en", "fr"),
+        classLoader = this::class.java.classLoader!!,
+    )
 
     override val client = network.client.newBuilder()
         .addInterceptor(::imageInterceptor)
@@ -236,10 +242,10 @@ abstract class Pam :
                     append(it.trim(), "\n\n")
                 }
                 data.releaseYear?.also {
-                    append("Sortie: ", it, "\n\n")
+                    append(intl["release_year"], ": ", it, "\n\n")
                 }
                 data.alternativeName?.also {
-                    append("Noms alternatifs: ", it)
+                    append(intl["alternative_names"], ": ", it)
                 }
             }.trim()
             genre = buildList {
@@ -292,7 +298,7 @@ abstract class Pam :
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         SwitchPreferenceCompat(screen.context).apply {
             key = HIDE_PREMIUM_PREF
-            title = prefPremiumTitle
+            title = intl["pref_hide_premium_title"]
             setDefaultValue(false)
         }.also(screen::addPreference)
     }

--- a/src/fr/epsilonscan/src/eu/kanade/tachiyomi/extension/fr/epsilonscan/EpsilonScan.kt
+++ b/src/fr/epsilonscan/src/eu/kanade/tachiyomi/extension/fr/epsilonscan/EpsilonScan.kt
@@ -11,8 +11,6 @@ import keiyoushi.annotation.Source
 @Source
 abstract class EpsilonScan : Pam() {
 
-    override val prefPremiumTitle = "Masquer les chapitres Premium"
-
     override val popularFilters = FilterList(SortFilter("Sort", sortValues, Filter.Sort.Selection(3, false)))
     override val latestFilters = FilterList(SortFilter("Sort", sortValues, Filter.Sort.Selection(2, false)))
 

--- a/src/fr/softepsilonscan/src/eu/kanade/tachiyomi/extension/fr/softepsilonscan/SoftEpsilonScan.kt
+++ b/src/fr/softepsilonscan/src/eu/kanade/tachiyomi/extension/fr/softepsilonscan/SoftEpsilonScan.kt
@@ -11,8 +11,6 @@ import keiyoushi.annotation.Source
 @Source
 abstract class SoftEpsilonScan : Pam() {
 
-    override val prefPremiumTitle = "Masquer les chapitres Premium"
-
     override val popularFilters = FilterList(SortFilter("Sort", sortValues, Filter.Sort.Selection(3, false)))
     override val latestFilters = FilterList(SortFilter("Sort", sortValues, Filter.Sort.Selection(2, false)))
 


### PR DESCRIPTION
Closes #18679

Checklist:

- [ ] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by running the extension
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
