### PR TITLE
CosmicScans: migrate to 1.6

### DIFF
--- a/src/id/cosmicscansid/build.gradle.kts
+++ b/src/id/cosmicscansid/build.gradle.kts
@@ -6,13 +6,18 @@ plugins {
 
 keiyoushi {
     name = "CosmicScans"
-    versionCode = 57
+    versionCode = 1
     contentWarning = ContentWarning.MIXED
-    libVersion = "1.4"
+    libVersion = "1.6"
 
     source {
         lang = "id"
         baseUrl = "https://04.cosmicscans.to"
         id = 6559481336553833282L
+    }
+
+    deeplink {
+        path("/series/..*")
+        path("/manga/..*")
     }
 }

--- a/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/CosmicScansID.kt
+++ b/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/CosmicScansID.kt
@@ -86,7 +86,7 @@ abstract class CosmicScansID : KeiSource() {
             return MangasPage(result.data.map { it.toSManga() }, false)
         }
 
-        val key = searchKey(filters)
+        val key = searchKey(query, filters, "filter")
         if (page > 1 && cursorCache["$key:$page"].isNullOrBlank()) {
             return MangasPage(emptyList(), false)
         }
@@ -108,14 +108,15 @@ abstract class CosmicScansID : KeiSource() {
         val firstSegment = url.pathSegments.firstOrNull()
         if (firstSegment != "series" && firstSegment != "manga") return null
         val slug = url.pathSegments.getOrNull(1)?.takeIf { it.isNotEmpty() } ?: return null
-        val response = client.get("$apiUrl/mangaDetail/$slug", ensureSuccess = false)
-        if (response.code == 404) return null
-        return response.parseAs<MangaDetailResponse>().data.toSMangaDetails()
+        val manga = SManga.create().apply {
+            setUrlWithoutDomain("/series/$slug")
+        }
+        return runCatching {
+            getMangaUpdate(manga, emptyList(), fetchDetails = true, fetchChapters = false).manga
+        }.getOrNull()
     }
 
     // ======================= Details and Chapters ==========================
-    override fun getMangaUrl(manga: SManga): String = "$baseUrl/series/${manga.slug()}"
-
     override fun getChapterUrl(chapter: SChapter): String = "$baseUrl/chapter/${chapter.url.substringAfterLast('/')}"
 
     override suspend fun fetchMangaUpdate(
@@ -131,7 +132,7 @@ abstract class CosmicScansID : KeiSource() {
             .filter { it.slug?.isNotBlank() == true && it.redirectLink.isNullOrBlank() }
             .map { it.toSChapter() }
         return SMangaUpdate(
-            manga = data.toSMangaDetails(),
+            manga = data.toSMangaDetails(slug),
             chapters = parsedChapters,
         )
     }
@@ -188,7 +189,9 @@ abstract class CosmicScansID : KeiSource() {
             .forEach { addQueryParameter("genres_slug", it.slug) }
     }
 
-    private fun searchKey(filters: FilterList): String = listOf(
+    private fun searchKey(query: String, filters: FilterList, endpoint: String): String = listOf(
+        endpoint,
+        query,
         filters.firstInstanceOrNull<OrderFilter>()?.value.orEmpty(),
         filters.firstInstanceOrNull<StatusFilter>()?.value.orEmpty(),
         filters.firstInstanceOrNull<TypeFilter>()?.value.orEmpty(),

--- a/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/CosmicScansID.kt
+++ b/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/CosmicScansID.kt
@@ -111,9 +111,7 @@ abstract class CosmicScansID : KeiSource() {
         val manga = SManga.create().apply {
             setUrlWithoutDomain("/series/$slug")
         }
-        return runCatching {
-            getMangaUpdate(manga, emptyList(), fetchDetails = true, fetchChapters = false).manga
-        }.getOrNull()
+        return getMangaUpdate(manga, emptyList(), fetchDetails = true, fetchChapters = false).manga
     }
 
     // ======================= Details and Chapters ==========================

--- a/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/CosmicScansID.kt
+++ b/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/CosmicScansID.kt
@@ -1,29 +1,27 @@
 package eu.kanade.tachiyomi.extension.id.cosmicscansid
 
-import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import keiyoushi.annotation.Source
+import keiyoushi.network.get
 import keiyoushi.network.rateLimit
+import keiyoushi.source.KeiSource
 import keiyoushi.utils.firstInstanceOrNull
 import keiyoushi.utils.parseAs
+import kotlinx.serialization.json.JsonElement
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Builder
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
-import okhttp3.Request
 import okhttp3.Response
-import rx.Observable
-import java.util.Locale
 import kotlin.time.Duration.Companion.seconds
 
 @Source
-abstract class CosmicScansID : HttpSource() {
-
-    override val supportsLatest = true
+abstract class CosmicScansID : KeiSource() {
 
     private val apiUrl = "https://cdncid.csmcscns.id/v1/manga"
 
@@ -31,13 +29,7 @@ abstract class CosmicScansID : HttpSource() {
 
     private val lastPage = mutableMapOf<String, Int>()
 
-    override val client: OkHttpClient = network.client.newBuilder()
-        .rateLimit(3, 1.seconds)
-        .build()
-
-    override fun headersBuilder() = super.headersBuilder()
-        .set("Origin", baseUrl)
-        .set("Referer", "$baseUrl/")
+    override fun OkHttpClient.Builder.configureClient(): OkHttpClient.Builder = rateLimit(3, 1.seconds)
 
     // URL compat: handle old "/manga/slug" and new "/series/slug"
     private fun SManga.slug(): String = url
@@ -45,123 +37,119 @@ abstract class CosmicScansID : HttpSource() {
         .removePrefix("/series/")
         .trimEnd('/')
 
-    // Popular
-    override fun popularMangaRequest(page: Int): Request {
+    // ============================== Popular ===============================
+    override suspend fun getPopularManga(page: Int): MangasPage {
         val key = "popular"
+        if (page > 1 && cursorCache["$key:$page"].isNullOrBlank()) {
+            return MangasPage(emptyList(), false)
+        }
         lastPage[key] = page
         val url = "$apiUrl/filter".toHttpUrl().newBuilder()
             .addQueryParameter("limit", PAGE_SIZE.toString())
             .addQueryParameter("order_by", "popular")
             .addCursor(key, page)
             .build()
-        return GET(url, headers)
+        val response = client.get(url)
+        return parseMangaPage(response, key)
     }
 
-    override fun popularMangaParse(response: Response): MangasPage = parseMangaPage(response, "popular")
-
-    // Latest
-    override fun latestUpdatesRequest(page: Int): Request {
+    // =============================== Latest ===============================
+    override suspend fun getLatestUpdates(page: Int): MangasPage {
         val key = "update"
+        if (page > 1 && cursorCache["$key:$page"].isNullOrBlank()) {
+            return MangasPage(emptyList(), false)
+        }
         lastPage[key] = page
         val url = "$apiUrl/filter".toHttpUrl().newBuilder()
             .addQueryParameter("limit", PAGE_SIZE.toString())
             .addQueryParameter("order_by", "update")
             .addCursor(key, page)
             .build()
-        return GET(url, headers)
-    }
-
-    override fun latestUpdatesParse(response: Response): MangasPage = parseMangaPage(response, "update")
-
-    // Search
-    override fun fetchSearchManga(
-        page: Int,
-        query: String,
-        filters: FilterList,
-    ): Observable<MangasPage> {
-        if (query.isBlank() && !filters.hasActiveFilters() && page > 1) {
-            return Observable.just(MangasPage(emptyList(), false))
-        }
-        return super.fetchSearchManga(page, query, filters)
-            .map { mangasPage ->
-                val clientFilters = filters.buildClientFilters()
-                if (clientFilters.isEmpty()) {
-                    mangasPage
-                } else {
-                    val filtered = mangasPage.mangas.filter { manga ->
-                        clientFilters.all { predicate -> predicate(manga) }
-                    }
-                    MangasPage(filtered, mangasPage.hasNextPage)
-                }
-            }
-    }
-
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        val endpoint = when {
-            query.isNotBlank() -> "search"
-            filters.firstInstanceOrNull<ProjectFilter>()?.state == 1 -> "latestProject"
-            else -> "filter"
-        }
-        val key = searchKey(query, filters, endpoint)
-        lastPage[key] = page
-        val url = "$apiUrl/$endpoint".toHttpUrl().newBuilder()
-            .addQueryParameter("limit", PAGE_SIZE.toString())
-            .apply {
-                if (query.isNotBlank()) addQueryParameter("q", query)
-                if (endpoint == "filter") addOrderFilter(filters)
-                if (endpoint != "search") addCursor(key, page)
-            }
-            .build()
-        return GET(url, headers)
-    }
-
-    override fun searchMangaParse(response: Response): MangasPage {
-        val query = response.request.url.queryParameter("q").orEmpty()
-        val path = response.request.url.encodedPath.substringAfterLast('/')
-        val key = when (path) {
-            "filter", "latestProject" -> searchKeyFromUrl(response, path)
-            else -> searchKey(query, FilterList(), "search")
-        }
+        val response = client.get(url)
         return parseMangaPage(response, key)
     }
 
-    // Details
-    override fun getMangaUrl(manga: SManga): String = "$baseUrl/series/${manga.slug()}"
+    // =============================== Search ===============================
+    override suspend fun getSearchMangaList(
+        page: Int,
+        query: String,
+        filters: FilterList,
+    ): MangasPage {
+        if (query.isNotBlank()) {
+            if (page > 1) return MangasPage(emptyList(), false)
+            val url = "$apiUrl/search".toHttpUrl().newBuilder()
+                .addQueryParameter("limit", "48")
+                .addQueryParameter("q", query)
+                .build()
+            val response = client.get(url)
+            val result = response.parseAs<MangaListResponse>()
+            return MangasPage(result.data.map { it.toSManga() }, false)
+        }
 
-    override fun mangaDetailsRequest(manga: SManga): Request {
-        val slug = manga.slug()
-        return GET("$apiUrl/mangaDetail/$slug", headers)
+        val key = searchKey(filters)
+        if (page > 1 && cursorCache["$key:$page"].isNullOrBlank()) {
+            return MangasPage(emptyList(), false)
+        }
+        lastPage[key] = page
+        val url = "$apiUrl/filter".toHttpUrl().newBuilder()
+            .addQueryParameter("limit", PAGE_SIZE.toString())
+            .apply {
+                addFilters(filters)
+                addCursor(key, page)
+            }
+            .build()
+
+        val response = client.get(url)
+        return parseMangaPage(response, key)
     }
 
-    override fun mangaDetailsParse(response: Response): SManga = response.parseAs<MangaDetailResponse>().data.toSMangaDetails()
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+        if (url.host != baseUrl.toHttpUrl().host) return null
+        val firstSegment = url.pathSegments.firstOrNull()
+        if (firstSegment != "series" && firstSegment != "manga") return null
+        val slug = url.pathSegments.getOrNull(1)?.takeIf { it.isNotEmpty() } ?: return null
+        val response = client.get("$apiUrl/mangaDetail/$slug", ensureSuccess = false)
+        if (response.code == 404) return null
+        return response.parseAs<MangaDetailResponse>().data.toSMangaDetails()
+    }
 
-    // Chapters
-    override fun chapterListRequest(manga: SManga): Request = mangaDetailsRequest(manga)
-
-    override fun chapterListParse(response: Response): List<SChapter> = response.parseAs<MangaDetailResponse>().data.chapters.orEmpty()
-        .filter { it.slug?.isNotBlank() == true && it.redirectLink.isNullOrBlank() }
-        .map { it.toSChapter() }
+    // ======================= Details and Chapters ==========================
+    override fun getMangaUrl(manga: SManga): String = "$baseUrl/series/${manga.slug()}"
 
     override fun getChapterUrl(chapter: SChapter): String = "$baseUrl/chapter/${chapter.url.substringAfterLast('/')}"
 
-    // Pages
-    override fun pageListRequest(chapter: SChapter): Request {
-        val slug = chapter.url.substringAfterLast('/')
-        return GET("$apiUrl/readingPage/$slug", headers)
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        val slug = manga.slug()
+        val response = client.get("$apiUrl/mangaDetail/$slug")
+        val data = response.parseAs<MangaDetailResponse>().data
+        val parsedChapters = data.chapters.orEmpty()
+            .filter { it.slug?.isNotBlank() == true && it.redirectLink.isNullOrBlank() }
+            .map { it.toSChapter() }
+        return SMangaUpdate(
+            manga = data.toSMangaDetails(),
+            chapters = parsedChapters,
+        )
     }
 
-    override fun pageListParse(response: Response): List<Page> {
+    // =============================== Pages ================================
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        val slug = chapter.url.substringAfterLast('/')
+        val response = client.get("$apiUrl/readingPage/$slug")
         val data = response.parseAs<ReadingPageResponse>().data
         if (!data.redirectLink.isNullOrBlank()) return emptyList()
-        return data.toPageList()
+        val chapterUrl = getChapterUrl(chapter)
+        return data.toPageList(chapterUrl)
     }
 
-    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
+    // ============================== Filters ===============================
+    override fun getFilterList(data: JsonElement?): FilterList = getCosmicScansIDFilterList()
 
-    // Filters
-    override fun getFilterList() = getCosmicScansIDFilterList()
-
-    // Utilities
+    // ============================= Utilities ==============================
     private fun parseMangaPage(response: Response, key: String): MangasPage {
         val result = response.parseAs<MangaListResponse>()
         val page = lastPage[key] ?: 1
@@ -178,77 +166,36 @@ abstract class CosmicScansID : HttpSource() {
         }
     }
 
-    private fun Builder.addOrderFilter(filters: FilterList): Builder = apply {
+    private fun Builder.addFilters(filters: FilterList): Builder = apply {
         filters.firstInstanceOrNull<OrderFilter>()?.value
             ?.takeIf { it.isNotBlank() }
             ?.let { addQueryParameter("order_by", it) }
+
+        filters.firstInstanceOrNull<StatusFilter>()?.value
+            ?.takeIf { it.isNotBlank() }
+            ?.let { addQueryParameter("release_status", it) }
+
+        filters.firstInstanceOrNull<TypeFilter>()?.value
+            ?.takeIf { it.isNotBlank() }
+            ?.let { addQueryParameter("type_manga", it) }
+
+        filters.firstInstanceOrNull<ProjectFilter>()?.value
+            ?.takeIf { it.isNotBlank() }
+            ?.let { addQueryParameter("is_project", it) }
+
+        filters.firstInstanceOrNull<GenreFilter>()?.state.orEmpty()
+            .filter { it.state }
+            .forEach { addQueryParameter("genres_slug", it.slug) }
     }
 
-    private fun FilterList.buildClientFilters(): List<(SManga) -> Boolean> {
-        val predicates = mutableListOf<(SManga) -> Boolean>()
-
-        firstInstanceOrNull<StatusFilter>()?.value?.takeIf { it.isNotBlank() }?.let { status ->
-            predicates += { manga ->
-                manga.status == when (status.lowercase(Locale.ROOT)) {
-                    "ongoing" -> SManga.ONGOING
-                    "completed", "complete" -> SManga.COMPLETED
-                    "hiatus" -> SManga.ON_HIATUS
-                    else -> SManga.UNKNOWN
-                }
-            }
-        }
-
-        firstInstanceOrNull<TypeFilter>()?.value?.takeIf { it.isNotBlank() }?.let { type ->
-            predicates += { manga ->
-                manga.description?.contains("Type: $type", ignoreCase = true) == true
-            }
-        }
-
-        val selectedGenres = firstInstanceOrNull<GenreFilter>()?.state
-            ?.filter { it.state }
-            ?.map { it.genre }
-            ?: emptyList()
-        if (selectedGenres.isNotEmpty()) {
-            predicates += { manga ->
-                val mangaGenres = manga.genre.orEmpty()
-                selectedGenres.all { selected ->
-                    mangaGenres.contains(selected, ignoreCase = true)
-                }
-            }
-        }
-
-        return predicates
-    }
-
-    private fun FilterList.hasActiveFilters(): Boolean = firstInstanceOrNull<OrderFilter>()?.state != 0 ||
-        firstInstanceOrNull<StatusFilter>()?.state != 0 ||
-        firstInstanceOrNull<TypeFilter>()?.state != 0 ||
-        firstInstanceOrNull<ProjectFilter>()?.state == 1 ||
-        firstInstanceOrNull<GenreFilter>()?.state.orEmpty().any { it.state }
-
-    private fun searchKey(query: String, filters: FilterList, endpoint: String): String = listOf(
-        endpoint,
-        query,
+    private fun searchKey(filters: FilterList): String = listOf(
         filters.firstInstanceOrNull<OrderFilter>()?.value.orEmpty(),
         filters.firstInstanceOrNull<StatusFilter>()?.value.orEmpty(),
         filters.firstInstanceOrNull<TypeFilter>()?.value.orEmpty(),
-        filters.firstInstanceOrNull<ProjectFilter>()?.state?.toString().orEmpty(),
+        filters.firstInstanceOrNull<ProjectFilter>()?.value.orEmpty(),
         filters.firstInstanceOrNull<GenreFilter>()?.state.orEmpty()
-            .filter { it.state }.joinToString(",") { it.genre },
+            .filter { it.state }.joinToString(",") { it.slug },
     ).joinToString(":")
-
-    private fun searchKeyFromUrl(response: Response, endpoint: String): String {
-        val url = response.request.url
-        return listOf(
-            endpoint,
-            "",
-            url.queryParameter("order_by").orEmpty(),
-            "",
-            "",
-            if (endpoint == "latestProject") "1" else "0",
-            "",
-        ).joinToString(":")
-    }
 
     companion object {
         private const val PAGE_SIZE = 24

--- a/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/Dto.kt
+++ b/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/Dto.kt
@@ -71,9 +71,10 @@ class MangaDetailDto(
     private val status: String? = null,
     val chapters: List<ChapterDto>? = null,
 ) {
-    fun toSMangaDetails(): SManga = SManga.create().apply {
+    fun toSMangaDetails(defaultSlug: String = ""): SManga = SManga.create().apply {
+        val s = this@MangaDetailDto.slug?.takeIf { it.isNotBlank() } ?: defaultSlug
         title = this@MangaDetailDto.title.orEmpty()
-        url = "/series/${this@MangaDetailDto.slug.orEmpty()}"
+        url = "/series/$s"
         thumbnail_url = this@MangaDetailDto.cover
         description = listOfNotNull(
             this@MangaDetailDto.sinopsis,

--- a/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/Dto.kt
+++ b/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/Dto.kt
@@ -3,15 +3,12 @@ package eu.kanade.tachiyomi.extension.id.cosmicscansid
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
+import keiyoushi.utils.tryParse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.jsoup.Jsoup
-import java.text.SimpleDateFormat
 import java.util.Locale
-import java.util.TimeZone
-
-private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ROOT)
-    .apply { timeZone = TimeZone.getTimeZone("UTC") }
+import kotlin.time.Instant
 
 @Serializable
 class MangaListResponse(
@@ -53,6 +50,7 @@ class MangaDto(
             "ongoing" -> SManga.ONGOING
             "completed", "complete" -> SManga.COMPLETED
             "hiatus", "on hiatus", "on-hold", "on hold" -> SManga.ON_HIATUS
+            "dropped" -> SManga.CANCELLED
             else -> SManga.UNKNOWN
         }
         description = this@MangaDto.type?.let { "Type: $it" }
@@ -88,6 +86,7 @@ class MangaDetailDto(
             "ongoing" -> SManga.ONGOING
             "completed", "complete" -> SManga.COMPLETED
             "hiatus", "on hiatus", "on-hold", "on hold" -> SManga.ON_HIATUS
+            "dropped" -> SManga.CANCELLED
             else -> SManga.UNKNOWN
         }
         initialized = true
@@ -105,7 +104,7 @@ class ChapterDto(
         name = "Chapter ${this@ChapterDto.chapterNum.orEmpty()}".trim()
         url = "/chapter/${this@ChapterDto.slug.orEmpty()}"
         chapter_number = this@ChapterDto.chapterNum?.toFloatOrNull() ?: -1f
-        date_upload = runCatching { dateFormat.parse(this@ChapterDto.time ?: "")?.time }.getOrNull() ?: 0L
+        date_upload = Instant.tryParse(this@ChapterDto.time)
     }
 }
 
@@ -114,10 +113,10 @@ class ReadingPageDto(
     private val chapters: List<String>? = null,
     @SerialName("redirect_link") val redirectLink: String? = null,
 ) {
-    fun toPageList(): List<Page> = chapters.orEmpty()
+    fun toPageList(chapterUrl: String = ""): List<Page> = chapters.orEmpty()
         .mapNotNull { html ->
             Jsoup.parse(html).selectFirst("img")?.attr("src")
                 ?.takeIf { it.isNotBlank() }
         }
-        .mapIndexed { index, imageUrl -> Page(index, imageUrl = imageUrl) }
+        .mapIndexed { index, imageUrl -> Page(index, chapterUrl, imageUrl = imageUrl) }
 }

--- a/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/Filters.kt
+++ b/src/id/cosmicscansid/src/eu/kanade/tachiyomi/extension/id/cosmicscansid/Filters.kt
@@ -23,10 +23,10 @@ internal class OrderFilter :
         "Urutkan",
         arrayOf(
             "Update" to "update",
-            "Popular" to "popular",
-            "A-Z" to "az",
-            "Z-A" to "za",
+            "A–Z" to "az",
+            "Z–A" to "za",
             "Baru Ditambahkan" to "added",
+            "Popular" to "popular",
         ),
     )
 
@@ -38,6 +38,7 @@ internal class StatusFilter :
             "Ongoing" to "Ongoing",
             "Completed" to "Completed",
             "Hiatus" to "Hiatus",
+            "Dropped" to "Dropped",
         ),
     )
 
@@ -49,23 +50,53 @@ internal class TypeFilter :
             "Manga" to "Manga",
             "Manhwa" to "Manhwa",
             "Manhua" to "Manhua",
+            "Webtoon" to "Webtoon",
         ),
     )
 
 internal class ProjectFilter :
-    Filter.Select<String>(
+    SelectFilter(
         "Project",
         arrayOf(
-            "Semua",
-            "Project",
+            "Semua" to "",
+            "Project Only" to "true",
         ),
     )
 
-internal class Genre(val genre: String) : Filter.CheckBox(genre)
+internal class Genre(name: String, val slug: String) : Filter.CheckBox(name)
 
 internal class GenreFilter(genres: List<Genre>) : Filter.Group<Genre>("Genre", genres)
 
 internal val GENRES = listOf(
-    "Action", "Adventure", "Comedy", "Drama", "Fantasy", "Martial Arts", "Romance",
-    "School Life", "Shounen", "Supernatural", "System", "Thriller", "Murim",
-).map { Genre(it) }
+    Genre("Action", "action"),
+    Genre("Adventure", "adventure"),
+    Genre("Comedy", "comedy"),
+    Genre("Cultivation", "cultivation"),
+    Genre("Delinquent", "delinquent"),
+    Genre("Drama", "drama"),
+    Genre("Ecchi", "ecchi"),
+    Genre("Fantasy", "fantasy"),
+    Genre("Harem", "harem"),
+    Genre("Historical", "historical"),
+    Genre("Horror", "horror"),
+    Genre("Isekai", "isekai"),
+    Genre("Martial Arts", "martial-arts"),
+    Genre("Murim", "murim"),
+    Genre("Mystery", "mystery"),
+    Genre("Psychological", "psychological"),
+    Genre("Reincarnation", "reincarnation"),
+    Genre("Returner", "returner"),
+    Genre("Revenge", "revenge"),
+    Genre("Romance", "romance"),
+    Genre("School Life", "school-life"),
+    Genre("Sci-Fi", "sci-fi"),
+    Genre("Seinen", "seinen"),
+    Genre("Shoujo", "shoujo"),
+    Genre("Shounen", "shounen"),
+    Genre("Slice of Life", "slice-of-life"),
+    Genre("Sports", "sports"),
+    Genre("Supernatural", "supernatural"),
+    Genre("System", "system"),
+    Genre("Thriller", "thriller"),
+    Genre("Tragedy", "tragedy"),
+)


### PR DESCRIPTION
## Description

- Migrate to KeiSource (`libVersion = "1.6"`)
- Implement server-side filtering with all website filters (status, type, project, order, genres)
- Add deep link intent filters for `/series/..*` and `/manga/..*`
- Add `getMangaByUrl` for URL resolution
- Replace deprecated `SimpleDateFormat` with `Instant.tryParse`

Tested with gradlew + device (Komikku)

## Checklist

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

---

🤖 This pull request was prepared and assisted by an AI agent under user supervision.