### PR TITLE
Fix Zinmanga.net chapters and image host

### DIFF
--- a/src/en/zinmanganet/build.gradle.kts
+++ b/src/en/zinmanganet/build.gradle.kts
@@ -6,13 +6,13 @@ plugins {
 
 keiyoushi {
     name = "Zinmanga.net"
-    versionCode = 0
+    versionCode = 1
     contentWarning = ContentWarning.SAFE
     libVersion = "1.4"
     theme = "madaralegacy"
 
     source {
         lang = "en"
-        baseUrl = "https://zinmanga.net"
+        baseUrl = "https://www.zinmanga.net"
     }
 }

--- a/src/en/zinmanganet/build.gradle.kts
+++ b/src/en/zinmanganet/build.gradle.kts
@@ -8,8 +8,8 @@ keiyoushi {
     name = "Zinmanga.net"
     versionCode = 1
     contentWarning = ContentWarning.SAFE
-    libVersion = "1.4"
-    theme = "madaralegacy"
+    libVersion = "1.6"
+    theme = "madara"
 
     source {
         lang = "en"

--- a/src/en/zinmanganet/src/eu/kanade/tachiyomi/extension/en/zinmanganet/ZinmangaNet.kt
+++ b/src/en/zinmanganet/src/eu/kanade/tachiyomi/extension/en/zinmanganet/ZinmangaNet.kt
@@ -1,15 +1,14 @@
 package eu.kanade.tachiyomi.extension.en.zinmanganet
 
-import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.multisrc.madara.MadaraNoAjax
 import keiyoushi.annotation.Source
-import java.text.SimpleDateFormat
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 @Source
-abstract class ZinmangaNet : Madara() {
-    override val dateFormat = SimpleDateFormat("MM/dd/yyyy", Locale.ROOT)
-    override val useLoadMoreRequest = LoadMoreStrategy.Never
-    override val useNewChapterEndpoint = true
+abstract class ZinmangaNet : MadaraNoAjax() {
+    override val chapterDateFormat = DateTimeFormatter.ofPattern("MM/dd/yyyy", Locale.ROOT)
+    override val chapterMode = ChapterMode.MangaAjax
 
     override val filterNonMangaItems = false
 }

--- a/src/en/zinmanganet/src/eu/kanade/tachiyomi/extension/en/zinmanganet/ZinmangaNet.kt
+++ b/src/en/zinmanganet/src/eu/kanade/tachiyomi/extension/en/zinmanganet/ZinmangaNet.kt
@@ -9,7 +9,7 @@ import java.util.Locale
 abstract class ZinmangaNet : Madara() {
     override val dateFormat = SimpleDateFormat("MM/dd/yyyy", Locale.ROOT)
     override val useLoadMoreRequest = LoadMoreStrategy.Never
-    override val useNewChapterEndpoint = false
+    override val useNewChapterEndpoint = true
 
     override val filterNonMangaItems = false
 }


### PR DESCRIPTION
Closes #18964

- Use the site's canonical `www.zinmanga.net` domain.
- Switch to the current Madara chapter endpoint.
- Fix the Referer base used for externally hosted images.