### PR TITLE
[Philia Scans] Cache token + 1.6 Migration

### DIFF
--- a/src/en/philiascans/build.gradle.kts
+++ b/src/en/philiascans/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Philia Scans"
-    versionCode = 59
+    versionCode = 60
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/en/philiascans/build.gradle.kts
+++ b/src/en/philiascans/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Philia Scans"
-    versionCode = 60
+    versionCode = 1
     contentWarning = ContentWarning.SAFE
     libVersion = "1.6"
 

--- a/src/en/philiascans/build.gradle.kts
+++ b/src/en/philiascans/build.gradle.kts
@@ -8,7 +8,7 @@ keiyoushi {
     name = "Philia Scans"
     versionCode = 60
     contentWarning = ContentWarning.SAFE
-    libVersion = "1.4"
+    libVersion = "1.6"
 
     source {
         lang = "en"

--- a/src/en/philiascans/src/eu/kanade/tachiyomi/extension/en/philiascans/Dto.kt
+++ b/src/en/philiascans/src/eu/kanade/tachiyomi/extension/en/philiascans/Dto.kt
@@ -101,6 +101,7 @@ private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale
 @Serializable
 class TokenResponse(
     val token: String,
+    val expiresAt: Long,
 )
 
 @Serializable

--- a/src/en/philiascans/src/eu/kanade/tachiyomi/extension/en/philiascans/Dto.kt
+++ b/src/en/philiascans/src/eu/kanade/tachiyomi/extension/en/philiascans/Dto.kt
@@ -4,9 +4,7 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import keiyoushi.utils.tryParse
 import kotlinx.serialization.Serializable
-import java.text.SimpleDateFormat
-import java.util.Locale
-import java.util.TimeZone
+import kotlin.time.Instant
 
 @Serializable
 class SeriesResponse(
@@ -89,13 +87,9 @@ class ChapterItem(
         val lock = if (isLocked) "🔒 " else ""
         val validTitle = title?.takeIf { it.isNotBlank() && it != "null" && it != number }
         name = lock + if (validTitle != null) "Chapter $number - $validTitle" else "Chapter $number"
-        date_upload = dateFormat.tryParse(publishedAt)
+        date_upload = Instant.tryParse(publishedAt)
         chapter_number = number.toFloat()
     }
-}
-
-private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ROOT).apply {
-    timeZone = TimeZone.getTimeZone("UTC")
 }
 
 @Serializable

--- a/src/en/philiascans/src/eu/kanade/tachiyomi/extension/en/philiascans/PhiliaScans.kt
+++ b/src/en/philiascans/src/eu/kanade/tachiyomi/extension/en/philiascans/PhiliaScans.kt
@@ -122,20 +122,64 @@ abstract class PhiliaScans :
         .set("X-Requested-With", "XMLHttpRequest")
         .build()
 
+    @Volatile
+    private var cachedToken: String? = null
+
+    @Volatile
+    private var cachedExpiresAtMs: Long = 0L
+
+    private fun getReaderAccessToken(forceRefresh: Boolean = false): String {
+        val now = System.currentTimeMillis()
+        if (!forceRefresh) {
+            cachedToken?.let { token ->
+                if (cachedExpiresAtMs - now > TOKEN_SKEW_MS) return token
+            }
+        }
+
+        val response = client.newCall(POST("$apiUrl/reader/access-token", tokenHeaders)).execute()
+        if (!response.isSuccessful) {
+            val code = response.code
+            response.close()
+            when (code) {
+                429 -> throw Exception("Rate limited by Philia Scans. Wait a moment and try again.")
+                401 -> throw Exception("Log in via WebView to renew access.")
+                else -> throw Exception("Failed to get reader access token (HTTP $code).")
+            }
+        }
+
+        val result = response.parseAs<TokenResponse>()
+        cachedToken = result.token
+        cachedExpiresAtMs = result.expiresAt * 1000L
+        return result.token
+    }
+
+    private fun readerHeaders(token: String) = tokenHeaders.newBuilder().add("X-Reader-Access-Token", token).build()
+
+    private fun fetchPageKeys(chapterId: Int, token: String): Pair<String, PageKeys> {
+        val response = client.newCall(GET("$apiUrl/chapters/$chapterId/page-keys", readerHeaders(token))).execute()
+        if (response.code == 404) {
+            response.close()
+            val refreshed = getReaderAccessToken(forceRefresh = true)
+            return refreshed to client.newCall(GET("$apiUrl/chapters/$chapterId/page-keys", readerHeaders(refreshed)))
+                .execute()
+                .parseAs()
+        }
+        return token to response.parseAs()
+    }
+
     override fun fetchPageList(chapter: SChapter): Observable<List<Page>> = Observable.fromCallable {
         val response = client.newCall(pageListRequest(chapter)).execute()
         val result = response.parseAs<ViewerResponse>()
         if (!result.hasAccess) throw Exception("Log in via Webview and purchased this chapter to read.")
 
-        val token = client.newCall(POST("$apiUrl/reader/access-token", tokenHeaders)).execute().parseAs<TokenResponse>().token
-        val readerHeaders = tokenHeaders.newBuilder().add("X-Reader-Access-Token", token).build()
+        val (token, pageKeyResponse) = fetchPageKeys(result.chapter.id, getReaderAccessToken())
+        val headers = readerHeaders(token)
 
         val isScrambled = if (result.chapter.scrambled) "1" else "0"
-        val pageKeyResponse = client.newCall(GET("$apiUrl/chapters/${result.chapter.id}/page-keys", readerHeaders)).execute().parseAs<PageKeys>()
 
         val (payloadA, payloadB) = if (pageKeyResponse.sessionDefault) {
-            val openResponse = client.newCall(POST("$apiUrl/chapters/${result.chapter.id}/open", readerHeaders)).execute().parseAs<OpenResponse>()
-            val drmCall = client.newCall(GET("$apiUrl/chapters/${result.chapter.id}/get-drm?session=${openResponse.sessionId}", readerHeaders)).execute()
+            val openResponse = client.newCall(POST("$apiUrl/chapters/${result.chapter.id}/open", headers)).execute().parseAs<OpenResponse>()
+            val drmCall = client.newCall(GET("$apiUrl/chapters/${result.chapter.id}/get-drm?session=${openResponse.sessionId}", headers)).execute()
             val drmResponse = if (drmCall.isSuccessful) {
                 drmCall.parseAs<DrmResponse>()
             } else {
@@ -170,5 +214,6 @@ abstract class PhiliaScans :
 
     companion object {
         private const val HIDE_LOCKED_PREF_KEY = "hide_locked"
+        private const val TOKEN_SKEW_MS = 60_000L
     }
 }

--- a/src/en/philiascans/src/eu/kanade/tachiyomi/extension/en/philiascans/PhiliaScans.kt
+++ b/src/en/philiascans/src/eu/kanade/tachiyomi/extension/en/philiascans/PhiliaScans.kt
@@ -39,14 +39,13 @@ abstract class PhiliaScans :
 
     private val emptyBody = ByteArray(0).toRequestBody(null)
 
-    private val tokenHeaders by lazy {
-        headersBuilder()
+    private val tokenHeaders
+        get() = headersBuilder()
             .set("Accept", "application/json")
             .set("Accept-Language", "de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7,ja;q=0.6")
             .set("Sec-Fetch-Mode", "cors")
             .set("X-Requested-With", "XMLHttpRequest")
             .build()
-    }
 
     private val tokenMutex = Mutex()
 
@@ -60,17 +59,17 @@ abstract class PhiliaScans :
 
     // ============================== Popular ==============================
 
-    override suspend fun getPopularManga(page: Int): MangasPage = searchManga(page, "", FilterList(SortFilter().apply { state = 2 }, OrderFilter()))
+    override suspend fun getPopularManga(page: Int): MangasPage =
+        getSearchMangaList(page, "", FilterList(SortFilter().apply { state = 2 }, OrderFilter()))
 
     // ============================== Latest ===============================
 
-    override suspend fun getLatestUpdates(page: Int): MangasPage = searchManga(page, "", FilterList(SortFilter(), OrderFilter()))
+    override suspend fun getLatestUpdates(page: Int): MangasPage =
+        getSearchMangaList(page, "", FilterList(SortFilter(), OrderFilter()))
 
     // ============================== Search ===============================
 
-    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage = searchManga(page, query, filters)
-
-    private suspend fun searchManga(page: Int, query: String, filters: FilterList): MangasPage {
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
         val url = "$apiUrl/manga".toHttpUrl().newBuilder()
             .addQueryParameter("page", page.toString())
             .addQueryParameter("perPage", "20")
@@ -113,7 +112,7 @@ abstract class PhiliaScans :
         }
         val chaptersDeferred = async {
             if (!fetchChapters) return@async chapters
-            parseChapterList(manga.url)
+            getChapterList(manga.url)
         }
         SMangaUpdate(detailsDeferred.await(), chaptersDeferred.await())
     }
@@ -130,7 +129,7 @@ abstract class PhiliaScans :
 
     // ============================= Chapters ==============================
 
-    private suspend fun parseChapterList(slug: String): List<SChapter> {
+    private suspend fun getChapterList(slug: String): List<SChapter> {
         val hideLocked = preferences.getBoolean(HIDE_LOCKED_PREF_KEY, false)
         return client.get("$apiUrl/manga/$slug/chapters").parseAs<ChapterResponse>().items
             .filter { !hideLocked || !it.isLocked }

--- a/src/en/philiascans/src/eu/kanade/tachiyomi/extension/en/philiascans/PhiliaScans.kt
+++ b/src/en/philiascans/src/eu/kanade/tachiyomi/extension/en/philiascans/PhiliaScans.kt
@@ -2,8 +2,6 @@ package eu.kanade.tachiyomi.extension.en.philiascans
 
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
-import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
@@ -11,54 +9,68 @@ import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import keiyoushi.annotation.Source
+import keiyoushi.network.get
+import keiyoushi.network.post
+import keiyoushi.source.KeiSource
 import keiyoushi.utils.firstInstanceOrNull
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.JsonElement
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.Request
-import okhttp3.Response
-import rx.Observable
+import okhttp3.OkHttpClient
+import okhttp3.RequestBody.Companion.toRequestBody
 
 @Source
 abstract class PhiliaScans :
-    HttpSource(),
+    KeiSource(),
     ConfigurableSource {
-
-    override val supportsLatest = true
 
     private val apiUrl: String
         get() = "$baseUrl/api"
 
     private val preferences by getPreferencesLazy()
 
-    override val client = network.client.newBuilder()
-        .addInterceptor(ImageInterceptor())
-        .build()
+    private val emptyBody = ByteArray(0).toRequestBody(null)
 
-    override fun headersBuilder() = super.headersBuilder()
-        .add("Referer", "$baseUrl/")
+    private val tokenHeaders by lazy {
+        headersBuilder()
+            .set("Accept", "application/json")
+            .set("Accept-Language", "de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7,ja;q=0.6")
+            .set("Sec-Fetch-Mode", "cors")
+            .set("X-Requested-With", "XMLHttpRequest")
+            .build()
+    }
+
+    private val tokenMutex = Mutex()
+
+    @Volatile
+    private var cachedToken: String? = null
+
+    @Volatile
+    private var cachedExpiresAtMs: Long = 0L
+
+    override fun OkHttpClient.Builder.configureClient() = addInterceptor(ImageInterceptor())
 
     // ============================== Popular ==============================
 
-    override fun popularMangaRequest(page: Int): Request = searchMangaRequest(page, "", FilterList(SortFilter().apply { state = 2 }, OrderFilter()))
-
-    override fun popularMangaParse(response: Response): MangasPage {
-        val result = response.parseAs<SeriesResponse>()
-        val mangas = result.items.map { it.toSManga(baseUrl) }
-        return MangasPage(mangas, result.hasNextPage())
-    }
+    override suspend fun getPopularManga(page: Int): MangasPage = searchManga(page, "", FilterList(SortFilter().apply { state = 2 }, OrderFilter()))
 
     // ============================== Latest ===============================
 
-    override fun latestUpdatesRequest(page: Int) = searchMangaRequest(page, "", FilterList(SortFilter(), OrderFilter()))
-
-    override fun latestUpdatesParse(response: Response) = popularMangaParse(response)
+    override suspend fun getLatestUpdates(page: Int): MangasPage = searchManga(page, "", FilterList(SortFilter(), OrderFilter()))
 
     // ============================== Search ===============================
 
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage = searchManga(page, query, filters)
+
+    private suspend fun searchManga(page: Int, query: String, filters: FilterList): MangasPage {
         val url = "$apiUrl/manga".toHttpUrl().newBuilder()
             .addQueryParameter("page", page.toString())
             .addQueryParameter("perPage", "20")
@@ -70,10 +82,13 @@ abstract class PhiliaScans :
                 addFilter("statuses", filters.firstInstanceOrNull<StatusFilter>())
                 addFilter("genres", filters.firstInstanceOrNull<GenreFilter>())
             }
-        return GET(url.build(), headers)
+            .build()
+
+        val result = client.get(url).parseAs<SeriesResponse>()
+        return MangasPage(result.items.map { it.toSManga(baseUrl) }, result.hasNextPage())
     }
 
-    override fun getFilterList() = FilterList(
+    override fun getFilterList(data: JsonElement?) = FilterList(
         Filter.Header("Note: Search and active filters are applied together"),
         SortFilter(),
         OrderFilter(),
@@ -82,24 +97,42 @@ abstract class PhiliaScans :
         GenreFilter(),
     )
 
-    override fun searchMangaParse(response: Response) = popularMangaParse(response)
-
     // ============================== Details ==============================
 
-    override fun mangaDetailsRequest(manga: SManga): Request = GET("$apiUrl/manga/${manga.url}", headers)
-
-    override fun mangaDetailsParse(response: Response): SManga = response.parseAs<DetailsResponse>().toSManga(baseUrl)
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate = coroutineScope {
+        val detailsDeferred = async {
+            if (!fetchDetails) return@async manga
+            client.get("$apiUrl/manga/${manga.url}").parseAs<DetailsResponse>().toSManga(baseUrl).apply {
+                url = manga.url
+            }
+        }
+        val chaptersDeferred = async {
+            if (!fetchChapters) return@async chapters
+            parseChapterList(manga.url)
+        }
+        SMangaUpdate(detailsDeferred.await(), chaptersDeferred.await())
+    }
 
     override fun getMangaUrl(manga: SManga): String = "$baseUrl/series/${manga.url}"
 
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+        if (url.pathSegments.firstOrNull() != "series") return null
+        val slug = url.pathSegments.getOrNull(1)?.takeIf { it.isNotBlank() } ?: return null
+        return client.get("$apiUrl/manga/$slug").parseAs<DetailsResponse>().toSManga(baseUrl).apply {
+            this.url = slug
+        }
+    }
+
     // ============================= Chapters ==============================
 
-    override fun chapterListRequest(manga: SManga): Request = GET("$apiUrl/manga/${manga.url}/chapters", headers)
-
-    override fun chapterListParse(response: Response): List<SChapter> {
+    private suspend fun parseChapterList(slug: String): List<SChapter> {
         val hideLocked = preferences.getBoolean(HIDE_LOCKED_PREF_KEY, false)
-        val slug = response.request.url.pathSegments[2]
-        return response.parseAs<ChapterResponse>().items
+        return client.get("$apiUrl/manga/$slug/chapters").parseAs<ChapterResponse>().items
             .filter { !hideLocked || !it.isLocked }
             .map { it.toSChapter(slug) }
     }
@@ -108,27 +141,75 @@ abstract class PhiliaScans :
 
     // =============================== Pages ===============================
 
-    override fun pageListRequest(chapter: SChapter): Request {
+    private suspend fun fetchPageKeys(chapterId: Int, token: String): Pair<String, PageKeys> {
+        val response = client.get(
+            "$apiUrl/chapters/$chapterId/page-keys",
+            readerHeaders(token),
+            ensureSuccess = false,
+        )
+        if (response.code == 404) {
+            response.close()
+            val refreshed = getReaderAccessToken(forceRefresh = true)
+            return refreshed to client.get(
+                "$apiUrl/chapters/$chapterId/page-keys",
+                readerHeaders(refreshed),
+            ).parseAs()
+        }
+        if (!response.isSuccessful) {
+            val code = response.code
+            response.close()
+            when (code) {
+                429 -> throw Exception("Rate limited by Philia Scans. Wait a moment and try again.")
+                401 -> throw Exception("Log in via WebView to renew access.")
+                else -> throw Exception("Failed to get page keys (HTTP $code).")
+            }
+        }
+        return token to response.parseAs()
+    }
+
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
         val parts = chapter.url.split("/")
         val mangaSlug = parts.first()
         val chapterSlug = parts.last()
-        return GET("$apiUrl/manga/$mangaSlug/chapters/$chapterSlug", headers)
+        val result = client.get("$apiUrl/manga/$mangaSlug/chapters/$chapterSlug").parseAs<ViewerResponse>()
+        if (!result.hasAccess) throw Exception("Log in via Webview and purchased this chapter to read.")
+
+        val (token, pageKeyResponse) = fetchPageKeys(result.chapter.id, getReaderAccessToken())
+        val headers = readerHeaders(token)
+
+        val isScrambled = if (result.chapter.scrambled) "1" else "0"
+
+        val (payloadA, payloadB) = if (pageKeyResponse.sessionDefault) {
+            val openResponse = client.post(
+                "$apiUrl/chapters/${result.chapter.id}/open",
+                headers,
+                emptyBody,
+            ).parseAs<OpenResponse>()
+            val drmCall = client.get(
+                "$apiUrl/chapters/${result.chapter.id}/get-drm?session=${openResponse.sessionId}",
+                headers,
+                ensureSuccess = false,
+            )
+            val drmResponse = if (drmCall.isSuccessful) {
+                drmCall.parseAs<DrmResponse>()
+            } else {
+                drmCall.close()
+                null
+            }
+            openResponse.payloadA to drmResponse?.payloadB
+        } else {
+            null to null
+        }
+
+        return result.chapter.pages.sortedBy { it.position }.mapIndexed { i, page ->
+            val imageUrl = if (page.url.startsWith("http")) page.url else "$baseUrl/${page.url}"
+            Page(i, imageUrl = "$imageUrl#$isScrambled;${page.mime};${pageKeyResponse.chapterKeyB64};${pageKeyResponse.gridSize};$payloadA;$payloadB;$i")
+        }
     }
 
-    private val tokenHeaders = headersBuilder()
-        .set("Accept", "application/json")
-        .set("Accept-Language", "de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7,ja;q=0.6")
-        .set("Sec-Fetch-Mode", "cors")
-        .set("X-Requested-With", "XMLHttpRequest")
-        .build()
+    // ============================= Utilities =============================
 
-    @Volatile
-    private var cachedToken: String? = null
-
-    @Volatile
-    private var cachedExpiresAtMs: Long = 0L
-
-    private fun getReaderAccessToken(forceRefresh: Boolean = false): String {
+    private suspend fun getReaderAccessToken(forceRefresh: Boolean = false): String = tokenMutex.withLock {
         val now = System.currentTimeMillis()
         if (!forceRefresh) {
             cachedToken?.let { token ->
@@ -136,7 +217,7 @@ abstract class PhiliaScans :
             }
         }
 
-        val response = client.newCall(POST("$apiUrl/reader/access-token", tokenHeaders)).execute()
+        val response = client.post("$apiUrl/reader/access-token", tokenHeaders, emptyBody, ensureSuccess = false)
         if (!response.isSuccessful) {
             val code = response.code
             response.close()
@@ -154,54 +235,6 @@ abstract class PhiliaScans :
     }
 
     private fun readerHeaders(token: String) = tokenHeaders.newBuilder().add("X-Reader-Access-Token", token).build()
-
-    private fun fetchPageKeys(chapterId: Int, token: String): Pair<String, PageKeys> {
-        val response = client.newCall(GET("$apiUrl/chapters/$chapterId/page-keys", readerHeaders(token))).execute()
-        if (response.code == 404) {
-            response.close()
-            val refreshed = getReaderAccessToken(forceRefresh = true)
-            return refreshed to client.newCall(GET("$apiUrl/chapters/$chapterId/page-keys", readerHeaders(refreshed)))
-                .execute()
-                .parseAs()
-        }
-        return token to response.parseAs()
-    }
-
-    override fun fetchPageList(chapter: SChapter): Observable<List<Page>> = Observable.fromCallable {
-        val response = client.newCall(pageListRequest(chapter)).execute()
-        val result = response.parseAs<ViewerResponse>()
-        if (!result.hasAccess) throw Exception("Log in via Webview and purchased this chapter to read.")
-
-        val (token, pageKeyResponse) = fetchPageKeys(result.chapter.id, getReaderAccessToken())
-        val headers = readerHeaders(token)
-
-        val isScrambled = if (result.chapter.scrambled) "1" else "0"
-
-        val (payloadA, payloadB) = if (pageKeyResponse.sessionDefault) {
-            val openResponse = client.newCall(POST("$apiUrl/chapters/${result.chapter.id}/open", headers)).execute().parseAs<OpenResponse>()
-            val drmCall = client.newCall(GET("$apiUrl/chapters/${result.chapter.id}/get-drm?session=${openResponse.sessionId}", headers)).execute()
-            val drmResponse = if (drmCall.isSuccessful) {
-                drmCall.parseAs<DrmResponse>()
-            } else {
-                drmCall.close()
-                null
-            }
-            openResponse.payloadA to drmResponse?.payloadB
-        } else {
-            null to null
-        }
-
-        result.chapter.pages.sortedBy { it.position }.mapIndexed { i, page ->
-            val imageUrl = if (page.url.startsWith("http")) page.url else "$baseUrl/${page.url}"
-            Page(i, imageUrl = "$imageUrl#$isScrambled;${page.mime};${pageKeyResponse.chapterKeyB64};${pageKeyResponse.gridSize};$payloadA;$payloadB;$i")
-        }
-    }
-
-    override fun pageListParse(response: Response): List<Page> = throw UnsupportedOperationException()
-
-    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
-
-    // ============================= Utilities =============================
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         SwitchPreferenceCompat(screen.context).apply {

--- a/src/en/philiascans/src/eu/kanade/tachiyomi/extension/en/philiascans/PhiliaScans.kt
+++ b/src/en/philiascans/src/eu/kanade/tachiyomi/extension/en/philiascans/PhiliaScans.kt
@@ -59,13 +59,11 @@ abstract class PhiliaScans :
 
     // ============================== Popular ==============================
 
-    override suspend fun getPopularManga(page: Int): MangasPage =
-        getSearchMangaList(page, "", FilterList(SortFilter().apply { state = 2 }, OrderFilter()))
+    override suspend fun getPopularManga(page: Int): MangasPage = getSearchMangaList(page, "", FilterList(SortFilter().apply { state = 2 }, OrderFilter()))
 
     // ============================== Latest ===============================
 
-    override suspend fun getLatestUpdates(page: Int): MangasPage =
-        getSearchMangaList(page, "", FilterList(SortFilter(), OrderFilter()))
+    override suspend fun getLatestUpdates(page: Int): MangasPage = getSearchMangaList(page, "", FilterList(SortFilter(), OrderFilter()))
 
     // ============================== Search ===============================
 


### PR DESCRIPTION
Cache the token to reduce the number of calls thus preventing 429s.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
