### PR TITLE
[Violet Scans] Remove novels

### DIFF
--- a/src/en/violetscans/build.gradle.kts
+++ b/src/en/violetscans/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 keiyoushi {
     name = "Violet Scans"
     pkgName = "en.shojoscans"
-    versionCode = 4
+    versionCode = 5
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
     theme = "mangathemesia"

--- a/src/en/violetscans/src/eu/kanade/tachiyomi/extension/en/violetscans/VioletScans.kt
+++ b/src/en/violetscans/src/eu/kanade/tachiyomi/extension/en/violetscans/VioletScans.kt
@@ -9,6 +9,9 @@ import org.jsoup.nodes.Document
 abstract class VioletScans : MangaThemesia() {
     override val mangaUrlDirectory = "/comics"
 
+    override fun searchMangaSelector() =
+        ".utao .uta .imgu, .listupd .bs .bsx:not(:has(.novelabel)), .listo .bs .bsx:not(:has(.novelabel))"
+
     override fun chapterListSelector(): String = "#chapterlist li:not(:has(svg))"
 
     override fun mangaDetailsParse(document: Document): SManga = super.mangaDetailsParse(document).apply {

--- a/src/en/violetscans/src/eu/kanade/tachiyomi/extension/en/violetscans/VioletScans.kt
+++ b/src/en/violetscans/src/eu/kanade/tachiyomi/extension/en/violetscans/VioletScans.kt
@@ -9,8 +9,7 @@ import org.jsoup.nodes.Document
 abstract class VioletScans : MangaThemesia() {
     override val mangaUrlDirectory = "/comics"
 
-    override fun searchMangaSelector() =
-        ".utao .uta .imgu, .listupd .bs .bsx:not(:has(.novelabel)), .listo .bs .bsx:not(:has(.novelabel))"
+    override fun searchMangaSelector() = ".utao .uta .imgu, .listupd .bs .bsx:not(:has(.novelabel)), .listo .bs .bsx:not(:has(.novelabel))"
 
     override fun chapterListSelector(): String = "#chapterlist li:not(:has(svg))"
 


### PR DESCRIPTION
Filter out novels from the list of results.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
