### PR TITLE
MangaDenizi: Fix NPE, add image descrambler, and migrate to KeiSource 1.6

### DIFF
--- a/src/tr/mangadenizi/build.gradle.kts
+++ b/src/tr/mangadenizi/build.gradle.kts
@@ -8,7 +8,11 @@ keiyoushi {
     name = "MangaDenizi"
     versionCode = 8
     contentWarning = ContentWarning.MIXED
-    libVersion = "1.4"
+    libVersion = "1.6"
+
+    deeplink {
+        path("/manga/..*")
+    }
 
     source {
         lang = "tr"

--- a/src/tr/mangadenizi/build.gradle.kts
+++ b/src/tr/mangadenizi/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 
 keiyoushi {
     name = "MangaDenizi"
-    versionCode = 7
-    contentWarning = ContentWarning.SAFE
+    versionCode = 8
+    contentWarning = ContentWarning.MIXED
     libVersion = "1.4"
 
     source {
         lang = "tr"
-        baseUrl = "https://www.mangadenizi.net"
+        baseUrl = "https://mangadenizi.net"
     }
 }

--- a/src/tr/mangadenizi/src/eu/kanade/tachiyomi/extension/tr/mangadenizi/Dto.kt
+++ b/src/tr/mangadenizi/src/eu/kanade/tachiyomi/extension/tr/mangadenizi/Dto.kt
@@ -9,16 +9,22 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
-import java.text.SimpleDateFormat
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import kotlin.time.Instant
 
 @Serializable
-class InertiaDto<T>(
-    val props: T,
+class MangaApiResponse<T>(
+    val data: T,
 )
 
 @Serializable
-class MangaIndexDto(
+class MangaIndexData(
     val manga: MangaListDataDto,
+)
+
+@Serializable
+class MangaDetailsData(
+    val manga: MangaDto,
 )
 
 @Serializable
@@ -29,32 +35,29 @@ class MangaListDataDto(
 )
 
 @Serializable
-class MangaDetailsDto(
-    val manga: MangaDto,
-)
-
-@Serializable
 class MangaDto(
     private val title: String,
     val slug: String,
-    @SerialName("cover_url") private val coverUrl: String,
+    @SerialName("cover_url") private val coverUrl: String? = null,
+    @SerialName("cover_thumb_url") private val coverThumbUrl: String? = null,
     private val description: String? = null,
     private val status: String? = null,
     private val categories: List<CategoryDto> = emptyList(),
+    private val genres: List<CategoryDto> = emptyList(),
     private val authors: List<AuthorDto> = emptyList(),
     val chapters: List<ChapterDto> = emptyList(),
 ) {
     fun toSManga() = SManga.create().apply {
         title = this@MangaDto.title
         url = "/manga/$slug"
-        thumbnail_url = coverUrl
+        thumbnail_url = coverUrl ?: coverThumbUrl
         description = this@MangaDto.description
         status = when (this@MangaDto.status) {
             "ongoing" -> SManga.ONGOING
             "completed" -> SManga.COMPLETED
             else -> SManga.UNKNOWN
         }
-        genre = categories.joinToString { it.name }
+        genre = (categories + genres).map { it.name }.distinct().joinToString()
         author = authors.joinToString { it.name }
     }
 }
@@ -74,24 +77,43 @@ class ChapterDto(
     private val number: JsonElement,
     private val title: String? = null,
     private val slug: String,
-    @SerialName("published_at") private val publishedAt: String,
+    @SerialName("published_at") private val publishedAt: String? = null,
 ) {
-    fun toSChapter(mangaSlug: String, dateFormat: SimpleDateFormat) = SChapter.create().apply {
+    fun toSChapter(mangaSlug: String) = SChapter.create().apply {
         url = "/read/$mangaSlug/$slug"
         val numberStr = number.jsonPrimitive.contentOrNull ?: number.toString()
         name = "Bölüm $numberStr" + (if (title.isNullOrBlank()) "" else ": $title")
-        date_upload = dateFormat.tryParse(publishedAt)
+        chapter_number = numberStr.toFloatOrNull() ?: -1f
+        date_upload = Instant.tryParse(publishedAt)
     }
 }
 
 @Serializable
 class ReaderDto(
-    val pages: List<ReaderPageDto>,
+    val pages: List<ReaderPageDto> = emptyList(),
 )
 
 @Serializable
 class ReaderPageDto(
     @SerialName("image_url") private val url: String,
+    private val scramble: ScrambleDto? = null,
 ) {
-    fun toPage(index: Int) = Page(index, imageUrl = url)
+    fun toPage(index: Int): Page {
+        val pageUrl = if (scramble?.method == "tiled-v1" && scramble.grid != null && scramble.seed != null) {
+            url.toHttpUrl().newBuilder()
+                .addQueryParameter(UnscramblerInterceptor.PARAM_GRID, scramble.grid.toString())
+                .addQueryParameter(UnscramblerInterceptor.PARAM_SEED, scramble.seed.toString())
+                .build().toString()
+        } else {
+            url
+        }
+        return Page(index, imageUrl = pageUrl)
+    }
 }
+
+@Serializable
+class ScrambleDto(
+    val method: String? = null,
+    val grid: Int? = null,
+    val seed: Long? = null,
+)

--- a/src/tr/mangadenizi/src/eu/kanade/tachiyomi/extension/tr/mangadenizi/Filters.kt
+++ b/src/tr/mangadenizi/src/eu/kanade/tachiyomi/extension/tr/mangadenizi/Filters.kt
@@ -1,0 +1,80 @@
+package eu.kanade.tachiyomi.extension.tr.mangadenizi
+
+import eu.kanade.tachiyomi.source.model.Filter
+
+open class UriPartFilter(
+    displayName: String,
+    private val vals: Array<Pair<String, String>>,
+    state: Int = 0,
+) : Filter.Select<String>(displayName, vals.map { it.first }.toTypedArray(), state) {
+    fun toUriPart() = vals[state].second
+}
+
+class SortFilter(state: Int = 0) :
+    UriPartFilter(
+        "Sıralama",
+        arrayOf(
+            Pair("Varsayılan", ""),
+            Pair("En Popüler", "popular"),
+            Pair("Son Güncellenen", "latest"),
+            Pair("En Yüksek Puan", "rating"),
+            Pair("Alfabetik (A-Z)", "name"),
+            Pair("Yıl (Yeni-Eski)", "year"),
+        ),
+        state,
+    )
+
+class StatusFilter(state: Int = 0) :
+    UriPartFilter(
+        "Durum",
+        arrayOf(
+            Pair("Tümü", ""),
+            Pair("Devam Ediyor", "ongoing"),
+            Pair("Tamamlandı", "completed"),
+            Pair("Ara Verildi", "hiatus"),
+            Pair("İptal Edildi", "cancelled"),
+        ),
+        state,
+    )
+
+class CategoryFilter(state: Int = 0) :
+    UriPartFilter(
+        "Kategori",
+        arrayOf(
+            Pair("Tümü", ""),
+            Pair("Aksiyon", "aksiyon"),
+            Pair("Bilim Kurgu", "bilim-kurgu"),
+            Pair("Doğaüstü", "dogaustu"),
+            Pair("Dövüş Sanatları", "dovus-sanatlari"),
+            Pair("Dram", "dram"),
+            Pair("Ecchi", "ecchi"),
+            Pair("Fantastik", "fantastik"),
+            Pair("Gerilim", "gerilim"),
+            Pair("Gizem", "gizem"),
+            Pair("Hayattan Bir Parça", "hayattan-bir-parca"),
+            Pair("Hayattan Kesitler", "hayattan-kesitler"),
+            Pair("Komedi", "komedi"),
+            Pair("Korku", "korku"),
+            Pair("Macera", "macera"),
+            Pair("Psikolojik", "psikolojik"),
+            Pair("Romantizm", "romantizm"),
+            Pair("Spor", "spor"),
+            Pair("Tarihi", "tarihi"),
+            Pair("Trajedi", "trajedi"),
+        ),
+        state,
+    )
+
+class DemographicFilter(state: Int = 0) :
+    UriPartFilter(
+        "Demografi",
+        arrayOf(
+            Pair("Tümü", ""),
+            Pair("Genç Erkek (Shounen)", "1"),
+            Pair("Genç Kız (Shoujo)", "2"),
+            Pair("Yetişkin Erkek (Seinen)", "3"),
+            Pair("Yetişkin Kadın (Josei)", "4"),
+            Pair("Çocuk (Kodomo)", "5"),
+        ),
+        state,
+    )

--- a/src/tr/mangadenizi/src/eu/kanade/tachiyomi/extension/tr/mangadenizi/MangaDenizi.kt
+++ b/src/tr/mangadenizi/src/eu/kanade/tachiyomi/extension/tr/mangadenizi/MangaDenizi.kt
@@ -1,26 +1,26 @@
 package eu.kanade.tachiyomi.extension.tr.mangadenizi
 
-import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import keiyoushi.annotation.Source
+import keiyoushi.network.get
+import keiyoushi.source.KeiSource
 import keiyoushi.utils.parseAs
+import kotlinx.serialization.json.JsonElement
 import okhttp3.Headers
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.Request
-import okhttp3.Response
+import okhttp3.OkHttpClient
 
 @Source
-abstract class MangaDenizi : HttpSource() {
-    override val supportsLatest = true
+abstract class MangaDenizi : KeiSource() {
+    override val supportsLatest get() = true
 
-    override val client = network.client.newBuilder()
-        .addInterceptor(UnscramblerInterceptor())
-        .build()
+    override fun OkHttpClient.Builder.configureClient(): OkHttpClient.Builder = addInterceptor(UnscramblerInterceptor())
 
     private val apiHeaders: Headers by lazy {
         headersBuilder()
@@ -29,40 +29,35 @@ abstract class MangaDenizi : HttpSource() {
             .build()
     }
 
-    // ===============================
-    // Popular
-    // ===============================
+    // =============================== Popular ===============================
 
-    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/api/v1/web/manga?sort=popular&page=$page", apiHeaders)
-
-    override fun popularMangaParse(response: Response): MangasPage {
-        val json = response.parseAs<MangaApiResponse<MangaIndexData>>().data.manga
+    override suspend fun getPopularManga(page: Int): MangasPage {
+        val json = client.get("$baseUrl/api/v1/web/manga?sort=popular&page=$page", apiHeaders)
+            .parseAs<MangaApiResponse<MangaIndexData>>().data.manga
         val mangas = json.data.map { it.toSManga() }
         val hasNextPage = json.currentPage < json.lastPage
         return MangasPage(mangas, hasNextPage)
     }
 
-    // ===============================
-    // Latest
-    // ===============================
+    // =============================== Latest ===============================
 
-    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/api/v1/web/manga?sort=latest&page=$page", apiHeaders)
+    override suspend fun getLatestUpdates(page: Int): MangasPage {
+        val json = client.get("$baseUrl/api/v1/web/manga?sort=latest&page=$page", apiHeaders)
+            .parseAs<MangaApiResponse<MangaIndexData>>().data.manga
+        val mangas = json.data.map { it.toSManga() }
+        val hasNextPage = json.currentPage < json.lastPage
+        return MangasPage(mangas, hasNextPage)
+    }
 
-    override fun latestUpdatesParse(response: Response): MangasPage = popularMangaParse(response)
+    // =============================== Search ===============================
 
-    // ===============================
-    // Search
-    // ===============================
-
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        val filterList = if (filters.isEmpty()) getFilterList() else filters
-
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
         val url = "$baseUrl/api/v1/web/manga".toHttpUrl().newBuilder().apply {
             addQueryParameter("page", page.toString())
             if (query.isNotBlank()) {
                 addQueryParameter("q", query.trim())
             }
-            filterList.forEach { filter ->
+            filters.forEach { filter ->
                 when (filter) {
                     is SortFilter -> {
                         if (filter.toUriPart().isNotEmpty()) {
@@ -88,59 +83,59 @@ abstract class MangaDenizi : HttpSource() {
                 }
             }
         }.build()
-        return GET(url, apiHeaders)
+
+        val json = client.get(url, apiHeaders)
+            .parseAs<MangaApiResponse<MangaIndexData>>().data.manga
+        val mangas = json.data.map { it.toSManga() }
+        val hasNextPage = json.currentPage < json.lastPage
+        return MangasPage(mangas, hasNextPage)
     }
 
-    override fun searchMangaParse(response: Response): MangasPage = popularMangaParse(response)
+    // =============================== Deeplink ==============================
 
-    // ===============================
-    // Filters
-    // ===============================
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+        if (!url.host.equals(baseUrl.toHttpUrl().host, ignoreCase = true)) return null
+        val segments = url.pathSegments
+        if (segments.firstOrNull() != "manga" || segments.size < 2) return null
+        val slug = segments[1]
+        val manga = client.get("$baseUrl/api/v1/web/manga/$slug", apiHeaders)
+            .parseAs<MangaApiResponse<MangaDetailsData>>().data.manga
+        return manga.toSManga()
+    }
 
-    override fun getFilterList() = FilterList(
+    // =============================== Details & Chapters ====================
+
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        val slug = manga.url.trim().removePrefix("/").removePrefix("manga/")
+        val mangaData = client.get("$baseUrl/api/v1/web/manga/$slug", apiHeaders)
+            .parseAs<MangaApiResponse<MangaDetailsData>>().data.manga
+        val sManga = mangaData.toSManga()
+        val sChapters = mangaData.chapters.map { it.toSChapter(mangaData.slug) }
+        return SMangaUpdate(sManga, sChapters)
+    }
+
+    // =============================== Pages =================================
+
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        val trimmed = chapter.url.trim().removePrefix("/").removePrefix("read/").removePrefix("manga/")
+        val mangaSlug = trimmed.substringBefore("/")
+        val chapterSlug = trimmed.substringAfter("/")
+        val dto = client.get("$baseUrl/api/v1/reader/$mangaSlug/$chapterSlug", apiHeaders)
+            .parseAs<ReaderDto>()
+        return dto.pages.mapIndexed { index, page -> page.toPage(index) }
+    }
+
+    // =============================== Filters ===============================
+
+    override fun getFilterList(data: JsonElement?): FilterList = FilterList(
         SortFilter(),
         StatusFilter(),
         CategoryFilter(),
         DemographicFilter(),
     )
-
-    // ===============================
-    // Details
-    // ===============================
-
-    override fun mangaDetailsRequest(manga: SManga): Request {
-        val slug = manga.url.trim().removePrefix("/").removePrefix("manga/")
-        return GET("$baseUrl/api/v1/web/manga/$slug", apiHeaders)
-    }
-
-    override fun mangaDetailsParse(response: Response): SManga = response.parseAs<MangaApiResponse<MangaDetailsData>>().data.manga.toSManga()
-
-    // ===============================
-    // Chapters
-    // ===============================
-
-    override fun chapterListRequest(manga: SManga): Request = mangaDetailsRequest(manga)
-
-    override fun chapterListParse(response: Response): List<SChapter> {
-        val manga = response.parseAs<MangaApiResponse<MangaDetailsData>>().data.manga
-        return manga.chapters.map { it.toSChapter(manga.slug) }
-    }
-
-    // ===============================
-    // Pages
-    // ===============================
-
-    override fun pageListRequest(chapter: SChapter): Request {
-        val trimmed = chapter.url.trim().removePrefix("/").removePrefix("read/").removePrefix("manga/")
-        val mangaSlug = trimmed.substringBefore("/")
-        val chapterSlug = trimmed.substringAfter("/")
-        return GET("$baseUrl/api/v1/reader/$mangaSlug/$chapterSlug", apiHeaders)
-    }
-
-    override fun pageListParse(response: Response): List<Page> {
-        val dto = response.parseAs<ReaderDto>()
-        return dto.pages.mapIndexed { index, page -> page.toPage(index) }
-    }
-
-    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
 }

--- a/src/tr/mangadenizi/src/eu/kanade/tachiyomi/extension/tr/mangadenizi/MangaDenizi.kt
+++ b/src/tr/mangadenizi/src/eu/kanade/tachiyomi/extension/tr/mangadenizi/MangaDenizi.kt
@@ -18,16 +18,13 @@ import okhttp3.OkHttpClient
 
 @Source
 abstract class MangaDenizi : KeiSource() {
-    override val supportsLatest get() = true
-
     override fun OkHttpClient.Builder.configureClient(): OkHttpClient.Builder = addInterceptor(UnscramblerInterceptor())
 
-    private val apiHeaders: Headers by lazy {
-        headersBuilder()
-            .add("Accept", "application/json")
-            .add("Referer", "$baseUrl/manga")
+    private val apiHeaders: Headers
+        get() = headersBuilder()
+            .set("Accept", "application/json")
+            .set("Referer", "$baseUrl/manga")
             .build()
-    }
 
     // =============================== Popular ===============================
 

--- a/src/tr/mangadenizi/src/eu/kanade/tachiyomi/extension/tr/mangadenizi/MangaDenizi.kt
+++ b/src/tr/mangadenizi/src/eu/kanade/tachiyomi/extension/tr/mangadenizi/MangaDenizi.kt
@@ -8,35 +8,35 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.annotation.Source
-import keiyoushi.utils.asJsoup
 import keiyoushi.utils.parseAs
+import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
-import org.jsoup.nodes.Document
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @Source
 abstract class MangaDenizi : HttpSource() {
     override val supportsLatest = true
 
-    private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'", Locale.ROOT)
+    override val client = network.client.newBuilder()
+        .addInterceptor(UnscramblerInterceptor())
+        .build()
+
+    private val apiHeaders: Headers by lazy {
+        headersBuilder()
+            .add("Accept", "application/json")
+            .add("Referer", "$baseUrl/manga")
+            .build()
+    }
 
     // ===============================
     // Popular
     // ===============================
 
-    override fun popularMangaRequest(page: Int): Request {
-        val url = "$baseUrl/manga".toHttpUrl().newBuilder()
-            .addQueryParameter("sort", "popular")
-            .addQueryParameter("page", page.toString())
-            .build()
-        return GET(url, headers)
-    }
+    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/api/v1/web/manga?sort=popular&page=$page", apiHeaders)
 
     override fun popularMangaParse(response: Response): MangasPage {
-        val json = response.asJsoup().extractInertia<MangaIndexDto>().manga
+        val json = response.parseAs<MangaApiResponse<MangaIndexData>>().data.manga
         val mangas = json.data.map { it.toSManga() }
         val hasNextPage = json.currentPage < json.lastPage
         return MangasPage(mangas, hasNextPage)
@@ -46,12 +46,7 @@ abstract class MangaDenizi : HttpSource() {
     // Latest
     // ===============================
 
-    override fun latestUpdatesRequest(page: Int): Request {
-        val url = "$baseUrl/manga".toHttpUrl().newBuilder()
-            .addQueryParameter("page", page.toString())
-            .build()
-        return GET(url, headers)
-    }
+    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/api/v1/web/manga?sort=latest&page=$page", apiHeaders)
 
     override fun latestUpdatesParse(response: Response): MangasPage = popularMangaParse(response)
 
@@ -60,28 +55,75 @@ abstract class MangaDenizi : HttpSource() {
     // ===============================
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        val url = "$baseUrl/manga".toHttpUrl().newBuilder()
-            .addQueryParameter("q", query)
-            .addQueryParameter("page", page.toString())
-            .build()
-        return GET(url, headers)
+        val filterList = if (filters.isEmpty()) getFilterList() else filters
+
+        val url = "$baseUrl/api/v1/web/manga".toHttpUrl().newBuilder().apply {
+            addQueryParameter("page", page.toString())
+            if (query.isNotBlank()) {
+                addQueryParameter("q", query.trim())
+            }
+            filterList.forEach { filter ->
+                when (filter) {
+                    is SortFilter -> {
+                        if (filter.toUriPart().isNotEmpty()) {
+                            addQueryParameter("sort", filter.toUriPart())
+                        }
+                    }
+                    is StatusFilter -> {
+                        if (filter.toUriPart().isNotEmpty()) {
+                            addQueryParameter("status[]", filter.toUriPart())
+                        }
+                    }
+                    is CategoryFilter -> {
+                        if (filter.toUriPart().isNotEmpty()) {
+                            addQueryParameter("categories[]", filter.toUriPart())
+                        }
+                    }
+                    is DemographicFilter -> {
+                        if (filter.toUriPart().isNotEmpty()) {
+                            addQueryParameter("demographics[]", filter.toUriPart())
+                        }
+                    }
+                    else -> {}
+                }
+            }
+        }.build()
+        return GET(url, apiHeaders)
     }
 
     override fun searchMangaParse(response: Response): MangasPage = popularMangaParse(response)
 
     // ===============================
+    // Filters
+    // ===============================
+
+    override fun getFilterList() = FilterList(
+        SortFilter(),
+        StatusFilter(),
+        CategoryFilter(),
+        DemographicFilter(),
+    )
+
+    // ===============================
     // Details
     // ===============================
 
-    override fun mangaDetailsParse(response: Response): SManga = response.asJsoup().extractInertia<MangaDetailsDto>().manga.toSManga()
+    override fun mangaDetailsRequest(manga: SManga): Request {
+        val slug = manga.url.trim().removePrefix("/").removePrefix("manga/")
+        return GET("$baseUrl/api/v1/web/manga/$slug", apiHeaders)
+    }
+
+    override fun mangaDetailsParse(response: Response): SManga = response.parseAs<MangaApiResponse<MangaDetailsData>>().data.manga.toSManga()
 
     // ===============================
     // Chapters
     // ===============================
 
+    override fun chapterListRequest(manga: SManga): Request = mangaDetailsRequest(manga)
+
     override fun chapterListParse(response: Response): List<SChapter> {
-        val json = response.asJsoup().extractInertia<MangaDetailsDto>().manga
-        return json.chapters.map { it.toSChapter(json.slug, dateFormat) }
+        val manga = response.parseAs<MangaApiResponse<MangaDetailsData>>().data.manga
+        return manga.chapters.map { it.toSChapter(manga.slug) }
     }
 
     // ===============================
@@ -89,28 +131,16 @@ abstract class MangaDenizi : HttpSource() {
     // ===============================
 
     override fun pageListRequest(chapter: SChapter): Request {
-        // Compatibility for old saved URLs
-        val url = if (chapter.url.startsWith("/manga/")) {
-            chapter.url.replace("/manga/", "/read/")
-        } else {
-            chapter.url
-        }
-        return GET(baseUrl + url, headers)
+        val trimmed = chapter.url.trim().removePrefix("/").removePrefix("read/").removePrefix("manga/")
+        val mangaSlug = trimmed.substringBefore("/")
+        val chapterSlug = trimmed.substringAfter("/")
+        return GET("$baseUrl/api/v1/reader/$mangaSlug/$chapterSlug", apiHeaders)
     }
 
     override fun pageListParse(response: Response): List<Page> {
-        val json = response.asJsoup().extractInertia<ReaderDto>()
-        return json.pages.mapIndexed { index, page -> page.toPage(index) }
+        val dto = response.parseAs<ReaderDto>()
+        return dto.pages.mapIndexed { index, page -> page.toPage(index) }
     }
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
-
-    // ===============================
-    // Utilities
-    // ===============================
-
-    private inline fun <reified T> Document.extractInertia(): T {
-        val data = selectFirst("div#app")!!.attr("data-page")
-        return data.parseAs<InertiaDto<T>>().props
-    }
 }

--- a/src/tr/mangadenizi/src/eu/kanade/tachiyomi/extension/tr/mangadenizi/UnscramblerInterceptor.kt
+++ b/src/tr/mangadenizi/src/eu/kanade/tachiyomi/extension/tr/mangadenizi/UnscramblerInterceptor.kt
@@ -1,0 +1,134 @@
+package eu.kanade.tachiyomi.extension.tr.mangadenizi
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.Rect
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import java.io.ByteArrayOutputStream
+
+class UnscramblerInterceptor : Interceptor {
+    companion object {
+        const val PARAM_GRID = "scramble_grid"
+        const val PARAM_SEED = "scramble_seed"
+
+        private const val TA = 2463534242L
+        private const val VO = 2654435769L
+        private const val BO = 2246822507L
+
+        private fun ft(s: Long): Long = s and 0xFFFFFFFFL
+
+        private class XorShift(seed: Long) {
+            private var e = ft(seed).takeIf { it != 0L } ?: TA
+
+            fun next(): Long {
+                e = ft(e xor ft(e shl 13))
+                e = ft(e xor (e ushr 17))
+                e = ft(e xor ft(e shl 5))
+                return e
+            }
+        }
+
+        private fun shuffle(length: Int, seed: Long): IntArray {
+            val t = IntArray(maxOf(1, length)) { it }
+            val rng = XorShift(seed)
+            for (n in t.size - 1 downTo 1) {
+                val i = (rng.next() % (n + 1)).toInt()
+                val temp = t[n]
+                t[n] = t[i]
+                t[i] = temp
+            }
+            return t
+        }
+
+        private class Slice(val offset: Int, val length: Int)
+
+        private fun createSlices(total: Int, pieces: Int): List<Slice> {
+            val t = maxOf(1, total)
+            val r = maxOf(1, minOf(pieces, t))
+            return (0 until r).map { i ->
+                val o = (i * t) / r
+                val a = ((i + 1) * t) / r
+                Slice(o, maxOf(1, a - o))
+            }
+        }
+
+        private fun mapSlices(slices: List<Slice>, indices: IntArray): List<Slice> {
+            var t = 0
+            return indices.map { r ->
+                val n = if (r in slices.indices) slices[r].length else 1
+                val slice = Slice(t, n)
+                t += n
+                slice
+            }
+        }
+    }
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val grid = request.url.queryParameter(PARAM_GRID)?.toIntOrNull()
+        val seed = request.url.queryParameter(PARAM_SEED)?.toLongOrNull()
+
+        if (grid == null || seed == null) {
+            return chain.proceed(request)
+        }
+
+        val cleanUrl = request.url.newBuilder()
+            .removeAllQueryParameters(PARAM_GRID)
+            .removeAllQueryParameters(PARAM_SEED)
+            .build()
+        val cleanRequest = request.newBuilder().url(cleanUrl).build()
+        val response = chain.proceed(cleanRequest)
+
+        val imageBody = response.body
+        val bytes = imageBody.bytes()
+
+        val descrambled = descramble(bytes, grid, seed)
+        val newBody = descrambled.toResponseBody("image/jpeg".toMediaType())
+        return response.newBuilder().body(newBody).build()
+    }
+
+    private fun descramble(bytes: ByteArray, grid: Int, seed: Long): ByteArray {
+        val src = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+            ?: return bytes
+
+        val w = src.width
+        val h = src.height
+        val l = maxOf(1, minOf(grid, minOf(w, h)))
+
+        val u = createSlices(w, l)
+        val c = createSlices(h, l)
+        val m = shuffle(l, (ft(seed) xor ft(BO)).takeIf { it != 0L } ?: TA)
+        val f = shuffle(l, (ft(seed) xor ft(VO)).takeIf { it != 0L } ?: TA)
+        val p = mapSlices(u, m)
+        val g = mapSlices(c, f)
+
+        val dst = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(dst)
+
+        for (hIdx in 0 until l) {
+            val d = f[hIdx]
+            val v = c[d]
+            val y = g[hIdx]
+            for (bIdx in 0 until l) {
+                val wIdx = m[bIdx]
+                val k = u[wIdx]
+                val t = p[bIdx]
+
+                val srcRect = Rect(t.offset, y.offset, t.offset + t.length, y.offset + y.length)
+                val dstRect = Rect(k.offset, v.offset, k.offset + k.length, v.offset + v.length)
+                canvas.drawBitmap(src, srcRect, dstRect, null)
+            }
+        }
+
+        src.recycle()
+
+        val output = ByteArrayOutputStream()
+        dst.compress(Bitmap.CompressFormat.JPEG, 90, output)
+        dst.recycle()
+        return output.toByteArray()
+    }
+}

--- a/src/tr/mangadenizi/src/eu/kanade/tachiyomi/extension/tr/mangadenizi/UnscramblerInterceptor.kt
+++ b/src/tr/mangadenizi/src/eu/kanade/tachiyomi/extension/tr/mangadenizi/UnscramblerInterceptor.kt
@@ -7,8 +7,9 @@ import android.graphics.Rect
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Response
-import okhttp3.ResponseBody.Companion.toResponseBody
-import java.io.ByteArrayOutputStream
+import okhttp3.ResponseBody.Companion.asResponseBody
+import okio.Buffer
+import java.io.InputStream
 
 class UnscramblerInterceptor : Interceptor {
     companion object {
@@ -83,17 +84,15 @@ class UnscramblerInterceptor : Interceptor {
         val cleanRequest = request.newBuilder().url(cleanUrl).build()
         val response = chain.proceed(cleanRequest)
 
-        val imageBody = response.body
-        val bytes = imageBody.bytes()
-
-        val descrambled = descramble(bytes, grid, seed)
-        val newBody = descrambled.toResponseBody("image/jpeg".toMediaType())
+        val output = response.body.byteStream().use { descramble(it, grid, seed) }
+        val newBody = output.asResponseBody("image/jpeg".toMediaType(), output.size)
         return response.newBuilder().body(newBody).build()
     }
 
-    private fun descramble(bytes: ByteArray, grid: Int, seed: Long): ByteArray {
-        val src = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
-            ?: return bytes
+    private fun descramble(image: InputStream, grid: Int, seed: Long): Buffer {
+        val src = BitmapFactory.decodeStream(image)
+        val output = Buffer()
+        if (src == null) return output
 
         val w = src.width
         val h = src.height
@@ -126,9 +125,8 @@ class UnscramblerInterceptor : Interceptor {
 
         src.recycle()
 
-        val output = ByteArrayOutputStream()
-        dst.compress(Bitmap.CompressFormat.JPEG, 90, output)
+        dst.compress(Bitmap.CompressFormat.JPEG, 90, output.outputStream())
         dst.recycle()
-        return output.toByteArray()
+        return output
     }
 }


### PR DESCRIPTION
Closes #18608

### Changes

- Migrated to `KeiSource` 1.6.
- Migrated to Nuxt 3 REST API (`/api/v1/web/manga`, `/api/v1/reader/...`) resolving `NullPointerException`.
- Implemented client-side image descrambler interceptor for `tiled-v1` PRNG scrambling using Okio `Buffer` and stream decoding.
- Added catalog filters (Sort, Status, Categories, Demographics).
- Added deep link intent filters (`/manga/..*`).

Tested with gradlew + device (Komikku)

### Checklist

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

---

🤖 This PR was opened by an AI agent under user direction to resolve #18608 by migrating MangaDenizi to its new Nuxt 3 REST API, migrating to KeiSource 1.6, and implementing an image descrambler interceptor with Okio Buffer.
