### PR TITLE
Shadow Manga: Migrate to KeiSource 1.6 and add NSFW source

### DIFF
--- a/src/es/shadowmanga/build.gradle.kts
+++ b/src/es/shadowmanga/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Shadow Manga"
-    versionCode = 3
+    versionCode = 4
     contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 

--- a/src/es/shadowmanga/build.gradle.kts
+++ b/src/es/shadowmanga/build.gradle.kts
@@ -8,10 +8,24 @@ keiyoushi {
     name = "Shadow Manga"
     versionCode = 4
     contentWarning = ContentWarning.MIXED
-    libVersion = "1.4"
+    libVersion = "1.6"
 
     source {
+        name = "Shadow Manga"
         lang = "es"
         baseUrl = "https://shademanga.com"
+        id = 5649269152264667286L
+    }
+
+    source {
+        name = "Shadow Manga (+18)"
+        lang = "es"
+        baseUrl = "https://shademanga.com"
+    }
+
+    deeplink {
+        host("shademanga.com")
+        path("/serie/local/.*")
+        path("/adultos/manga/.*")
     }
 }

--- a/src/es/shadowmanga/src/eu/kanade/tachiyomi/extension/es/shadowmanga/Dto.kt
+++ b/src/es/shadowmanga/src/eu/kanade/tachiyomi/extension/es/shadowmanga/Dto.kt
@@ -14,14 +14,27 @@ class SeriesWrapper(
 )
 
 @Serializable
