### PR TITLE
LustToon: Fix no pages, latest updates & migrate to 1.6

### DIFF
--- a/src/en/lusttoon/build.gradle.kts
+++ b/src/en/lusttoon/build.gradle.kts
@@ -6,12 +6,16 @@ plugins {
 
 keiyoushi {
     name = "LustToon"
-    versionCode = 1
+    versionCode = 2
     contentWarning = ContentWarning.MIXED
-    libVersion = "1.4"
+    libVersion = "1.6"
 
     source {
         lang = "en"
         baseUrl = "https://lustoon.com"
+    }
+
+    deeplink {
+        path("/comic/..*")
     }
 }

--- a/src/en/lusttoon/src/eu/kanade/tachiyomi/extension/en/lusttoon/Dto.kt
+++ b/src/en/lusttoon/src/eu/kanade/tachiyomi/extension/en/lusttoon/Dto.kt
@@ -2,8 +2,11 @@ package eu.kanade.tachiyomi.extension.en.lusttoon
 
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
+import keiyoushi.utils.parseAs
+import keiyoushi.utils.tryParse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.time.Instant
 
 @Serializable
 class SearchResponseDto(
@@ -74,7 +77,7 @@ class ChapterDto(
     val slug: String? = null,
     private val num: Float? = null,
     private val name: String? = null,
-    val createdAt: String? = null,
+    private val createdAt: String? = null,
 ) {
     fun toSChapter(mangaSlug: String) = SChapter.create().apply {
         url = "/comic/$mangaSlug/$slug"
@@ -85,9 +88,25 @@ class ChapterDto(
             "Chapter ${num?.toString()?.removeSuffix(".0") ?: ""}".trim()
         }
         chapter_number = num ?: -1f
+        date_upload = Instant.tryParse(createdAt)
     }
 
     companion object {
         private val digitRegex = Regex("""\d""")
     }
+}
+
+@Serializable
+class PagechesDto(
+    private val urlImg: String? = null,
+) {
+    val images: List<String>
+        get() = runCatching { urlImg?.parseAs<List<String>>() }.getOrNull() ?: emptyList()
+}
+
+@Serializable
+class HomeDto(
+    private val comics: List<SearchItemDto>? = null,
+) {
+    val mangas get() = comics?.filter { it.slug != null }?.map { it.toSManga() } ?: emptyList()
 }

--- a/src/en/lusttoon/src/eu/kanade/tachiyomi/extension/en/lusttoon/Dto.kt
+++ b/src/en/lusttoon/src/eu/kanade/tachiyomi/extension/en/lusttoon/Dto.kt
@@ -59,6 +59,7 @@ class SerieDto(
             else -> SManga.UNKNOWN
         }
         genre = genders?.joinToString { it.name }?.takeIf { it.isNotBlank() }
+        initialized = true
     }
 }
 

