### PR TITLE
SilentQuill: use rsc for pages

### DIFF
--- a/src/en/silentquill/build.gradle.kts
+++ b/src/en/silentquill/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 keiyoushi {
     name = "SilentQuill"
     pkgName = "en.armageddon"
-    versionCode = 1
+    versionCode = 2
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
 

--- a/src/en/silentquill/src/eu/kanade/tachiyomi/extension/en/silentquill/Dto.kt
+++ b/src/en/silentquill/src/eu/kanade/tachiyomi/extension/en/silentquill/Dto.kt
@@ -17,9 +17,7 @@ class ChapterResponse(
     fun toSChapter(mangaSlug: String): SChapter = SChapter.create().apply {
         url = id.toString()
         name = "Chapter $chapterNo"
-        chapter_number = CHAPTER_NUMBER_REGEX.find(chapterNo)?.let {
-            it.groupValues[1].toFloat() + if (it.groups[2] != null) 0.005f else 0f
-        } ?: -1f
+        chapter_number = CHAPTER_NUMBER_REGEX.find(chapterNo)?.value?.toFloat() ?: -1f
         date_upload = timeAgo.toRelativeDate()
         memo = buildJsonObject {
             put("slug", slug)
@@ -28,7 +26,7 @@ class ChapterResponse(
     }
 }
 
-private val CHAPTER_NUMBER_REGEX = Regex("""^(\d+(?:\.\d+)?)\s*(\S.*)?$""")
+private val CHAPTER_NUMBER_REGEX = Regex("""^\d+(?:\.\d+)?""")
 private val RELATIVE_DATE_REGEX = Regex("""(\d+)\s+(minute|hour|day|week|month|year)s?""")
 
 private fun String.toRelativeDate(): Long {

--- a/src/en/silentquill/src/eu/kanade/tachiyomi/extension/en/silentquill/Dto.kt
+++ b/src/en/silentquill/src/eu/kanade/tachiyomi/extension/en/silentquill/Dto.kt
@@ -14,17 +14,21 @@ class ChapterResponse(
     val slug: String,
     @SerialName("time_ago") val timeAgo: String,
 ) {
-    fun toSChapter(): SChapter = SChapter.create().apply {
+    fun toSChapter(mangaSlug: String): SChapter = SChapter.create().apply {
         url = id.toString()
         name = "Chapter $chapterNo"
-        chapter_number = chapterNo.toFloatOrNull() ?: -1f
+        chapter_number = CHAPTER_NUMBER_REGEX.find(chapterNo)?.let {
+            it.groupValues[1].toFloat() + if (it.groups[2] != null) 0.005f else 0f
+        } ?: -1f
         date_upload = timeAgo.toRelativeDate()
         memo = buildJsonObject {
             put("slug", slug)
+            put("mangaSlug", mangaSlug)
         }
     }
 }
 
+private val CHAPTER_NUMBER_REGEX = Regex("""^(\d+(?:\.\d+)?)\s*(\S.*)?$""")
 private val RELATIVE_DATE_REGEX = Regex("""(\d+)\s+(minute|hour|day|week|month|year)s?""")
 
 private fun String.toRelativeDate(): Long {
@@ -49,10 +53,10 @@ class ViewerResponseBody(
 
 @Serializable
 class ViewerResponse(
-    val paginas: List<Pagina>,
+    val pages: List<Pages>,
 )
 
 @Serializable
-class Pagina(
-    @SerialName("t") val pages: String,
+class Pages(
+    val url: String,
 )

--- a/src/en/silentquill/src/eu/kanade/tachiyomi/extension/en/silentquill/SilentQuill.kt
+++ b/src/en/silentquill/src/eu/kanade/tachiyomi/extension/en/silentquill/SilentQuill.kt
@@ -8,7 +8,6 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import keiyoushi.annotation.Source
 import keiyoushi.network.get
-import keiyoushi.network.post
 import keiyoushi.source.KeiSource
 import keiyoushi.utils.asJsoup
 import keiyoushi.utils.extractNextJs
@@ -16,10 +15,8 @@ import keiyoushi.utils.firstInstanceOrNull
 import keiyoushi.utils.getArrayOrNull
 import keiyoushi.utils.getString
 import keiyoushi.utils.getStringOrNull
-import keiyoushi.utils.parseAs
 import keiyoushi.utils.string
 import keiyoushi.utils.textOrNull
-import keiyoushi.utils.toJsonRequestBody
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -28,7 +25,6 @@ import okhttp3.Response
 
 @Source
 abstract class SilentQuill : KeiSource() {
-    private val apiUrl get() = "$baseUrl/api"
     private val rscHeaders get() = headersBuilder()
         .set("rsc", "1")
         .build()
@@ -97,7 +93,10 @@ abstract class SilentQuill : KeiSource() {
         fetchChapters: Boolean,
     ): SMangaUpdate {
         val document = client.get(getMangaUrl(manga)).asJsoup()
-        val updatedChapters = document.extractNextJs<List<ChapterResponse>>().orEmpty().map { it.toSChapter() }.reversed()
+        val updatedChapters = document.extractNextJs<List<ChapterResponse>>()
+            .orEmpty()
+            .map { it.toSChapter(manga.url) }
+            .sortedByDescending { it.chapter_number }
 
         val authorLine = document.selectFirst("p.mt-2.text-sm.text-ink-dim")?.textOrNull()
         val state = document.selectFirst("dt:containsOwn(Status)")?.nextElementSibling()?.textOrNull()
@@ -122,13 +121,13 @@ abstract class SilentQuill : KeiSource() {
     }
 
     override suspend fun getPageList(chapter: SChapter): List<Page> {
-        val result = client.post("$apiUrl/lectura/", ViewerResponseBody(chapter.url.toInt()).toJsonRequestBody()).parseAs<ViewerResponse>()
-        return result.paginas.mapIndexed { index, url ->
-            Page(index, imageUrl = "$apiUrl/p/${url.pages}")
+        val result = client.get(getChapterUrl(chapter), rscHeaders).extractNextJs<ViewerResponse>()
+        return result?.pages.orEmpty().mapIndexed { index, url ->
+            Page(index, imageUrl = baseUrl + url.url)
         }
     }
 
     override fun getMangaUrl(manga: SManga): String = "$baseUrl/series/${manga.url}/"
 
-    override fun getChapterUrl(chapter: SChapter): String = "$baseUrl/${chapter.memo["slug"]!!.string}/"
+    override fun getChapterUrl(chapter: SChapter): String = "$baseUrl/series/${chapter.memo["mangaSlug"]!!.string}/${chapter.memo["slug"]!!.string}/"
 }


### PR DESCRIPTION
Closes #18923
api endpoint is gone

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
