### PR TITLE
KomikNesia: Fix encrypted API responses & migrate to 1.6

### DIFF
--- a/src/id/komiknesia/build.gradle.kts
+++ b/src/id/komiknesia/build.gradle.kts
@@ -6,12 +6,18 @@ plugins {
 
 keiyoushi {
     name = "KomikNesia"
-    versionCode = 2
+    versionCode = 3
     contentWarning = ContentWarning.MIXED
-    libVersion = "1.4"
+    libVersion = "1.6"
 
     source {
         lang = "id"
         baseUrl = "https://v1.komiknesiaku.com"
+    }
+
+    deeplink {
+        host("komiknesiaku.com")
+        host("v1.komiknesiaku.com")
+        path("/komik/..*")
     }
 }

--- a/src/id/komiknesia/src/eu/kanade/tachiyomi/extension/id/komiknesia/Dto.kt
+++ b/src/id/komiknesia/src/eu/kanade/tachiyomi/extension/id/komiknesia/Dto.kt
@@ -6,6 +6,12 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+class EncryptedEnvelopeDto(
+    val data: String,
+    val time: Double,
+)
+
+@Serializable
 class PayloadDto<T>(
     val data: T,
     val meta: MetaDto? = null,

--- a/src/id/komiknesia/src/eu/kanade/tachiyomi/extension/id/komiknesia/KomikNesia.kt
+++ b/src/id/komiknesia/src/eu/kanade/tachiyomi/extension/id/komiknesia/KomikNesia.kt
@@ -1,92 +1,117 @@
 package eu.kanade.tachiyomi.extension.id.komiknesia
 
-import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import keiyoushi.annotation.Source
+import keiyoushi.network.get
+import keiyoushi.source.KeiSource
 import keiyoushi.utils.parseAs
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import kotlinx.serialization.json.JsonElement
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.Request
-import okhttp3.Response
+import okhttp3.OkHttpClient
+import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.ByteString.Companion.decodeBase64
+import java.io.IOException
+import java.util.Locale
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
 
 @Source
-abstract class KomikNesia : HttpSource() {
+abstract class KomikNesia : KeiSource() {
 
     private val apiUrl = "https://api-be.komiknesia.my.id/api"
-    override val supportsLatest = true
 
-    override fun headersBuilder() = super.headersBuilder()
-        .add("Referer", "$baseUrl/")
+    override fun OkHttpClient.Builder.configureClient(): OkHttpClient.Builder = addInterceptor { chain ->
+        val request = chain.request()
+        val response = chain.proceed(request)
+        if (!request.url.host.contains("api-be.komiknesia.my.id")) {
+            return@addInterceptor response
+        }
 
-    private var genresList: List<Pair<String, String>> = emptyList()
-    private var genresFetched: Boolean = false
-    private var fetchGenresAttempts: Int = 0
+        val body = response.body
+        val bodyString = body.string()
+        if (!bodyString.contains("\"encrypted\":true") && !bodyString.contains("\"encrypted\": true")) {
+            return@addInterceptor response.newBuilder()
+                .body(bodyString.toResponseBody(body.contentType()))
+                .build()
+        }
 
-    private val scope = CoroutineScope(Dispatchers.IO)
-    private fun launchIO(block: () -> Unit) = scope.launch { block() }
+        val envelope = bodyString.parseAs<EncryptedEnvelopeDto>()
+        val decryptedJson = decrypt(envelope.data, envelope.time)
+        response.newBuilder()
+            .body(decryptedJson.toResponseBody(body.contentType()))
+            .build()
+    }
+
+    private fun decrypt(encryptedData: String, time: Double): String {
+        try {
+            val keyStr = String.format(Locale.US, "%.8f", time / 32.0).padEnd(32, '0').take(32)
+            val raw = encryptedData.decodeBase64()?.toByteArray()
+                ?: throw IOException("Failed to decode base64 encrypted data")
+            if (raw.size < 16) throw IOException("Encrypted data too short")
+            val iv = raw.copyOfRange(0, 16)
+            val ciphertext = raw.copyOfRange(16, raw.size)
+            val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+            cipher.init(Cipher.DECRYPT_MODE, SecretKeySpec(keyStr.toByteArray(Charsets.UTF_8), "AES"), IvParameterSpec(iv))
+            return String(cipher.doFinal(ciphertext), Charsets.UTF_8)
+        } catch (e: Exception) {
+            throw IOException("Failed to decrypt API response", e)
+        }
+    }
 
     // ===============================
     // Popular
     // ===============================
 
-    override fun popularMangaRequest(page: Int): Request = searchMangaRequest(page, "", FilterList(OrderFilter().apply { state = 2 }))
-
-    override fun popularMangaParse(response: Response): MangasPage = searchMangaParse(response)
+    override suspend fun getPopularManga(page: Int): MangasPage = getSearchMangaList(page, "", FilterList(OrderFilter().apply { state = 2 }))
 
     // ===============================
     // Latest
     // ===============================
 
-    override fun latestUpdatesRequest(page: Int): Request = searchMangaRequest(page, "", FilterList(OrderFilter().apply { state = 0 }))
-
-    override fun latestUpdatesParse(response: Response): MangasPage = searchMangaParse(response)
+    override suspend fun getLatestUpdates(page: Int): MangasPage = getSearchMangaList(page, "", FilterList())
 
     // ===============================
     // Search
     // ===============================
 
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        val url = "$apiUrl/contents".toHttpUrl().newBuilder()
-            .addQueryParameter("page", page.toString())
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
+        val url = "$apiUrl/contents".toHttpUrl().newBuilder().apply {
+            addQueryParameter("page", page.toString())
 
-        if (query.isNotEmpty()) {
-            url.addQueryParameter("q", query)
-        }
-
-        filters.forEach { filter ->
-            when (filter) {
-                is GenreFilter -> {
-                    filter.state
-                        .filter { it.state }
-                        .forEach { url.addQueryParameter("genre[]", it.id) }
-                }
-                is StatusFilter -> {
-                    if (filter.state != 0) {
-                        url.addQueryParameter("status", filter.toUriPart())
-                    }
-                }
-                is OrderFilter -> {
-                    if (filter.state != 0) {
-                        url.addQueryParameter("orderBy", filter.toUriPart())
-                    }
-                }
-                else -> {}
+            if (query.isNotBlank()) {
+                addQueryParameter("q", query)
             }
-        }
 
-        return GET(url.build(), headers)
-    }
+            filters.forEach { filter ->
+                when (filter) {
+                    is GenreFilter -> {
+                        filter.state
+                            .filter { it.state }
+                            .forEach { addQueryParameter("genre[]", it.id) }
+                    }
+                    is StatusFilter -> {
+                        if (filter.state != 0) {
+                            addQueryParameter("status", filter.toUriPart())
+                        }
+                    }
+                    is OrderFilter -> {
+                        if (filter.state != 0) {
+                            addQueryParameter("orderBy", filter.toUriPart())
+                        }
+                    }
+                    else -> {}
+                }
+            }
+        }.build()
 
-    override fun searchMangaParse(response: Response): MangasPage {
-        val payload = response.parseAs<PayloadDto<List<MangaDto>>>()
+        val payload = client.get(url, headers).parseAs<PayloadDto<List<MangaDto>>>()
         val mangas = payload.data.map { it.toSManga() }
         val hasNextPage = payload.meta?.let { it.page < it.totalPages } ?: false
         return MangasPage(mangas, hasNextPage)
@@ -96,86 +121,67 @@ abstract class KomikNesia : HttpSource() {
     // Details
     // ===============================
 
-    override fun mangaDetailsRequest(manga: SManga): Request = GET("$apiUrl/comic/${manga.url}", headers)
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        val slug = manga.url.removePrefix("/komik/").removePrefix("/")
+        val payload = client.get("$apiUrl/comic/$slug", headers)
+            .parseAs<PayloadDto<MangaDto>>()
+        return SMangaUpdate(
+            payload.data.toSManga(),
+            payload.data.chapters?.map { it.toSChapter() } ?: emptyList(),
+        )
+    }
 
-    override fun mangaDetailsParse(response: Response): SManga {
-        val payload = response.parseAs<PayloadDto<MangaDto>>()
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+        val pathSegments = url.pathSegments.filter { it.isNotEmpty() }
+        if (pathSegments.firstOrNull() != "komik") return null
+        val slug = pathSegments.getOrNull(1) ?: return null
+        val payload = client.get("$apiUrl/comic/$slug", headers)
+            .parseAs<PayloadDto<MangaDto>>()
         return payload.data.toSManga()
     }
 
-    override fun getMangaUrl(manga: SManga): String = "$baseUrl/komik/${manga.url}"
+    override fun getMangaUrl(manga: SManga): String = "$baseUrl/komik/${manga.url.removePrefix("/komik/").removePrefix("/")}"
 
-    // ===============================
-    // Chapters
-    // ===============================
-
-    override fun chapterListRequest(manga: SManga): Request = mangaDetailsRequest(manga)
-
-    override fun chapterListParse(response: Response): List<SChapter> {
-        val payload = response.parseAs<PayloadDto<MangaDto>>()
-        return payload.data.chapters?.map { it.toSChapter() } ?: emptyList()
-    }
-
-    override fun getChapterUrl(chapter: SChapter): String = "$baseUrl/view/${chapter.url}"
+    override fun getChapterUrl(chapter: SChapter): String = "$baseUrl/view/${chapter.url.removePrefix("/view/").removePrefix("/")}"
 
     // ===============================
     // Pages
     // ===============================
 
-    override fun pageListRequest(chapter: SChapter): Request = GET("$apiUrl/chapters/slug/${chapter.url}", headers)
-
-    override fun pageListParse(response: Response): List<Page> {
-        val payload = response.parseAs<PayloadDto<PageListDto>>()
-        // Lock exception disabled: the backend API allows reading locked chapters without login,
-        // so we don't throw an error when loading page images.
-        // if (payload.data.images.isEmpty()) {
-        //     throw java.io.IOException("Chapter terbaru dapat dibaca setelah login melalui WebView, atau tunggu hingga 2 jam dari rilis untuk membaca tanpa login.")
-        // }
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        val slug = chapter.url.removePrefix("/view/").removePrefix("/")
+        val payload = client.get("$apiUrl/chapters/slug/$slug", headers)
+            .parseAs<PayloadDto<PageListDto>>()
         return payload.data.images.mapIndexed { idx, img ->
             Page(idx, imageUrl = img)
         }
     }
 
-    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
-
     // ===============================
     // Filters
     // ===============================
 
-    override fun getFilterList(): FilterList {
-        launchIO { fetchGenres() }
+    override val supportsFilterFetching = true
 
-        val filters = mutableListOf<Filter<*>>(
-            OrderFilter(),
-            StatusFilter(),
+    override suspend fun fetchFilterData(): JsonElement = client.get("$apiUrl/contents/genres", headers).parseAs()
+
+    override fun getFilterList(data: JsonElement?): FilterList {
+        val genres = data?.parseAs<PayloadDto<List<GenreDto>>>()?.data
+            ?.map { Genre(it.name, it.id.toString()) }
+
+        return FilterList(
+            listOfNotNull(
+                OrderFilter(),
+                StatusFilter(),
+                genres?.takeIf { it.isNotEmpty() }?.let {
+                    GenreFilter(it)
+                },
+            ),
         )
-
-        if (genresList.isNotEmpty()) {
-            filters += listOf(
-                Filter.Separator(),
-                GenreFilter(genresList.map { Genre(it.first, it.second) }),
-            )
-        } else {
-            filters += listOf(
-                Filter.Header("Press 'Reset' to load genres"),
-            )
-        }
-
-        return FilterList(filters)
-    }
-
-    private fun fetchGenres() {
-        if (fetchGenresAttempts < 3 && !genresFetched) {
-            try {
-                client.newCall(GET("$apiUrl/contents/genres", headers)).execute().use { response ->
-                    val payload = response.parseAs<PayloadDto<List<GenreDto>>>()
-                    genresList = payload.data.map { it.name to it.id.toString() }
-                    genresFetched = true
-                }
-            } catch (_: Exception) {
-            } finally {
-                fetchGenresAttempts++
-            }
-        }
     }
 }

--- a/src/id/komiknesia/src/eu/kanade/tachiyomi/extension/id/komiknesia/KomikNesia.kt
+++ b/src/id/komiknesia/src/eu/kanade/tachiyomi/extension/id/komiknesia/KomikNesia.kt
@@ -13,8 +13,7 @@ import keiyoushi.utils.parseAs
 import kotlinx.serialization.json.JsonElement
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.OkHttpClient
-import okhttp3.ResponseBody.Companion.toResponseBody
+import okhttp3.Response
 import okio.ByteString.Companion.decodeBase64
 import java.io.IOException
 import java.util.Locale
@@ -27,27 +26,16 @@ abstract class KomikNesia : KeiSource() {
 
     private val apiUrl = "https://api-be.komiknesia.my.id/api"
 
-    override fun OkHttpClient.Builder.configureClient(): OkHttpClient.Builder = addInterceptor { chain ->
-        val request = chain.request()
-        val response = chain.proceed(request)
-        if (!request.url.host.contains("api-be.komiknesia.my.id")) {
-            return@addInterceptor response
-        }
-
-        val body = response.body
-        val bodyString = body.string()
-        if (!bodyString.contains("\"encrypted\":true") && !bodyString.contains("\"encrypted\": true")) {
-            return@addInterceptor response.newBuilder()
-                .body(bodyString.toResponseBody(body.contentType()))
-                .build()
-        }
-
-        val envelope = bodyString.parseAs<EncryptedEnvelopeDto>()
-        val decryptedJson = decrypt(envelope.data, envelope.time)
-        response.newBuilder()
-            .body(decryptedJson.toResponseBody(body.contentType()))
-            .build()
-    }
+    private inline fun <reified T> Response.parseAs(): T = parseAs(
+        transform = { bodyString ->
+            if (bodyString.contains("\"encrypted\":true") || bodyString.contains("\"encrypted\": true")) {
+                val envelope = bodyString.parseAs<EncryptedEnvelopeDto>()
+                decrypt(envelope.data, envelope.time)
+            } else {
+                bodyString
+            }
+        },
+    )
 
     private fun decrypt(encryptedData: String, time: Double): String {
         try {
@@ -111,7 +99,7 @@ abstract class KomikNesia : KeiSource() {
             }
         }.build()
 
-        val payload = client.get(url, headers).parseAs<PayloadDto<List<MangaDto>>>()
+        val payload = client.get(url).parseAs<PayloadDto<List<MangaDto>>>()
         val mangas = payload.data.map { it.toSManga() }
         val hasNextPage = payload.meta?.let { it.page < it.totalPages } ?: false
         return MangasPage(mangas, hasNextPage)
@@ -128,22 +116,23 @@ abstract class KomikNesia : KeiSource() {
         fetchChapters: Boolean,
     ): SMangaUpdate {
         val slug = manga.url.removePrefix("/komik/").removePrefix("/")
-        val payload = client.get("$apiUrl/comic/$slug", headers)
+        val payload = client.get("$apiUrl/comic/$slug")
             .parseAs<PayloadDto<MangaDto>>()
         return SMangaUpdate(
-            payload.data.toSManga(),
+            payload.data.toSManga().apply { initialized = true },
             payload.data.chapters?.map { it.toSChapter() } ?: emptyList(),
         )
     }
 
-    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? = runCatching {
+        if (!url.host.endsWith("komiknesiaku.com")) return null
         val pathSegments = url.pathSegments.filter { it.isNotEmpty() }
         if (pathSegments.firstOrNull() != "komik") return null
         val slug = pathSegments.getOrNull(1) ?: return null
-        val payload = client.get("$apiUrl/comic/$slug", headers)
+        val payload = client.get("$apiUrl/comic/$slug")
             .parseAs<PayloadDto<MangaDto>>()
-        return payload.data.toSManga()
-    }
+        payload.data.toSManga().apply { initialized = true }
+    }.getOrNull()
 
     override fun getMangaUrl(manga: SManga): String = "$baseUrl/komik/${manga.url.removePrefix("/komik/").removePrefix("/")}"
 
@@ -155,7 +144,7 @@ abstract class KomikNesia : KeiSource() {
 
     override suspend fun getPageList(chapter: SChapter): List<Page> {
         val slug = chapter.url.removePrefix("/view/").removePrefix("/")
-        val payload = client.get("$apiUrl/chapters/slug/$slug", headers)
+        val payload = client.get("$apiUrl/chapters/slug/$slug")
             .parseAs<PayloadDto<PageListDto>>()
         return payload.data.images.mapIndexed { idx, img ->
             Page(idx, imageUrl = img)
@@ -168,7 +157,7 @@ abstract class KomikNesia : KeiSource() {
 
     override val supportsFilterFetching = true
 
-    override suspend fun fetchFilterData(): JsonElement = client.get("$apiUrl/contents/genres", headers).parseAs()
+    override suspend fun fetchFilterData(): JsonElement = client.get("$apiUrl/contents/genres").parseAs()
 
     override fun getFilterList(data: JsonElement?): FilterList {
         val genres = data?.parseAs<PayloadDto<List<GenreDto>>>()?.data


### PR DESCRIPTION
Closes #18753

- Migrate to `KeiSource` (`libVersion = "1.6"`)
- Implement AES-256-CBC response decryption interceptor to handle encrypted API payloads transparently
- Use built-in filter fetching with `supportsFilterFetching = true`
- Add deeplink configuration in `build.gradle.kts`
- Bump `versionCode` to 3
- Tested with gradlew + device (Komikku).

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

🤖 This PR was created by an AI agent (Antigravity). The agent was tasked with resolving issue #18753 ("Error Expected start of the array '['"), reverse-engineering and implementing AES-256-CBC decryption for encrypted backend API responses, and migrating KomikNesia to KeiSource.
