### PR TITLE
KuraManga: Fix search, popular, and migrate to 1.6

### DIFF
--- a/src/en/kuramanga/build.gradle.kts
+++ b/src/en/kuramanga/build.gradle.kts
@@ -6,12 +6,16 @@ plugins {
 
 keiyoushi {
     name = "KuraManga"
-    versionCode = 2
+    versionCode = 3
     contentWarning = ContentWarning.MIXED
-    libVersion = "1.4"
+    libVersion = "1.6"
 
     source {
         lang = "en"
         baseUrl = "https://kuramanga.com"
+    }
+
+    deeplink {
+        path("/..*")
     }
 }

--- a/src/en/kuramanga/src/eu/kanade/tachiyomi/extension/en/kuramanga/Dto.kt
+++ b/src/en/kuramanga/src/eu/kanade/tachiyomi/extension/en/kuramanga/Dto.kt
@@ -6,19 +6,20 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 class SearchResponse(
-    val data: List<MangaDto>,
-    val total: Int,
+    val data: List<MangaDto> = emptyList(),
+    val total: Int = 0,
 )
 
 @Serializable
 class MangaDto(
     private val title: String,
+    private val thumb: String? = null,
     @SerialName("cover_image_url") private val coverImageUrl: String? = null,
     @SerialName("normalized_title") private val normalizedTitle: String,
 ) {
     fun toSManga() = SManga.create().apply {
         this.title = this@MangaDto.title
         this.url = "/${this@MangaDto.normalizedTitle}"
-        this.thumbnail_url = this@MangaDto.coverImageUrl
+        this.thumbnail_url = this@MangaDto.thumb ?: this@MangaDto.coverImageUrl
     }
 }

--- a/src/en/kuramanga/src/eu/kanade/tachiyomi/extension/en/kuramanga/Filters.kt
+++ b/src/en/kuramanga/src/eu/kanade/tachiyomi/extension/en/kuramanga/Filters.kt
@@ -12,8 +12,28 @@ class Genre(name: String) : Filter.CheckBox(name)
 
 class AdultFilter(name: String) : Filter.CheckBox(name, true)
 
-internal val statusList = arrayOf("All", "Ongoing", "Completed", "On_hold", "Upcoming")
+internal val statusList = arrayOf("All", "Ongoing", "Completed", "Hiatus", "On Hold", "Canceled")
 
 internal val genreNames = listOf(
-    "Action", "Adaptation", "Adult", "Adventure", "BL", "Borderline H", "College life", "Comedy", "Crime", "Drama", "Ecchi", "Explicit Sex", "Fantasy", "GL", "Gender Bender", "Harem", "Historical", "Horror", "Isekai", "Josei", "Loli", "Magic", "Magical", "Manhua", "Manhwa", "Martial Arts", "Mature", "Mystery", "Office Workers", "Psychological", "Reincarnation", "Revenge", "Romance", "School Life", "Sci-Fi", "Seinen", "Shoujo", "Shounen", "Slice of Life", "Smut", "Sport", "Supernatural", "Survival", "Thriller", "Time travel", "Tragedy", "Uncensored", "Vampire", "Violence", "Webtoons", "Yuri",
+    "+100 Chapter", "Ability", "Academy", "Acting", "Action", "Adaptation", "Adult", "Adventure", "Ai", "Aliens",
+    "Animals", "Anthology", "Apocalypse", "Award Winning", "Battleofintellect", "BDSM", "BL", "Borderline H",
+    "Boys Love", "Bullying", "Campus", "Cheating/infidelity", "Cohabitation", "College", "College life", "Comedy",
+    "Comic", "Cooking", "Crazy MC", "Crime", "Crossdressing", "Cultivation", "Curse", "Dark Fantasy", "Darkfantasy",
+    "Delinquents", "Demon", "Demons", "Difference in Status", "Doujinshi", "Drama", "Dungeons", "Ecchi", "Elementals",
+    "Elf", "Explicit Sex", "Family", "Fantasia", "Fantasy", "Fight", "Folklore", "Friday Webtoons", "Full Color",
+    "Game", "Gamelit", "Gang", "Gender Bender", "Genderswap", "Genius", "Genius MC", "Ghosts", "Girls Love", "GL",
+    "Gore", "Growth", "Guideverse", "Hardcore", "Harem", "Hentai", "Hidden", "Historical", "Horror", "Humiliation",
+    "Hunter", "Hunters", "Hypnosis", "Idols", "Illusion", "Incest", "Isekai", "Josei", "Legendary", "Live",
+    "Long Strip", "Love Triangle", "Mafia", "Magic", "Magical", "Manhua", "Manhwa", "Married Woman", "Martial Arts",
+    "Mature", "Mecha", "Medical", "Milf", "Military", "Modernfantasy", "Money", "Monster Girls", "Monsters", "Mother",
+    "Mother and Daughter", "Murim", "Music", "Mystery", "Myth", "Necromancer", "Netori", "Nonhumanbeings",
+    "Novel Adaptation", "Ntl", "NTR", "Office", "Office Workers", "Omegaverse", "One shot", "Original Novel",
+    "Overpowered", "Overpoweredmc", "Philosophical", "Politics", "Post-Apocalyptic", "Psychological", "Raw", "Reborn",
+    "Regression", "Reincarnation", "Returner", "Revenge", "Reverse Harem", "Robots", "Romance", "Royal family",
+    "School", "School Life", "Schoollife", "Sci-Fi", "Seinen", "Serial", "Short Story", "Shoujo", "Shounen",
+    "Shounen Ai", "Showbiz", "Sisters", "Slice of Life", "Sm", "Smut", "Sport", "Sports", "Stepmother", "Superhero",
+    "Supernatural", "Superpower", "Survival", "Swapping", "Swordsman", "System", "Teacher", "Threesome", "Thriller",
+    "Time Travel", "Tower", "Traditional Games", "Tragedy", "Training", "Transmigration", "Uncensored", "Urban",
+    "Vampires", "Video Games", "Villain", "Villainess", "Violence", "Virtual Reality", "Visualshock", "Web Comic",
+    "Webtoon", "Webtoons", "Wholesome", "Workplace", "Wuxia", "Xuanhuan", "Yaoi", "Yuri", "Zombies",
 )

--- a/src/en/kuramanga/src/eu/kanade/tachiyomi/extension/en/kuramanga/KuraManga.kt
+++ b/src/en/kuramanga/src/eu/kanade/tachiyomi/extension/en/kuramanga/KuraManga.kt
@@ -22,19 +22,15 @@ import java.util.Locale
 @Source
 abstract class KuraManga : KeiSource() {
 
-    private val baseUrlHost by lazy { baseUrl.toHttpUrl().host }
-
     // ============================== Popular ===============================
     override suspend fun getPopularManga(page: Int): MangasPage {
-        if (page > 1) return MangasPage(emptyList(), false)
-
         val document = client.get(baseUrl).asJsoup()
         val mangas = document.select("section:has(h2:contains(Popular)) a.sp-card").mapNotNull { element ->
             val titleEl = element.selectFirst(".sp-cap h3") ?: return@mapNotNull null
             SManga.create().apply {
-                this.title = titleEl.text()
-                this.url = "/" + element.attr("href").removePrefix("/")
-                this.thumbnail_url = element.selectFirst("img")?.attr("abs:src")
+                title = titleEl.text()
+                url = "/" + element.attr("href").removePrefix("/")
+                thumbnail_url = element.selectFirst("img")?.attr("abs:src")
             }
         }
         return MangasPage(mangas, false)
@@ -47,9 +43,9 @@ abstract class KuraManga : KeiSource() {
         val mangas = document.select(".update-list .update-row").mapNotNull { element ->
             val link = element.selectFirst("a.update-series-link") ?: return@mapNotNull null
             SManga.create().apply {
-                this.title = link.text()
-                this.url = "/" + link.attr("href").removePrefix("/")
-                this.thumbnail_url = element.selectFirst("img")?.attr("abs:src")
+                title = link.text()
+                url = "/" + link.attr("href").removePrefix("/")
+                thumbnail_url = element.selectFirst("img")?.attr("abs:src")
             }
         }.distinctBy { it.url }
 
@@ -58,9 +54,7 @@ abstract class KuraManga : KeiSource() {
     }
 
     // =============================== Search ===============================
-    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage = search(page, query, filters)
-
-    private suspend fun search(page: Int, query: String = "", filters: FilterList = FilterList()): MangasPage {
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
         val url = "$baseUrl/search".toHttpUrl().newBuilder().apply {
             addQueryParameter("ajax", "1")
             addQueryParameter("page", page.toString())
@@ -104,15 +98,15 @@ abstract class KuraManga : KeiSource() {
     }
 
     // =========================== Manga Details ============================
-    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
-        if (url.host != baseUrlHost) return null
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? = runCatching {
+        if (url.host != baseUrl.toHttpUrl().host) return null
         val slug = url.pathSegments.firstOrNull { it.isNotBlank() } ?: return null
         if (slug in setOf("search", "assets", "api", "login", "register")) return null
         val document = client.get("$baseUrl/$slug").asJsoup()
-        return mangaDetailsParse(document).apply {
+        mangaDetailsParse(document).apply {
             this.url = "/$slug"
         }
-    }
+    }.getOrNull()
 
     override suspend fun fetchMangaUpdate(
         manga: SManga,
@@ -120,16 +114,13 @@ abstract class KuraManga : KeiSource() {
         fetchDetails: Boolean,
         fetchChapters: Boolean,
     ): SMangaUpdate {
-        val document = client.get("$baseUrl${manga.url}").asJsoup()
-        val updatedManga = if (fetchDetails) {
-            mangaDetailsParse(document).apply {
-                this.url = manga.url
-            }
-        } else {
-            manga
-        }
-        val updatedChapters = if (fetchChapters) chapterListParse(document) else chapters
-        return SMangaUpdate(updatedManga, updatedChapters)
+        val document = client.get(getMangaUrl(manga)).asJsoup()
+        return SMangaUpdate(
+            manga = mangaDetailsParse(document).apply {
+                url = manga.url
+            },
+            chapters = chapterListParse(document),
+        )
     }
 
     private fun mangaDetailsParse(document: Document): SManga = SManga.create().apply {
@@ -152,6 +143,7 @@ abstract class KuraManga : KeiSource() {
                 ?: document.selectFirst(".meta-grid div:contains(Status:)")?.text()?.substringAfter("Status:")
             )?.trim()?.lowercase().parseStatus()
         thumbnail_url = document.selectFirst("meta[property='og:image']")?.attr("content")
+        initialized = true
     }
 
     private fun String?.parseStatus(): Int = when (this) {
@@ -167,16 +159,16 @@ abstract class KuraManga : KeiSource() {
         return document.select(".chapter-list .chapter-item").mapNotNull { element ->
             val link = element.selectFirst("a") ?: return@mapNotNull null
             SChapter.create().apply {
-                this.name = link.text()
-                this.url = "/" + link.attr("href").removePrefix("/")
-                this.date_upload = dateFormat.tryParseDate(element.selectFirst("time")?.text())
+                name = link.text()
+                url = "/" + link.attr("href").removePrefix("/")
+                date_upload = dateFormat.tryParseDate(element.selectFirst("time")?.text())
             }
         }
     }
 
     // =============================== Pages ================================
     override suspend fun getPageList(chapter: SChapter): List<Page> {
-        val document = client.get("$baseUrl${chapter.url}").asJsoup()
+        val document = client.get(getChapterUrl(chapter)).asJsoup()
         return document.select("#chapterImages img").mapIndexed { index, img ->
             val imageUrl = img.attr("abs:data-src").ifEmpty { img.attr("abs:src") }
             Page(index, imageUrl = imageUrl)

--- a/src/en/kuramanga/src/eu/kanade/tachiyomi/extension/en/kuramanga/KuraManga.kt
+++ b/src/en/kuramanga/src/eu/kanade/tachiyomi/extension/en/kuramanga/KuraManga.kt
@@ -1,83 +1,72 @@
 package eu.kanade.tachiyomi.extension.en.kuramanga
 
-import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import keiyoushi.annotation.Source
+import keiyoushi.network.get
+import keiyoushi.source.KeiSource
 import keiyoushi.utils.asJsoup
 import keiyoushi.utils.parseAs
-import keiyoushi.utils.tryParse
-import okhttp3.Headers
+import keiyoushi.utils.tryParseDate
+import kotlinx.serialization.json.JsonElement
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.Request
-import okhttp3.Response
-import java.text.SimpleDateFormat
+import org.jsoup.nodes.Document
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 @Source
-abstract class KuraManga : HttpSource() {
+abstract class KuraManga : KeiSource() {
 
-    override val supportsLatest = true
-
-    override fun headersBuilder(): Headers.Builder = super.headersBuilder()
-        .add("Referer", "$baseUrl/")
+    private val baseUrlHost by lazy { baseUrl.toHttpUrl().host }
 
     // ============================== Popular ===============================
-    override fun popularMangaRequest(page: Int): Request = if (page == 1) {
-        GET(baseUrl, headers)
-    } else {
-        val url = "$baseUrl/search".toHttpUrl().newBuilder()
-            .addQueryParameter("ajax", "1")
-            .addQueryParameter("offset", ((page - 1) * PAGE_SIZE).toString())
-            .build()
-        GET(url, headers)
-    }
+    override suspend fun getPopularManga(page: Int): MangasPage {
+        if (page > 1) return MangasPage(emptyList(), false)
 
-    override fun popularMangaParse(response: Response): MangasPage {
-        if (response.request.url.queryParameter("ajax") == "1") {
-            return searchMangaParse(response)
-        }
-
-        val document = response.asJsoup()
-        val mangas = document.select(".popular-glide .manga-card").mapNotNull { element ->
-            val titleEl = element.selectFirst(".manga-title") ?: return@mapNotNull null
+        val document = client.get(baseUrl).asJsoup()
+        val mangas = document.select("section:has(h2:contains(Popular)) a.sp-card").mapNotNull { element ->
+            val titleEl = element.selectFirst(".sp-cap h3") ?: return@mapNotNull null
             SManga.create().apply {
-                title = titleEl.text()
-                url = "/" + element.attr("href").removePrefix("/")
-                thumbnail_url = element.selectFirst("img.manga-thumb")?.attr("abs:src")
+                this.title = titleEl.text()
+                this.url = "/" + element.attr("href").removePrefix("/")
+                this.thumbnail_url = element.selectFirst("img")?.attr("abs:src")
             }
         }
-        return MangasPage(mangas, true)
-    }
-
-    // =============================== Latest ===============================
-    override fun latestUpdatesRequest(page: Int): Request = GET(baseUrl, headers)
-
-    override fun latestUpdatesParse(response: Response): MangasPage {
-        val document = response.asJsoup()
-        val mangas = document.select(".update-list .update-row").mapNotNull { element ->
-            val link = element.selectFirst("a.update-series-link") ?: return@mapNotNull null
-            SManga.create().apply {
-                title = link.text()
-                url = "/" + link.attr("href").removePrefix("/")
-                thumbnail_url = element.selectFirst("img")?.attr("abs:src")
-            }
-        }.distinctBy { it.url }
         return MangasPage(mangas, false)
     }
 
+    // =============================== Latest ===============================
+    override suspend fun getLatestUpdates(page: Int): MangasPage {
+        val pageUrl = if (page > 1) "$baseUrl/?page=$page" else "$baseUrl/"
+        val document = client.get(pageUrl).asJsoup()
+        val mangas = document.select(".update-list .update-row").mapNotNull { element ->
+            val link = element.selectFirst("a.update-series-link") ?: return@mapNotNull null
+            SManga.create().apply {
+                this.title = link.text()
+                this.url = "/" + link.attr("href").removePrefix("/")
+                this.thumbnail_url = element.selectFirst("img")?.attr("abs:src")
+            }
+        }.distinctBy { it.url }
+
+        val hasNextPage = document.selectFirst("a[data-lu-next]:not(.is-disabled)") != null
+        return MangasPage(mangas, hasNextPage)
+    }
+
     // =============================== Search ===============================
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage = search(page, query, filters)
+
+    private suspend fun search(page: Int, query: String = "", filters: FilterList = FilterList()): MangasPage {
         val url = "$baseUrl/search".toHttpUrl().newBuilder().apply {
             addQueryParameter("ajax", "1")
-            if (query.isNotEmpty()) {
+            addQueryParameter("page", page.toString())
+            if (query.isNotBlank()) {
                 addQueryParameter("name", query)
             }
-            addQueryParameter("offset", ((page - 1) * PAGE_SIZE).toString())
 
             filters.forEach { filter ->
                 when (filter) {
@@ -91,7 +80,7 @@ abstract class KuraManga : HttpSource() {
                     }
                     is StatusFilter -> {
                         if (filter.state != 0) {
-                            addQueryParameter("status", filter.vals[filter.state].lowercase())
+                            addQueryParameter("status", filter.vals[filter.state].replace(" ", "_").lowercase())
                         }
                     }
                     is AdultFilter -> {
@@ -104,72 +93,107 @@ abstract class KuraManga : HttpSource() {
             }
         }.build()
 
-        return GET(url, headers)
-    }
+        val searchHeaders = headers.newBuilder()
+            .add("X-Requested-With", "XMLHttpRequest")
+            .build()
+        val response = client.get(url, searchHeaders).parseAs<SearchResponse>()
 
-    override fun searchMangaParse(response: Response): MangasPage {
-        val searchResponse = response.parseAs<SearchResponse>()
-        val mangas = searchResponse.data.map { it.toSManga() }
-        val offset = response.request.url.queryParameter("offset")?.toInt() ?: 0
-        val hasNextPage = (searchResponse.data.size == PAGE_SIZE) && (offset + searchResponse.data.size < searchResponse.total)
+        val mangas = response.data.map { it.toSManga() }
+        val hasNextPage = response.data.size == PAGE_SIZE && (response.total == 0 || page * PAGE_SIZE < response.total)
         return MangasPage(mangas, hasNextPage)
     }
 
     // =========================== Manga Details ============================
-    override fun mangaDetailsParse(response: Response): SManga {
-        val document = response.asJsoup()
-        return SManga.create().apply {
-            title = document.selectFirst("h1.manga-title")!!.text()
-            description = document.selectFirst(".summary-inner")?.text()
-            author = document.selectFirst(".meta-grid div:contains(Author:)")?.text()?.substringAfter("Author:")?.trim()
-            artist = document.selectFirst(".meta-grid div:contains(Artist:)")?.text()?.substringAfter("Artist:")?.trim()
-            genre = document.select(".genre-list a.genre-chip").joinToString { it.text() }
-            status = document.selectFirst(".meta-grid div:contains(Status:)")?.text()?.substringAfter("Status:")?.trim()?.lowercase().parseStatus()
-            thumbnail_url = document.selectFirst("meta[property='og:image']")?.attr("content")
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+        if (url.host != baseUrlHost) return null
+        val slug = url.pathSegments.firstOrNull { it.isNotBlank() } ?: return null
+        if (slug in setOf("search", "assets", "api", "login", "register")) return null
+        val document = client.get("$baseUrl/$slug").asJsoup()
+        return mangaDetailsParse(document).apply {
+            this.url = "/$slug"
         }
+    }
+
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        val document = client.get("$baseUrl${manga.url}").asJsoup()
+        val updatedManga = if (fetchDetails) {
+            mangaDetailsParse(document).apply {
+                this.url = manga.url
+            }
+        } else {
+            manga
+        }
+        val updatedChapters = if (fetchChapters) chapterListParse(document) else chapters
+        return SMangaUpdate(updatedManga, updatedChapters)
+    }
+
+    private fun mangaDetailsParse(document: Document): SManga = SManga.create().apply {
+        title = document.selectFirst("h1.manga-title")!!.text()
+        description = document.selectFirst(".summary-inner")?.text()
+            ?: document.selectFirst(".mp-synopsis")?.text()
+        val storyAndArt = document.selectFirst(".mp-cred:has(.mp-cred-k:contains(Story & Art)) .mp-cred-v")?.text()
+            ?: document.selectFirst(".mp-cred:has(.mp-cred-k:contains(Author & Artist)) .mp-cred-v")?.text()
+        author = document.selectFirst(".mp-cred:has(.mp-cred-k:contains(Author)) .mp-cred-v")?.text()
+            ?: document.selectFirst(".mp-cred:has(.mp-cred-k:contains(Story)) .mp-cred-v")?.text()
+            ?: storyAndArt
+            ?: document.selectFirst(".meta-grid div:contains(Author:)")?.text()?.substringAfter("Author:")?.trim()
+        artist = document.selectFirst(".mp-cred:has(.mp-cred-k:contains(Artist)) .mp-cred-v")?.text()
+            ?: document.selectFirst(".mp-cred:has(.mp-cred-k:contains(Art)) .mp-cred-v")?.text()
+            ?: storyAndArt
+            ?: document.selectFirst(".meta-grid div:contains(Artist:)")?.text()?.substringAfter("Artist:")?.trim()
+        genre = document.select(".genre-list a.genre-chip").joinToString { it.text() }
+        status = (
+            document.selectFirst(".mp-status")?.text()
+                ?: document.selectFirst(".meta-grid div:contains(Status:)")?.text()?.substringAfter("Status:")
+            )?.trim()?.lowercase().parseStatus()
+        thumbnail_url = document.selectFirst("meta[property='og:image']")?.attr("content")
     }
 
     private fun String?.parseStatus(): Int = when (this) {
         "ongoing", "upcoming" -> SManga.ONGOING
         "completed" -> SManga.COMPLETED
-        "on_hold", "on hold" -> SManga.ON_HIATUS
+        "on_hold", "on hold", "hiatus" -> SManga.ON_HIATUS
+        "canceled", "cancelled" -> SManga.CANCELLED
         else -> SManga.UNKNOWN
     }
 
     // ============================== Chapters ==============================
-    override fun chapterListParse(response: Response): List<SChapter> {
-        val document = response.asJsoup()
+    private fun chapterListParse(document: Document): List<SChapter> {
         return document.select(".chapter-list .chapter-item").mapNotNull { element ->
             val link = element.selectFirst("a") ?: return@mapNotNull null
             SChapter.create().apply {
-                name = link.text()
-                url = "/" + link.attr("href").removePrefix("/")
-                date_upload = dateFormat.tryParse(element.selectFirst("time")?.text())
+                this.name = link.text()
+                this.url = "/" + link.attr("href").removePrefix("/")
+                this.date_upload = dateFormat.tryParseDate(element.selectFirst("time")?.text())
             }
         }
     }
 
     // =============================== Pages ================================
-    override fun pageListParse(response: Response): List<Page> {
-        val document = response.asJsoup()
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        val document = client.get("$baseUrl${chapter.url}").asJsoup()
         return document.select("#chapterImages img").mapIndexed { index, img ->
-            Page(index, imageUrl = img.attr("abs:src"))
+            val imageUrl = img.attr("abs:data-src").ifEmpty { img.attr("abs:src") }
+            Page(index, imageUrl = imageUrl)
         }
     }
 
-    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
-
     // ============================== Filters ===============================
-    override fun getFilterList(): FilterList = FilterList(
+    override fun getFilterList(data: JsonElement?): FilterList = FilterList(
         StatusFilter("Status", statusList),
         AdultFilter("Include Adult Content"),
         GenreFilter("Genres", genreNames.map { Genre(it) }),
     )
 
     // ============================== Private ===============================
-    private val dateFormat = SimpleDateFormat("MMM d, yyyy", Locale.ENGLISH)
+    private val dateFormat = DateTimeFormatter.ofPattern("MMM d, yyyy", Locale.ENGLISH)
 
     companion object {
-        private const val PAGE_SIZE = 10
+        private const val PAGE_SIZE = 18
     }
 }


### PR DESCRIPTION
Fixes #18817

- Migrate to `KeiSource` (`libVersion = "1.6"`)
- Fix search query parameters (`page` instead of `offset`, `PAGE_SIZE = 18`, and `X-Requested-With` header)
- Fix popular manga parsing for homepage carousel/spotlight
- Fix latest updates pagination
- Update status and genre filter lists to match current website
- Add deeplink configuration in `build.gradle.kts`
- Bump `versionCode` to 3
- Tested with gradlew + device (Komikku).

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

🤖 This PR was created by an AI agent (Antigravity). The agent was tasked with fixing search and popular manga failing due to website/API changes (#18817) and migrating KuraManga to KeiSource.