### PR TITLE
Bacami: migrate to 1.6

### DIFF
--- a/src/id/bacami/build.gradle.kts
+++ b/src/id/bacami/build.gradle.kts
@@ -6,12 +6,16 @@ plugins {
 
 keiyoushi {
     name = "Bacami"
-    versionCode = 3
+    versionCode = 1
     contentWarning = ContentWarning.SAFE
-    libVersion = "1.4"
+    libVersion = "1.6"
 
     source {
         lang = "id"
         baseUrl = "https://v1.bacami.site"
+    }
+
+    deeplink {
+        path("/komik/..*")
     }
 }

--- a/src/id/bacami/build.gradle.kts
+++ b/src/id/bacami/build.gradle.kts
@@ -17,5 +17,6 @@ keiyoushi {
 
     deeplink {
         path("/komik/..*")
+        path("/..*-chapter-..*")
     }
 }

--- a/src/id/bacami/src/eu/kanade/tachiyomi/extension/id/bacami/Bacami.kt
+++ b/src/id/bacami/src/eu/kanade/tachiyomi/extension/id/bacami/Bacami.kt
@@ -17,7 +17,6 @@ import keiyoushi.utils.tryParseDate
 import kotlinx.serialization.json.JsonElement
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.time.ZoneId
@@ -30,22 +29,26 @@ abstract class Bacami : KeiSource() {
     private val dateFormat = DateTimeFormatter.ofPattern("d MMMM, yyyy", Locale.ENGLISH)
     private val chapterRegex = Regex("""(?:Chapter|Ch\.)\s+([0-9]+(?:\.[0-9]+)?)""", RegexOption.IGNORE_CASE)
 
-    private fun pagePath(page: Int) = if (page > 1) "page/$page/" else ""
-
     // ============================== Popular ===============================
     override suspend fun getPopularManga(page: Int): MangasPage {
-        val url = "$baseUrl/custom-search/orderby/score/${pagePath(page)}".toHttpUrl()
-        val response = client.get(url, ensureSuccess = false)
-        if (response.code == 404) return MangasPage(emptyList(), false)
-        return mangaListParse(response)
+        val url = baseUrl.toHttpUrl().newBuilder().apply {
+            addPathSegments("custom-search/orderby/score")
+            if (page > 1) {
+                addPathSegments("page/$page")
+            }
+        }.build()
+        return mangaListParse(client.get(url).asJsoup())
     }
 
     // =============================== Latest ===============================
     override suspend fun getLatestUpdates(page: Int): MangasPage {
-        val url = "$baseUrl/custom-search/orderby/latest/${pagePath(page)}".toHttpUrl()
-        val response = client.get(url, ensureSuccess = false)
-        if (response.code == 404) return MangasPage(emptyList(), false)
-        return mangaListParse(response)
+        val url = baseUrl.toHttpUrl().newBuilder().apply {
+            addPathSegments("custom-search/orderby/latest")
+            if (page > 1) {
+                addPathSegments("page/$page")
+            }
+        }.build()
+        return mangaListParse(client.get(url).asJsoup())
     }
 
     // =============================== Search ===============================
@@ -55,49 +58,58 @@ abstract class Bacami : KeiSource() {
                 addPathSegment("search")
                 addPathSegment(query)
                 if (page > 1) {
-                    addPathSegment("page")
-                    addPathSegment(page.toString())
+                    addPathSegments("page/$page")
                 }
-                addPathSegment("")
             }.build()
         } else {
             val isNewKomik = filters.firstInstanceOrNull<NewKomikFilter>()?.state == true
             if (isNewKomik) {
-                "$baseUrl/komik-baru/${pagePath(page)}".toHttpUrl()
+                baseUrl.toHttpUrl().newBuilder().apply {
+                    addPathSegment("komik-baru")
+                    if (page > 1) {
+                        addPathSegments("page/$page")
+                    }
+                }.build()
             } else {
                 val genre = filters.firstInstanceOrNull<GenreFilter>()?.toUriPart() ?: "all"
                 val status = filters.firstInstanceOrNull<StatusFilter>()?.toUriPart() ?: "all"
                 val type = filters.firstInstanceOrNull<TypeFilter>()?.toUriPart() ?: "all"
                 val orderby = filters.firstInstanceOrNull<OrderByFilter>()?.toUriPart() ?: "latest"
 
-                val urlString = buildString {
-                    append("$baseUrl/custom-search/")
-                    if (genre != "all") append("genre/$genre/")
-                    if (status != "all") append("status/$status/")
-                    if (type != "all") append("type/$type/")
-                    if (orderby != "latest") append("orderby/$orderby/")
-                    if (page > 1) append("page/$page/")
-                }
-                urlString.toHttpUrl()
+                baseUrl.toHttpUrl().newBuilder().apply {
+                    addPathSegment("custom-search")
+                    if (genre != "all") addPathSegments("genre/$genre")
+                    if (status != "all") addPathSegments("status/$status")
+                    if (type != "all") addPathSegments("type/$type")
+                    if (orderby != "latest") addPathSegments("orderby/$orderby")
+                    if (page > 1) addPathSegments("page/$page")
+                }.build()
             }
         }
 
-        val response = client.get(url, ensureSuccess = false)
-        if (response.code == 404) return MangasPage(emptyList(), false)
-        return mangaListParse(response)
+        return mangaListParse(client.get(url).asJsoup())
     }
 
