### PR TITLE
Fix: Update URL

### DIFF
--- a/src/fr/hentaiscantrad/build.gradle.kts
+++ b/src/fr/hentaiscantrad/build.gradle.kts
@@ -6,13 +6,13 @@ plugins {
 
 keiyoushi {
     name = "Hentai-Scantrad"
-    versionCode = 1
+    versionCode = 2
     contentWarning = ContentWarning.NSFW
     libVersion = "1.6"
     theme = "madara"
 
     source {
         lang = "fr"
-        baseUrl = "https://hentai.scantrad-vf.cc"
+        baseUrl = "https://hentai-scantrad.org"
     }
 }


### PR DESCRIPTION
Fix Hentai-Scantrad by updating the base URL to the site's new domain.

Closes #18823

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
