### PR TITLE
Kappa Beast: migrate to 1.6

### DIFF
--- a/src/en/kappabeast/build.gradle.kts
+++ b/src/en/kappabeast/build.gradle.kts
@@ -6,13 +6,17 @@ plugins {
 
 keiyoushi {
     name = "Kappa Beast"
-    versionCode = 33
+    versionCode = 1
     contentWarning = ContentWarning.MIXED
-    libVersion = "1.4"
+    libVersion = "1.6"
 
     source {
         lang = "en"
         baseUrl = "https://kappabeast.com"
         versionId = 2
+    }
+
+    deeplink {
+        path("/series/..*")
     }
 }

--- a/src/en/kappabeast/src/eu/kanade/tachiyomi/extension/en/kappabeast/Dto.kt
+++ b/src/en/kappabeast/src/eu/kanade/tachiyomi/extension/en/kappabeast/Dto.kt
@@ -5,9 +5,7 @@ import eu.kanade.tachiyomi.source.model.SManga
 import keiyoushi.utils.tryParse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.text.SimpleDateFormat
-import java.util.Locale
-import java.util.TimeZone
+import kotlin.time.Instant
 
 @Serializable
 class SearchResponse(
@@ -26,7 +24,10 @@ class Data(
     private val slug: String,
     private val media: List<Media>?,
     private val category: List<Category>?,
+    private val chapters: List<ChapterData>? = null,
 ) {
+    fun toSChapters() = chapters.orEmpty().map { it.toSChapter(slug, documentId) }
+
     fun toSManga(cdnUrl: String) = SManga.create().apply {
         url = "$slug#$documentId"
         title = this@Data.title
@@ -71,11 +72,14 @@ class Category(
     val name: String,
 )
 
-// Chapters
 @Serializable
-class ChapterResponse(
-    val data: List<ChapterData>,
-    val meta: Meta,
+class ChapterPageResponse(
+    val data: List<ChapterPage>,
+)
+
+@Serializable
+class ChapterPage(
+    val htmlContent: String?,
 )
 
 @Serializable
@@ -83,27 +87,15 @@ class ChapterData(
     private val number: Float,
     private val title: String?,
     private val createdAt: String?,
-    private val manga: Manga,
-    val htmlContent: String?,
 ) {
-    fun toSChapter() = SChapter.create().apply {
+    fun toSChapter(slug: String, documentId: String) = SChapter.create().apply {
         val chapterNum = if (number % 1f == 0f) number.toInt() else number
-        url = "${manga.slug}/$number#${manga.documentId}"
+        url = "$slug/$number#$documentId"
         name = buildString {
             append("Chapter $chapterNum")
             if (!title.isNullOrBlank() && title != "Chapter $chapterNum") append(" - $title")
         }
         chapter_number = number
-        date_upload = dateFormat.tryParse(createdAt)
+        date_upload = Instant.tryParse(createdAt)
     }
 }
-
-private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ROOT).apply {
-    timeZone = TimeZone.getTimeZone("UTC")
-}
-
-@Serializable
-class Manga(
-    val documentId: String,
-    val slug: String,
-)

--- a/src/en/kappabeast/src/eu/kanade/tachiyomi/extension/en/kappabeast/KappaBeast.kt
+++ b/src/en/kappabeast/src/eu/kanade/tachiyomi/extension/en/kappabeast/KappaBeast.kt
@@ -1,46 +1,56 @@
 package eu.kanade.tachiyomi.extension.en.kappabeast
 
-import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import keiyoushi.annotation.Source
+import keiyoushi.network.get
 import keiyoushi.network.rateLimit
-import keiyoushi.utils.firstInstance
+import keiyoushi.source.KeiSource
+import keiyoushi.utils.firstInstanceOrNull
 import keiyoushi.utils.parseAs
+import kotlinx.serialization.json.JsonElement
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Builder
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.Request
-import okhttp3.Response
+import okhttp3.OkHttpClient
 import org.jsoup.Jsoup
-import rx.Observable
 
 @Source
-abstract class KappaBeast : HttpSource() {
-    override val supportsLatest = true
+abstract class KappaBeast : KeiSource() {
+    private val domain get() = baseUrl.toHttpUrl().host
+    private val cdnUrl get() = "https://strapi.$domain"
+    private val apiUrl get() = "$cdnUrl/api"
 
-    private val domain = baseUrl.toHttpUrl().host
-    private val cdnUrl = "https://strapi.$domain"
-    private val apiUrl = "$cdnUrl/api"
+    override fun OkHttpClient.Builder.configureClient() = apply {
+        rateLimit(3)
+    }
 
-    override val client = network.client.newBuilder()
-        .rateLimit(3)
-        .build()
+    override suspend fun getPopularManga(page: Int): MangasPage = fetchMangas(page, "", "", "", "", "")
 
-    override fun popularMangaRequest(page: Int): Request = searchMangaRequest(page, "", getFilterList().apply { firstInstance<SortFilter>().state = 0 })
+    override suspend fun getLatestUpdates(page: Int): MangasPage = fetchMangas(page, "", "", "", "", "updatedAt:desc")
 
-    override fun popularMangaParse(response: Response): MangasPage = searchMangaParse(response)
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
+        val genre = filters.firstInstanceOrNull<GenreFilter>()?.value.orEmpty()
+        val status = filters.firstInstanceOrNull<StatusFilter>()?.value.orEmpty()
+        val type = filters.firstInstanceOrNull<TypeFilter>()?.value.orEmpty()
+        val sort = filters.firstInstanceOrNull<SortFilter>()?.value.orEmpty()
+        return fetchMangas(page, query, genre, status, type, sort)
+    }
 
-    override fun latestUpdatesRequest(page: Int): Request = searchMangaRequest(page, "", getFilterList().apply { firstInstance<SortFilter>().state = 1 })
-
-    override fun latestUpdatesParse(response: Response): MangasPage = searchMangaParse(response)
-
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        fun Builder.addFilter(param: String, filter: SelectFilter) = filter.value.takeIf { it.isNotBlank() }?.let { addQueryParameter(param, it) }
+    private suspend fun fetchMangas(
+        page: Int,
+        query: String,
+        genre: String,
+        status: String,
+        type: String,
+        sort: String,
+    ): MangasPage {
+        fun Builder.addParam(param: String, value: String) = value.takeIf { it.isNotBlank() }?.let { addQueryParameter(param, it) }
 
         val url = "$apiUrl/mangas".toHttpUrl().newBuilder().apply {
             if (query.isNotBlank()) addQueryParameter($$"filters[title][$containsi]", query)
@@ -50,18 +60,17 @@ abstract class KappaBeast : HttpSource() {
             addQueryParameter("populate[media][populate]", "*")
             addQueryParameter("populate[category][fields][0]", "name")
 
-            if (filters.isNotEmpty()) {
-                addFilter($$"filters[category][name][$eq]", filters.firstInstance<GenreFilter>())
-                addFilter($$"filters[manga_status][$eq]", filters.firstInstance<StatusFilter>())
-                addFilter($$"filters[type][$eq]", filters.firstInstance<TypeFilter>())
-                addFilter("sort[0]", filters.firstInstance<SortFilter>())
-            }
+            addParam($$"filters[category][name][$eq]", genre)
+            addParam($$"filters[manga_status][$eq]", status)
+            addParam($$"filters[type][$eq]", type)
+            addParam("sort[0]", sort)
         }.build()
 
-        return GET(url, headers)
+        val result = client.get(url).parseAs<SearchResponse>()
+        return MangasPage(result.data.map { it.toSManga(cdnUrl) }, result.meta.pagination.hasNextPage())
     }
 
-    override fun getFilterList() = FilterList(
+    override fun getFilterList(data: JsonElement?) = FilterList(
         Filter.Header("Note: Search and active filters are applied together"),
         GenreFilter(),
         StatusFilter(),
@@ -69,80 +78,61 @@ abstract class KappaBeast : HttpSource() {
         SortFilter(),
     )
 
-    override fun searchMangaParse(response: Response): MangasPage {
-        val result = response.parseAs<SearchResponse>()
-        val mangas = result.data.map { it.toSManga(cdnUrl) }
-        return MangasPage(mangas, result.meta.pagination.hasNextPage())
-    }
-
     override fun getMangaUrl(manga: SManga): String = "$baseUrl/series/${manga.url}"
 
-    override fun mangaDetailsRequest(manga: SManga): Request {
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
         val slug = "$baseUrl/${manga.url}".toHttpUrl().pathSegments.first()
+
         val url = "$apiUrl/mangas".toHttpUrl().newBuilder()
+            .addQueryParameter($$"filters[slug][$eq]", slug)
+            .addQueryParameter("populate[media][populate]", "*")
+            .addQueryParameter("populate[category][fields][0]", "name")
+            .addQueryParameter("populate[chapters][fields][0]", "number")
+            .addQueryParameter("populate[chapters][fields][1]", "title")
+            .addQueryParameter("populate[chapters][fields][2]", "createdAt")
+            .addQueryParameter("populate[chapters][sort][0]", "number:desc")
+            .addQueryParameter("pagination[pageSize]", "1")
+            .build()
+
+        val data = client.get(url).parseAs<SearchResponse>().data.first()
+        return SMangaUpdate(data.toSManga(cdnUrl), data.toSChapters())
+    }
+
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+        if (url.host != baseUrl.toHttpUrl().host || url.pathSegments.firstOrNull() != "series") return null
+        val slug = url.pathSegments.getOrNull(1)?.takeIf { it.isNotBlank() } ?: return null
+        val api = "$apiUrl/mangas".toHttpUrl().newBuilder()
             .addQueryParameter($$"filters[slug][$eq]", slug)
             .addQueryParameter("populate[media][populate]", "*")
             .addQueryParameter("populate[category][fields][0]", "name")
             .addQueryParameter("pagination[pageSize]", "1")
             .build()
 
-        return GET(url, headers)
-    }
-
-    override fun mangaDetailsParse(response: Response): SManga = response.parseAs<SearchResponse>().data.first().toSManga(cdnUrl)
-
-    override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> {
-        val documentId = "$baseUrl/${manga.url}".toHttpUrl().fragment
-        if (documentId.isNullOrBlank()) {
-            throw Exception("Migrate from $name to $name.")
-        }
-        val chapters = mutableListOf<SChapter>()
-        var page = 1
-        var result: ChapterResponse
-
-        do {
-            val url = "$apiUrl/chapters".toHttpUrl().newBuilder()
-                .addQueryParameter($$"filters[manga][documentId][$eq]", documentId)
-                .addQueryParameter("populate[pages][populate]", "*")
-                .addQueryParameter("populate", "manga")
-                .addQueryParameter("sort[0]", "number:desc")
-                .addQueryParameter("pagination[page]", page.toString())
-                .addQueryParameter("pagination[pageSize]", "100")
-                .build()
-
-            result = client.newCall(GET(url, headers)).execute().parseAs<ChapterResponse>()
-            chapters += result.data.map { it.toSChapter() }
-            page++
-        } while (result.meta.pagination.hasNextPage())
-
-        return Observable.just(chapters)
+        val data = client.get(api).parseAs<SearchResponse>().data.firstOrNull() ?: return null
+        return data.toSManga(cdnUrl).apply { initialized = true }
     }
 
     override fun getChapterUrl(chapter: SChapter): String = "$baseUrl/reader/${chapter.url}"
 
-    override fun pageListRequest(chapter: SChapter): Request {
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
         val parts = "$baseUrl/${chapter.url}".toHttpUrl()
         val documentId = parts.fragment
         val chapterNum = parts.pathSegments[1]
         val url = "$apiUrl/chapters".toHttpUrl().newBuilder()
             .addQueryParameter($$"filters[manga][documentId][$eq]", documentId)
             .addQueryParameter($$"filters[number][$eq]", chapterNum)
-            .addQueryParameter("populate[pages][populate]", "*")
-            .addQueryParameter("populate", "manga")
-            .addQueryParameter("sort[0]", "number:desc")
             .addQueryParameter("pagination[pageSize]", "1")
             .build()
-        return GET(url, headers)
-    }
 
-    override fun pageListParse(response: Response): List<Page> {
-        val result = response.parseAs<ChapterResponse>().data.first().htmlContent ?: throw Exception("This chapter contains no pages.")
-        return Jsoup.parseBodyFragment(result).select("div.separator > a").mapIndexed { i, url ->
-            Page(i, imageUrl = url.absUrl("href").toHttpUrl().newBuilder().setPathSegment(4, "s0").build().toString())
+        val html = client.get(url).parseAs<ChapterPageResponse>().data.firstOrNull()?.htmlContent
+            ?: return emptyList()
+        return Jsoup.parseBodyFragment(html, baseUrl).select("div.separator > a").mapIndexed { i, element ->
+            Page(i, imageUrl = element.absUrl("href").toHttpUrl().newBuilder().setPathSegment(4, "s0").build().toString())
         }
     }
-
-    override fun chapterListRequest(manga: SManga): Request = throw UnsupportedOperationException()
-    override fun chapterListParse(response: Response): List<SChapter> = throw UnsupportedOperationException()
-    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
 }


### PR DESCRIPTION
Combined details + chapters into one request because the API allowed it. This also skips pagination. Wasn't sure if there was a way to gracefully migrate URLs, so skipped using `memo`. Added deeplink support.

Mostly AI. Tested with `gradlew` + device.

Checklist:

- [ ] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