-    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? = runCatching {
         if (url.host != baseUrl.toHttpUrl().host) return null
-        if (url.pathSegments.firstOrNull() != "komik") return null
-        val slug = url.pathSegments.getOrNull(1)?.takeIf { it.isNotEmpty() } ?: return null
-        val targetUrl = "$baseUrl/komik/$slug/".toHttpUrl()
-        val document = client.get(targetUrl).asJsoup()
-        val manga = SManga.create().apply {
-            setUrlWithoutDomain(targetUrl.toString())
+        if (url.pathSegments.none { it.isNotEmpty() }) return null
+
+        val mangaPath = if (url.pathSegments.firstOrNull() == "komik") {
+            url.encodedPath
+        } else {
+            val document = client.get(url).asJsoup()
+            val href = document.selectFirst("div.allc a[href*='/komik/'], a.midall[href*='/komik/'], .breadcrumb a[href*='/komik/']")?.absUrl("href")
+                ?: return null
+            href.toHttpUrl().encodedPath
         }
-        return parseDetails(document, manga)
-    }
+
+        val manga = SManga.create().apply {
+            setUrlWithoutDomain(mangaPath)
+        }
+        getMangaUpdate(manga, emptyList(), fetchDetails = true, fetchChapters = false).manga.apply {
+            initialized = true
+        }
+    }.getOrNull()
 
     // ======================= Details and Chapters ==========================
     override suspend fun fetchMangaUpdate(
@@ -106,36 +118,36 @@ abstract class Bacami : KeiSource() {
         fetchDetails: Boolean,
         fetchChapters: Boolean,
     ): SMangaUpdate {
-        val document = client.get(baseUrl + manga.url).asJsoup()
+        val document = client.get(getMangaUrl(manga)).asJsoup()
         return SMangaUpdate(
-            manga = parseDetails(document, manga),
+            manga = parseDetails(document).apply {
+                url = manga.url
+                if (title.isEmpty()) {
+                    title = manga.title
+                }
+            },
             chapters = parseChapters(document),
         )
     }
 
-    private fun parseDetails(document: Document, manga: SManga): SManga = manga.apply {
+    private fun parseDetails(document: Document): SManga = SManga.create().apply {
         val content = document.selectFirst("#komik > section.manga-content") ?: return@apply
 
-        if (title.isEmpty()) {
-            val parsedTitle = content.selectFirst("header > h1")?.text()?.removeSuffix("Bahasa Indonesia")?.trim()
-            if (!parsedTitle.isNullOrEmpty()) {
-                title = parsedTitle
-            }
-        }
-
+        title = content.selectFirst("header > h1")?.text()?.removeSuffix("Bahasa Indonesia")?.trim().orEmpty()
         thumbnail_url = content.selectFirst("figure .image-wrap img")?.imgAttr()
         author = content.selectFirst(".info-item:contains(Author) .info-value")?.text()
             ?.ifEmpty { content.selectFirst("div > div > div:nth-child(3) > span.info-value")?.text() }
         genre = content.select("nav > span > a").joinToString { it.text() }
         status = parseStatus(document)
 
-        val altTitle = content.select("p.manga-altname").text().trim()
-        val desc = content.select("p.manga-description").text().trim()
+        val altTitle = content.select("p.manga-altname").text()
+        val desc = content.select("p.manga-description").text()
         description = if (altTitle.isNotEmpty()) {
             if (desc.isNotEmpty()) "$desc\n\nAlternative Title: $altTitle" else "Alternative Title: $altTitle"
         } else {
             desc
         }
+        initialized = true
     }
 
     private fun parseStatus(document: Document): Int = when {
@@ -159,15 +171,14 @@ abstract class Bacami : KeiSource() {
 
     // =============================== Pages ================================
     override suspend fun getPageList(chapter: SChapter): List<Page> {
-        val chapterUrl = baseUrl + chapter.url
-        val document = client.get(chapterUrl).asJsoup()
+        val document = client.get(getChapterUrl(chapter)).asJsoup()
         val scriptContent = document.selectFirst("script:containsData(imageUrls)")?.data()
             ?: return emptyList()
 
         val jsonString = scriptContent.substringAfter("imageUrls:").substringBefore("],").plus("]")
         val imageUrls = jsonString.parseAs<List<String>>()
         return imageUrls.mapIndexed { index, url ->
-            Page(index, chapterUrl, imageUrl = url)
+            Page(index, imageUrl = url)
         }
     }
 
@@ -185,8 +196,7 @@ abstract class Bacami : KeiSource() {
     )
 
     // ============================= Utilities ==============================
-    private fun mangaListParse(response: Response): MangasPage {
-        val document = response.asJsoup()
+    private fun mangaListParse(document: Document): MangasPage {
         val mangas = document.select("article.genre-card").map { element ->
             searchMangaFromElement(element)
         }
@@ -195,10 +205,8 @@ abstract class Bacami : KeiSource() {
     }
 
     private fun searchMangaFromElement(element: Element): SManga = SManga.create().apply {
-        title = element.selectFirst("div.genre-info > a")?.text().orEmpty()
-        element.selectFirst("div.genre-cover > a")?.let {
-            setUrlWithoutDomain(it.absUrl("href"))
-        }
+        title = element.selectFirst("div.genre-info > a")!!.text()
+        setUrlWithoutDomain(element.selectFirst("div.genre-cover > a")!!.absUrl("href"))
         thumbnail_url = element.selectFirst("div.genre-cover > a > img")?.imgAttr()
     }
 

--- a/src/id/bacami/src/eu/kanade/tachiyomi/extension/id/bacami/Bacami.kt
+++ b/src/id/bacami/src/eu/kanade/tachiyomi/extension/id/bacami/Bacami.kt
@@ -1,110 +1,140 @@
 package eu.kanade.tachiyomi.extension.id.bacami
 
-import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import keiyoushi.annotation.Source
+import keiyoushi.network.get
+import keiyoushi.source.KeiSource
 import keiyoushi.utils.asJsoup
 import keiyoushi.utils.firstInstanceOrNull
 import keiyoushi.utils.parseAs
-import keiyoushi.utils.tryParse
-import okhttp3.Request
+import keiyoushi.utils.tryParseDate
+import kotlinx.serialization.json.JsonElement
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
-import java.text.SimpleDateFormat
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 @Source
-abstract class Bacami : HttpSource() {
+abstract class Bacami : KeiSource() {
 
-    override val supportsLatest = true
+    private val dateFormat = DateTimeFormatter.ofPattern("d MMMM, yyyy", Locale.ENGLISH)
+    private val chapterRegex = Regex("""(?:Chapter|Ch\.)\s+([0-9]+(?:\.[0-9]+)?)""", RegexOption.IGNORE_CASE)
 
-    private val dateFormat = SimpleDateFormat("dd MMMM, yyyy", Locale.ENGLISH)
+    private fun pagePath(page: Int) = if (page > 1) "page/$page/" else ""
 
     // ============================== Popular ===============================
-    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/custom-search/orderby/score/page/$page/", headers)
-
-    override fun popularMangaParse(response: Response): MangasPage {
-        val document = response.asJsoup()
-        val mangas = document.select("article.genre-card").map { element ->
-            searchMangaFromElement(element)
-        }
-        val hasNextPage = document.selectFirst("div.paginate a.next.page-numbers") != null
-        return MangasPage(mangas, hasNextPage)
+    override suspend fun getPopularManga(page: Int): MangasPage {
+        val url = "$baseUrl/custom-search/orderby/score/${pagePath(page)}".toHttpUrl()
+        val response = client.get(url, ensureSuccess = false)
+        if (response.code == 404) return MangasPage(emptyList(), false)
+        return mangaListParse(response)
     }
 
-    private fun searchMangaFromElement(element: Element): SManga = SManga.create().apply {
-        title = element.selectFirst("div.genre-info > a")!!.text()
-        setUrlWithoutDomain(element.selectFirst("div.genre-cover > a")!!.attr("href"))
-        thumbnail_url = element.selectFirst("div.genre-cover > a > img")?.let {
-            it.attr("abs:data-src").ifEmpty { it.attr("abs:src") }
-        }
+    // =============================== Latest ===============================
+    override suspend fun getLatestUpdates(page: Int): MangasPage {
+        val url = "$baseUrl/custom-search/orderby/latest/${pagePath(page)}".toHttpUrl()
+        val response = client.get(url, ensureSuccess = false)
+        if (response.code == 404) return MangasPage(emptyList(), false)
+        return mangaListParse(response)
     }
 
-    // ============================== Latest ================================
-    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/custom-search/orderby/latest/page/$page/", headers)
-
-    override fun latestUpdatesParse(response: Response): MangasPage = popularMangaParse(response)
-
-    // ============================== Search ================================
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        if (query.isNotBlank()) {
-            return GET("$baseUrl/search/$query/page/$page/", headers)
-        }
-
-        filters.firstInstanceOrNull<NewKomikFilter>()?.let {
-            if (it.state) {
-                return GET("$baseUrl/komik-baru/", headers)
-            }
-        }
-
-        val orderby = filters.firstInstanceOrNull<OrderByFilter>()?.toUriPart() ?: "latest"
-        val status = filters.firstInstanceOrNull<StatusFilter>()?.toUriPart() ?: "all"
-        val type = filters.firstInstanceOrNull<TypeFilter>()?.toUriPart() ?: "all"
-        val genre = filters.firstInstanceOrNull<GenreFilter>()?.toUriPart() ?: "all"
-
-        val url = buildString {
-            append("$baseUrl/custom-search/")
-            if (orderby != "latest") append("orderby/$orderby/")
-            if (status != "all") append("status/$status/")
-            if (type != "all") append("type/$type/")
-            if (genre != "all") append("genre/$genre/")
-            append("page/$page/")
-        }
-
-        return GET(url, headers)
-    }
-
-    override fun searchMangaParse(response: Response): MangasPage = popularMangaParse(response)
-
-    // =========================== Manga Details ============================
-    override fun mangaDetailsParse(response: Response): SManga {
-        val document = response.asJsoup()
-        return SManga.create().apply {
-            val content = document.selectFirst("#komik > section.manga-content")!!
-            title = content.selectFirst("header > h1")!!.text()
-            thumbnail_url = content.selectFirst("figure .image-wrap img")?.let {
-                it.attr("abs:data-src").ifEmpty { it.attr("abs:src") }
-            }
-            author = content.selectFirst(".info-item:contains(Author) .info-value")?.text()
-                ?.ifEmpty { content.selectFirst("div > div > div:nth-child(3) > span.info-value")?.text() }
-            genre = content.select("nav > span > a").joinToString { it.text() }
-            status = parseStatus(document)
-
-            val altTitle = content.select("p.manga-altname").text()
-            description = content.select("p.manga-description").text().let {
-                if (altTitle.isNotEmpty()) {
-                    "$it\n\nAlternative Title: $altTitle".trim()
-                } else {
-                    it
+    // =============================== Search ===============================
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
+        val url = if (query.isNotBlank()) {
+            baseUrl.toHttpUrl().newBuilder().apply {
+                addPathSegment("search")
+                addPathSegment(query)
+                if (page > 1) {
+                    addPathSegment("page")
+                    addPathSegment(page.toString())
                 }
+                addPathSegment("")
+            }.build()
+        } else {
+            val isNewKomik = filters.firstInstanceOrNull<NewKomikFilter>()?.state == true
+            if (isNewKomik) {
+                "$baseUrl/komik-baru/${pagePath(page)}".toHttpUrl()
+            } else {
+                val genre = filters.firstInstanceOrNull<GenreFilter>()?.toUriPart() ?: "all"
+                val status = filters.firstInstanceOrNull<StatusFilter>()?.toUriPart() ?: "all"
+                val type = filters.firstInstanceOrNull<TypeFilter>()?.toUriPart() ?: "all"
+                val orderby = filters.firstInstanceOrNull<OrderByFilter>()?.toUriPart() ?: "latest"
+
+                val urlString = buildString {
+                    append("$baseUrl/custom-search/")
+                    if (genre != "all") append("genre/$genre/")
+                    if (status != "all") append("status/$status/")
+                    if (type != "all") append("type/$type/")
+                    if (orderby != "latest") append("orderby/$orderby/")
+                    if (page > 1) append("page/$page/")
+                }
+                urlString.toHttpUrl()
             }
+        }
+
+        val response = client.get(url, ensureSuccess = false)
+        if (response.code == 404) return MangasPage(emptyList(), false)
+        return mangaListParse(response)
+    }
+
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+        if (url.host != baseUrl.toHttpUrl().host) return null
+        if (url.pathSegments.firstOrNull() != "komik") return null
+        val slug = url.pathSegments.getOrNull(1)?.takeIf { it.isNotEmpty() } ?: return null
+        val targetUrl = "$baseUrl/komik/$slug/".toHttpUrl()
+        val document = client.get(targetUrl).asJsoup()
+        val manga = SManga.create().apply {
+            setUrlWithoutDomain(targetUrl.toString())
+        }
+        return parseDetails(document, manga)
+    }
+
+    // ======================= Details and Chapters ==========================
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        val document = client.get(baseUrl + manga.url).asJsoup()
+        return SMangaUpdate(
+            manga = parseDetails(document, manga),
+            chapters = parseChapters(document),
+        )
+    }
+
+    private fun parseDetails(document: Document, manga: SManga): SManga = manga.apply {
+        val content = document.selectFirst("#komik > section.manga-content") ?: return@apply
+
+        if (title.isEmpty()) {
+            val parsedTitle = content.selectFirst("header > h1")?.text()?.removeSuffix("Bahasa Indonesia")?.trim()
+            if (!parsedTitle.isNullOrEmpty()) {
+                title = parsedTitle
+            }
+        }
+
+        thumbnail_url = content.selectFirst("figure .image-wrap img")?.imgAttr()
+        author = content.selectFirst(".info-item:contains(Author) .info-value")?.text()
+            ?.ifEmpty { content.selectFirst("div > div > div:nth-child(3) > span.info-value")?.text() }
+        genre = content.select("nav > span > a").joinToString { it.text() }
+        status = parseStatus(document)
+
+        val altTitle = content.select("p.manga-altname").text().trim()
+        val desc = content.select("p.manga-description").text().trim()
+        description = if (altTitle.isNotEmpty()) {
+            if (desc.isNotEmpty()) "$desc\n\nAlternative Title: $altTitle" else "Alternative Title: $altTitle"
+        } else {
+            desc
         }
     }
 
@@ -114,44 +144,63 @@ abstract class Bacami : HttpSource() {
         else -> SManga.UNKNOWN
     }
 
-    // ============================== Chapters ==============================
-    override fun chapterListParse(response: Response): List<SChapter> {
-        val document = response.asJsoup()
-        return document.select("ol.chapter-list > li").map { element ->
-            SChapter.create().apply {
-                val link = element.selectFirst("a.ch-link")!!
-                name = link.text().substringAfter("–").trim()
-                setUrlWithoutDomain(link.attr("href"))
-                date_upload = dateFormat.tryParse(element.select("span.ch-date").text())
+    private fun parseChapters(document: Document): List<SChapter> = document.select("ol.chapter-list > li").map { element ->
+        val link = element.selectFirst("a.ch-link")!!
+        SChapter.create().apply {
+            val rawName = link.text()
+            name = rawName.substringAfter("–").substringAfter("-").trim().ifEmpty { rawName }
+            setUrlWithoutDomain(link.absUrl("href"))
+            chapterRegex.find(name)?.let {
+                chapter_number = it.groupValues[1].toFloatOrNull() ?: -1f
             }
+            date_upload = dateFormat.tryParseDate(element.select("span.ch-date").text(), ZoneId.of("Asia/Jakarta"))
         }
     }
 
     // =============================== Pages ================================
-    override fun pageListParse(response: Response): List<Page> {
-        val document = response.asJsoup()
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        val chapterUrl = baseUrl + chapter.url
+        val document = client.get(chapterUrl).asJsoup()
         val scriptContent = document.selectFirst("script:containsData(imageUrls)")?.data()
             ?: return emptyList()
 
         val jsonString = scriptContent.substringAfter("imageUrls:").substringBefore("],").plus("]")
         val imageUrls = jsonString.parseAs<List<String>>()
         return imageUrls.mapIndexed { index, url ->
-            Page(index, imageUrl = url)
+            Page(index, chapterUrl, imageUrl = url)
         }
     }
 
-    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException("Not used.")
-
     // ============================== Filters ===============================
-    override fun getFilterList(): FilterList = FilterList(
+    override fun getFilterList(data: JsonElement?): FilterList = FilterList(
         Filter.Header("Filter diabaikan jika menggunakan pencarian teks."),
         Filter.Separator(),
-        OrderByFilter(),
+        GenreFilter(),
         StatusFilter(),
         TypeFilter(),
-        GenreFilter(),
+        OrderByFilter(),
         Filter.Separator(),
         Filter.Header("Centang 'Komik Baru' akan mengabaikan filter lain."),
         NewKomikFilter(),
     )
+
+    // ============================= Utilities ==============================
+    private fun mangaListParse(response: Response): MangasPage {
+        val document = response.asJsoup()
+        val mangas = document.select("article.genre-card").map { element ->
+            searchMangaFromElement(element)
+        }
+        val hasNextPage = document.selectFirst("div.paginate a.next.page-numbers") != null
+        return MangasPage(mangas, hasNextPage)
+    }
+
+    private fun searchMangaFromElement(element: Element): SManga = SManga.create().apply {
+        title = element.selectFirst("div.genre-info > a")?.text().orEmpty()
+        element.selectFirst("div.genre-cover > a")?.let {
+            setUrlWithoutDomain(it.absUrl("href"))
+        }
+        thumbnail_url = element.selectFirst("div.genre-cover > a > img")?.imgAttr()
+    }
+
+    private fun Element.imgAttr(): String = absUrl("data-src").ifEmpty { absUrl("src") }
 }

--- a/src/id/bacami/src/eu/kanade/tachiyomi/extension/id/bacami/Filters.kt
+++ b/src/id/bacami/src/eu/kanade/tachiyomi/extension/id/bacami/Filters.kt
@@ -4,7 +4,7 @@ import eu.kanade.tachiyomi.source.model.Filter
 
 class NewKomikFilter : Filter.CheckBox("Komik Baru")
 
-open class UriPartFilter(displayName: String, val vals: Array<Pair<String, String>>) : Filter.Select<String>(displayName, vals.map { it.first }.toTypedArray()) {
+open class UriPartFilter(displayName: String, private val vals: Array<Pair<String, String>>) : Filter.Select<String>(displayName, vals.map { it.first }.toTypedArray()) {
     fun toUriPart() = vals[state].second
 }
 


### PR DESCRIPTION
## Description

- Migrate to `KeiSource` (`libVersion = "1.6"`)
- Add deeplink DSL for manga URLs
- Update date parsing to `java.time.format.DateTimeFormatter` + `tryParseDate`
- Fix combined search filter segment ordering

Tested with gradlew + device (Komikku)

## Checklist

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

---

🤖 This pull request was prepared and assisted by an AI agent under user supervision.
