### PR TITLE
Soul Scans: Fix search and latest updates

### DIFF
--- a/src/id/soulscans/build.gradle.kts
+++ b/src/id/soulscans/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Soul Scans"
-    versionCode = 0
+    versionCode = 1
     contentWarning = ContentWarning.SAFE
     libVersion = "1.6"
 

--- a/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/Dto.kt
+++ b/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/Dto.kt
@@ -58,6 +58,7 @@ class SeriesDetailDto(
         artist = artistName
         genre = genres.joinToString()
         status = comicStatus.parseStatus()
+        initialized = true
     }
 
     fun toSChapterList() = units.map { it.toSChapter(slug) }
@@ -79,7 +80,7 @@ class UnitDto(
 ) {
     fun toSChapter(seriesSlug: String) = SChapter.create().apply {
         url = "/comic/$seriesSlug/chapter/$slug"
-        name = "Chapter " + number.toFloatOrNull()?.toString()?.removeSuffix(".0")
+        name = "Chapter " + (number.toFloatOrNull()?.toString()?.removeSuffix(".0") ?: number)
         chapter_number = number.toFloatOrNull() ?: -1f
         date_upload = Instant.tryParse(createdAt)
     }

--- a/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/Dto.kt
+++ b/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/Dto.kt
@@ -97,3 +97,21 @@ class ChapterPagesDto(private val pages: List<PageDto>) {
 
 @Serializable
 class PageDto(@SerialName("image_url") val imageUrl: String)
+
+@Serializable
+class HomeSectionsDto(
+    @SerialName("latest_comic_updates") val latestComicUpdates: List<LatestComicUpdateDto> = emptyList(),
+)
+
+@Serializable
+class LatestComicUpdateDto(
+    @SerialName("series_title") private val seriesTitle: String,
+    @SerialName("series_slug") private val seriesSlug: String,
+    @SerialName("poster_image_url") private val posterImageUrl: String?,
+) {
+    fun toSManga() = SManga.create().apply {
+        title = seriesTitle
+        url = "/comic/$seriesSlug"
+        thumbnail_url = posterImageUrl
+    }
+}

--- a/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/SoulScans.kt
+++ b/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/SoulScans.kt
@@ -27,7 +27,29 @@ abstract class SoulScans : KeiSource() {
 
     override suspend fun getPopularManga(page: Int): MangasPage = getMangaList(searchUrl(page, sort = "popular"))
 
-    override suspend fun getLatestUpdates(page: Int): MangasPage = getMangaList(searchUrl(page, sort = "latest"))
+    private var latestCache: List<SManga> = emptyList()
+
+    override suspend fun getLatestUpdates(page: Int): MangasPage {
+        if (page == 1 || latestCache.isEmpty()) {
+            val response = client.get("$baseUrl/api/comic/home-sections?sections=latest_comic_updates&updateLimit=240")
+                .parseAs<HomeSectionsDto>()
+
+            latestCache = response.latestComicUpdates.map { it.toSManga() }
+        }
+
+        val itemsPerPage = 24
+        val startIndex = (page - 1) * itemsPerPage
+        val endIndex = minOf(startIndex + itemsPerPage, latestCache.size)
+
+        if (startIndex >= latestCache.size) {
+            return MangasPage(emptyList(), false)
+        }
+
+        return MangasPage(
+            latestCache.subList(startIndex, endIndex),
+            endIndex < latestCache.size,
+        )
+    }
 
     override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage = getMangaList(searchUrl(page, query, filters = filters))
 
@@ -38,22 +60,21 @@ abstract class SoulScans : KeiSource() {
             addQueryParameter("type", "COMIC")
             addQueryParameter("limit", "20")
             addQueryParameter("page", page.toString())
-            addQueryParameter("q", query)
+            if (query.isNotBlank()) addQueryParameter("q", query)
 
             filters?.forEach { filter ->
                 when (filter) {
-                    is SelectFilter.Status -> addQueryParameter("status", filter.selected)
-                    is SelectFilter.Genre -> addQueryParameter("genre", filter.selected)
-                    is SelectFilter.Type -> addQueryParameter("comic_type", filter.selected)
-                    is SelectFilter.Colored -> addQueryParameter("color_format", filter.selected)
-                    is SelectFilter.Format -> addQueryParameter("reading_format", filter.selected)
-                    is TextFilter.Author -> addQueryParameter("author", filter.state)
-                    is TextFilter.Artist -> addQueryParameter("artist", filter.state)
-                    is TextFilter.Publisher -> addQueryParameter("publisher", filter.state)
-                    is SelectFilter.Sort -> addQueryParameter("sort", filter.selected)
-                    is SelectFilter.Order -> addQueryParameter("order", filter.selected)
-                    else -> {
-                    }
+                    is SelectFilter.Status -> filter.selected.takeIf(String::isNotEmpty)?.let { addQueryParameter("status", it) }
+                    is SelectFilter.Genre -> filter.selected.takeIf(String::isNotEmpty)?.let { addQueryParameter("genre", it) }
+                    is SelectFilter.Type -> filter.selected.takeIf(String::isNotEmpty)?.let { addQueryParameter("comic_type", it) }
+                    is SelectFilter.Colored -> filter.selected.takeIf(String::isNotEmpty)?.let { addQueryParameter("color_format", it) }
+                    is SelectFilter.Format -> filter.selected.takeIf(String::isNotEmpty)?.let { addQueryParameter("reading_format", it) }
+                    is TextFilter.Author -> filter.state.takeIf(String::isNotBlank)?.let { addQueryParameter("author", it) }
+                    is TextFilter.Artist -> filter.state.takeIf(String::isNotBlank)?.let { addQueryParameter("artist", it) }
+                    is TextFilter.Publisher -> filter.state.takeIf(String::isNotBlank)?.let { addQueryParameter("publisher", it) }
+                    is SelectFilter.Sort -> filter.selected.takeIf(String::isNotEmpty)?.let { addQueryParameter("sort", it) }
+                    is SelectFilter.Order -> filter.selected.takeIf(String::isNotEmpty)?.let { addQueryParameter("order", it) }
+                    else -> {}
                 }
             }
             if (sort != null) setQueryParameter("sort", sort)
@@ -109,7 +130,7 @@ abstract class SoulScans : KeiSource() {
         )
 
         if (genres != null) {
-            filters += SelectFilter.Genre(genres)
+            filters += SelectFilter.Genre(listOf("All" to "") + genres)
         }
 
         filters += listOf(

--- a/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/SoulScans.kt
+++ b/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/SoulScans.kt
@@ -27,28 +27,13 @@ abstract class SoulScans : KeiSource() {
 
     override suspend fun getPopularManga(page: Int): MangasPage = getMangaList(searchUrl(page, sort = "popular"))
 
-    private var latestCache: List<SManga> = emptyList()
-
     override suspend fun getLatestUpdates(page: Int): MangasPage {
-        if (page == 1 || latestCache.isEmpty()) {
-            val response = client.get("$baseUrl/api/comic/home-sections?sections=latest_comic_updates&updateLimit=240")
-                .parseAs<HomeSectionsDto>()
+        if (page > 1) return MangasPage(emptyList(), false)
 
-            latestCache = response.latestComicUpdates.map { it.toSManga() }
-        }
+        val response = client.get("$baseUrl/api/comic/home-sections?sections=latest_comic_updates&updateLimit=240")
+            .parseAs<HomeSectionsDto>()
 
-        val itemsPerPage = 24
-        val startIndex = (page - 1) * itemsPerPage
-        val endIndex = minOf(startIndex + itemsPerPage, latestCache.size)
-
-        if (startIndex >= latestCache.size) {
-            return MangasPage(emptyList(), false)
-        }
-
-        return MangasPage(
-            latestCache.subList(startIndex, endIndex),
-            endIndex < latestCache.size,
-        )
+        return MangasPage(response.latestComicUpdates.map { it.toSManga() }, false)
     }
 
     override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage = getMangaList(searchUrl(page, query, filters = filters))
@@ -81,10 +66,11 @@ abstract class SoulScans : KeiSource() {
         }
         .build()
 
-    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? = runCatching {
+        if (url.host != baseUrl.toHttpUrl().host) return null
         val slug = url.pathSegments.lastOrNull { it.isNotBlank() } ?: return null
-        return fetchSeriesDetail(slug).toSManga()
-    }
+        fetchSeriesDetail(slug).toSManga()
+    }.getOrNull()
 
     override suspend fun fetchMangaUpdate(
         manga: SManga,

--- a/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/SoulScans.kt
+++ b/src/id/soulscans/src/eu/kanade/tachiyomi/extension/id/soulscans/SoulScans.kt
@@ -28,8 +28,6 @@ abstract class SoulScans : KeiSource() {
     override suspend fun getPopularManga(page: Int): MangasPage = getMangaList(searchUrl(page, sort = "popular"))
 
     override suspend fun getLatestUpdates(page: Int): MangasPage {
-        if (page > 1) return MangasPage(emptyList(), false)
-
         val response = client.get("$baseUrl/api/comic/home-sections?sections=latest_comic_updates&updateLimit=240")
             .parseAs<HomeSectionsDto>()
 


### PR DESCRIPTION
Fixes #18942

- Add "All" option to genre filter so searches do not default to filtering by the first genre
- Clean up query parameters in `searchUrl` so blank values are omitted
- Fix latest updates by fetching from the `home-sections` endpoint (`latest_comic_updates`) which reflects actual recent chapter releases
- Bump versionCode to 1
- Tested with gradlew + device (Komikku).

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

🤖 This PR was created by an AI agent (Antigravity). The agent was tasked with fixing search failing to return results (#18942) and fixing the Latest tab not matching the website's latest releases for Soul Scans.