### PR TITLE
Fix Origines theme paged chapters showing a single page

### DIFF
--- a/lib-multisrc/origines/build.gradle.kts
+++ b/lib-multisrc/origines/build.gradle.kts
@@ -3,6 +3,6 @@ plugins {
 }
 
 keiyoushi {
-    baseVersionCode = 3
+    baseVersionCode = 4
     libVersion = "1.6"
 }

--- a/lib-multisrc/origines/src/eu/kanade/tachiyomi/multisrc/origines/Origines.kt
+++ b/lib-multisrc/origines/src/eu/kanade/tachiyomi/multisrc/origines/Origines.kt
@@ -273,7 +273,7 @@ abstract class Origines : KeiSource() {
     // =============================== Pages ================================
 
     override suspend fun getPageList(chapter: SChapter): List<Page> {
-        val document = client.get("$baseUrl/$mangaPath/${chapter.url.toChapterSlug()}/").asJsoup()
+        val document = client.get("$baseUrl/$mangaPath/${chapter.url.toChapterSlug()}/?style=list").asJsoup()
 
         return document.select("div.reading-content img.wp-manga-chapter-img").mapIndexed { index, img ->
             val image = when {


### PR DESCRIPTION
Fix single-page chapters on Mangas-Origines theme by forcing list-mode rendering.

Closes #18900

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
