### PR TITLE
MangaFox: migrate to 1.6

### DIFF
--- a/src/en/mangafox/build.gradle.kts
+++ b/src/en/mangafox/build.gradle.kts
@@ -6,9 +6,9 @@ plugins {
 
 keiyoushi {
     name = "MangaFox"
-    versionCode = 9
+    versionCode = 1
     contentWarning = ContentWarning.MIXED
-    libVersion = "1.4"
+    libVersion = "1.6"
 
     source {
         lang = "en"

--- a/src/en/mangafox/src/eu/kanade/tachiyomi/extension/en/mangafox/MangaFox.kt
+++ b/src/en/mangafox/src/eu/kanade/tachiyomi/extension/en/mangafox/MangaFox.kt
@@ -1,42 +1,39 @@
 package eu.kanade.tachiyomi.extension.en.mangafox
 
 import android.webkit.CookieManager
-import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import keiyoushi.annotation.Source
+import keiyoushi.network.get
 import keiyoushi.network.rateLimit
+import keiyoushi.source.KeiSource
 import keiyoushi.utils.asJsoup
-import keiyoushi.utils.tryParse
+import keiyoushi.utils.tryParseDate
+import kotlinx.serialization.json.JsonElement
 import okhttp3.Cookie
 import okhttp3.CookieJar
-import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.Response
+import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
-import java.text.SimpleDateFormat
+import java.time.format.DateTimeFormatter
 import java.util.Calendar
 import java.util.Locale
 import kotlin.time.Duration.Companion.seconds
 
 @Source
-abstract class MangaFox : HttpSource() {
+abstract class MangaFox : KeiSource() {
 
     private val mobileUrl get() = baseUrl.replace("://", "://m.")
 
-    override val supportsLatest: Boolean = true
-
-    override val client: OkHttpClient = network.client.newBuilder()
-        // Force readway=2 cookie to get all page URLs at once
-        .cookieJar(
+    override fun OkHttpClient.Builder.configureClient() = // Force readway=2 cookie to get all page URLs at once
+        cookieJar(
             object : CookieJar {
                 private val cookieManager by lazy { CookieManager.getInstance() }
 
@@ -63,20 +60,13 @@ abstract class MangaFox : HttpSource() {
                 }
             },
         )
-        .rateLimit(1, 1.seconds)
-        .build()
+            .rateLimit(1, 1.seconds)
 
-    override fun headersBuilder(): Headers.Builder = super.headersBuilder().add("Referer", "$baseUrl/")
+    private val dateFormat = DateTimeFormatter.ofPattern("MMM d,yyyy", Locale.ENGLISH)
 
-    private val dateFormat = SimpleDateFormat("MMM d,yyyy", Locale.ENGLISH)
-
-    override fun popularMangaRequest(page: Int): Request {
+    override suspend fun getPopularManga(page: Int): MangasPage {
         val pageStr = if (page != 1) "$page.html" else ""
-        return GET("$baseUrl/directory/$pageStr", headers)
-    }
-
-    override fun popularMangaParse(response: Response): MangasPage {
-        val document = response.asJsoup()
+        val document = client.get("$baseUrl/directory/$pageStr").asJsoup()
         val mangas = document.select(popularMangaSelector()).map { popularMangaFromElement(it) }
         val hasNextPage = document.select(popularMangaNextPageSelector()).isNotEmpty()
         return MangasPage(mangas, hasNextPage)
@@ -94,19 +84,15 @@ abstract class MangaFox : HttpSource() {
 
     private fun popularMangaNextPageSelector() = ".pager-list-left a.active + a + a"
 
-    override fun latestUpdatesRequest(page: Int): Request {
+    override suspend fun getLatestUpdates(page: Int): MangasPage {
         val pageStr = if (page != 1) "$page.html" else ""
-        return GET("$baseUrl/directory/$pageStr?latest", headers)
-    }
-
-    override fun latestUpdatesParse(response: Response): MangasPage {
-        val document = response.asJsoup()
+        val document = client.get("$baseUrl/directory/$pageStr?latest").asJsoup()
         val mangas = document.select(popularMangaSelector()).map { popularMangaFromElement(it) }
         val hasNextPage = document.select(popularMangaNextPageSelector()).isNotEmpty()
         return MangasPage(mangas, hasNextPage)
     }
 
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
         val genres = mutableListOf<Int>()
         val genresEx = mutableListOf<Int>()
         val url = baseUrl.toHttpUrl().newBuilder().apply {
@@ -144,12 +130,8 @@ abstract class MangaFox : HttpSource() {
             addQueryParameter("nogenres", genresEx.joinToString(","))
             addQueryParameter("sort", "")
             addQueryParameter("stype", "1")
-        }.build().toString()
-        return GET(url, headers)
-    }
-
-    override fun searchMangaParse(response: Response): MangasPage {
-        val document = response.asJsoup()
+        }.build()
+        val document = client.get(url).asJsoup()
         val mangas = document.select(searchMangaSelector()).map { searchMangaFromElement(it) }
         val hasNextPage = document.select(popularMangaNextPageSelector()).isNotEmpty()
         return MangasPage(mangas, hasNextPage)
@@ -159,8 +141,17 @@ abstract class MangaFox : HttpSource() {
 
     private fun searchMangaFromElement(element: Element): SManga = popularMangaFromElement(element)
 
-    override fun mangaDetailsParse(response: Response): SManga = SManga.create().apply {
-        val document = response.asJsoup()
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        val document = client.get(getMangaUrl(manga)).asJsoup()
+        return SMangaUpdate(mangaDetailsFromDocument(document), chapterListFromDocument(document))
+    }
+
+    private fun mangaDetailsFromDocument(document: Document): SManga = SManga.create().apply {
         document.select(".detail-info-right").first()!!.let { it ->
             author = it.select(".detail-info-right-say a").joinToString(", ") { it.text() }
             genre = it.select(".detail-info-right-tag-list a").joinToString(", ") { it.text() }
@@ -170,10 +161,7 @@ abstract class MangaFox : HttpSource() {
         }
     }
 
-    override fun chapterListParse(response: Response): List<SChapter> {
-        val document = response.asJsoup()
-        return document.select(chapterListSelector()).map { chapterFromElement(it) }
-    }
+    private fun chapterListFromDocument(document: Document): List<SChapter> = document.select(chapterListSelector()).map { chapterFromElement(it) }
 
     private fun chapterListSelector() = "ul.detail-main-list li a"
 
@@ -199,25 +187,19 @@ abstract class MangaFox : HttpSource() {
             set(Calendar.MILLISECOND, 0)
         }.timeInMillis
     } else {
-        dateFormat.tryParse(date)
+        dateFormat.tryParseDate(date)
     }
 
-    override fun pageListRequest(chapter: SChapter): Request {
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
         val mobilePath = chapter.url.replace("/manga/", "/roll_manga/")
 
         val headers = headersBuilder().set("Referer", "$mobileUrl/").build()
 
-        return GET("$mobileUrl$mobilePath", headers)
-    }
-
-    override fun pageListParse(response: Response): List<Page> {
-        val document = response.asJsoup()
+        val document = client.get("$mobileUrl$mobilePath", headers).asJsoup()
         return document.select("#viewer img").mapIndexed { idx, it ->
             Page(idx, imageUrl = it.attr("abs:data-original"))
         }
     }
-
-    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
 
     private fun parseStatus(status: String) = when {
         status.contains("Ongoing") -> SManga.ONGOING
@@ -225,7 +207,7 @@ abstract class MangaFox : HttpSource() {
         else -> SManga.UNKNOWN
     }
 
-    override fun getFilterList(): FilterList = FilterList(
+    override fun getFilterList(data: JsonElement?): FilterList = FilterList(
         NameFilter(),
         EntryTypeFilter(),
         CompletedFilter(),

--- a/src/en/mangafox/src/eu/kanade/tachiyomi/extension/en/mangafox/MangaFox.kt
+++ b/src/en/mangafox/src/eu/kanade/tachiyomi/extension/en/mangafox/MangaFox.kt
@@ -68,17 +68,17 @@ abstract class MangaFox : KeiSource() {
         val pageStr = if (page != 1) "$page.html" else ""
         val document = client.get("$baseUrl/directory/$pageStr").asJsoup()
         val mangas = document.select(popularMangaSelector()).map { popularMangaFromElement(it) }
-        val hasNextPage = document.select(popularMangaNextPageSelector()).isNotEmpty()
+        val hasNextPage = document.selectFirst(popularMangaNextPageSelector()) != null
         return MangasPage(mangas, hasNextPage)
     }
 
     private fun popularMangaSelector() = "ul.manga-list-1-list li"
 
     private fun popularMangaFromElement(element: Element): SManga = SManga.create().apply {
-        element.select("a").first()!!.let {
+        element.selectFirst("a")!!.let {
             setUrlWithoutDomain(it.absUrl("href"))
             title = it.attr("title")
-            thumbnail_url = it.select("img").attr("abs:src")
+            thumbnail_url = it.selectFirst("img")?.attr("abs:src")
         }
     }
 
@@ -88,7 +88,7 @@ abstract class MangaFox : KeiSource() {
         val pageStr = if (page != 1) "$page.html" else ""
         val document = client.get("$baseUrl/directory/$pageStr?latest").asJsoup()
         val mangas = document.select(popularMangaSelector()).map { popularMangaFromElement(it) }
-        val hasNextPage = document.select(popularMangaNextPageSelector()).isNotEmpty()
+        val hasNextPage = document.selectFirst(popularMangaNextPageSelector()) != null
         return MangasPage(mangas, hasNextPage)
     }
 
@@ -98,7 +98,7 @@ abstract class MangaFox : KeiSource() {
         val url = baseUrl.toHttpUrl().newBuilder().apply {
             addPathSegment("search")
             addQueryParameter("title", query)
-            (if (filters.isEmpty()) getFilterList() else filters).forEach { filter ->
+            filters.forEach { filter ->
                 when (filter) {
                     is UriPartFilter -> addQueryParameter(filter.query, filter.toUriPart())
 
@@ -133,7 +133,7 @@ abstract class MangaFox : KeiSource() {
         }.build()
         val document = client.get(url).asJsoup()
         val mangas = document.select(searchMangaSelector()).map { searchMangaFromElement(it) }
-        val hasNextPage = document.select(popularMangaNextPageSelector()).isNotEmpty()
+        val hasNextPage = document.selectFirst(popularMangaNextPageSelector()) != null
         return MangasPage(mangas, hasNextPage)
     }
 
@@ -152,12 +152,12 @@ abstract class MangaFox : KeiSource() {
     }
 
     private fun mangaDetailsFromDocument(document: Document): SManga = SManga.create().apply {
-        document.select(".detail-info-right").first()!!.let { it ->
-            author = it.select(".detail-info-right-say a").joinToString(", ") { it.text() }
-            genre = it.select(".detail-info-right-tag-list a").joinToString(", ") { it.text() }
-            description = it.select("p.fullcontent").first()?.text()
-            status = it.select(".detail-info-right-title-tip").first()?.text().orEmpty().let { parseStatus(it) }
-            thumbnail_url = document.select(".detail-info-cover-img").first()?.attr("abs:src")
+        document.selectFirst(".detail-info-right")!!.let { it ->
+            author = it.select(".detail-info-right-say a").joinToString { it.text() }
+            genre = it.select(".detail-info-right-tag-list a").joinToString { it.text() }
+            description = it.selectFirst("p.fullcontent")?.text()
+            status = it.selectFirst(".detail-info-right-title-tip")?.text().let { parseStatus(it) }
+            thumbnail_url = document.selectFirst(".detail-info-cover-img")?.attr("abs:src")
         }
     }
 
@@ -167,7 +167,7 @@ abstract class MangaFox : KeiSource() {
 
     private fun chapterFromElement(element: Element): SChapter = SChapter.create().apply {
         setUrlWithoutDomain(element.absUrl("href"))
-        name = element.select(".detail-main-list-main p").first()?.text().orEmpty()
+        name = element.selectFirst(".detail-main-list-main p")!!.text()
         date_upload = element.select(".detail-main-list-main p").last()?.text()?.let { parseChapterDate(it) } ?: 0
     }
 
@@ -201,7 +201,8 @@ abstract class MangaFox : KeiSource() {
         }
     }
 
-    private fun parseStatus(status: String) = when {
+    private fun parseStatus(status: String?) = when {
+        status == null -> SManga.UNKNOWN
         status.contains("Ongoing") -> SManga.ONGOING
         status.contains("Completed") -> SManga.COMPLETED
         else -> SManga.UNKNOWN

--- a/src/en/mangafox/src/eu/kanade/tachiyomi/extension/en/mangafox/MangaFox.kt
+++ b/src/en/mangafox/src/eu/kanade/tachiyomi/extension/en/mangafox/MangaFox.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.extension.en.mangafox
 
-import android.webkit.CookieManager
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
@@ -9,15 +8,13 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import keiyoushi.annotation.Source
+import keiyoushi.network.addCookie
 import keiyoushi.network.get
 import keiyoushi.network.rateLimit
 import keiyoushi.source.KeiSource
 import keiyoushi.utils.asJsoup
 import keiyoushi.utils.tryParseDate
 import kotlinx.serialization.json.JsonElement
-import okhttp3.Cookie
-import okhttp3.CookieJar
-import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import org.jsoup.nodes.Document
@@ -32,35 +29,9 @@ abstract class MangaFox : KeiSource() {
 
     private val mobileUrl get() = baseUrl.replace("://", "://m.")
 
-    override fun OkHttpClient.Builder.configureClient() = // Force readway=2 cookie to get all page URLs at once
-        cookieJar(
-            object : CookieJar {
-                private val cookieManager by lazy { CookieManager.getInstance() }
-
-                init {
-                    cookieManager.setCookie(mobileUrl.toHttpUrl().host, "readway=2")
-                    cookieManager.setCookie(baseUrl.toHttpUrl().host, "isAdult=1")
-                }
-
-                override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
-                    val urlString = url.toString()
-                    cookies.forEach { cookieManager.setCookie(urlString, it.toString()) }
-                }
-
-                override fun loadForRequest(url: HttpUrl): List<Cookie> {
-                    val cookies = cookieManager.getCookie(url.toString())
-
-                    return if (cookies != null && cookies.isNotEmpty()) {
-                        cookies.split(";").mapNotNull {
-                            Cookie.parse(url, it)
-                        }
-                    } else {
-                        emptyList()
-                    }
-                }
-            },
-        )
-            .rateLimit(1, 1.seconds)
+    override fun OkHttpClient.Builder.configureClient() = rateLimit(1, 1.seconds)
+        .addCookie({ mobileUrl.toHttpUrl().host }, "readway" to "2") // Get all page URLs at once
+        .addCookie("isAdult" to "1") // NOTE: subdomain must be ordered before the main domain
 
     private val dateFormat = DateTimeFormatter.ofPattern("MMM d,yyyy", Locale.ENGLISH)
 


### PR DESCRIPTION
Not sure what the status was on bumping `versionCode` when going from 1.4 to 1.6. The new version here is in any case 1.6.1. I can change it to 1.6.10 if desired.

Checklist:

- [ ] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