--- a/src/en/lusttoon/src/eu/kanade/tachiyomi/extension/en/lusttoon/LustToon.kt
+++ b/src/en/lusttoon/src/eu/kanade/tachiyomi/extension/en/lusttoon/LustToon.kt
@@ -26,8 +26,6 @@ abstract class LustToon : KeiSource() {
 
     private val apiUrl = "https://back.lustoon.com"
 
-    private val baseUrlHost by lazy { baseUrl.toHttpUrl().host }
-
     override fun OkHttpClient.Builder.configureClient(): OkHttpClient.Builder = apply {
         addInterceptor { chain ->
             val request = chain.request()
@@ -119,16 +117,16 @@ abstract class LustToon : KeiSource() {
 
     // =========================== Manga Details ============================
 
-    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
-        if (url.host != baseUrlHost) return null
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? = runCatching {
+        if (url.host != baseUrl.toHttpUrl().host) return null
         val slug = url.pathSegments.getOrNull(1) ?: return null
         if (url.pathSegments.firstOrNull() != "comic" || slug.isBlank()) return null
 
         val manga = SManga.create().apply {
             this.url = "/comic/$slug"
         }
-        return getMangaUpdate(manga, emptyList(), fetchDetails = true, fetchChapters = false).manga
-    }
+        getMangaUpdate(manga, emptyList(), fetchDetails = true, fetchChapters = false).manga
+    }.getOrNull()
 
     override suspend fun fetchMangaUpdate(
         manga: SManga,
@@ -139,45 +137,40 @@ abstract class LustToon : KeiSource() {
         val rscHeaders = headers.newBuilder()
             .add("RSC", "1")
             .build()
-        val response = client.get("$baseUrl${manga.url}", rscHeaders)
+        val response = client.get(getMangaUrl(manga), rscHeaders)
         val serie = response.extractNextJs<SerieDto> { element ->
             element is JsonObject && "slug" in element && "chapters" in element
         } ?: throw Exception("Failed to find valid series data")
 
         val mangaSlug = serie.slug ?: manga.url.substringAfterLast("/")
 
-        val updatedManga = if (fetchDetails) serie.toSManga() else manga
-        val updatedChapters = if (fetchChapters) {
-            serie.chapters?.filter { it.slug != null }?.map { it.toSChapter(mangaSlug) } ?: emptyList()
-        } else {
-            chapters
-        }
-
-        return SMangaUpdate(updatedManga, updatedChapters)
+        return SMangaUpdate(
+            manga = serie.toSManga(),
+            chapters = serie.chapters?.filter { it.slug != null }?.map { it.toSChapter(mangaSlug) } ?: emptyList(),
+        )
     }
 
     // =============================== Pages ===============================
 
     override suspend fun getPageList(chapter: SChapter): List<Page> {
-        val response = client.get(baseUrl + chapter.url)
+        val response = client.get(getChapterUrl(chapter))
         val document = response.asJsoup()
         val pageches = document.extractNextJs<PagechesDto> { element ->
             element is JsonObject && "urlImg" in element && "chapterId" in element
         }
 
-        val images = pageches?.images?.ifEmpty { null } ?: run {
-            imageUrlRegex.findAll(document.html())
+        val images = pageches?.images?.ifEmpty { null }
+            ?: imageUrlRegex.findAll(document.html())
                 .map { it.value }
                 .filter { it.contains("/serie/") }
-                .distinct()
                 .toList()
-                .ifEmpty { null }
-        } ?: throw Exception("No pages found")
 
         return images
+            .map { it.replace("http://", "https://") }
+            .distinct()
             .filterNot { it.contains("brakeout") }
             .mapIndexed { i, url ->
-                Page(i, imageUrl = url.replace("http://", "https://"))
+                Page(i, imageUrl = url)
             }
     }
 

--- a/src/en/lusttoon/src/eu/kanade/tachiyomi/extension/en/lusttoon/LustToon.kt
+++ b/src/en/lusttoon/src/eu/kanade/tachiyomi/extension/en/lusttoon/LustToon.kt
@@ -1,40 +1,35 @@
 package eu.kanade.tachiyomi.extension.en.lusttoon
 
-import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import keiyoushi.annotation.Source
+import keiyoushi.network.get
+import keiyoushi.source.KeiSource
 import keiyoushi.utils.asJsoup
 import keiyoushi.utils.extractNextJs
 import keiyoushi.utils.firstInstanceOrNull
 import keiyoushi.utils.parseAs
-import keiyoushi.utils.tryParse
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.Request
-import okhttp3.Response
-import java.text.SimpleDateFormat
-import java.util.Locale
-import java.util.TimeZone
-
-private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS", Locale.ROOT).apply {
-    timeZone = TimeZone.getTimeZone("UTC")
-}
+import okhttp3.OkHttpClient
 
 @Source
-abstract class LustToon : HttpSource() {
+abstract class LustToon : KeiSource() {
 
     private val apiUrl = "https://back.lustoon.com"
 
-    override val supportsLatest = true
+    private val baseUrlHost by lazy { baseUrl.toHttpUrl().host }
 
-    override val client = network.client.newBuilder()
-        .addInterceptor { chain ->
+    override fun OkHttpClient.Builder.configureClient(): OkHttpClient.Builder = apply {
+        addInterceptor { chain ->
             val request = chain.request()
             if (request.url.scheme == "http") {
                 val newUrl = request.url.newBuilder().scheme("https").build()
@@ -43,15 +38,11 @@ abstract class LustToon : HttpSource() {
                 chain.proceed(request)
             }
         }
-        .build()
-
-    override fun headersBuilder() = super.headersBuilder()
-        .add("Referer", "$baseUrl/")
-        .add("Origin", baseUrl)
+    }
 
     // ============================== Popular ==============================
 
-    override fun popularMangaRequest(page: Int): Request {
+    override suspend fun getPopularManga(page: Int): MangasPage {
         val url = "$apiUrl/filtrar".toHttpUrl().newBuilder()
             .addQueryParameter("page", page.toString())
             .addQueryParameter("limit", "24")
@@ -63,19 +54,28 @@ abstract class LustToon : HttpSource() {
             .addQueryParameter("loading", "true")
             .build()
 
-        return GET(url, headers)
-    }
-
-    override fun popularMangaParse(response: Response): MangasPage {
-        val resp = response.parseAs<SearchResponseDto>()
+        val resp = client.get(url).parseAs<SearchResponseDto>()
         return MangasPage(resp.mangas, resp.hasNext)
     }
 
     // ============================== Latest ===============================
 
-    override fun latestUpdatesRequest(page: Int): Request {
+    override suspend fun getLatestUpdates(page: Int): MangasPage {
+        if (page == 1) {
+            val rscHeaders = headers.newBuilder()
+                .add("RSC", "1")
+                .build()
+            val response = client.get(baseUrl, rscHeaders)
+            val home = response.extractNextJs<HomeDto> { element ->
+                element is JsonObject && "comics" in element && element["comics"] is JsonArray
+            }
+            if (home != null && home.mangas.isNotEmpty()) {
+                return MangasPage(home.mangas, true)
+            }
+        }
+
         val url = "$apiUrl/filtrar".toHttpUrl().newBuilder()
-            .addQueryParameter("page", page.toString())
+            .addQueryParameter("page", (page - 1).toString())
             .addQueryParameter("limit", "24")
             .addQueryParameter("orderBy", "3")
             .addQueryParameter("sort", "desc")
@@ -85,19 +85,19 @@ abstract class LustToon : HttpSource() {
             .addQueryParameter("loading", "true")
             .build()
 
-        return GET(url, headers)
+        val resp = client.get(url).parseAs<SearchResponseDto>()
+        return MangasPage(resp.mangas, resp.hasNext)
     }
-
-    override fun latestUpdatesParse(response: Response) = popularMangaParse(response)
 
     // ============================== Search ===============================
 
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
         if (query.isNotBlank()) {
             val url = "$apiUrl/home/buscar".toHttpUrl().newBuilder()
                 .addQueryParameter("query", query)
                 .build()
-            return GET(url, headers)
+            val items = client.get(url).parseAs<List<SearchItemDto>>()
+            return MangasPage(items.filter { it.slug != null }.map { it.toSManga() }, false)
         }
 
         val sortFilter = filters.firstInstanceOrNull<SortFilter>()
@@ -113,69 +113,81 @@ abstract class LustToon : HttpSource() {
             .addQueryParameter("state", filters.firstInstanceOrNull<StatusFilter>()?.selected ?: "")
             .build()
 
-        return GET(url, headers)
+        val resp = client.get(url).parseAs<SearchResponseDto>()
+        return MangasPage(resp.mangas, resp.hasNext)
     }
 
-    override fun searchMangaParse(response: Response): MangasPage {
-        val url = response.request.url.toString()
-        if (url.contains("/home/buscar")) {
-            val items = response.parseAs<List<SearchItemDto>>()
-            return MangasPage(items.filter { it.slug != null }.map { it.toSManga() }, false)
+    // =========================== Manga Details ============================
+
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+        if (url.host != baseUrlHost) return null
+        val slug = url.pathSegments.getOrNull(1) ?: return null
+        if (url.pathSegments.firstOrNull() != "comic" || slug.isBlank()) return null
+
+        val manga = SManga.create().apply {
+            this.url = "/comic/$slug"
         }
-
-        return popularMangaParse(response)
+        return getMangaUpdate(manga, emptyList(), fetchDetails = true, fetchChapters = false).manga
     }
 
-    // ============================== Details ==============================
-
-    override fun mangaDetailsRequest(manga: SManga): Request = GET(baseUrl + manga.url, headersBuilder().add("RSC", "1").build())
-
-    override fun mangaDetailsParse(response: Response): SManga {
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        val rscHeaders = headers.newBuilder()
+            .add("RSC", "1")
+            .build()
+        val response = client.get("$baseUrl${manga.url}", rscHeaders)
         val serie = response.extractNextJs<SerieDto> { element ->
             element is JsonObject && "slug" in element && "chapters" in element
         } ?: throw Exception("Failed to find valid series data")
 
-        return serie.toSManga()
-    }
+        val mangaSlug = serie.slug ?: manga.url.substringAfterLast("/")
 
-    // ============================= Chapters ==============================
+        val updatedManga = if (fetchDetails) serie.toSManga() else manga
+        val updatedChapters = if (fetchChapters) {
+            serie.chapters?.filter { it.slug != null }?.map { it.toSChapter(mangaSlug) } ?: emptyList()
+        } else {
+            chapters
+        }
 
-    override fun chapterListRequest(manga: SManga) = mangaDetailsRequest(manga)
-
-    override fun chapterListParse(response: Response): List<SChapter> {
-        val serie = response.extractNextJs<SerieDto> { element ->
-            element is JsonObject && "slug" in element && "chapters" in element
-        } ?: return emptyList()
-
-        val mangaSlug = serie.slug ?: return emptyList()
-
-        return serie.chapters?.filter { it.slug != null }?.map { chapter ->
-            chapter.toSChapter(mangaSlug).apply {
-                chapter.createdAt?.substringBefore("+")?.substringBefore("Z")?.let {
-                    date_upload = dateFormat.tryParse(it)
-                }
-            }
-        } ?: emptyList()
+        return SMangaUpdate(updatedManga, updatedChapters)
     }
 
     // =============================== Pages ===============================
 
-    override fun pageListRequest(chapter: SChapter): Request = GET(baseUrl + chapter.url, headers)
-
-    override fun pageListParse(response: Response): List<Page> {
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        val response = client.get(baseUrl + chapter.url)
         val document = response.asJsoup()
-        val images = document.select("div.max-w-4xl img")
-
-        return images.mapIndexed { i, img ->
-            Page(i, imageUrl = img.absUrl("src").replace("http://", "https://"))
+        val pageches = document.extractNextJs<PagechesDto> { element ->
+            element is JsonObject && "urlImg" in element && "chapterId" in element
         }
+
+        val images = pageches?.images?.ifEmpty { null } ?: run {
+            imageUrlRegex.findAll(document.html())
+                .map { it.value }
+                .filter { it.contains("/serie/") }
+                .distinct()
+                .toList()
+                .ifEmpty { null }
+        } ?: throw Exception("No pages found")
+
+        return images
+            .filterNot { it.contains("brakeout") }
+            .mapIndexed { i, url ->
+                Page(i, imageUrl = url.replace("http://", "https://"))
+            }
     }
 
-    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
+    companion object {
+        private val imageUrlRegex = Regex("""https?://media\.lustoon\.com/file/[^"\s']+\.(?:jpg|jpeg|png|webp|avif)""", RegexOption.IGNORE_CASE)
+    }
 
-    // ============================== Filters ==============================
+    // ============================== Filters ===============================
 
-    override fun getFilterList() = FilterList(
+    override fun getFilterList(data: JsonElement?): FilterList = FilterList(
         SortFilter(),
         Filter.Separator(),
         TypeFilter(),


### PR DESCRIPTION
Closes #18810

- Migrate to `KeiSource` (`libVersion = "1.6"`)
- Fix chapter page extraction by using `PagechesDto` from Next.js RSC payload and fallback image URL regex (preventing ad domains from breaking the reader decoder)
- Ensure all chapter and cover image URLs use `https` to prevent HTTP 521 errors from Cloudflare
- Fix latest updates by fetching the "Recent Updates" list from the homepage Next.js RSC payload on page 1
- Add deeplink configuration in `build.gradle.kts`
- Bump `versionCode` to 2
- Tested with gradlew + device (Komikku).

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

🤖 This PR was created by an AI agent (Antigravity). The agent was tasked with resolving issue #18810 ("No pages found in Lustoon"), fixing decoder initialization failures caused by ad URLs, aligning the latest updates tab with website updates, and migrating LustToon to KeiSource.