### PR TITLE
Mokuro: Fix volume loading & migrate to 1.6

### DIFF
--- a/src/ja/mokuro/build.gradle.kts
+++ b/src/ja/mokuro/build.gradle.kts
@@ -6,9 +6,15 @@ plugins {
 
 keiyoushi {
     name = "Mokuro"
-    versionCode = 4
+    versionCode = 5
     contentWarning = ContentWarning.MIXED
-    libVersion = "1.4"
+    libVersion = "1.6"
+
+    deeplink {
+        host("mokuro.moe")
+        path("/catalog.*")
+        path("/mokuro-reader/..*")
+    }
 
     source {
         lang = "ja"

--- a/src/ja/mokuro/src/eu/kanade/tachiyomi/extension/ja/mokuro/Dto.kt
+++ b/src/ja/mokuro/src/eu/kanade/tachiyomi/extension/ja/mokuro/Dto.kt
@@ -67,10 +67,10 @@ class CatalogSeriesDto(
             if (anilistId != null || malId != null) {
                 appendLine()
                 anilistId?.let {
-                    append("AniList: https://anilist.co/manga/").appendLine(it)
+                    appendLine("[AniList](https://anilist.co/manga/$it)")
                 }
                 malId?.let {
-                    append("MyAnimeList: https://myanimelist.net/manga/").appendLine(it)
+                    appendLine("[MyAnimeList](https://myanimelist.net/manga/$it)")
                 }
             }
         }.trim().ifEmpty { null }

--- a/src/ja/mokuro/src/eu/kanade/tachiyomi/extension/ja/mokuro/Dto.kt
+++ b/src/ja/mokuro/src/eu/kanade/tachiyomi/extension/ja/mokuro/Dto.kt
@@ -4,47 +4,111 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import okhttp3.HttpUrl.Companion.toHttpUrl
 
 @Serializable
-class LibraryDto(
-    val series: List<SeriesDto>,
+class CatalogDto(
+    val series: List<CatalogSeriesDto>,
 )
 
 @Serializable
-class SeriesDto(
-    val name: String,
-    val path: String,
-    private val cover: String? = null,
-    val volumes: List<VolumeDto>,
+class CatalogSeriesDto(
+    @SerialName("series_title") val seriesTitle: String,
+    @SerialName("external_ids") private val externalIds: ExternalIdsDto? = null,
+    private val titles: TitlesDto? = null,
+    private val synonyms: List<String> = emptyList(),
+    val tag: String? = null,
+    @SerialName("updated_at") val updatedAt: String? = null,
 ) {
-    fun toSManga(apiBaseUrl: String, useLatestVolumeCover: Boolean = false): SManga = SManga.create().apply {
-        title = name
-        url = path
-        val mangaCover = if (useLatestVolumeCover) {
-            volumes.lastOrNull()?.cover ?: cover
-        } else {
-            cover
+    fun displayTitle(pref: String = "native"): String {
+        val base = when (pref) {
+            "english" -> titles?.english ?: titles?.romaji ?: titles?.native ?: seriesTitle
+            "romaji" -> titles?.romaji ?: titles?.english ?: titles?.native ?: seriesTitle
+            "folder" -> seriesTitle
+            else -> titles?.native ?: titles?.romaji ?: titles?.english ?: seriesTitle
         }
-        thumbnail_url = mangaCover?.let {
-            apiBaseUrl.toHttpUrl().newBuilder()
-                .addPathSegment("cover")
-                .addQueryParameter("path", it)
-                .build()
-                .toString()
-        }
+        if (tag.isNullOrBlank()) return base
+        val stripped = stripOuterBrackets(tag)
+        return if (stripped.isNotBlank()) "$base ($stripped)" else base
+    }
+
+    fun matches(query: String, pref: String = "native"): Boolean {
+        val q = query.trim()
+        return displayTitle(pref).contains(q, ignoreCase = true) ||
+            seriesTitle.contains(q, ignoreCase = true) ||
+            (titles?.native?.contains(q, ignoreCase = true) == true) ||
+            (titles?.romaji?.contains(q, ignoreCase = true) == true) ||
+            (titles?.english?.contains(q, ignoreCase = true) == true) ||
+            synonyms.any { it.contains(q, ignoreCase = true) }
+    }
+
+    fun toSManga(pref: String = "native"): SManga = SManga.create().apply {
+        title = displayTitle(pref)
+        url = seriesTitle
+    }
+
+    fun fillDetails(manga: SManga, pref: String = "native") {
+        manga.title = displayTitle(pref)
+        manga.genre = tag
+        manga.description = buildString {
+            titles?.english?.takeIf { it.isNotBlank() && it != manga.title }?.let {
+                append("English: ").appendLine(it)
+            }
+            titles?.romaji?.takeIf { it.isNotBlank() && it != manga.title }?.let {
+                append("Romaji: ").appendLine(it)
+            }
+            titles?.native?.takeIf { it.isNotBlank() && it != manga.title }?.let {
+                append("Native: ").appendLine(it)
+            }
+            if (synonyms.isNotEmpty()) {
+                append("Synonyms: ").appendLine(synonyms.joinToString())
+            }
+            val anilistId = externalIds?.anilist
+            val malId = externalIds?.mal
+            if (anilistId != null || malId != null) {
+                appendLine()
+                anilistId?.let {
+                    append("AniList: https://anilist.co/manga/").appendLine(it)
+                }
+                malId?.let {
+                    append("MyAnimeList: https://myanimelist.net/manga/").appendLine(it)
+                }
+            }
+        }.trim().ifEmpty { null }
     }
 }
 
 @Serializable
-class VolumeDto(
-    val name: String,
-    internal val cover: String? = null,
+class ExternalIdsDto(
+    val anilist: Int? = null,
+    val mal: Int? = null,
+)
+
+@Serializable
+class TitlesDto(
+    val native: String? = null,
+    val romaji: String? = null,
+    val english: String? = null,
+)
+
+@Serializable
+class SeriesDetailDto(
+    @SerialName("series_title") val seriesTitle: String,
+    private val titles: TitlesDto? = null,
+    val volumes: List<VolumeDto> = emptyList(),
 ) {
-    fun toSChapter(series: SeriesDto): SChapter = SChapter.create().apply {
-        name = this@VolumeDto.name
-        chapter_number = parseChapterNumber(this@VolumeDto.name)
-        url = series.path + "|" + this@VolumeDto.name
+    fun displayTitle(): String = titles?.native ?: titles?.romaji ?: titles?.english ?: seriesTitle
+}
+
+@Serializable
+class VolumeDto(
+    @SerialName("volume_title") val volumeTitle: String,
+    @SerialName("mokuro_modified") private val mokuroModified: Long? = null,
+) {
+    fun toSChapter(seriesTitle: String) = SChapter.create().apply {
+        name = this@VolumeDto.volumeTitle
+        chapter_number = parseChapterNumber(this@VolumeDto.volumeTitle)
+        date_upload = mokuroModified?.times(1000L) ?: 0L
+        url = "$seriesTitle|${this@VolumeDto.volumeTitle}"
     }
 
     private fun parseChapterNumber(name: String): Float = chapterNumberRegex.findAll(name).lastOrNull()?.value?.toFloatOrNull() ?: -1f
@@ -69,3 +133,15 @@ class ImageRequest(
 )
 
 private val chapterNumberRegex = """(\d+(\.\d+)?)""".toRegex()
+
+// Mirrors catalog.js stripOuterBracketPair: strips exactly one surrounding bracket pair.
+private val bracketPairs = listOf('(' to ')', '[' to ']', '（' to '）', '【' to '】')
+
+private fun stripOuterBrackets(value: String): String {
+    for ((open, close) in bracketPairs) {
+        if (value.length > 1 && value.first() == open && value.last() == close) {
+            return value.substring(1, value.length - 1).trim()
+        }
+    }
+    return value
+}

--- a/src/ja/mokuro/src/eu/kanade/tachiyomi/extension/ja/mokuro/Filters.kt
+++ b/src/ja/mokuro/src/eu/kanade/tachiyomi/extension/ja/mokuro/Filters.kt
@@ -1,0 +1,28 @@
+package eu.kanade.tachiyomi.extension.ja.mokuro
+
+import eu.kanade.tachiyomi.source.model.Filter
+
+class SortFilter :
+    Filter.Sort(
+        "Sort",
+        arrayOf("Title", "Latest update", "Catalog order"),
+        Selection(0, true),
+    )
+
+class TagFilter : Filter.Select<String>("Tag", TAGS) {
+    companion object {
+        // All edition/quality tags observed in catalog.json as of 2026-08-29
+        val TAGS = arrayOf(
+            "All",
+            "Colored",
+            "Colored, Upscaled",
+            "Full Colour version, upscaled",
+            "HD Scan",
+            "ReMaster Edition",
+            "Semi-Colored",
+            "Upscale",
+            "Upscaled",
+            "Webcomic",
+        )
+    }
+}

--- a/src/ja/mokuro/src/eu/kanade/tachiyomi/extension/ja/mokuro/Mokuro.kt
+++ b/src/ja/mokuro/src/eu/kanade/tachiyomi/extension/ja/mokuro/Mokuro.kt
@@ -1,84 +1,185 @@
 package eu.kanade.tachiyomi.extension.ja.mokuro
 
+import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
-import androidx.preference.SwitchPreferenceCompat
-import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.asObservableSuccess
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import keiyoushi.annotation.Source
+import keiyoushi.network.get
+import keiyoushi.source.KeiSource
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.toJsonString
-import keiyoushi.zip.zipDirectory
-import okhttp3.Headers
+import keiyoushi.zip.zipDirectoryAsync
+import kotlinx.serialization.json.JsonElement
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.Request
-import okhttp3.Response
-import rx.Observable
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
+import java.net.URLDecoder
+import java.net.URLEncoder
 
 @Source
 abstract class Mokuro :
-    HttpSource(),
+    KeiSource(),
     ConfigurableSource {
 
-    override val supportsLatest = false
-
-    private val apiBaseUrl = "$baseUrl/catalog/api"
-
-    override val client = network.client.newBuilder()
-        .addInterceptor(CbzInterceptor())
-        .build()
-
-    override fun headersBuilder(): Headers.Builder = super.headersBuilder()
-        .add("Referer", "$baseUrl/catalog")
+    override val supportsLatest = true
 
     private val preferences by getPreferencesLazy()
+
+    private val titleLang: String
+        get() = preferences.getString(TITLE_LANG_PREF, TITLE_LANG_DEFAULT) ?: TITLE_LANG_DEFAULT
+
+    override fun OkHttpClient.Builder.configureClient() = apply {
+        addInterceptor(CbzInterceptor())
+    }
 
     // ===============================
     // Popular
     // ===============================
 
-    override fun fetchPopularManga(page: Int): Observable<MangasPage> = getLibrary().map { library ->
-        MangasPage(library.series.map { it.toSManga(apiBaseUrl, useLatestVolumeCover) }, false)
+    override suspend fun getPopularManga(page: Int): MangasPage {
+        val catalog = getCatalog()
+        val pref = titleLang
+        return MangasPage(catalog.series.map { it.toSManga(pref) }, false)
+    }
+
+    // ===============================
+    // Latest
+    // ===============================
+
+    override suspend fun getLatestUpdates(page: Int): MangasPage {
+        val catalog = getCatalog()
+        val pref = titleLang
+        val mangas = catalog.series
+            .sortedByDescending { it.updatedAt.orEmpty() }
+            .map { it.toSManga(pref) }
+        return MangasPage(mangas, false)
     }
 
     // ===============================
     // Search
     // ===============================
 
-    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = getLibrary().map { library ->
-        val mangas = library.series
-            .filter { it.name.contains(query.trim(), ignoreCase = true) }
-            .map { it.toSManga(apiBaseUrl, useLatestVolumeCover) }
-        MangasPage(mangas, false)
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
+        val catalog = getCatalog()
+        val pref = titleLang
+        var sequence = catalog.series.asSequence()
+
+        if (query.isNotBlank()) {
+            sequence = sequence.filter { it.matches(query, pref) }
+        }
+
+        filters.forEach { filter ->
+            when (filter) {
+                is TagFilter -> {
+                    val selected = filter.values[filter.state]
+                    if (selected != "All") {
+                        sequence = sequence.filter { it.tag?.contains(selected, ignoreCase = true) == true }
+                    }
+                }
+                is SortFilter -> {
+                    filter.state?.let { sort ->
+                        sequence = if (sort.ascending) {
+                            when (sort.index) {
+                                0 -> sequence.sortedBy { it.displayTitle(pref).lowercase() }
+                                1 -> sequence.sortedBy { it.updatedAt.orEmpty() }
+                                else -> sequence
+                            }
+                        } else {
+                            when (sort.index) {
+                                0 -> sequence.sortedByDescending { it.displayTitle(pref).lowercase() }
+                                1 -> sequence.sortedByDescending { it.updatedAt.orEmpty() }
+                                else -> sequence.toList().asReversed().asSequence()
+                            }
+                        }
+                    }
+                }
+                else -> {}
+            }
+        }
+
+        return MangasPage(sequence.map { it.toSManga(pref) }.toList(), false)
+    }
+
+    override fun getFilterList(data: JsonElement?): FilterList = FilterList(
+        SortFilter(),
+        TagFilter(),
+    )
+
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+        val host = url.host
+        val seriesTitle: String? = when {
+            host == baseUrl.toHttpUrl().host -> {
+                url.fragment?.takeIf { it.isNotEmpty() }
+                    ?: if (url.pathSegments.firstOrNull() == "mokuro-reader") url.pathSegments.getOrNull(1) else null
+            }
+            host == "reader.mokuro.app" -> {
+                val fragment = url.fragment ?: ""
+                val cbzParam = fragment.substringAfter("cbz=", "").substringBefore("&").takeIf { it.isNotEmpty() }
+                    ?: url.queryParameter("cbz")
+                cbzParam?.let { raw ->
+                    val decoded = runCatching { URLDecoder.decode(raw, "UTF-8") }.getOrDefault(raw)
+                    val cbzHttpUrl = decoded.toHttpUrlOrNull()
+                    if (cbzHttpUrl != null && cbzHttpUrl.pathSegments.firstOrNull() == "mokuro-reader") {
+                        cbzHttpUrl.pathSegments.getOrNull(1)
+                    } else {
+                        null
+                    }
+                }
+            }
+            else -> null
+        }
+
+        if (seriesTitle.isNullOrEmpty()) return null
+
+        val decodedTitle = runCatching { URLDecoder.decode(seriesTitle, "UTF-8") }.getOrDefault(seriesTitle)
+        val catalog = getCatalog()
+        val entry = catalog.series.find {
+            it.seriesTitle.equals(seriesTitle, ignoreCase = true) ||
+                it.seriesTitle.equals(decodedTitle, ignoreCase = true)
+        } ?: return null
+
+        return entry.toSManga(titleLang)
     }
 
     // ===============================
-    // Details
+    // Details & Chapters
     // ===============================
 
-    override fun fetchMangaDetails(manga: SManga): Observable<SManga> = getLibrary().map { library ->
-        library.series.find { it.path == manga.url }?.toSManga(apiBaseUrl, useLatestVolumeCover)
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        val catalog = getCatalog()
+        val catalogEntry = catalog.series.find { it.seriesTitle == manga.url }
             ?: throw Exception("Series not found")
+
+        val updatedManga = manga.apply {
+            catalogEntry.fillDetails(this, titleLang)
+        }
+
+        val chapterList = if (fetchChapters) {
+            val detail = getSeriesDetail(manga.url)
+            detail.volumes.asReversed().map { it.toSChapter(detail.seriesTitle) }
+        } else {
+            chapters
+        }
+
+        return SMangaUpdate(updatedManga, chapterList)
     }
 
-    override fun getMangaUrl(manga: SManga): String = "$baseUrl/catalog#${manga.url}"
-
-    // ===============================
-    // Chapters
-    // ===============================
-
-    override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> = getLibrary().map { library ->
-        val series = library.series.find { it.path == manga.url }
-            ?: throw Exception("Series not found")
-
-        series.volumes.asReversed().map { it.toSChapter(series) }
+    override fun getMangaUrl(manga: SManga): String {
+        val encoded = URLEncoder.encode(manga.url, "UTF-8").replace("+", "%20")
+        return "$baseUrl/catalog#$encoded"
     }
 
     override fun getChapterUrl(chapter: SChapter): String {
@@ -90,7 +191,7 @@ abstract class Mokuro :
             .build()
             .toString()
 
-        val encodedUrl = java.net.URLEncoder.encode(cbzUrl, "UTF-8")
+        val encodedUrl = URLEncoder.encode(cbzUrl, "UTF-8")
 
         return "https://reader.mokuro.app/#/upload?cbz=$encodedUrl"
     }
@@ -99,114 +200,71 @@ abstract class Mokuro :
     // Pages
     // ===============================
 
-    override fun pageListRequest(chapter: SChapter): Request {
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
         val (seriesPath, volumeName) = chapter.url.split("|", limit = 2)
         val url = "$baseUrl/mokuro-reader".toHttpUrl().newBuilder()
             .addPathSegment(seriesPath)
             .addPathSegment("$volumeName.mokuro")
             .build()
-        return GET(url, headers)
-    }
 
-    override fun pageListParse(response: Response): List<Page> {
-        val mokuro = response.parseAs<MokuroDto>()
-        val url = response.request.url
-        val cbzUrl = url.newBuilder()
-            .encodedPath(url.encodedPath.removeSuffix(".mokuro") + ".cbz")
-            .build()
+        val response = client.get(url, headers)
+        return response.use { resp ->
+            val mokuro = resp.parseAs<MokuroDto>()
+            val cbzUrl = resp.request.url.newBuilder()
+                .encodedPath(resp.request.url.encodedPath.removeSuffix(".mokuro") + ".cbz")
+                .build()
 
-        val byName = client.zipDirectory(cbzUrl.toString(), headers).entries.associateBy { it.name }
+            val byName = client.zipDirectoryAsync(cbzUrl.toString(), headers).entries.associateBy { it.name }
 
-        return mokuro.pages.mapIndexed { index, page ->
-            val entry = byName[page.imgPath] ?: throw Exception("Entry not found in CBZ: ${page.imgPath}")
-            val data = ImageRequest(
-                page.imgPath,
-                entry.localHeaderOffset,
-                entry.compressedSize,
-                entry.method,
-            ).toJsonString()
-            Page(index, imageUrl = "$cbzUrl#$data")
+            mokuro.pages.mapIndexed { index, page ->
+                val entry = byName[page.imgPath] ?: throw Exception("Entry not found in CBZ: ${page.imgPath}")
+                val data = ImageRequest(
+                    page.imgPath,
+                    entry.localHeaderOffset,
+                    entry.compressedSize,
+                    entry.method,
+                ).toJsonString()
+                Page(index, imageUrl = "$cbzUrl#$data")
+            }
         }
     }
 
     // ===============================
-    // Settings
+    // Preferences
     // ===============================
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        SwitchPreferenceCompat(screen.context).apply {
-            key = PREF_USE_LATEST_VOLUME_COVER
-            title = "最新巻の表紙を使用"
-            summary = "デフォルトのシリーズ表紙の代わりに、最新巻の表紙を漫画のサムネイルとして使用します。"
-            setDefaultValue(PREF_USE_LATEST_VOLUME_COVER_DEFAULT)
+        ListPreference(screen.context).apply {
+            key = TITLE_LANG_PREF
+            title = "Display title language"
+            summary = "%s"
+            entries = arrayOf("Native", "English", "Romaji", "Folder name")
+            entryValues = arrayOf("native", "english", "romaji", "folder")
+            setDefaultValue(TITLE_LANG_DEFAULT)
         }.also(screen::addPreference)
-    }
-
-    private val useLatestVolumeCover: Boolean
-        get() = preferences.getBoolean(PREF_USE_LATEST_VOLUME_COVER, PREF_USE_LATEST_VOLUME_COVER_DEFAULT)
-
-    companion object {
-        private const val PREF_USE_LATEST_VOLUME_COVER = "pref_use_latest_volume_cover"
-        private const val PREF_USE_LATEST_VOLUME_COVER_DEFAULT = false
     }
 
     // ===============================
     // Helpers
     // ===============================
 
-    @Volatile
-    private var libraryCache: LibraryDto? = null
-    private var libraryCacheTime = 0L
-    private val cacheDuration = 10 * 60 * 1000L
-
-    @Volatile
-    private var inFlight: Observable<LibraryDto>? = null
-
-    private fun updateLibraryCache(response: Response): LibraryDto {
-        val now = System.currentTimeMillis()
-        return response.parseAs<LibraryDto>().also {
-            synchronized(this) {
-                libraryCache = it
-                libraryCacheTime = now
-            }
-        }
+    private suspend fun getCatalog(): CatalogDto {
+        val response = client.get("$baseUrl/mokuro-reader/catalog.json", headers)
+        return response.use { it.parseAs<CatalogDto>() }
     }
 
-    private fun getLibrary(): Observable<LibraryDto> {
-        val now = System.currentTimeMillis()
-        val cached = libraryCache
+    private suspend fun getSeriesDetail(seriesTitle: String): SeriesDetailDto {
+        val url = "$baseUrl/mokuro-reader".toHttpUrl().newBuilder()
+            .addPathSegment(seriesTitle)
+            .addPathSegment("series.json")
+            .build()
 
-        if (cached != null && now - libraryCacheTime < cacheDuration) {
-            return Observable.just(cached)
-        }
-
-        synchronized(this) {
-            inFlight?.let { return it }
-
-            val observable = client.newCall(GET("$apiBaseUrl/library", headers))
-                .asObservableSuccess()
-                .map { updateLibraryCache(it) }
-                .doOnTerminate { inFlight = null }
-                .cache()
-
-            inFlight = observable
-            return observable
-        }
+        val response = client.get(url, headers)
+        return response.use { it.parseAs<SeriesDetailDto>() }
     }
 
-    // ===============================
-    // Unused
-    // ===============================
-
-    override fun popularMangaRequest(page: Int): Request = throw UnsupportedOperationException()
-    override fun popularMangaParse(response: Response): MangasPage = throw UnsupportedOperationException()
-    override fun latestUpdatesRequest(page: Int): Request = throw UnsupportedOperationException()
-    override fun latestUpdatesParse(response: Response): MangasPage = throw UnsupportedOperationException()
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request = throw UnsupportedOperationException()
-    override fun searchMangaParse(response: Response): MangasPage = throw UnsupportedOperationException()
-    override fun mangaDetailsRequest(manga: SManga): Request = throw UnsupportedOperationException()
-    override fun mangaDetailsParse(response: Response): SManga = throw UnsupportedOperationException()
-    override fun chapterListRequest(manga: SManga): Request = throw UnsupportedOperationException()
-    override fun chapterListParse(response: Response): List<SChapter> = throw UnsupportedOperationException()
-    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
+    companion object {
+        private const val TITLE_LANG_PREF = "mokuro_title_lang"
+        private const val TITLE_LANG_DEFAULT = "native"
+    }
 }

--- a/src/ja/mokuro/src/eu/kanade/tachiyomi/extension/ja/mokuro/Mokuro.kt
+++ b/src/ja/mokuro/src/eu/kanade/tachiyomi/extension/ja/mokuro/Mokuro.kt
@@ -29,8 +29,6 @@ abstract class Mokuro :
     KeiSource(),
     ConfigurableSource {
 
-    override val supportsLatest = true
-
     private val preferences by getPreferencesLazy()
 
     private val titleLang: String
@@ -159,12 +157,16 @@ abstract class Mokuro :
         fetchDetails: Boolean,
         fetchChapters: Boolean,
     ): SMangaUpdate {
-        val catalog = getCatalog()
-        val catalogEntry = catalog.series.find { it.seriesTitle == manga.url }
-            ?: throw Exception("Series not found")
+        val updatedManga = if (fetchDetails) {
+            val catalog = getCatalog()
+            val catalogEntry = catalog.series.find { it.seriesTitle == manga.url }
+                ?: throw Exception("Series not found")
 
-        val updatedManga = manga.apply {
-            catalogEntry.fillDetails(this, titleLang)
+            manga.apply {
+                catalogEntry.fillDetails(this, titleLang)
+            }
+        } else {
+            manga
         }
 
         val chapterList = if (fetchChapters) {
@@ -249,8 +251,8 @@ abstract class Mokuro :
     // ===============================
 
     private suspend fun getCatalog(): CatalogDto {
-        val response = client.get("$baseUrl/mokuro-reader/catalog.json", headers)
-        return response.use { it.parseAs<CatalogDto>() }
+        val response = client.get("$baseUrl/mokuro-reader/catalog.json")
+        return response.parseAs<CatalogDto>()
     }
 
     private suspend fun getSeriesDetail(seriesTitle: String): SeriesDetailDto {
@@ -259,8 +261,8 @@ abstract class Mokuro :
             .addPathSegment("series.json")
             .build()
 
-        val response = client.get(url, headers)
-        return response.use { it.parseAs<SeriesDetailDto>() }
+        val response = client.get(url)
+        return response.parseAs<SeriesDetailDto>()
     }
 
     companion object {


### PR DESCRIPTION
### Description
Fixes issue #18746 where volume list was missing from the global catalog by consuming WebDAV JSON endpoints (`/mokuro-reader/catalog.json` and `{series}/series.json`). Also migrates the extension to `KeiSource` (lib `1.6`).

### Changes
- Migrated to `libVersion = "1.6"` / `KeiSource` and bumped `versionCode = 5`.
- Replaced old dynamic API library endpoint with static WebDAV `catalog.json` and `{series}/series.json`.
- Implemented `ConfigurableSource` with a Title Language preference (Native, English, Romaji, Folder name).
- Added `TagFilter` and `SortFilter` (Title, Latest update, Catalog order).
- Enabled `supportsLatest = true` using catalog update timestamps.
- Added deep link intent filters for `mokuro.moe`.
- Formatted AniList / MyAnimeList tracking links and alternative titles in manga details.

Closes #18746

### Pull Request checklist
- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts`
- [x] Referenced all related issues in the PR body (Closes #18746)
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio / ADB
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop