### PR TITLE
Fix: Update MangaReadOrg chapterMode to MangaAjax

### DIFF
--- a/src/en/mangareadorg/build.gradle.kts
+++ b/src/en/mangareadorg/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "MangaRead.org"
-    versionCode = 2
+    versionCode = 3
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
     theme = "madara"

--- a/src/en/mangareadorg/src/eu/kanade/tachiyomi/extension/en/mangareadorg/MangaReadOrg.kt
+++ b/src/en/mangareadorg/src/eu/kanade/tachiyomi/extension/en/mangareadorg/MangaReadOrg.kt
@@ -8,4 +8,8 @@ import java.util.Locale
 @Source
 abstract class MangaReadOrg : Madara() {
     override val chapterDateFormat = DateTimeFormatter.ofPattern("dd.MM.yyy", Locale.US)
+
+    // Switch to the new JS-based AJAX endpoint because
+    // the raw HTML doesn't contain the chapters initially
+    override val chapterMode = ChapterMode.MangaAjax
 }

--- a/src/en/mangareadorg/src/eu/kanade/tachiyomi/extension/en/mangareadorg/MangaReadOrg.kt
+++ b/src/en/mangareadorg/src/eu/kanade/tachiyomi/extension/en/mangareadorg/MangaReadOrg.kt
@@ -9,7 +9,5 @@ import java.util.Locale
 abstract class MangaReadOrg : Madara() {
     override val chapterDateFormat = DateTimeFormatter.ofPattern("dd.MM.yyy", Locale.US)
 
-    // Switch to the new JS-based AJAX endpoint because
-    // the raw HTML doesn't contain the chapters initially
     override val chapterMode = ChapterMode.MangaAjax
 }


### PR DESCRIPTION
### What is this PR doing?
Fixes the broken chapter list for MangaRead.org.

### Why is this needed?
The source website recently updated their architecture. The default WordPress `admin-ajax.php` endpoint is now dead and returns a `0` response. The site currently renders chapter lists dynamically using a hidden AJAX endpoint (`/ajax/chapters/`).

### How did I fix it?
Updated the extension's `chapterMode` to `ChapterMode.MangaAjax` so the Madara base class targets the new endpoint instead of the dead one. 

### Testing
Compiled the APK locally and tested on a physical Android device via Mihon. The chapter list now populates correctly and pages load successfully.