### PR TITLE
Fix Dassous scan + add premium chapter display

### DIFF
--- a/src/fr/dassouscan/build.gradle.kts
+++ b/src/fr/dassouscan/build.gradle.kts
@@ -6,13 +6,17 @@ plugins {
 
 keiyoushi {
     name = "Dassou Scan"
-    versionCode = 52
+    versionCode = 1
     contentWarning = ContentWarning.SAFE
-    libVersion = "1.4"
+    libVersion = "1.6"
 
     source {
         lang = "fr"
         baseUrl = "https://dassouscan.com"
         versionId = 2
+    }
+
+    deeplink {
+        path("/manga/..*")
     }
 }

--- a/src/fr/dassouscan/build.gradle.kts
+++ b/src/fr/dassouscan/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Dassou Scan"
-    versionCode = 51
+    versionCode = 52
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
 

--- a/src/fr/dassouscan/src/eu/kanade/tachiyomi/extension/fr/dassouscan/DassouScan.kt
+++ b/src/fr/dassouscan/src/eu/kanade/tachiyomi/extension/fr/dassouscan/DassouScan.kt
@@ -1,6 +1,9 @@
 package eu.kanade.tachiyomi.extension.fr.dassouscan
 
+import androidx.preference.PreferenceScreen
+import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
@@ -9,6 +12,7 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.annotation.Source
 import keiyoushi.utils.asJsoup
+import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.tryParse
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
@@ -17,19 +21,37 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 
 @Source
-abstract class DassouScan : HttpSource() {
+abstract class DassouScan :
+    HttpSource(),
+    ConfigurableSource {
 
     override val supportsLatest = true
 
+    private val preferences by getPreferencesLazy()
+
+    private val hidePremium: Boolean
+        get() = preferences.getBoolean(PREF_HIDE_PREMIUM, true)
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        SwitchPreferenceCompat(screen.context).apply {
+            key = PREF_HIDE_PREMIUM
+            title = "Masquer les chapitres premium"
+            summary = "Masquer les chapitres verrouillés en accès anticipé payant"
+            setDefaultValue(true)
+        }.also(screen::addPreference)
+    }
+
     private val dateFormat = SimpleDateFormat("d MMMM yyyy 'à' HH:mm", Locale.FRENCH)
+    private val shortDateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.FRENCH)
 
     // ============================== Popular ==============================
 
     override fun popularMangaRequest(page: Int): Request {
-        val path = if (page > 1) "page/$page/" else ""
-        val url = "$baseUrl/$path".toHttpUrl().newBuilder().apply {
-            addQueryParameter("post_type", "dsc_manga")
+        val url = "$baseUrl/catalogue".toHttpUrl().newBuilder().apply {
             addQueryParameter("tri", "popular")
+            if (page > 1) {
+                addQueryParameter("page", page.toString())
+            }
         }.build()
 
         return GET(url, headers)
@@ -38,17 +60,18 @@ abstract class DassouScan : HttpSource() {
     override fun popularMangaParse(response: Response): MangasPage {
         val document = response.asJsoup()
 
-        val mangas = document.select("article.featured-card").map { element ->
+        val mangas = document.select("article.dsc-cat-card").map { element ->
             SManga.create().apply {
-                title = element.attr("data-title").takeIf { it.isNotEmpty() } ?: throw Exception("Title is empty")
-                setUrlWithoutDomain(element.selectFirst("a.dsc-card-link")!!.absUrl("href"))
+                title = element.attr("data-title")
+                    .ifEmpty { element.selectFirst(".dsc-cat-card__title a")?.text().orEmpty() }
+                    .ifEmpty { throw Exception("Title is empty") }
+                setUrlWithoutDomain(element.selectFirst("a.dsc-cat-card__cover-link, .dsc-cat-card__title a, a.dsc-cat-card__open")!!.absUrl("href"))
 
-                val bgStyle = element.selectFirst(".cover")?.attr("style") ?: ""
-                thumbnail_url = bgStyle.substringAfter("url(").substringBefore(")").removeSurrounding("\"").removeSurrounding("'")
+                thumbnail_url = element.selectFirst(".dsc-cat-card__cover img")?.attr("abs:src")
             }
         }
 
-        val hasNextPage = document.selectFirst("a.next.page-numbers, button.dmaj-pagination__next:not([disabled])") != null
+        val hasNextPage = document.selectFirst("a.dsc-cat__pager-btn[href]:contains(Suivant)") != null
 
         return MangasPage(mangas, hasNextPage)
     }
@@ -56,9 +79,11 @@ abstract class DassouScan : HttpSource() {
     // ============================== Latest ===============================
 
     override fun latestUpdatesRequest(page: Int): Request {
-        val path = if (page > 1) "page/$page/" else ""
-        val url = "$baseUrl/$path".toHttpUrl().newBuilder().apply {
-            addQueryParameter("post_type", "dsc_manga")
+        val url = "$baseUrl/catalogue".toHttpUrl().newBuilder().apply {
+            addQueryParameter("tri", "latest")
+            if (page > 1) {
+                addQueryParameter("page", page.toString())
+            }
         }.build()
 
         return GET(url, headers)
@@ -69,10 +94,11 @@ abstract class DassouScan : HttpSource() {
     // ============================== Search ===============================
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        val path = if (page > 1) "page/$page/" else ""
-        val url = "$baseUrl/$path".toHttpUrl().newBuilder().apply {
-            addQueryParameter("post_type", "dsc_manga")
-            addQueryParameter("s", query)
+        val url = "$baseUrl/catalogue".toHttpUrl().newBuilder().apply {
+            addQueryParameter("q", query)
+            if (page > 1) {
+                addQueryParameter("page", page.toString())
+            }
         }.build()
 
         return GET(url, headers)
@@ -87,11 +113,10 @@ abstract class DassouScan : HttpSource() {
 
         return SManga.create().apply {
             title = document.selectFirst("h1")?.text()?.takeIf { it.isNotEmpty() } ?: throw Exception("Manga title is missing")
-            description = document.selectFirst(".hero-synopsis p")?.text()
-            genre = document.select(".hero-tags a.tag:not(.tag--dsc-tag)").joinToString { it.text() }
+            description = document.selectFirst(".dsc-mf__synopsis-text")?.text()
+            genre = document.select(".dsc-mf__tags a.dsc-mf__tag").joinToString { it.text() }
 
-            val bgStyle = document.selectFirst(".cover")?.attr("style") ?: ""
-            thumbnail_url = bgStyle.substringAfter("url(").substringBefore(")").removeSurrounding("\"").removeSurrounding("'")
+            thumbnail_url = document.selectFirst(".dsc-mf__cover img")?.attr("abs:src")
         }
     }
 
@@ -99,19 +124,31 @@ abstract class DassouScan : HttpSource() {
 
     override fun chapterListParse(response: Response): List<SChapter> {
         val document = response.asJsoup()
-        return document.select("div.dsc-manga-chapter-block:not(:has(a[href*=/inscription/]))").map { element ->
+        return document.select("div.dsc-manga-chapter-block:not(:has(a[href*=/inscription/]))").mapNotNull { element ->
+            val isPremium = element.hasClass("chapter--locked") ||
+                element.selectFirst(".dsc-ch-hl__access--premium, a.is-locked") != null
+            if (isPremium && hidePremium) {
+                return@mapNotNull null
+            }
             SChapter.create().apply {
                 val link = element.selectFirst("a.dsc-manga-chapter-block__title-link")!!
 
                 setUrlWithoutDomain(link.absUrl("href"))
-                name = element.selectFirst(".chapter-title")?.ownText() ?: link.text()
+                name = buildString {
+                    if (isPremium) {
+                        append("🔒 ")
+                    }
+                    append(element.selectFirst(".chapter-title")?.ownText() ?: link.text())
+                }
 
                 val dateStr = element.selectFirst(".chapter-info")?.text() ?: ""
-                if (dateStr.contains("à")) {
-                    date_upload = dateFormat.tryParse(dateStr)
+                date_upload = if (dateStr.contains("à")) {
+                    dateFormat.tryParse(dateStr)
+                } else {
+                    shortDateFormat.tryParse(dateStr)
                 }
             }
-        }
+        }.reversed()
     }
 
     // =============================== Pages ===============================
@@ -126,4 +163,8 @@ abstract class DassouScan : HttpSource() {
     }
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
+
+    companion object {
+        private const val PREF_HIDE_PREMIUM = "pref_hide_premium"
+    }
 }

--- a/src/fr/dassouscan/src/eu/kanade/tachiyomi/extension/fr/dassouscan/DassouScan.kt
+++ b/src/fr/dassouscan/src/eu/kanade/tachiyomi/extension/fr/dassouscan/DassouScan.kt
@@ -28,8 +28,6 @@ abstract class DassouScan :
     KeiSource(),
     ConfigurableSource {
 
-    override val supportsLatest = true
-
     private val preferences by getPreferencesLazy()
 
     private val hidePremium: Boolean

--- a/src/fr/dassouscan/src/eu/kanade/tachiyomi/extension/fr/dassouscan/DassouScan.kt
+++ b/src/fr/dassouscan/src/eu/kanade/tachiyomi/extension/fr/dassouscan/DassouScan.kt
@@ -2,27 +2,30 @@ package eu.kanade.tachiyomi.extension.fr.dassouscan
 
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
-import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import keiyoushi.annotation.Source
+import keiyoushi.network.get
+import keiyoushi.source.KeiSource
 import keiyoushi.utils.asJsoup
 import keiyoushi.utils.getPreferencesLazy
-import keiyoushi.utils.tryParse
+import keiyoushi.utils.tryParseDate
+import keiyoushi.utils.tryParseDateTime
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.Request
-import okhttp3.Response
-import java.text.SimpleDateFormat
+import org.jsoup.nodes.Document
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 @Source
 abstract class DassouScan :
-    HttpSource(),
+    KeiSource(),
     ConfigurableSource {
 
     override val supportsLatest = true
@@ -41,12 +44,13 @@ abstract class DassouScan :
         }.also(screen::addPreference)
     }
 
-    private val dateFormat = SimpleDateFormat("d MMMM yyyy 'à' HH:mm", Locale.FRENCH)
-    private val shortDateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.FRENCH)
+    private val dateTimeFormat = DateTimeFormatter.ofPattern("d MMMM yyyy 'à' HH:mm", Locale.FRENCH)
+    private val dateFormat = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.FRENCH)
+    private val zoneId = ZoneId.of("Europe/Paris")
 
     // ============================== Popular ==============================
 
-    override fun popularMangaRequest(page: Int): Request {
+    override suspend fun getPopularManga(page: Int): MangasPage {
         val url = "$baseUrl/catalogue".toHttpUrl().newBuilder().apply {
             addQueryParameter("tri", "popular")
             if (page > 1) {
@@ -54,12 +58,36 @@ abstract class DassouScan :
             }
         }.build()
 
-        return GET(url, headers)
+        return parseCatalogue(client.get(url).asJsoup())
     }
 
-    override fun popularMangaParse(response: Response): MangasPage {
-        val document = response.asJsoup()
+    // ============================== Latest ===============================
 
+    override suspend fun getLatestUpdates(page: Int): MangasPage {
+        val url = "$baseUrl/catalogue".toHttpUrl().newBuilder().apply {
+            addQueryParameter("tri", "latest")
+            if (page > 1) {
+                addQueryParameter("page", page.toString())
+            }
+        }.build()
+
+        return parseCatalogue(client.get(url).asJsoup())
+    }
+
+    // ============================== Search ===============================
+
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
+        val url = "$baseUrl/catalogue".toHttpUrl().newBuilder().apply {
+            addQueryParameter("q", query)
+            if (page > 1) {
+                addQueryParameter("page", page.toString())
+            }
+        }.build()
+
+        return parseCatalogue(client.get(url).asJsoup())
+    }
+
+    private fun parseCatalogue(document: Document): MangasPage {
         val mangas = document.select("article.dsc-cat-card").map { element ->
             SManga.create().apply {
                 title = element.attr("data-title")
@@ -76,54 +104,40 @@ abstract class DassouScan :
         return MangasPage(mangas, hasNextPage)
     }
 
-    // ============================== Latest ===============================
-
-    override fun latestUpdatesRequest(page: Int): Request {
-        val url = "$baseUrl/catalogue".toHttpUrl().newBuilder().apply {
-            addQueryParameter("tri", "latest")
-            if (page > 1) {
-                addQueryParameter("page", page.toString())
-            }
-        }.build()
-
-        return GET(url, headers)
-    }
-
-    override fun latestUpdatesParse(response: Response): MangasPage = popularMangaParse(response)
-
-    // ============================== Search ===============================
-
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        val url = "$baseUrl/catalogue".toHttpUrl().newBuilder().apply {
-            addQueryParameter("q", query)
-            if (page > 1) {
-                addQueryParameter("page", page.toString())
-            }
-        }.build()
-
-        return GET(url, headers)
-    }
-
-    override fun searchMangaParse(response: Response): MangasPage = popularMangaParse(response)
-
     // ============================== Details ==============================
 
-    override fun mangaDetailsParse(response: Response): SManga {
-        val document = response.asJsoup()
-
-        return SManga.create().apply {
-            title = document.selectFirst("h1")?.text()?.takeIf { it.isNotEmpty() } ?: throw Exception("Manga title is missing")
-            description = document.selectFirst(".dsc-mf__synopsis-text")?.text()
-            genre = document.select(".dsc-mf__tags a.dsc-mf__tag").joinToString { it.text() }
-
-            thumbnail_url = document.selectFirst(".dsc-mf__cover img")?.attr("abs:src")
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+        if (url.host != baseUrl.toHttpUrl().host) {
+            return null
         }
+        if (url.pathSegments.firstOrNull() != "manga" || url.pathSegments.size != 2) {
+            return null
+        }
+        return parseMangaDetails(client.get(url).asJsoup())
+    }
+
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        val document = client.get(getMangaUrl(manga)).asJsoup()
+        return SMangaUpdate(parseMangaDetails(document), parseChapterList(document))
+    }
+
+    private fun parseMangaDetails(document: Document): SManga = SManga.create().apply {
+        setUrlWithoutDomain(document.location())
+        title = document.selectFirst("h1")?.text()?.takeIf { it.isNotEmpty() } ?: throw Exception("Manga title is missing")
+        description = document.selectFirst(".dsc-mf__synopsis-text")?.text()
+        genre = document.select(".dsc-mf__tags a.dsc-mf__tag").joinToString { it.text() }
+
+        thumbnail_url = document.selectFirst(".dsc-mf__cover img")?.attr("abs:src")
     }
 
     // ============================= Chapters ==============================
 
-    override fun chapterListParse(response: Response): List<SChapter> {
-        val document = response.asJsoup()
+    private fun parseChapterList(document: Document): List<SChapter> {
         return document.select("div.dsc-manga-chapter-block:not(:has(a[href*=/inscription/]))").mapNotNull { element ->
             val isPremium = element.hasClass("chapter--locked") ||
                 element.selectFirst(".dsc-ch-hl__access--premium, a.is-locked") != null
@@ -143,9 +157,9 @@ abstract class DassouScan :
 
                 val dateStr = element.selectFirst(".chapter-info")?.text() ?: ""
                 date_upload = if (dateStr.contains("à")) {
-                    dateFormat.tryParse(dateStr)
+                    dateTimeFormat.tryParseDateTime(dateStr, zoneId)
                 } else {
-                    shortDateFormat.tryParse(dateStr)
+                    dateFormat.tryParseDate(dateStr, zoneId)
                 }
             }
         }.reversed()
@@ -153,16 +167,14 @@ abstract class DassouScan :
 
     // =============================== Pages ===============================
 
-    override fun pageListParse(response: Response): List<Page> {
-        val document = response.asJsoup()
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        val document = client.get(getChapterUrl(chapter)).asJsoup()
 
         return document.select("#dsc-chapter-reader-content .dsc-chapter-strip-img").mapIndexed { i, img ->
             val url = img.attr("abs:data-src").ifEmpty { img.attr("abs:src") }
             Page(i, imageUrl = url)
         }
     }
-
-    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
 
     companion object {
         private const val PREF_HIDE_PREMIUM = "pref_hide_premium"


### PR DESCRIPTION
Fix Dassou Scan after the site redesign, and add an option to hide premium chapters.

Closes #18204

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
