### PR TITLE
S2Manga: Fix page list parsing

### DIFF
--- a/src/en/s2manga/build.gradle.kts
+++ b/src/en/s2manga/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "S2Manga"
-    versionCode = 4
+    versionCode = 5
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
     theme = "madara"

--- a/src/en/s2manga/src/eu/kanade/tachiyomi/extension/en/s2manga/S2Manga.kt
+++ b/src/en/s2manga/src/eu/kanade/tachiyomi/extension/en/s2manga/S2Manga.kt
@@ -2,9 +2,10 @@ package eu.kanade.tachiyomi.extension.en.s2manga
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import keiyoushi.annotation.Source
+import org.jsoup.nodes.Element
 
 @Source
 abstract class S2Manga : Madara() {
 
-    override val pageListParseSelector = "div.page-break img[src*=\"https\"]"
+    override fun imageFromElement(element: Element): String? = super.imageFromElement(element)?.trim()
 }


### PR DESCRIPTION
Closes #18737

### Changes
- Remove obsolete `pageListParseSelector` that expected `src` attributes, falling back to Madara default selector to support lazy-loaded images.
- Override `imageFromElement` with `trim()` to handle leading whitespace in `data-src`.
- Bump `versionCode`.
- Tested with gradlew + device (Komikku).

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

🤖 This PR was opened by an AI agent (Antigravity) upon user request after verifying the fix for issue #18737.