+class RecentChaptersResponse(
+    val items: List<RecentChapterItem> = emptyList(),
+    val page: Int = 1,
+    val pageSize: Int = 24,
+    val totalPages: Int = 1,
+)
+
+@Serializable
+class RecentChapterItem(
+    val serie: Series,
+)
+
+@Serializable
 class Series(
     val id: Int,
     @SerialName("titulo") val title: String,
-    @SerialName("portadaUrl") private val thumbnailUrl: String?,
-    @SerialName("descripcion") private val description: String?,
-    @SerialName("autor") private val author: String?,
-    @SerialName("generos") private val genres: String?,
-    @SerialName("estado") private val status: String?,
+    @SerialName("portadaUrl") private val thumbnailUrl: String? = null,
+    @SerialName("descripcion") private val description: String? = null,
+    @SerialName("autor") private val author: String? = null,
+    @SerialName("generos") private val genres: String? = null,
+    @SerialName("estado") private val status: String? = null,
     @SerialName("capitulos") val chapters: List<Chapter> = emptyList(),
 ) {
     fun toSManga() = SManga.create().apply {
@@ -75,3 +88,58 @@ class Chapter(
 class PagesWrapper(
     @SerialName("paginas") val pages: List<String>,
 )
+
+@Serializable
+class AdultCatalogResponse(
+    val total: Int = 0,
+    val items: List<AdultSeriesItem> = emptyList(),
+    val page: Int = 1,
+    val pageSize: Int = 48,
+    val totalPages: Int = 1,
+    val pageTokens: PageTokens? = null,
+)
+
+@Serializable
+class PageTokens(
+    val next: String? = null,
+)
+
+@Serializable
+class AdultSeriesItem(
+    val id: Int = 0,
+    @SerialName("titulo") val title: String,
+    @SerialName("portadaUrl") private val thumbnailUrl: String? = null,
+    @SerialName("autor") private val author: String? = null,
+    @SerialName("generos") private val genres: String? = null,
+    val externo: Boolean = false,
+    val smId: Long? = null,
+) {
+    fun toSManga() = SManga.create().apply {
+        title = this@AdultSeriesItem.title
+        url = if ((externo || id == 0) && smId != null) "ext/$smId" else id.toString()
+        thumbnail_url = this@AdultSeriesItem.thumbnailUrl
+    }
+
+    fun getGenreList(): List<String> = genres.orEmpty().split(",").map { it.trim() }
+}
+
+@Serializable
+class OneshotDetails(
+    val smId: Long,
+    @SerialName("titulo") val title: String,
+    @SerialName("autor") private val author: String? = null,
+    @SerialName("descripcion") private val description: String? = null,
+    @SerialName("generos") private val genres: String? = null,
+    @SerialName("portadaUrl") private val thumbnailUrl: String? = null,
+    @SerialName("capituloId") val chapterId: Int = 1,
+    @SerialName("totalPaginas") val totalPages: Int = 0,
+) {
+    fun toSMangaDetails() = SManga.create().apply {
+        title = this@OneshotDetails.title
+        thumbnail_url = this@OneshotDetails.thumbnailUrl
+        description = this@OneshotDetails.description
+        author = this@OneshotDetails.author
+        genre = genres?.split(",")?.joinToString { it.trim() }
+        status = SManga.COMPLETED
+    }
+}

--- a/src/es/shadowmanga/src/eu/kanade/tachiyomi/extension/es/shadowmanga/Dto.kt
+++ b/src/es/shadowmanga/src/eu/kanade/tachiyomi/extension/es/shadowmanga/Dto.kt
@@ -5,8 +5,7 @@ import eu.kanade.tachiyomi.source.model.SManga
 import keiyoushi.utils.tryParse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.text.SimpleDateFormat
-import java.util.Locale
+import kotlin.time.Instant
 
 @Serializable
 class SeriesWrapper(
@@ -62,8 +61,6 @@ class Series(
     }
 }
 
-private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS", Locale.ROOT)
-
 @Serializable
 class Chapter(
     private val id: Int,
@@ -80,7 +77,7 @@ class Chapter(
             }
         }
         url = "$mangaId/$id"
-        date_upload = dateFormat.tryParse(uploadDate)
+        date_upload = Instant.tryParse(uploadDate)
     }
 }
 

--- a/src/es/shadowmanga/src/eu/kanade/tachiyomi/extension/es/shadowmanga/Filters.kt
+++ b/src/es/shadowmanga/src/eu/kanade/tachiyomi/extension/es/shadowmanga/Filters.kt
@@ -2,6 +2,18 @@ package eu.kanade.tachiyomi.extension.es.shadowmanga
 
 import eu.kanade.tachiyomi.source.model.Filter
 
+class SectionFilter :
+    Filter.Select<String>(
+        "Sección",
+        arrayOf("Predeterminado", "Todo público (SFW)", "Adultos (+18)"),
+    )
+
+class OrderByFilter :
+    Filter.Select<String>(
+        "Orden (solo sección Adultos)",
+        arrayOf("Recientes", "Más vistos", "A-Z"),
+    )
+
 open class UriMultiTriStateOption(name: String, val value: String) : Filter.TriState(name)
 
 class GenreFilter(genres: List<String>) :

--- a/src/es/shadowmanga/src/eu/kanade/tachiyomi/extension/es/shadowmanga/Filters.kt
+++ b/src/es/shadowmanga/src/eu/kanade/tachiyomi/extension/es/shadowmanga/Filters.kt
@@ -2,15 +2,9 @@ package eu.kanade.tachiyomi.extension.es.shadowmanga
 
 import eu.kanade.tachiyomi.source.model.Filter
 
-class SectionFilter :
-    Filter.Select<String>(
-        "Sección",
-        arrayOf("Predeterminado", "Todo público (SFW)", "Adultos (+18)"),
-    )
-
 class OrderByFilter :
     Filter.Select<String>(
-        "Orden (solo sección Adultos)",
+        "Orden",
         arrayOf("Recientes", "Más vistos", "A-Z"),
     )
 

--- a/src/es/shadowmanga/src/eu/kanade/tachiyomi/extension/es/shadowmanga/ShadowManga.kt
+++ b/src/es/shadowmanga/src/eu/kanade/tachiyomi/extension/es/shadowmanga/ShadowManga.kt
@@ -24,8 +24,6 @@ import kotlin.time.Duration.Companion.seconds
 
 @Source
 abstract class ShadowManga : KeiSource() {
-    private val baseUrlHost by lazy { baseUrl.toHttpUrl().host }
-
     private val isNsfw by lazy { name.contains("+18") }
 
     private val cdnHosts = listOf(
@@ -35,8 +33,8 @@ abstract class ShadowManga : KeiSource() {
 
     private val fallbackPrefix = "/api/media/"
 
-    override fun OkHttpClient.Builder.configureClient(): OkHttpClient.Builder = addInterceptor(ImageFallbackInterceptor(cdnHosts, baseUrlHost, fallbackPrefix))
-        .rateLimit(2, 1.seconds, 500.milliseconds) { it.host == baseUrlHost }
+    override fun OkHttpClient.Builder.configureClient(): OkHttpClient.Builder = addInterceptor(ImageFallbackInterceptor(cdnHosts, "shademanga.com", fallbackPrefix))
+        .rateLimit(2, 1.seconds, 500.milliseconds) { it.host == "shademanga.com" }
 
     private fun getAdultPageToken(page: Int, pageSize: Int = 24): String {
         val half = pageSize / 2
@@ -232,7 +230,7 @@ abstract class ShadowManga : KeiSource() {
     override suspend fun fetchFilterData(): JsonElement = client.get("$baseUrl/api/series-locales/tags").parseAs()
 
     override fun getFilterList(data: JsonElement?): FilterList {
-        val tags = data?.runCatching { parseAs<List<String>>() }?.getOrNull().orEmpty()
+        val tags = data?.parseAs<List<String>>().orEmpty()
         return if (isNsfw) {
             FilterList(
                 OrderByFilter(),

--- a/src/es/shadowmanga/src/eu/kanade/tachiyomi/extension/es/shadowmanga/ShadowManga.kt
+++ b/src/es/shadowmanga/src/eu/kanade/tachiyomi/extension/es/shadowmanga/ShadowManga.kt
@@ -1,7 +1,11 @@
 package eu.kanade.tachiyomi.extension.es.shadowmanga
 
+import android.util.Base64
+import androidx.preference.ListPreference
+import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.extension.es.shadowmanga.interceptor.ImageFallbackInterceptor
 import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
@@ -12,6 +16,7 @@ import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.annotation.Source
 import keiyoushi.network.rateLimit
 import keiyoushi.utils.firstInstanceOrNull
+import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -19,15 +24,23 @@ import kotlinx.coroutines.launch
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 @Source
-abstract class ShadowManga : HttpSource() {
+abstract class ShadowManga :
+    HttpSource(),
+    ConfigurableSource {
     private val baseUrlHost by lazy { baseUrl.toHttpUrl().host }
 
     override val supportsLatest = true
 
     private val scope = CoroutineScope(Dispatchers.IO)
+
+    private val preferences by getPreferencesLazy()
+
+    private val isAdultSection: Boolean
+        get() = preferences.getString(PREF_SECTION, SECTION_SFW) == SECTION_NSFW
 
     private val cdnHosts = listOf(
         "media.shademanga.com",
@@ -38,46 +51,138 @@ abstract class ShadowManga : HttpSource() {
 
     override val client = network.client.newBuilder()
         .addInterceptor(ImageFallbackInterceptor(cdnHosts, baseUrlHost, fallbackPrefix))
-        .rateLimit(3, 1.seconds) { it.host == baseUrlHost }
+        .rateLimit(2, 1.seconds, 500.milliseconds) { it.host == baseUrlHost }
         .build()
 
     override fun headersBuilder() = super.headersBuilder()
         .add("Referer", "$baseUrl/")
 
-    override fun popularMangaRequest(page: Int) = GET("$baseUrl/api/series-locales/popular", headers)
+    private fun getAdultPageToken(page: Int, pageSize: Int = 24): String {
+        val half = pageSize / 2
+        val lo = (page - 1) * half
+        val so = (page - 1) * half
+        val json = """{"lo":$lo,"so":$so}"""
+        val b64 = Base64.encodeToString(json.toByteArray(), Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+        return "cx_$b64"
+    }
+
+    override fun popularMangaRequest(page: Int): Request = if (isAdultSection) {
+        val url = "$baseUrl/api/series-locales/adultos".toHttpUrl().newBuilder()
+            .addQueryParameter("orden", "vistos")
+            .addQueryParameter("pageSize", "48")
+        if (page > 1) {
+            url.addQueryParameter("p", getAdultPageToken(page, 48))
+        }
+        GET(url.build(), headers)
+    } else {
+        GET("$baseUrl/api/series-locales/popular", headers)
+    }
 
     override fun popularMangaParse(response: Response): MangasPage {
+        if (response.request.url.encodedPath.contains("/adultos")) {
+            val result = response.parseAs<AdultCatalogResponse>()
+            val mangas = result.items
+                .filter { !it.externo }
+                .map { it.toSManga() }
+            val hasNextPage = mangas.isNotEmpty() && (result.pageTokens?.next != null || result.page < result.totalPages)
+            return MangasPage(mangas, hasNextPage)
+        }
         val result = response.parseAs<List<SeriesWrapper>>()
         val series = result.flatMap { it.series }.distinctBy { it.id }.map { it.toSManga() }
         return MangasPage(series, false)
     }
 
-    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/api/series-locales/novedades", headers)
+    override fun latestUpdatesRequest(page: Int): Request = if (isAdultSection) {
+        val url = "$baseUrl/api/series-locales/adultos".toHttpUrl().newBuilder()
+            .addQueryParameter("orden", "recientes")
+            .addQueryParameter("pageSize", "48")
+        if (page > 1) {
+            url.addQueryParameter("p", getAdultPageToken(page, 48))
+        }
+        GET(url.build(), headers)
+    } else {
+        GET("$baseUrl/api/series-locales/capitulos/recientes?page=$page&pageSize=24", headers)
+    }
 
-    override fun latestUpdatesParse(response: Response) = popularMangaParse(response)
+    override fun latestUpdatesParse(response: Response): MangasPage {
+        if (response.request.url.encodedPath.contains("/adultos")) {
+            return popularMangaParse(response)
+        }
+        val result = response.parseAs<RecentChaptersResponse>()
+        val mangas = result.items.map { it.serie.toSManga() }.distinctBy { it.url }
+        val hasNextPage = result.page < result.totalPages
+        return MangasPage(mangas, hasNextPage)
+    }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        val url = "$baseUrl/api/series-locales/search-candidates".toHttpUrl().newBuilder()
-        url.addQueryParameter("q", query)
-        url.addQueryParameter("includeAdult", "true")
-        url.addQueryParameter("showSinPortada", "false")
-        url.addQueryParameter("take", MAX_RESULTS.toString())
+        val sectionFilter = filters.firstInstanceOrNull<SectionFilter>()
+        val searchAdult = when (sectionFilter?.state) {
+            1 -> false
+            2 -> true
+            else -> isAdultSection
+        }
 
         val genreFilter = filters.firstInstanceOrNull<GenreFilter>()
+        val excludedGenres = genreFilter?.getExcluded().orEmpty()
+
+        if (searchAdult) {
+            val url = "$baseUrl/api/series-locales/adultos".toHttpUrl().newBuilder()
+                .addQueryParameter("pageSize", "24")
+            if (page > 1) {
+                url.addQueryParameter("p", getAdultPageToken(page))
+            }
+            if (query.isNotBlank()) {
+                url.addQueryParameter("q", query)
+            }
+            val includedGenres = genreFilter?.getIncluded().orEmpty()
+            if (includedGenres.isNotEmpty()) {
+                url.addQueryParameter("generos", includedGenres.joinToString(","))
+            }
+            val orderByFilter = filters.firstInstanceOrNull<OrderByFilter>()
+            val orden = when (orderByFilter?.state) {
+                1 -> "vistos"
+                2 -> "az"
+                else -> "recientes"
+            }
+            if (orden != "recientes") {
+                url.addQueryParameter("orden", orden)
+            }
+            return GET(url.build(), headers).newBuilder()
+                .tag(List::class.java, excludedGenres)
+                .build()
+        }
+
+        val url = "$baseUrl/api/series-locales/search-candidates".toHttpUrl().newBuilder()
+        url.addQueryParameter("q", query)
+        url.addQueryParameter("includeAdult", "false")
+        url.addQueryParameter("showSinPortada", "false")
+        url.addQueryParameter("take", MAX_RESULTS.toString())
 
         genreFilter?.getIncluded()?.forEach {
             url.addQueryParameter("tags", it)
         }
-
-        val excludedGenres = genreFilter?.getExcluded().orEmpty()
 
         return GET(url.build(), headers).newBuilder()
             .tag(List::class.java, excludedGenres)
             .build()
     }
 
+    @Suppress("UNCHECKED_CAST")
     override fun searchMangaParse(response: Response): MangasPage {
         val excludedGenres = response.request.tag(List::class.java) as? List<String>
+        if (response.request.url.encodedPath.contains("/adultos")) {
+            val result = response.parseAs<AdultCatalogResponse>()
+            val mangas = result.items
+                .filter { series ->
+                    excludedGenres.isNullOrEmpty() || series.getGenreList().none { genre ->
+                        genre in excludedGenres
+                    }
+                }
+                .map { it.toSManga() }
+            val hasNextPage = result.items.isNotEmpty() && (result.pageTokens?.next != null || result.page < result.totalPages)
+            return MangasPage(mangas, hasNextPage)
+        }
+
         val mangas = response.parseAs<List<Series>>()
             .filter { series ->
                 excludedGenres.isNullOrEmpty() || series.getGenreList().none { genre ->
@@ -90,28 +195,52 @@ abstract class ShadowManga : HttpSource() {
 
     override fun mangaDetailsRequest(manga: SManga): Request = GET("$baseUrl/api/series-locales/${manga.url}", headers)
 
-    override fun getMangaUrl(manga: SManga) = "$baseUrl/serie/local/${manga.url}"
+    override fun getMangaUrl(manga: SManga): String = if (manga.url.startsWith("ext/")) {
+        "$baseUrl/adultos/manga/o/${manga.url.removePrefix("ext/")}"
+    } else {
+        "$baseUrl/serie/local/${manga.url}"
+    }
 
-    override fun mangaDetailsParse(response: Response): SManga = response.parseAs<Series>().toSMangaDetails()
+    override fun mangaDetailsParse(response: Response): SManga = if (response.request.url.encodedPath.contains("/ext/")) {
+        response.parseAs<OneshotDetails>().toSMangaDetails()
+    } else {
+        response.parseAs<Series>().toSMangaDetails()
+    }
 
     override fun chapterListRequest(manga: SManga) = mangaDetailsRequest(manga)
 
     override fun chapterListParse(response: Response): List<SChapter> {
+        if (response.request.url.encodedPath.contains("/ext/")) {
+            val oneshot = response.parseAs<OneshotDetails>()
+            return listOf(
+                SChapter.create().apply {
+                    name = "Capítulo 1"
+                    url = "ext/${oneshot.smId}/${oneshot.chapterId}"
+                    date_upload = 0L
+                },
+            )
+        }
         val series = response.parseAs<Series>()
         return series.chapters
             .sortedByDescending { it.chapterNumber }
             .map { it.toSChapter(series.id) }
     }
 
-    override fun getChapterUrl(chapter: SChapter): String {
+    override fun getChapterUrl(chapter: SChapter): String = if (chapter.url.startsWith("ext/")) {
+        val smId = chapter.url.removePrefix("ext/").substringBefore("/")
+        "$baseUrl/adultos/manga/o/$smId"
+    } else {
         val chapterId = chapter.url.substringAfter("/")
-        return "$baseUrl/reader/local/$chapterId"
+        "$baseUrl/reader/local/$chapterId"
     }
 
-    override fun pageListRequest(chapter: SChapter): Request {
+    override fun pageListRequest(chapter: SChapter): Request = if (chapter.url.startsWith("ext/")) {
+        val smId = chapter.url.removePrefix("ext/").substringBefore("/")
+        GET("$baseUrl/api/series-locales/ext/$smId/paginas", headers)
+    } else {
         val mangaId = chapter.url.substringBefore("/")
         val chapterId = chapter.url.substringAfter("/")
-        return GET("$baseUrl/api/series-locales/$mangaId/capitulos/$chapterId/paginas", headers)
+        GET("$baseUrl/api/series-locales/$mangaId/capitulos/$chapterId/paginas", headers)
     }
 
     override fun pageListParse(response: Response): List<Page> {
@@ -124,6 +253,8 @@ abstract class ShadowManga : HttpSource() {
     override fun getFilterList(): FilterList {
         fetchFilters()
         return FilterList(
+            SectionFilter(),
+            OrderByFilter(),
             if (genresList.isEmpty()) {
                 Filter.Header("Presione 'Reiniciar' para intentar cargar los filtros.")
             } else {
@@ -131,6 +262,17 @@ abstract class ShadowManga : HttpSource() {
             },
         )
     }
+
+    private val adultGenres = listOf(
+        "Ahegao", "Anal", "Bañador", "Bondage", "Control mental", "Creampie",
+        "DILF", "Doble penetración", "Embarazada", "Enfermera", "Femdom",
+        "Footjob", "Futanari", "Gafas", "Grupal", "Gyaru", "Harén", "Incesto",
+        "Infidelidad", "Juguetes", "Lactancia", "MILF", "Maid", "Medias",
+        "Mind break", "Musculosa", "Netorare", "Netorase", "Non-con", "Oral",
+        "Paizuri", "Pechos enormes", "Pechos grandes", "Piel morena", "Preñez",
+        "Primera vez", "Profesora", "Tomboy", "Trasero grande", "Uniforme escolar",
+        "Yaoi", "Yuri",
+    )
 
     private var genresList: List<String> = emptyList()
     private var fetchFiltersAttempts = 0
@@ -142,9 +284,10 @@ abstract class ShadowManga : HttpSource() {
         fetchFiltersAttempts++
         scope.launch {
             try {
-                val response = client.newCall(GET("$baseUrl/api/series-locales/tags", headers)).execute()
-                genresList = response.parseAs<List<String>>()
+                val tagsResponse = client.newCall(GET("$baseUrl/api/series-locales/tags", headers)).execute()
+                val tagsList = tagsResponse.parseAs<List<String>>()
 
+                genresList = (tagsList + adultGenres).distinct().sorted()
                 filtersState = FiltersState.FETCHED
             } catch (_: Throwable) {
                 filtersState = FiltersState.NOT_FETCHED
@@ -156,7 +299,21 @@ abstract class ShadowManga : HttpSource() {
 
     override fun imageUrlParse(response: Response) = throw UnsupportedOperationException()
 
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        ListPreference(screen.context).apply {
+            key = PREF_SECTION
+            title = "Sección de navegación"
+            summary = "%s"
+            entries = arrayOf("Todo público (SFW)", "Adultos (+18)")
+            entryValues = arrayOf(SECTION_SFW, SECTION_NSFW)
+            setDefaultValue(SECTION_SFW)
+        }.also(screen::addPreference)
+    }
+
     companion object {
         const val MAX_RESULTS = 120
+        private const val PREF_SECTION = "pref_section"
+        private const val SECTION_SFW = "sfw"
+        private const val SECTION_NSFW = "nsfw"
     }
 }

--- a/src/es/shadowmanga/src/eu/kanade/tachiyomi/extension/es/shadowmanga/ShadowManga.kt
+++ b/src/es/shadowmanga/src/eu/kanade/tachiyomi/extension/es/shadowmanga/ShadowManga.kt
@@ -1,46 +1,32 @@
 package eu.kanade.tachiyomi.extension.es.shadowmanga
 
 import android.util.Base64
-import androidx.preference.ListPreference
-import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.extension.es.shadowmanga.interceptor.ImageFallbackInterceptor
-import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import keiyoushi.annotation.Source
+import keiyoushi.network.get
 import keiyoushi.network.rateLimit
+import keiyoushi.source.KeiSource
 import keiyoushi.utils.firstInstanceOrNull
-import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import kotlinx.serialization.json.JsonElement
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.Request
-import okhttp3.Response
+import okhttp3.OkHttpClient
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 @Source
-abstract class ShadowManga :
-    HttpSource(),
-    ConfigurableSource {
+abstract class ShadowManga : KeiSource() {
     private val baseUrlHost by lazy { baseUrl.toHttpUrl().host }
 
-    override val supportsLatest = true
-
-    private val scope = CoroutineScope(Dispatchers.IO)
-
-    private val preferences by getPreferencesLazy()
-
-    private val isAdultSection: Boolean
-        get() = preferences.getString(PREF_SECTION, SECTION_SFW) == SECTION_NSFW
+    private val isNsfw by lazy { name.contains("+18") }
 
     private val cdnHosts = listOf(
         "media.shademanga.com",
@@ -49,13 +35,8 @@ abstract class ShadowManga :
 
     private val fallbackPrefix = "/api/media/"
 
-    override val client = network.client.newBuilder()
-        .addInterceptor(ImageFallbackInterceptor(cdnHosts, baseUrlHost, fallbackPrefix))
+    override fun OkHttpClient.Builder.configureClient(): OkHttpClient.Builder = addInterceptor(ImageFallbackInterceptor(cdnHosts, baseUrlHost, fallbackPrefix))
         .rateLimit(2, 1.seconds, 500.milliseconds) { it.host == baseUrlHost }
-        .build()
-
-    override fun headersBuilder() = super.headersBuilder()
-        .add("Referer", "$baseUrl/")
 
     private fun getAdultPageToken(page: Int, pageSize: Int = 24): String {
         val half = pageSize / 2
@@ -66,66 +47,57 @@ abstract class ShadowManga :
         return "cx_$b64"
     }
 
-    override fun popularMangaRequest(page: Int): Request = if (isAdultSection) {
+    // ============================== Popular ===============================
+
+    override suspend fun getPopularManga(page: Int): MangasPage = if (isNsfw) {
         val url = "$baseUrl/api/series-locales/adultos".toHttpUrl().newBuilder()
             .addQueryParameter("orden", "vistos")
             .addQueryParameter("pageSize", "48")
         if (page > 1) {
             url.addQueryParameter("p", getAdultPageToken(page, 48))
         }
-        GET(url.build(), headers)
+        val result = client.get(url.build()).parseAs<AdultCatalogResponse>()
+        val mangas = result.items
+            .filter { !it.externo }
+            .map { it.toSManga() }
+        val hasNextPage = mangas.isNotEmpty() && (result.pageTokens?.next != null || result.page < result.totalPages)
+        MangasPage(mangas, hasNextPage)
     } else {
-        GET("$baseUrl/api/series-locales/popular", headers)
-    }
-
-    override fun popularMangaParse(response: Response): MangasPage {
-        if (response.request.url.encodedPath.contains("/adultos")) {
-            val result = response.parseAs<AdultCatalogResponse>()
-            val mangas = result.items
-                .filter { !it.externo }
-                .map { it.toSManga() }
-            val hasNextPage = mangas.isNotEmpty() && (result.pageTokens?.next != null || result.page < result.totalPages)
-            return MangasPage(mangas, hasNextPage)
-        }
-        val result = response.parseAs<List<SeriesWrapper>>()
+        val result = client.get("$baseUrl/api/series-locales/popular").parseAs<List<SeriesWrapper>>()
         val series = result.flatMap { it.series }.distinctBy { it.id }.map { it.toSManga() }
-        return MangasPage(series, false)
+        MangasPage(series, false)
     }
 
-    override fun latestUpdatesRequest(page: Int): Request = if (isAdultSection) {
+    // =============================== Latest ===============================
+
+    override suspend fun getLatestUpdates(page: Int): MangasPage = if (isNsfw) {
         val url = "$baseUrl/api/series-locales/adultos".toHttpUrl().newBuilder()
             .addQueryParameter("orden", "recientes")
             .addQueryParameter("pageSize", "48")
         if (page > 1) {
             url.addQueryParameter("p", getAdultPageToken(page, 48))
         }
-        GET(url.build(), headers)
+        val result = client.get(url.build()).parseAs<AdultCatalogResponse>()
+        val mangas = result.items
+            .filter { !it.externo }
+            .map { it.toSManga() }
+        val hasNextPage = mangas.isNotEmpty() && (result.pageTokens?.next != null || result.page < result.totalPages)
+        MangasPage(mangas, hasNextPage)
     } else {
-        GET("$baseUrl/api/series-locales/capitulos/recientes?page=$page&pageSize=24", headers)
-    }
-
-    override fun latestUpdatesParse(response: Response): MangasPage {
-        if (response.request.url.encodedPath.contains("/adultos")) {
-            return popularMangaParse(response)
-        }
-        val result = response.parseAs<RecentChaptersResponse>()
+        val result = client.get("$baseUrl/api/series-locales/capitulos/recientes?page=$page&pageSize=24").parseAs<RecentChaptersResponse>()
         val mangas = result.items.map { it.serie.toSManga() }.distinctBy { it.url }
         val hasNextPage = result.page < result.totalPages
-        return MangasPage(mangas, hasNextPage)
+        MangasPage(mangas, hasNextPage)
     }
 
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        val sectionFilter = filters.firstInstanceOrNull<SectionFilter>()
-        val searchAdult = when (sectionFilter?.state) {
-            1 -> false
-            2 -> true
-            else -> isAdultSection
-        }
+    // =============================== Search ===============================
 
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
         val genreFilter = filters.firstInstanceOrNull<GenreFilter>()
         val excludedGenres = genreFilter?.getExcluded().orEmpty()
+        val includedGenres = genreFilter?.getIncluded().orEmpty()
 
-        if (searchAdult) {
+        if (isNsfw) {
             val url = "$baseUrl/api/series-locales/adultos".toHttpUrl().newBuilder()
                 .addQueryParameter("pageSize", "24")
             if (page > 1) {
@@ -134,7 +106,6 @@ abstract class ShadowManga :
             if (query.isNotBlank()) {
                 url.addQueryParameter("q", query)
             }
-            val includedGenres = genreFilter?.getIncluded().orEmpty()
             if (includedGenres.isNotEmpty()) {
                 url.addQueryParameter("generos", includedGenres.joinToString(","))
             }
@@ -147,34 +118,10 @@ abstract class ShadowManga :
             if (orden != "recientes") {
                 url.addQueryParameter("orden", orden)
             }
-            return GET(url.build(), headers).newBuilder()
-                .tag(List::class.java, excludedGenres)
-                .build()
-        }
-
-        val url = "$baseUrl/api/series-locales/search-candidates".toHttpUrl().newBuilder()
-        url.addQueryParameter("q", query)
-        url.addQueryParameter("includeAdult", "false")
-        url.addQueryParameter("showSinPortada", "false")
-        url.addQueryParameter("take", MAX_RESULTS.toString())
-
-        genreFilter?.getIncluded()?.forEach {
-            url.addQueryParameter("tags", it)
-        }
-
-        return GET(url.build(), headers).newBuilder()
-            .tag(List::class.java, excludedGenres)
-            .build()
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    override fun searchMangaParse(response: Response): MangasPage {
-        val excludedGenres = response.request.tag(List::class.java) as? List<String>
-        if (response.request.url.encodedPath.contains("/adultos")) {
-            val result = response.parseAs<AdultCatalogResponse>()
+            val result = client.get(url.build()).parseAs<AdultCatalogResponse>()
             val mangas = result.items
                 .filter { series ->
-                    excludedGenres.isNullOrEmpty() || series.getGenreList().none { genre ->
+                    excludedGenres.isEmpty() || series.getGenreList().none { genre ->
                         genre in excludedGenres
                     }
                 }
@@ -183,9 +130,19 @@ abstract class ShadowManga :
             return MangasPage(mangas, hasNextPage)
         }
 
-        val mangas = response.parseAs<List<Series>>()
+        val url = "$baseUrl/api/series-locales/search-candidates".toHttpUrl().newBuilder()
+            .addQueryParameter("q", query)
+            .addQueryParameter("includeAdult", "false")
+            .addQueryParameter("showSinPortada", "false")
+            .addQueryParameter("take", MAX_RESULTS.toString())
+
+        includedGenres.forEach {
+            url.addQueryParameter("tags", it)
+        }
+
+        val mangas = client.get(url.build()).parseAs<List<Series>>()
             .filter { series ->
-                excludedGenres.isNullOrEmpty() || series.getGenreList().none { genre ->
+                excludedGenres.isEmpty() || series.getGenreList().none { genre ->
                     genre in excludedGenres
                 }
             }.sortedBy { it.title }
@@ -193,37 +150,28 @@ abstract class ShadowManga :
         return MangasPage(mangas, false)
     }
 
-    override fun mangaDetailsRequest(manga: SManga): Request = GET("$baseUrl/api/series-locales/${manga.url}", headers)
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+        if (!url.host.equals(baseUrl.toHttpUrl().host, ignoreCase = true)) return null
+        val segments = url.pathSegments
+        if (segments.size >= 3 && segments[0] == "serie" && segments[1] == "local") {
+            val id = segments[2]
+            val series = client.get("$baseUrl/api/series-locales/$id").parseAs<Series>()
+            return series.toSMangaDetails()
+        }
+        if (segments.size >= 4 && segments[0] == "adultos" && segments[1] == "manga" && segments[2] == "o") {
+            val smId = segments[3]
+            val oneshot = client.get("$baseUrl/api/series-locales/ext/$smId").parseAs<OneshotDetails>()
+            return oneshot.toSMangaDetails()
+        }
+        return null
+    }
+
+    // ======================= Manga URLs ===================================
 
     override fun getMangaUrl(manga: SManga): String = if (manga.url.startsWith("ext/")) {
         "$baseUrl/adultos/manga/o/${manga.url.removePrefix("ext/")}"
     } else {
         "$baseUrl/serie/local/${manga.url}"
-    }
-
-    override fun mangaDetailsParse(response: Response): SManga = if (response.request.url.encodedPath.contains("/ext/")) {
-        response.parseAs<OneshotDetails>().toSMangaDetails()
-    } else {
-        response.parseAs<Series>().toSMangaDetails()
-    }
-
-    override fun chapterListRequest(manga: SManga) = mangaDetailsRequest(manga)
-
-    override fun chapterListParse(response: Response): List<SChapter> {
-        if (response.request.url.encodedPath.contains("/ext/")) {
-            val oneshot = response.parseAs<OneshotDetails>()
-            return listOf(
-                SChapter.create().apply {
-                    name = "Capítulo 1"
-                    url = "ext/${oneshot.smId}/${oneshot.chapterId}"
-                    date_upload = 0L
-                },
-            )
-        }
-        val series = response.parseAs<Series>()
-        return series.chapters
-            .sortedByDescending { it.chapterNumber }
-            .map { it.toSChapter(series.id) }
     }
 
     override fun getChapterUrl(chapter: SChapter): String = if (chapter.url.startsWith("ext/")) {
@@ -234,33 +182,69 @@ abstract class ShadowManga :
         "$baseUrl/reader/local/$chapterId"
     }
 
-    override fun pageListRequest(chapter: SChapter): Request = if (chapter.url.startsWith("ext/")) {
-        val smId = chapter.url.removePrefix("ext/").substringBefore("/")
-        GET("$baseUrl/api/series-locales/ext/$smId/paginas", headers)
-    } else {
-        val mangaId = chapter.url.substringBefore("/")
-        val chapterId = chapter.url.substringAfter("/")
-        GET("$baseUrl/api/series-locales/$mangaId/capitulos/$chapterId/paginas", headers)
+    // ======================= Details and Chapters =========================
+
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        if (manga.url.startsWith("ext/")) {
+            val smId = manga.url.removePrefix("ext/")
+            val oneshot = client.get("$baseUrl/api/series-locales/ext/$smId").parseAs<OneshotDetails>()
+            val chapter = SChapter.create().apply {
+                name = "Capítulo 1"
+                url = "ext/${oneshot.smId}/${oneshot.chapterId}"
+                date_upload = 0L
+            }
+            return SMangaUpdate(oneshot.toSMangaDetails(), listOf(chapter))
+        }
+
+        val series = client.get("$baseUrl/api/series-locales/${manga.url}").parseAs<Series>()
+        val chapterList = series.chapters
+            .sortedByDescending { it.chapterNumber }
+            .map { it.toSChapter(series.id) }
+        return SMangaUpdate(series.toSMangaDetails(), chapterList)
     }
 
-    override fun pageListParse(response: Response): List<Page> {
-        val result = response.parseAs<PagesWrapper>()
-        return result.pages.mapIndexed { index, url ->
-            Page(index, imageUrl = url)
+    // ======================= Pages ========================================
+
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        val url = if (chapter.url.startsWith("ext/")) {
+            val smId = chapter.url.removePrefix("ext/").substringBefore("/")
+            "$baseUrl/api/series-locales/ext/$smId/paginas"
+        } else {
+            val mangaId = chapter.url.substringBefore("/")
+            val chapterId = chapter.url.substringAfter("/")
+            "$baseUrl/api/series-locales/$mangaId/capitulos/$chapterId/paginas"
+        }
+        val result = client.get(url).parseAs<PagesWrapper>()
+        return result.pages.mapIndexed { index, pageUrl ->
+            Page(index, imageUrl = pageUrl)
         }
     }
 
-    override fun getFilterList(): FilterList {
-        fetchFilters()
-        return FilterList(
-            SectionFilter(),
-            OrderByFilter(),
-            if (genresList.isEmpty()) {
-                Filter.Header("Presione 'Reiniciar' para intentar cargar los filtros.")
+    // ============================== Filters ===============================
+
+    override val supportsFilterFetching get() = !isNsfw
+
+    override suspend fun fetchFilterData(): JsonElement = client.get("$baseUrl/api/series-locales/tags").parseAs()
+
+    override fun getFilterList(data: JsonElement?): FilterList {
+        val tags = data?.runCatching { parseAs<List<String>>() }?.getOrNull().orEmpty()
+        return if (isNsfw) {
+            FilterList(
+                OrderByFilter(),
+                GenreFilter(adultGenres),
+            )
+        } else {
+            if (tags.isEmpty()) {
+                FilterList(Filter.Header("Presione 'Reiniciar' para intentar cargar los filtros."))
             } else {
-                GenreFilter(genresList)
-            },
-        )
+                FilterList(GenreFilter(tags.sorted()))
+            }
+        }
     }
 
     private val adultGenres = listOf(
@@ -274,46 +258,7 @@ abstract class ShadowManga :
         "Yaoi", "Yuri",
     )
 
-    private var genresList: List<String> = emptyList()
-    private var fetchFiltersAttempts = 0
-    private var filtersState = FiltersState.NOT_FETCHED
-
-    private fun fetchFilters() {
-        if (filtersState != FiltersState.NOT_FETCHED || fetchFiltersAttempts >= 3) return
-        filtersState = FiltersState.FETCHING
-        fetchFiltersAttempts++
-        scope.launch {
-            try {
-                val tagsResponse = client.newCall(GET("$baseUrl/api/series-locales/tags", headers)).execute()
-                val tagsList = tagsResponse.parseAs<List<String>>()
-
-                genresList = (tagsList + adultGenres).distinct().sorted()
-                filtersState = FiltersState.FETCHED
-            } catch (_: Throwable) {
-                filtersState = FiltersState.NOT_FETCHED
-            }
-        }
-    }
-
-    private enum class FiltersState { NOT_FETCHED, FETCHING, FETCHED }
-
-    override fun imageUrlParse(response: Response) = throw UnsupportedOperationException()
-
-    override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        ListPreference(screen.context).apply {
-            key = PREF_SECTION
-            title = "Sección de navegación"
-            summary = "%s"
-            entries = arrayOf("Todo público (SFW)", "Adultos (+18)")
-            entryValues = arrayOf(SECTION_SFW, SECTION_NSFW)
-            setDefaultValue(SECTION_SFW)
-        }.also(screen::addPreference)
-    }
-
     companion object {
         const val MAX_RESULTS = 120
-        private const val PREF_SECTION = "pref_section"
-        private const val SECTION_SFW = "sfw"
-        private const val SECTION_NSFW = "nsfw"
     }
 }


### PR DESCRIPTION
Closes #18772

### Changes

- Migrated to `KeiSource` 1.6.
- Split into two sources (`Shadow Manga` [SFW] and `Shadow Manga (+18)` [NSFW]) using `source {}` blocks.
- Added Genre and Order filters for the adult catalog.
- Added dynamic filter fetching for SFW tags (`fetchFilterData()`).
- Supported both local adult series and external doujinshis / oneshots (`smhentai`).
- Implemented cursor-based pagination (`p` token) for adult catalog to avoid HTTP 429 rate limits.
- Updated SFW latest updates to use `/api/series-locales/capitulos/recientes`.
- Filtered local series on NSFW Popular and Latest tabs to match the website's curated lists.
- Added deep link intent filters.

Tested with gradlew + device (Komikku)

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

---

🤖 This PR was opened by an AI agent to resolve issue #18772 by migrating to KeiSource 1.6, splitting into SFW and NSFW sources, adding cursor pagination, and oneshot reader support for Shadow Manga.
