### PR TITLE
Com-X (ru): fix search

### DIFF
--- a/src/ru/comx/build.gradle.kts
+++ b/src/ru/comx/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Com-X"
-    versionCode = 40
+    versionCode = 41
     contentWarning = ContentWarning.SAFE
     libVersion = "1.6"
 

--- a/src/ru/comx/src/eu/kanade/tachiyomi/extension/ru/comx/ComX.kt
+++ b/src/ru/comx/src/eu/kanade/tachiyomi/extension/ru/comx/ComX.kt
@@ -26,6 +26,7 @@ import keiyoushi.utils.tryParseDate
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.buildJsonObject
 import okhttp3.FormBody
+import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
@@ -46,6 +47,13 @@ abstract class ComX :
     override fun OkHttpClient.Builder.configureClient() = apply {
         addInterceptor(DleGuardResolver.interceptor(baseUrl))
         rateLimit(3)
+    }
+
+    override fun Headers.Builder.configureHeaders(): Headers.Builder = apply {
+        set("Sec-Fetch-Dest", "document")
+        set("Sec-Fetch-Mode", "navigate")
+        set("Sec-Fetch-Site", "none")
+        set("Sec-Fetch-User", "?1")
     }
 
     // ============================== Popular ==============================

--- a/src/ru/comx/src/eu/kanade/tachiyomi/extension/ru/comx/ComX.kt
+++ b/src/ru/comx/src/eu/kanade/tachiyomi/extension/ru/comx/ComX.kt
@@ -311,7 +311,9 @@ abstract class ComX :
                         if (matchNumber != null && (matchNumber - counter) in 0f..1f) {
                             matchNumber
                         } else {
-                            if (isExtraChapter(chap.title)) {
+                            // Extra have a certain word in title or contains exactly `# 1` in title.
+                            // Regex should exclude any #1.0, #12 but match `#1-`, `#1:` or `# 1 `.
+                            if (isExtraChapter(chap.title) || noInfoExtra.containsMatchIn(chap.title)) {
                                 counter + 0.1f
                             } else {
                                 if (anyNumber != null && (anyNumber - counter) in 0f..1f) {
@@ -494,6 +496,7 @@ abstract class ComX :
         private const val FORCE_IMG_DOMAIN_PREF = "FORCE_IMG_DOMAIN_PREF"
         private val chapterNumberRegex = """(?:\d+\s*-|.*?Глава)\s*([\d.]+)""".toRegex()
         private val chapterAnyNumberRegex = """([\d.]+)""".toRegex()
+        private val noInfoExtra = """#\s?1(?!\d|\.\d)""".toRegex()
         private val whitespacesRegex = """\s{2,}""".toRegex()
     }
 }


### PR DESCRIPTION
Checklist:

Closes #18777

Site returns this page in search and manga details without those headers:

<details><summary>Click for html code</summary>

```
<!doctype html>
<html>
 <head>
  <meta charset="UTF-8">
  <meta name="robots" content="noindex,nofollow">
  <meta name="viewport" content="width=device-width,initial-scale=1">
  <title></title>
  <style>
    body {
      margin: 0;
      background: #050505;
      display: flex;
      align-items: center;
      justify-content: center;
      height: 100vh;
    }
    .x52616 {
      width: 40px;
      height: 40px;
      border-radius: 50%;
      border: 4px solid rgba(255,255,255,.15);
      border-top-color: #fff;
      animation: k78627 .6s linear infinite;
    }
    @keyframes k78627 {
      to { transform: rotate(360deg); }
    }
  </style>
 </head>
 <body>
  <div class="x52616"></div>
  <script type="ignore">
    <a href="/956264502-tor-equinox-trellis-briar-glass.html" rel="nofollow">.</a>
  </script>
  <script type="module" src="https://static.cloudflareinsights.com/beacon.min.js/v3d52b47920f24c319d37e2661827c42b1787588026925" integrity="sha512-d9sL6GJLXn6fInD1+TVXhTcQOsmxeHfmHAvwGDIxp5TO+uo1fiWW7mHomMj4MLRlCsJDTqXzWLHJFFlPCEIj/A==" data-cf-beacon='{"version":"2024.11.0","token":"25f677d88cab45b1a83c0cdbd480376d"}' crossorigin="anonymous"></script>
 </body>
</html>
```
</details>

Not sure why those headers, just compared successful response with unsuccessful, found headers, set them to believable value and everything works. Tested on emulator and phone.
Not sure how solid this fix is ...

Is it related to #18775? Maybe it's a template update on both sites?

Also added regex to properly get `chapter_number` for extra chapters if they have only `# 1` (exactly this string) in the title. 

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
