### PR TITLE
fix(id/soulscans): new api

### DIFF
--- a/src/id/soulscans/build.gradle.kts
+++ b/src/id/soulscans/build.gradle.kts
@@ -6,13 +6,12 @@ plugins {
 
 keiyoushi {
     name = "Soul Scans"
-    versionCode = 2
+    versionCode = 3
     contentWarning = ContentWarning.SAFE
-    libVersion = "1.4"
-    theme = "mangathemesia"
+    libVersion = "1.6"
 
     source {
         lang = "id"
-        baseUrl = "https://soulscans.my.id"
+        baseUrl = "https://v1.soulscans.org"
     }
 }

--- a/src/id/soulscans/build.gradle.kts
+++ b/src/id/soulscans/build.gradle.kts
@@ -6,12 +6,16 @@ plugins {
 
 keiyoushi {
     name = "Soul Scans"
-    versionCode = 3
+    versionCode = 35
     contentWarning = ContentWarning.SAFE
     libVersion = "1.6"
 
     source {
-        lang = "id"
         baseUrl = "https://v1.soulscans.org"
+        lang = "id"
+    }
+
+    deeplink {
+        path("/..*")
     }
 }

--- a/src/id/soulscans/build.gradle.kts
+++ b/src/id/soulscans/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Soul Scans"
-    versionCode = 35
+    versionCode = 0
     contentWarning = ContentWarning.SAFE
     libVersion = "1.6"
 

--- a/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/Dto.kt
+++ b/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/Dto.kt
@@ -1,0 +1,94 @@
+package eu.kanade.tachiyomi.extension.id.soulscans
+
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import keiyoushi.utils.tryParse
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.time.Instant
+
+@Serializable
+class MangaListResponseDto(
+    val data: List<MangaListItemDto>,
+    @SerialName("total_pages") val totalPages: Int,
+)
+
+@Serializable
+class MangaListItemDto(
+    private val title: String,
+    private val slug: String,
+    @SerialName("poster_image_url") private val posterImageUrl: String?,
+) {
+    fun toSManga() = SManga.create().apply {
+        title = this@MangaListItemDto.title
+        url = "/comic/$slug"
+        thumbnail_url = posterImageUrl
+    }
+}
+
+@Serializable
+class GenreDto(private val name: String) {
+    override fun toString() = name
+}
+
+@Serializable
+class SeriesDetailDto(
+    private val title: String,
+    private val slug: String,
+    private val synopsis: String?,
+    @SerialName("poster_image_url") private val posterImageUrl: String?,
+    @SerialName("author_name") private val authorName: String?,
+    @SerialName("artist_name") private val artistName: String?,
+    @SerialName("comic_status") private val comicStatus: String?,
+    private val genres: List<GenreDto> = emptyList(),
+    private val units: List<UnitDto> = emptyList(),
+) {
+    fun toSManga() = SManga.create().apply {
+        title = this@SeriesDetailDto.title
+        url = "/comic/$slug"
+        description = synopsis
+        thumbnail_url = posterImageUrl
+        author = authorName
+        artist = artistName
+        genre = genres.joinToString()
+        status = comicStatus.parseStatus()
+    }
+
+    fun toSChapterList() = units.map { it.toSChapter(slug) }
+
+    private fun String?.parseStatus() = when (this?.lowercase()) {
+        "ongoing" -> SManga.ONGOING
+        "completed" -> SManga.COMPLETED
+        "hiatus" -> SManga.ON_HIATUS
+        "cancelled", "dropped" -> SManga.CANCELLED
+        else -> SManga.UNKNOWN
+    }
+}
+
+@Serializable
+class UnitDto(
+    private val slug: String,
+    private val number: String,
+    @SerialName("created_at") private val createdAt: String,
+) {
+    fun toSChapter(seriesSlug: String) = SChapter.create().apply {
+        url = "/comic/$seriesSlug/chapter/$slug"
+        name = "Chapter " + number.toFloatOrNull()?.toString()?.removeSuffix(".0")
+        chapter_number = number.toFloatOrNull() ?: -1f
+        date_upload = Instant.tryParse(createdAt)
+    }
+}
+
+@Serializable
+class ChapterPagesResponseDto(private val chapter: ChapterPagesDto) {
+    fun toPageList() = chapter.toPageList()
+}
+
+@Serializable
+class ChapterPagesDto(private val pages: List<PageDto>) {
+    fun toPageList() = pages.mapIndexed { index, page -> Page(index, imageUrl = page.imageUrl) }
+}
+
+@Serializable
+class PageDto(@SerialName("image_url") val imageUrl: String)

--- a/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/Dto.kt
+++ b/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/Dto.kt
@@ -28,7 +28,12 @@ class MangaListItemDto(
 }
 
 @Serializable
-class GenreDto(private val name: String) {
+class GenreDto(
+    private val slug: String,
+    private val name: String,
+) {
+    fun toPair() = name to slug
+
     override fun toString() = name
 }
 

--- a/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/Filters.kt
+++ b/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/Filters.kt
@@ -1,0 +1,24 @@
+package eu.kanade.tachiyomi.extension.id.soulscans
+
+import eu.kanade.tachiyomi.source.model.Filter
+
+sealed class SelectFilter(
+    name: String,
+    private val options: List<Pair<String, String>>,
+) : Filter.Select<String>(name, options.map { it.first }.toTypedArray()) {
+    val selected get() = options[state].second
+
+    class Status(options: List<Pair<String, String>>) : SelectFilter("Status", options)
+    class Genre(options: List<Pair<String, String>>) : SelectFilter("Genre", options)
+    class Type(options: List<Pair<String, String>>) : SelectFilter("Type", options)
+    class Colored(options: List<Pair<String, String>>) : SelectFilter("Colored", options)
+    class Format(options: List<Pair<String, String>>) : SelectFilter("Format", options)
+    class Sort(options: List<Pair<String, String>>) : SelectFilter("Sort", options)
+    class Order(options: List<Pair<String, String>>) : SelectFilter("Order", options)
+}
+
+sealed class TextFilter(name: String) : Filter.Text(name) {
+    class Author : TextFilter("Author")
+    class Artist : TextFilter("Artist")
+    class Publisher : TextFilter("Publisher")
+}

--- a/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/SoulScans.kt
+++ b/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/SoulScans.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.extension.id.soulscans
 
+import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
@@ -10,6 +11,7 @@ import keiyoushi.annotation.Source
 import keiyoushi.network.get
 import keiyoushi.source.KeiSource
 import keiyoushi.utils.parseAs
+import kotlinx.serialization.json.JsonElement
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 
@@ -27,21 +29,34 @@ abstract class SoulScans : KeiSource() {
 
     override suspend fun getLatestUpdates(page: Int): MangasPage = getMangaList(searchUrl(page, sort = "latest"))
 
-    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage = getMangaList(searchUrl(page, query = query))
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage = getMangaList(searchUrl(page, query, filters = filters))
 
-    private fun searchUrl(page: Int, query: String = "", sort: String = "latest") = baseUrl.toHttpUrl()
+    private fun searchUrl(page: Int, query: String = "", sort: String? = null, filters: FilterList? = null) = baseUrl.toHttpUrl()
         .newBuilder()
         .addPathSegments("api/search")
-        .addQueryParameter("type", "COMIC")
-        .addQueryParameter("limit", "20")
-        .addQueryParameter("page", page.toString())
         .apply {
-            if (query.isNotBlank()) {
-                addQueryParameter("q", query)
-            } else {
-                addQueryParameter("sort", sort)
-                addQueryParameter("order", "desc")
+            addQueryParameter("type", "COMIC")
+            addQueryParameter("limit", "20")
+            addQueryParameter("page", page.toString())
+            addQueryParameter("q", query)
+
+            filters?.forEach { filter ->
+                when (filter) {
+                    is SelectFilter.Status -> addQueryParameter("status", filter.selected)
+                    is SelectFilter.Genre -> addQueryParameter("genre", filter.selected)
+                    is SelectFilter.Type -> addQueryParameter("comic_type", filter.selected)
+                    is SelectFilter.Colored -> addQueryParameter("color_format", filter.selected)
+                    is SelectFilter.Format -> addQueryParameter("reading_format", filter.selected)
+                    is TextFilter.Author -> addQueryParameter("author", filter.state)
+                    is TextFilter.Artist -> addQueryParameter("artist", filter.state)
+                    is TextFilter.Publisher -> addQueryParameter("publisher", filter.state)
+                    is SelectFilter.Sort -> addQueryParameter("sort", filter.selected)
+                    is SelectFilter.Order -> addQueryParameter("order", filter.selected)
+                    else -> {
+                    }
+                }
             }
+            if (sort != null) setQueryParameter("sort", sort)
         }
         .build()
 
@@ -70,5 +85,79 @@ abstract class SoulScans : KeiSource() {
         return client.get("$baseUrl/api/series/comic/$seriesSlug/chapter/$chapterSlug", headers)
             .parseAs<ChapterPagesResponseDto>()
             .toPageList()
+    }
+
+    // ============================== Filters ==============================
+
+    override val supportsFilterFetching get() = true
+
+    override suspend fun fetchFilterData(): JsonElement = client.get("$baseUrl/api/genres").parseAs()
+
+    override fun getFilterList(data: JsonElement?): FilterList {
+        val genres = data?.parseAs<List<GenreDto>>()?.map { it.toPair() }
+
+        val filters = mutableListOf<Filter<*>>(
+            SelectFilter.Status(
+                listOf(
+                    "All" to "",
+                    "Ongoing" to "ONGOING",
+                    "Completed" to "COMPLETED",
+                    "Hiatus" to "HIATUS",
+                ),
+            ),
+
+        )
+
+        if (genres != null) {
+            filters += SelectFilter.Genre(genres)
+        }
+
+        filters += listOf(
+
+            SelectFilter.Type(
+                listOf(
+                    "All" to "",
+                    "Manga" to "MANGA",
+                    "Manhwa" to "MANHWA",
+                    "Manhua" to "MANHUA",
+                ),
+            ),
+            SelectFilter.Colored(
+                listOf(
+                    "All" to "",
+                    "Full Color" to "FULL_COLOR",
+                    "B&W" to "BW",
+                ),
+            ),
+            SelectFilter.Format(
+                listOf(
+                    "All" to "",
+                    "Vertical Scroll" to "VERTICAL_SCROLL",
+                    "Page" to "PAGE",
+                ),
+            ),
+            TextFilter.Author(),
+            TextFilter.Artist(),
+            TextFilter.Publisher(),
+            SelectFilter.Sort(
+                listOf(
+                    "Latest Update" to "latest",
+                    "Created Date" to "new",
+                    "Top Views" to "views",
+                    "Top Rate" to "rate",
+                    "Top Bookmark" to "bookmark",
+                    "Title A-Z" to "az",
+                    "Title Z-A" to "za",
+
+                ),
+            ),
+            SelectFilter.Order(
+                listOf(
+                    "DESC" to "desc",
+                    "ASC" to "asc",
+                ),
+            ),
+        )
+        return FilterList(filters)
     }
 }

--- a/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/SoulScans.kt
+++ b/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/SoulScans.kt
@@ -1,47 +1,74 @@
 package eu.kanade.tachiyomi.extension.id.soulscans
 
-import eu.kanade.tachiyomi.multisrc.mangathemesia.MangaThemesia
+import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import keiyoushi.annotation.Source
-import org.jsoup.nodes.Document
-import java.util.Locale
+import keiyoushi.network.get
+import keiyoushi.source.KeiSource
+import keiyoushi.utils.parseAs
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 
 @Source
-abstract class SoulScans : MangaThemesia() {
+abstract class SoulScans : KeiSource() {
 
-    override val hasProjectPage = true
+    private suspend fun getMangaList(url: HttpUrl): MangasPage {
+        val result = client.get(url, headers).parseAs<MangaListResponseDto>()
 
-    override fun searchMangaSelector() = ".listupd .bs .bsx:not(:has(.novelabel))"
-
-    override fun mangaDetailsParse(document: Document) = SManga.create().apply {
-        document.selectFirst(seriesDetailsSelector)?.let { seriesDetails ->
-            title = seriesDetails.selectFirst(seriesTitleSelector)?.text().orEmpty()
-            artist = seriesDetails.selectFirst(seriesArtistSelector)?.ownText().removeEmptyPlaceholder()
-            author = seriesDetails.selectFirst(seriesAuthorSelector)?.ownText().removeEmptyPlaceholder()
-            description = seriesDetails.select(seriesDescriptionSelector).joinToString("\n") { it.text() }.trim()
-            // Add alternative name to manga description
-            val altName = seriesDetails.selectFirst(seriesAltNameSelector)?.ownText().takeIf { it.isNullOrBlank().not() }
-            altName?.let {
-                description = "$description\n\n$altNamePrefix$altName".trim()
-            }
-            val genres = seriesDetails.select(seriesGenreSelector).map { it.text() }.toMutableList()
-            // Add series type (manga/manhwa/manhua/other) to genre
-            seriesDetails.selectFirst(seriesTypeSelector)?.ownText().takeIf { it.isNullOrBlank().not() }?.let { genres.add(it) }
-            genre = genres.map { genre ->
-                genre.lowercase(Locale.forLanguageTag(lang)).replaceFirstChar { char ->
-                    if (char.isLowerCase()) {
-                        char.titlecase(Locale.forLanguageTag(lang))
-                    } else {
-                        char.toString()
-                    }
-                }
-            }
-                .joinToString { it.trim() }
-
-            status = seriesDetails.selectFirst(seriesStatusSelector)?.text().parseStatus()
-            seriesDetails.select(seriesThumbnailSelector).firstOrNull()?.let { thumbnail_url = it.imgAttr() }
-        }
+        val page = url.queryParameter("page")!!.toInt()
+        return MangasPage(result.data.map { it.toSManga() }, page < result.totalPages)
     }
 
-    override val pageSelector = "div#readerarea img:not([src*='.gif'])"
+    override suspend fun getPopularManga(page: Int): MangasPage = getMangaList(searchUrl(page, sort = "popular"))
+
+    override suspend fun getLatestUpdates(page: Int): MangasPage = getMangaList(searchUrl(page, sort = "latest"))
+
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage = getMangaList(searchUrl(page, query = query))
+
+    private fun searchUrl(page: Int, query: String = "", sort: String = "latest") = baseUrl.toHttpUrl()
+        .newBuilder()
+        .addPathSegments("api/search")
+        .addQueryParameter("type", "COMIC")
+        .addQueryParameter("limit", "20")
+        .addQueryParameter("page", page.toString())
+        .apply {
+            if (query.isNotBlank()) {
+                addQueryParameter("q", query)
+            } else {
+                addQueryParameter("sort", sort)
+                addQueryParameter("order", "desc")
+            }
+        }
+        .build()
+
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+        val slug = url.pathSegments.lastOrNull { it.isNotBlank() } ?: return null
+        return fetchSeriesDetail(slug).toSManga()
+    }
+
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        val detail = fetchSeriesDetail(manga.url.substringAfterLast("/"))
+
+        return SMangaUpdate(detail.toSManga(), detail.toSChapterList())
+    }
+
+    private suspend fun fetchSeriesDetail(slug: String) = client.get("$baseUrl/api/series/comic/$slug", headers).parseAs<SeriesDetailDto>()
+
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        val path = chapter.url.removePrefix("/comic/")
+        val (seriesSlug, chapterSlug) = path.split("/chapter/")
+
+        return client.get("$baseUrl/api/series/comic/$seriesSlug/chapter/$chapterSlug", headers)
+            .parseAs<ChapterPagesResponseDto>()
+            .toPageList()
+    }
 }

--- a/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/SoulScans.kt
+++ b/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/SoulScans.kt
@@ -19,7 +19,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 abstract class SoulScans : KeiSource() {
 
     private suspend fun getMangaList(url: HttpUrl): MangasPage {
-        val result = client.get(url, headers).parseAs<MangaListResponseDto>()
+        val result = client.get(url).parseAs<MangaListResponseDto>()
 
         val page = url.queryParameter("page")!!.toInt()
         return MangasPage(result.data.map { it.toSManga() }, page < result.totalPages)
@@ -76,13 +76,13 @@ abstract class SoulScans : KeiSource() {
         return SMangaUpdate(detail.toSManga(), detail.toSChapterList())
     }
 
-    private suspend fun fetchSeriesDetail(slug: String) = client.get("$baseUrl/api/series/comic/$slug", headers).parseAs<SeriesDetailDto>()
+    private suspend fun fetchSeriesDetail(slug: String) = client.get("$baseUrl/api/series/comic/$slug").parseAs<SeriesDetailDto>()
 
     override suspend fun getPageList(chapter: SChapter): List<Page> {
         val path = chapter.url.removePrefix("/comic/")
         val (seriesSlug, chapterSlug) = path.split("/chapter/")
 
-        return client.get("$baseUrl/api/series/comic/$seriesSlug/chapter/$chapterSlug", headers)
+        return client.get("$baseUrl/api/series/comic/$seriesSlug/chapter/$chapterSlug")
             .parseAs<ChapterPagesResponseDto>()
             .toPageList()
     }


### PR DESCRIPTION
soulscans.my.id now serves a static link-out page pointing readers to v1.soulscans.org, which is a full SvelteKit rewrite of the site - no wordpress/mangathemesia html left to scrape, so popular and latest both returned zero results.

Also KeiSource + 1.6 + Filters

Closes #18302
Closes #17592

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop