### PR TITLE
fix(zh/wnacg): Fix the image regular expression to resolve 403 errors

### DIFF
--- a/src/zh/wnacg/build.gradle.kts
+++ b/src/zh/wnacg/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "WNACG"
-    versionCode = 23
+    versionCode = 24
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
 

--- a/src/zh/wnacg/src/eu/kanade/tachiyomi/extension/zh/wnacg/WNACG.kt
+++ b/src/zh/wnacg/src/eu/kanade/tachiyomi/extension/zh/wnacg/WNACG.kt
@@ -157,6 +157,6 @@ abstract class WNACG :
     }
 
     companion object {
-        private val pageImageRegex = Regex("""//\S*(jpeg|jpg|png|webp|gif)""")
+        private val pageImageRegex = Regex("""//[^\s"'\\]+\.(?:jpeg|jpg|png|webp|gif)(?:\?[^\s"'\\]*)?""", RegexOption.IGNORE_CASE)
     }
 }


### PR DESCRIPTION
The old regular expression could not match image links containing query parameters or escaped quotation marks, resulting in page image parsing failure and a 403 response. The updated regular expression supports query strings and ignores case, while also increasing the version number.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
