### PR TITLE
Batcave: fix search

### DIFF
--- a/src/en/batcave/build.gradle.kts
+++ b/src/en/batcave/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "BatCave"
-    versionCode = 9
+    versionCode = 10
     contentWarning = ContentWarning.SAFE
     libVersion = "1.6"
 

--- a/src/en/batcave/src/eu/kanade/tachiyomi/extension/en/batcave/BatCave.kt
+++ b/src/en/batcave/src/eu/kanade/tachiyomi/extension/en/batcave/BatCave.kt
@@ -11,7 +11,6 @@ import keiyoushi.annotation.Source
 import keiyoushi.network.get
 import keiyoushi.network.post
 import keiyoushi.source.KeiSource
-import keiyoushi.utils.applicationContext
 import keiyoushi.utils.asJsoup
 import keiyoushi.utils.firstInstanceOrNull
 import keiyoushi.utils.parseAs
@@ -36,10 +35,6 @@ abstract class BatCave : KeiSource() {
     // Use client to sync cookies with WebView and intercept the DLE Guard redirect.
     override fun OkHttpClient.Builder.configureClient() = apply {
         addInterceptor(DleGuardResolver.interceptor(baseUrl))
-    }
-
-    init {
-        applicationContext.cacheDir.resolve("source_$id").deleteRecursively()
     }
 
     override fun Headers.Builder.configureHeaders(): Headers.Builder = apply {
@@ -102,7 +97,7 @@ abstract class BatCave : KeiSource() {
             if (filtersApplied) {
                 addPathSegments(filterPath)
             } else {
-                // Send this to always stay in ComicList
+                // Send something to use ComicList
                 addPathSegment("y[from]=1926")
                 addPathSegment("y[to]=${Calendar.getInstance().get(Calendar.YEAR)}")
             }

--- a/src/en/batcave/src/eu/kanade/tachiyomi/extension/en/batcave/BatCave.kt
+++ b/src/en/batcave/src/eu/kanade/tachiyomi/extension/en/batcave/BatCave.kt
@@ -45,12 +45,7 @@ abstract class BatCave : KeiSource() {
     }
 
     // ============================== Popular ==============================
-    override suspend fun getPopularManga(page: Int) = searchCatalog(page, "rating")
-
-    // ============================== Latest ===============================
-    override suspend fun getLatestUpdates(page: Int) = searchCatalog(page, "editdate")
-
-    private suspend fun searchCatalog(page: Int, sortBy: String): MangasPage {
+    override suspend fun getPopularManga(page: Int): MangasPage {
         val url = baseUrl.toHttpUrl().newBuilder().apply {
             addPathSegment("comix")
             if (page > 1) {
@@ -60,13 +55,40 @@ abstract class BatCave : KeiSource() {
         }.build()
 
         val body = FormBody.Builder()
-            .add("dlenewssortby", sortBy)
+            .add("dlenewssortby", "rating")
             .add("dledirection", "desc")
             .add("set_new_sort", "dle_sort_cat_1")
             .add("set_direction_sort", "dle_direction_cat_1")
             .build()
 
         return parseSearchMangas(client.post(url, body))
+    }
+
+    // ============================== Latest ===============================
+    override suspend fun getLatestUpdates(page: Int): MangasPage {
+        val url = baseUrl.toHttpUrl().newBuilder().apply {
+            if (page > 1) {
+                addPathSegments("page/$page")
+                addPathSegment("")
+            }
+        }.build()
+
+        val document = client.get(url).asJsoup()
+
+        val entries = document.select("#content-load > .latest.grid-item").mapNotNull { element ->
+            SManga.create().apply {
+                with(element.selectFirst(".latest__title > a")!!) {
+                    if (ownText().isEmpty()) return@mapNotNull null
+                    setUrlWithoutDomain(absUrl("href"))
+                    title = ownText()
+                }
+                thumbnail_url = element.selectFirst(".latest__img img")?.absUrl("src")
+            }
+        }
+
+        val hasNextPage = document.selectFirst("li.pagination a[href]") != null
+
+        return MangasPage(entries, hasNextPage)
     }
 
     // ============================== Search ===============================
@@ -97,7 +119,7 @@ abstract class BatCave : KeiSource() {
             if (filtersApplied) {
                 addPathSegments(filterPath)
             } else {
-                // Send something to use ComicList
+                // Send something to force ComicList
                 addPathSegment("y[from]=1926")
                 addPathSegment("y[to]=${Calendar.getInstance().get(Calendar.YEAR)}")
             }

--- a/src/en/batcave/src/eu/kanade/tachiyomi/extension/en/batcave/BatCave.kt
+++ b/src/en/batcave/src/eu/kanade/tachiyomi/extension/en/batcave/BatCave.kt
@@ -11,6 +11,7 @@ import keiyoushi.annotation.Source
 import keiyoushi.network.get
 import keiyoushi.network.post
 import keiyoushi.source.KeiSource
+import keiyoushi.utils.applicationContext
 import keiyoushi.utils.asJsoup
 import keiyoushi.utils.firstInstanceOrNull
 import keiyoushi.utils.parseAs
@@ -20,13 +21,14 @@ import keiyoushi.utils.tryParseDate
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.buildJsonObject
 import okhttp3.FormBody
+import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Response
 import org.jsoup.nodes.Document
-import java.net.URLEncoder
 import java.time.format.DateTimeFormatter
+import java.util.Calendar
 
 @Source
 abstract class BatCave : KeiSource() {
@@ -36,85 +38,90 @@ abstract class BatCave : KeiSource() {
         addInterceptor(DleGuardResolver.interceptor(baseUrl))
     }
 
+    init {
+        applicationContext.cacheDir.resolve("source_$id").deleteRecursively()
+    }
+
+    override fun Headers.Builder.configureHeaders(): Headers.Builder = apply {
+        set("Sec-Fetch-Dest", "document")
+        set("Sec-Fetch-Mode", "navigate")
+        set("Sec-Fetch-Site", "none")
+        set("Sec-Fetch-User", "?1")
+    }
+
     // ============================== Popular ==============================
-    override suspend fun getPopularManga(page: Int) = getSearchMangaList(page, "", SortFilter.POPULAR)
+    override suspend fun getPopularManga(page: Int) = searchCatalog(page, "rating")
 
     // ============================== Latest ===============================
-    override suspend fun getLatestUpdates(page: Int) = parseLatestMangas(client.get("$baseUrl/page/$page"))
+    override suspend fun getLatestUpdates(page: Int) = searchCatalog(page, "editdate")
 
-    private fun parseLatestMangas(response: Response): MangasPage {
-        val document = response.asJsoup()
-
-        val entries = document.select("#content-load > .latest.grid-item").map { element ->
-            SManga.create().apply {
-                with(element.selectFirst(".latest__title > a")!!) {
-                    setUrlWithoutDomain(absUrl("href"))
-                    title = ownText()
-                }
-                thumbnail_url = element.selectFirst(".latest__img img")?.absUrl("src")
+    private suspend fun searchCatalog(page: Int, sortBy: String): MangasPage {
+        val url = baseUrl.toHttpUrl().newBuilder().apply {
+            addPathSegment("comix")
+            if (page > 1) {
+                addPathSegments("page/$page")
             }
-        }
-        val hasNextPage = document.selectFirst("li.pagination a[href]") != null
+            addPathSegment("")
+        }.build()
 
-        return MangasPage(entries, hasNextPage)
+        val body = FormBody.Builder()
+            .add("dlenewssortby", sortBy)
+            .add("dledirection", "desc")
+            .add("set_new_sort", "dle_sort_cat_1")
+            .add("set_direction_sort", "dle_direction_cat_1")
+            .build()
+
+        return parseSearchMangas(client.post(url, body))
     }
 
     // ============================== Search ===============================
     override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
         if (query.isNotBlank()) {
-            val url = buildString {
-                append(baseUrl)
-                append("/search/")
-                append(URLEncoder.encode(query.trim(), "UTF-8"))
+            val url = baseUrl.toHttpUrl().newBuilder().apply {
+                addPathSegment("search")
+                addPathSegment(query)
                 if (page > 1) {
-                    append("/page/")
-                    append(page)
-                    append("/")
+                    addPathSegment("page")
+                    addPathSegment(page.toString())
+                    addPathSegment("")
                 }
             }
-            return parseSearchMangas(client.get(url))
+            return parseSearchMangas(client.get(url.build()))
         }
 
         var filtersApplied = false
         val filterPath = buildString {
-            filters.firstInstanceOrNull<YearFilter>()?.addFilterToUrl(this)?.also { filtersApplied = true }
-            filters.firstInstanceOrNull<PublisherFilter>()?.addFilterToUrl(this)?.also { filtersApplied = true }
-            filters.firstInstanceOrNull<GenreFilter>()?.addFilterToUrl(this)?.also { filtersApplied = true }
+            filters.firstInstanceOrNull<YearFilter>()?.takeIf { it.addFilterToUrl(this) }?.let { filtersApplied = true }
+            filters.firstInstanceOrNull<PublisherFilter>()?.takeIf { it.addFilterToUrl(this) }?.let { filtersApplied = true }
+            filters.firstInstanceOrNull<GenreFilter>()?.takeIf { it.addFilterToUrl(this) }?.let { filtersApplied = true }
         }
 
-        val url = buildString {
-            append(baseUrl)
+        val url = baseUrl.toHttpUrl().newBuilder().apply {
+            addPathSegment("ComicList")
+
             if (filtersApplied) {
-                append("/ComicList/")
-                append(filterPath)
+                addPathSegments(filterPath)
             } else {
-                append("/comix/")
+                // Send this to always stay in ComicList
+                addPathSegment("y[from]=1926")
+                addPathSegment("y[to]=${Calendar.getInstance().get(Calendar.YEAR)}")
             }
             if (page > 1) {
-                append("page/")
-                append(page)
-                append("/")
+                addPathSegments("page/$page")
             }
+            addPathSegment("")
         }
 
         val sort = filters.firstInstanceOrNull<SortFilter>() ?: SortFilter()
 
-        return if (sort.getSort().isEmpty()) {
-            parseSearchMangas(client.get(url))
-        } else {
-            val form = FormBody.Builder().apply {
-                add("dlenewssortby", sort.getSort())
-                add("dledirection", sort.getDirection())
-                if (filtersApplied) {
-                    add("set_new_sort", "dle_sort_xfilter")
-                    add("set_direction_sort", "dle_direction_xfilter")
-                } else {
-                    add("set_new_sort", "dle_sort_cat_1")
-                    add("set_direction_sort", "dle_direction_cat_1")
-                }
-            }.build()
-            parseSearchMangas(client.post(url, form))
-        }
+        val body = FormBody.Builder()
+            .add("dlenewssortby", sort.getSort())
+            .add("dledirection", sort.getDirection())
+            .add("set_new_sort", "dle_sort_xfilter")
+            .add("set_direction_sort", "dle_direction_xfilter")
+            .build()
+
+        return parseSearchMangas(client.post(url.build(), body))
     }
 
     private fun parseSearchMangas(response: Response): MangasPage {
@@ -126,7 +133,7 @@ abstract class BatCave : KeiSource() {
                     setUrlWithoutDomain(absUrl("href"))
                     title = ownText()
                 }
-                thumbnail_url = element.selectFirst("img")?.absUrl("data-src")
+                thumbnail_url = element.selectFirst(".readed__img img")?.absUrl("data-src")
             }
         }
         val hasNextPage = document.selectFirst("div.pagination__pages")
@@ -185,8 +192,8 @@ abstract class BatCave : KeiSource() {
         doc.selectFirst(".page__similar-panel.is-active")?.select(".scroller-2 a.poster")?.let { anchor ->
             memo = buildJsonObject {
                 val similar = anchor.mapNotNull {
-                    val title = it.selectFirst(".poster__title")?.text()?.takeIf { it.isNotBlank() }
-                    val url = it.attr("href").takeIf { it.isNotBlank() }
+                    val title = it.selectFirst(".poster__title")?.text()?.takeIf { str -> str.isNotBlank() }
+                    val url = it.attr("href").takeIf { str -> str.isNotBlank() }
                     val thumb = it.selectFirst("img")?.attr("data-src")
                     if (title != null && url != null) RelatedComic(title, url, thumb) else null
                 }
@@ -254,7 +261,7 @@ abstract class BatCave : KeiSource() {
     override val supportsFilterFetching = true
 
     override suspend fun fetchFilterData(): JsonElement {
-        val doc = client.get("$baseUrl/comix").asJsoup()
+        val doc = client.get("$baseUrl/comix/").asJsoup()
         val script = doc.selectFirst("script:containsData(window.__XFILTER__)")?.data()
             ?: error("Filter data not found")
 

--- a/src/en/batcave/src/eu/kanade/tachiyomi/extension/en/batcave/BatCave.kt
+++ b/src/en/batcave/src/eu/kanade/tachiyomi/extension/en/batcave/BatCave.kt
@@ -127,7 +127,7 @@ abstract class BatCave : KeiSource() {
                 addPathSegments("page/$page")
             }
             addPathSegment("")
-        }
+        }.build()
 
         val sort = filters.firstInstanceOrNull<SortFilter>() ?: SortFilter()
 
@@ -138,7 +138,7 @@ abstract class BatCave : KeiSource() {
             .add("set_direction_sort", "dle_direction_xfilter")
             .build()
 
-        return parseSearchMangas(client.post(url.build(), body))
+        return parseSearchMangas(client.post(url, body))
     }
 
     private fun parseSearchMangas(response: Response): MangasPage {

--- a/src/en/batcave/src/eu/kanade/tachiyomi/extension/en/batcave/BatCave.kt
+++ b/src/en/batcave/src/eu/kanade/tachiyomi/extension/en/batcave/BatCave.kt
@@ -102,8 +102,8 @@ abstract class BatCave : KeiSource() {
                     addPathSegment(page.toString())
                     addPathSegment("")
                 }
-            }
-            return parseSearchMangas(client.get(url.build()))
+            }.build()
+            return parseSearchMangas(client.get(url))
         }
 
         var filtersApplied = false

--- a/src/en/batcave/src/eu/kanade/tachiyomi/extension/en/batcave/Filters.kt
+++ b/src/en/batcave/src/eu/kanade/tachiyomi/extension/en/batcave/Filters.kt
@@ -1,7 +1,6 @@
 package eu.kanade.tachiyomi.extension.en.batcave
 
 import eu.kanade.tachiyomi.source.model.Filter
-import eu.kanade.tachiyomi.source.model.FilterList
 import java.util.Calendar
 
 interface UrlPartFilter {
@@ -95,7 +94,7 @@ class YearFilter :
 }
 
 class SortFilter(
-    select: Selection = Selection(0, false),
+    select: Selection = Selection(2, false),
 ) : Filter.Sort(
     "Sort",
     sorts.map { it.first }.toTypedArray(),
@@ -103,15 +102,9 @@ class SortFilter(
 ) {
     fun getSort() = sorts[state?.index ?: 0].second
     fun getDirection() = if (state?.ascending != false) "asc" else "desc"
-
-    companion object {
-        val POPULAR = FilterList(SortFilter(Selection(3, false)))
-        val LATEST = FilterList(SortFilter(Selection(2, false)))
-    }
 }
 
 private val sorts = listOf(
-    "Default" to "",
     "Date" to "date",
     "Date of change" to "editdate",
     "Rating" to "rating",


### PR DESCRIPTION
Checklist:

Closes #18762

Without this headers site might return a challenge page instead of normal page, that caused errors (probably related to #18779 since both sites use same template as a base). Can't say which one of those headers are crucial, site were inconsistent while i tried different combinations, but with all 4 of them i didn't get challenge page even once.

Default (empty) sort option didn't work at all, so i removed it.
Also changed url forming from `BuildString` to `toHttpUrl` Builder.

`getSearchMangaList` - instead of switching between two endpoints `comix` (list without parameters) and `ComicList` (list with parameters) forced second by always sending year from/year to with maximum range when no parameters are sent. Shouldn't affect search at all, but should make things easier/cleaner by forcing one endpoint.

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
