### PR TITLE
AllManga (EN): Add checks and mirror

### DIFF
--- a/src/en/allanime/build.gradle.kts
+++ b/src/en/allanime/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "AllManga"
-    versionCode = 28
+    versionCode = 29
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
 

--- a/src/en/allanime/build.gradle.kts
+++ b/src/en/allanime/build.gradle.kts
@@ -12,12 +12,18 @@ keiyoushi {
 
     source {
         lang = "en"
-        baseUrl = "https://mkissa.to"
+        baseUrl {
+            mirrors(
+                "https://mkissa.to",
+                "https://isekai2nd.com",
+            )
+        }
         id = 4709139914729853090L
     }
 
     deeplink {
         host("mkissa.to")
+        host("isekai2nd.com")
         host("allmanga.to")
         path("/manga/..*")
         path("/read/..*")

--- a/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/AllManga.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/AllManga.kt
@@ -34,6 +34,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 @Source
 abstract class AllManga :
@@ -313,7 +314,7 @@ abstract class AllManga :
             }
         }
 
-        val payload = runWebView {
+        val payload = runWebView(timeout = 20.seconds) {
             blockImages = true
             userAgent = headers["User-Agent"]!!
 
@@ -357,13 +358,23 @@ abstract class AllManga :
                 evaluateJs(script)
             }
 
+            interceptRequest {
+                if (it.url.toString().contains("/mreferer/")) {
+                    error("Failed to attach listener")
+                }
+                null
+            }
+
             var captchaAttempts = 0
 
-            poll(300.milliseconds) {
+            poll(250.milliseconds) {
                 evaluateJs(
-                    "document.querySelector('.captcha-overlay--visible') != null",
+                    """
+                     document.title.includes("Just a moment") ||
+                    document.querySelector('.captcha-overlay--visible') != null
+                    """.trimIndent(),
                 ) { result ->
-                    if (result == "true" && ++captchaAttempts >= 10) { // 3s
+                    if (result == "true" && ++captchaAttempts >= 20) { // 5
                         wvChapterUrl = "$baseUrl$chapterUrl"
                         error("Solve captcha in WebView and retry")
                     }

--- a/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/AllManga.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/AllManga.kt
@@ -33,6 +33,7 @@ import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import kotlin.time.Duration.Companion.milliseconds
 
 @Source
 abstract class AllManga :
@@ -127,7 +128,9 @@ abstract class AllManga :
 
     override fun getFilterList(data: JsonElement?) = getFilters()
 
-    override fun getMangaUrl(manga: SManga) = if (manga.url.startsWith("/")) {
+    var wvChapterUrl: String? = null
+
+    override fun getMangaUrl(manga: SManga) = wvChapterUrl ?: if (manga.url.startsWith("/")) {
         val mangaId = manga.url.split("/")[2]
         "$baseUrl/manga/$mangaId"
     } else {
@@ -321,7 +324,7 @@ abstract class AllManga :
                     }
 
                    let checkAttempts = 0;
-                   const maxAttempts = 300; // 15 seconds
+                   const maxAttempts = 200; // 10 seconds
 
                    function check() {
                        if (document.querySelector('[data-href]')) {
@@ -340,11 +343,28 @@ abstract class AllManga :
             """.trimIndent()
 
             jsBridge(interfaceName) {
+                wvChapterUrl = null
                 resolve(it)
             }
 
             onPageStarted {
+                evaluateJs(
+                    "localStorage.clear(); sessionStorage.clear()",
+                )
                 evaluateJs(script)
+            }
+
+            var captchaAttempts = 0
+
+            poll(300.milliseconds) {
+                evaluateJs(
+                    "document.querySelector('.captcha-overlay--visible') != null",
+                ) { result ->
+                    if (result == "true" && ++captchaAttempts >= 10) { // 3s
+                        wvChapterUrl = "$baseUrl$chapterUrl"
+                        error("Solve captcha in WebView and retry")
+                    }
+                }
             }
 
             loadData(mangaUrl, document.outerHtml())

--- a/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/AllManga.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/AllManga.kt
@@ -157,7 +157,10 @@ abstract class AllManga :
                 mangaId,
                 "manga@$mangaId",
                 // Manga = null for some if not present
-                mapOf("fromSearch" to true),
+                mapOf(
+                    "fromSearch" to true,
+                    "allowAdult" to true,
+                ),
             ),
         )
 

--- a/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/AllManga.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/extension/en/allanime/AllManga.kt
@@ -114,9 +114,6 @@ abstract class AllManga :
     }
 
     override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
-        if (url.host != baseUrl.toHttpUrl().host) {
-            throw Exception("Unsupported url")
-        }
         val id = url.pathSegments.getOrNull(1)
             ?: throw Exception("Unsupported url")
 
@@ -374,7 +371,7 @@ abstract class AllManga :
                     document.querySelector('.captcha-overlay--visible') != null
                     """.trimIndent(),
                 ) { result ->
-                    if (result == "true" && ++captchaAttempts >= 20) { // 5
+                    if (result == "true" && ++captchaAttempts >= 20) { // 5s
                         wvChapterUrl = "$baseUrl$chapterUrl"
                         error("Solve captcha in WebView and retry")
                     }


### PR DESCRIPTION
I could reproduce a couple timeout related issues

1- Captcha widget may show for some people in reader interface, It does auto solve fine, unless UA is bad, so added explicit error and mangaUrl swap.
2- certain expiry based number stored in _MK.olTimeInter local storage can do a redirect to mirror https://isekai2nd.com, and the webivew patch won't register due url refresh. didn't dig more on it since it doesn't matter. only clearing local storage each time to avoid the condition meeting, and explicit error if /mreferer/ still happened, which it shouldn't.
and added that mirror (doesn't have CloudFlare on for now)

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
