### PR TITLE
InkStory (ru): fix bugs

### DIFF
--- a/lib-multisrc/inkstory/build.gradle.kts
+++ b/lib-multisrc/inkstory/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 keiyoushi {
-    baseVersionCode = 1
+    baseVersionCode = 2
     libVersion = "1.6"
 
     deeplink {

--- a/lib-multisrc/inkstory/src/eu/kanade/tachiyomi/multisrc/inkstory/Dto.kt
+++ b/lib-multisrc/inkstory/src/eu/kanade/tachiyomi/multisrc/inkstory/Dto.kt
@@ -96,14 +96,18 @@ class MangaFullDto(
             }
         }
         author = relations
-            ?.filter { it.type == "AUTHOR" }
-            ?.mapNotNull { it.publisher?.name?.trim()?.takeIf(String::isNotEmpty) }
+            ?.mapNotNull { rel ->
+                rel.takeIf { it.type == "AUTHOR" }
+                    ?.publisher?.name?.trim()?.takeIf(String::isNotEmpty)
+            }
             ?.distinct()
             ?.joinToString()
             ?.ifBlank { null }
         artist = relations
-            ?.filter { it.type == "ARTIST" }
-            ?.mapNotNull { it.publisher?.name?.trim()?.takeIf(String::isNotEmpty) }
+            ?.mapNotNull { rel ->
+                rel.takeIf { it.type == "ARTIST" }
+                    ?.publisher?.name?.trim()?.takeIf(String::isNotEmpty)
+            }
             ?.distinct()
             ?.joinToString()
             ?.ifBlank { null }
@@ -158,8 +162,8 @@ class ChapterDto(
 ) {
     fun toSChapter(branches: Map<String, String?>, slug: String): SChapter = SChapter.create().apply {
         url = id
-        val vol = volume.toString().removeSuffix(".0").takeIf { it.isNotBlank() }
-        val num = number.toString().removeSuffix(".0").takeIf { it.isNotBlank() }
+        val vol = volume?.toString()?.removeSuffix(".0")?.takeIf(String::isNotBlank)
+        val num = number?.toString()?.removeSuffix(".0")?.takeIf(String::isNotBlank)
         val baseChapterName = when {
             vol != null && num != null -> "Том $vol Глава $num"
             num != null -> "Глава $num"
@@ -208,11 +212,6 @@ class PagesDto(
 class ChapterPageDto(
     val index: Int? = null,
     val image: String? = null,
-)
-
-class NormalizedImage(
-    val url: String,
-    val requiresXorDecode: Boolean,
 )
 
 enum class ImageCodec {

--- a/lib-multisrc/inkstory/src/eu/kanade/tachiyomi/multisrc/inkstory/InkStory.kt
+++ b/lib-multisrc/inkstory/src/eu/kanade/tachiyomi/multisrc/inkstory/InkStory.kt
@@ -63,16 +63,15 @@ abstract class InkStory :
 
     // ============================== Interceptors ===============================
     private fun imageDecryptInterceptor(chain: Interceptor.Chain): Response {
-        val request = chain.request()
-        if (detectImageCodec(request.url.toString()) != ImageCodec.XOR) {
-            return chain.proceed(request)
-        }
-
-        val response = chain.proceed(request)
+        val response = chain.proceed(chain.request())
         if (!response.isSuccessful) return response
 
         val contentType = response.body.contentType()
         if (contentType?.subtype == "json") {
+            return response
+        }
+
+        if (detectImageCodec(response.request.url.toString()) != ImageCodec.XOR) {
             return response
         }
 

--- a/lib-multisrc/inkstory/src/eu/kanade/tachiyomi/multisrc/inkstory/InkStory.kt
+++ b/lib-multisrc/inkstory/src/eu/kanade/tachiyomi/multisrc/inkstory/InkStory.kt
@@ -24,7 +24,7 @@ import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.asResponseBody
@@ -108,7 +108,7 @@ abstract class InkStory :
             payload[i] = (payload[i].toInt() xor SECRET_KEY_BYTES[i % SECRET_KEY_BYTES.size].toInt()).toByte()
         }
 
-        val mediaType = detectedType.toMediaTypeOrNull() ?: contentType
+        val mediaType = detectedType.toMediaType()
         return response.newBuilder()
             .body(payload.toResponseBody(mediaType))
             .build()
@@ -133,6 +133,12 @@ abstract class InkStory :
             payload[8] == 0x57.toByte() && payload[9] == 0x45.toByte() &&
             payload[10] == 0x42.toByte() && payload[11] == 0x50.toByte()
         if (isWebp) return "image/webp"
+
+        val isAvif = payload[4] == 0x66.toByte() && payload[5] == 0x74.toByte() &&
+            payload[6] == 0x79.toByte() && payload[7] == 0x70.toByte() &&
+            payload[8] == 0x61.toByte() && payload[9] == 0x76.toByte() &&
+            payload[10] == 0x69.toByte()
+        if (isAvif) return "image/avif"
 
         return null
     }

--- a/lib-multisrc/inkstory/src/eu/kanade/tachiyomi/multisrc/inkstory/InkStory.kt
+++ b/lib-multisrc/inkstory/src/eu/kanade/tachiyomi/multisrc/inkstory/InkStory.kt
@@ -23,7 +23,6 @@ import kotlinx.serialization.json.JsonElement
 import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
@@ -39,7 +38,18 @@ abstract class InkStory :
     private val domain: String get() = baseUrl.toHttpUrl().topPrivateDomain() ?: baseUrl.toHttpUrl().host
     private val apiUrl: String get() = "https://api.$domain/v2"
 
-    private val preferences by getPreferencesLazy()
+    private val preferences by getPreferencesLazy {
+        val keysToRemove = listOf(
+            "inkstory_image_quality",
+            "inkstory_image_type",
+            "inkstory_image_width",
+        )
+        if (keysToRemove.any(::contains)) {
+            edit().apply {
+                keysToRemove.forEach(::remove)
+            }.apply()
+        }
+    }
 
     override fun Headers.Builder.configureHeaders(): Headers.Builder = apply {
         // User Agent required by source. Don't change
@@ -293,28 +303,15 @@ abstract class InkStory :
             .mapIndexedNotNull { index, page ->
                 page.image?.takeIf(String::isNotBlank)?.let { imageUrl ->
                     val normalized = normalizeImageUrl(imageUrl)
-                    Page(
-                        index = index,
-                        imageUrl = normalized.url,
-                    )
+                    Page(index = index, imageUrl = normalized)
                 }
             }
     }
 
-    private fun normalizeImageUrl(rawImageUrl: String): NormalizedImage {
-        var imageUrl = rawImageUrl
-        var codec = detectImageCodec(imageUrl)
-
-        if (codec == ImageCodec.SEC) {
-            imageUrl = replaceFileNameMode(imageUrl, 'x')
-            codec = ImageCodec.XOR
-        }
-
-        if (codec != ImageCodec.XOR) {
-            return NormalizedImage(url = imageUrl, requiresXorDecode = false)
-        }
-
-        return NormalizedImage(url = imageUrl, requiresXorDecode = true)
+    private fun normalizeImageUrl(imageUrl: String): String = if (detectImageCodec(imageUrl) == ImageCodec.SEC) {
+        replaceFileNameMode(imageUrl)
+    } else {
+        imageUrl
     }
 
     private fun detectImageCodec(imageUrl: String): ImageCodec? {
@@ -328,24 +325,15 @@ abstract class InkStory :
         }
     }
 
-    private fun replaceFileNameMode(imageUrl: String, replacementMode: Char): String {
-        val parsed = imageUrl.toHttpUrlOrNull() ?: return imageUrl
-        val pathSegments = parsed.pathSegments.toMutableList()
-        val fileName = pathSegments.lastOrNull() ?: return imageUrl
-        val baseName = fileName.substringBeforeLast('.', missingDelimiterValue = fileName)
-        if (baseName.length != IMAGE_NAME_LENGTH || baseName.getOrNull(IMAGE_MODE_INDEX) == null) {
-            return imageUrl
-        }
-        val ext = fileName.substringAfterLast('.', missingDelimiterValue = "")
-        val updatedBaseName = baseName.substring(0, IMAGE_MODE_INDEX) +
-            replacementMode +
-            baseName.substring(IMAGE_MODE_INDEX + 1)
-        val updatedName = if (ext.isBlank()) updatedBaseName else "$updatedBaseName.$ext"
-        pathSegments[pathSegments.lastIndex] = updatedName
-        return parsed.newBuilder()
-            .encodedPath("/" + pathSegments.joinToString("/"))
-            .build()
-            .toString()
+    private fun replaceFileNameMode(imageUrl: String, replacementMode: Char = 'x'): String {
+        val lastSlash = imageUrl.lastIndexOf('/')
+        if (lastSlash == -1) return imageUrl
+        val modeIndex = lastSlash + 1 + IMAGE_MODE_INDEX
+        if (modeIndex >= imageUrl.length) return imageUrl
+
+        val chars = imageUrl.toCharArray()
+        chars[modeIndex] = replacementMode
+        return String(chars)
     }
 
     // ============================== Filters ===============================

--- a/lib-multisrc/inkstory/src/eu/kanade/tachiyomi/multisrc/inkstory/InkStory.kt
+++ b/lib-multisrc/inkstory/src/eu/kanade/tachiyomi/multisrc/inkstory/InkStory.kt
@@ -200,7 +200,7 @@ abstract class InkStory :
             val mangas = response.parseAs<List<BookFromSearchDto>>().map { it.toSManga() }
             val totalHits = response.header("x-estimated-total-hits")?.toIntOrNull()
             val hasNextPage = if (totalHits != null) {
-                (page + 1) * PAGE_SIZE < totalHits
+                page * PAGE_SIZE < totalHits
             } else {
                 mangas.size >= PAGE_SIZE
             }

--- a/lib-multisrc/inkstory/src/eu/kanade/tachiyomi/multisrc/inkstory/InkStory.kt
+++ b/lib-multisrc/inkstory/src/eu/kanade/tachiyomi/multisrc/inkstory/InkStory.kt
@@ -87,7 +87,7 @@ abstract class InkStory :
 
         // Peek the first bytes without consuming from buffer
         val peek = buffer.peek().readByteArray(MIN_IMAGE_SIGNATURE_SIZE.toLong())
-        if (looksLikeImage(peek)) {
+        if (looksLikeImage(peek) != null) {
             return response.newBuilder()
                 .body(buffer.asResponseBody(contentType, buffer.size))
                 .build()
@@ -97,43 +97,44 @@ abstract class InkStory :
         val decryptedHeader = ByteArray(MIN_IMAGE_SIGNATURE_SIZE) { index ->
             (peek[index].toInt() xor SECRET_KEY_BYTES[index % SECRET_KEY_BYTES.size].toInt()).toByte()
         }
-        if (!looksLikeImage(decryptedHeader)) {
-            return response.newBuilder()
+
+        val detectedType = looksLikeImage(decryptedHeader)
+            ?: return response.newBuilder()
                 .body(buffer.asResponseBody(contentType, buffer.size))
                 .build()
-        }
 
         val payload = buffer.readByteArray()
         for (i in payload.indices) {
             payload[i] = (payload[i].toInt() xor SECRET_KEY_BYTES[i % SECRET_KEY_BYTES.size].toInt()).toByte()
         }
 
-        val mediaType = contentType ?: "image/jpeg".toMediaTypeOrNull()
+        val mediaType = detectedType.toMediaTypeOrNull() ?: contentType
         return response.newBuilder()
             .body(payload.toResponseBody(mediaType))
             .build()
     }
 
-    private fun looksLikeImage(payload: ByteArray): Boolean {
-        if (payload.size < MIN_IMAGE_SIGNATURE_SIZE) return false
+    private fun looksLikeImage(payload: ByteArray): String? {
+        if (payload.size < MIN_IMAGE_SIGNATURE_SIZE) return null
 
         val isJpeg = payload[0] == 0xFF.toByte() && payload[1] == 0xD8.toByte() && payload[2] == 0xFF.toByte()
-        if (isJpeg) return true
+        if (isJpeg) return "image/jpeg"
 
         val isPng = payload[0] == 0x89.toByte() && payload[1] == 0x50.toByte() &&
             payload[2] == 0x4E.toByte() && payload[3] == 0x47.toByte()
-        if (isPng) return true
+        if (isPng) return "image/png"
 
         val isGif = payload[0] == 0x47.toByte() && payload[1] == 0x49.toByte() &&
             payload[2] == 0x46.toByte() && payload[3] == 0x38.toByte()
-        if (isGif) return true
+        if (isGif) return "image/gif"
 
         val isWebp = payload[0] == 0x52.toByte() && payload[1] == 0x49.toByte() &&
             payload[2] == 0x46.toByte() && payload[3] == 0x46.toByte() &&
             payload[8] == 0x57.toByte() && payload[9] == 0x45.toByte() &&
             payload[10] == 0x42.toByte() && payload[11] == 0x50.toByte()
+        if (isWebp) return "image/webp"
 
-        return isWebp
+        return null
     }
 
     // ============================== Popular ===============================

--- a/lib-multisrc/inkstory/src/eu/kanade/tachiyomi/multisrc/inkstory/InkStory.kt
+++ b/lib-multisrc/inkstory/src/eu/kanade/tachiyomi/multisrc/inkstory/InkStory.kt
@@ -63,7 +63,12 @@ abstract class InkStory :
 
     // ============================== Interceptors ===============================
     private fun imageDecryptInterceptor(chain: Interceptor.Chain): Response {
-        val response = chain.proceed(chain.request())
+        val request = chain.request()
+        if (detectImageCodec(request.url.toString()) != ImageCodec.XOR) {
+            return chain.proceed(request)
+        }
+
+        val response = chain.proceed(request)
         if (!response.isSuccessful) return response
 
         val contentType = response.body.contentType()

--- a/src/ru/puremanga/build.gradle.kts
+++ b/src/ru/puremanga/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 keiyoushi {
     name = "PureManga"
     versionCode = 0
-    contentWarning = ContentWarning.NSFW
+    contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
     theme = "inkstory"
 


### PR DESCRIPTION
Checklist:

1. Fixed mistake in `toSChapter` function which might happen if `volume` or `chapter`  were actually `null`. 
2. Changes to `author` and `artist`: instead of calling `filter` and then `mapNotNull` combined it into one `mapNotNull`.
3. Fix pagination calculation.
4. Added removal of old preferences that were removed in #18611
5. PureManga has SFW content -> changing rating to MIXED.
6. content type for encoded images are `application/octet-stream` -> change to `looksLikeImage` to return detected content type. Also added check for `avif` type.
7. Changes to `normalizeImageUrl` and `replaceFileNameMode`. I've decided to figure out how they actually work, and changed accordingly.

Explanation about these functions, how they work, and why I changed them (did it for myself while figuring out how they work):

<details>
<summary>Click for explanation</summary>

Purpose of `normalizeImageUrl` 
The source servers store and protect chapter images using specific encryption/encoding modes. The mode is encoded directly inside the file name's UUID at index 14.
There are two modes:
- 'x' (XOR mode): The image is encrypted using an XOR cipher (SECRET_KEY).
- 's' (SEC / proprietary mode): The server protects the file under a proprietary scheme, but the server also provides the XOR-encrypted version if you request the file name with 'x' instead of 's'.
- Any other char: Plain, unencrypted image files.

`normalizeImageUrl` checks what mode the image URL is using, rewrites 's' into 'x' (with `replaceFileNameMode`) so the extension can request and decode the XOR version, and flags whether XOR decoding will be required.
For example image: `https://**skipped**/chapters/**skipped**/6897080c-ab23-x6a4-ae54-25621027b006.png`
6897080c-ab23-**x**6a4-ae54-25621027b006.png -> **x**_6a4 and:
```
var codec = detectImageCodec(imageUrl)

if (codec == ImageCodec.SEC) {
    // Skipped, because codec is XOR, not SEC ('s')
    imageUrl = replaceFileNameMode(imageUrl, 'x')
    codec = ImageCodec.XOR
}

if (codec != ImageCodec.XOR) {
    // Skipped, because codec IS XOR
    return NormalizedImage(url = imageUrl, requiresXorDecode = false)
}

return NormalizedImage(url = imageUrl, requiresXorDecode = true)
```

Only replacing **s** to **x**, and skipping everything else, which can be simplified. 
`requiresXorDecode` - were used only to set `Page.url`, but since `Page.imageUrl` was also set, it had no effect. Previous code:
```
Page(
    index = index,
    url = if (normalized.requiresXorDecode) encodePageMeta(chapterId, SECRET_KEY) else "",
    imageUrl = normalized.url,
)
```
Upd. `requiresXorDecode` - is a leftover after #18611. It didn't do anything since the interceptor was changed, and any code that might have worked with it was removed by the source owner.

Replacement was handled by `replaceFileNameMode`:

1. Parses the entire string into an HttpUrl object.
2. Clones the internal path segment list into a new ArrayList<String>.
3. Extracts the last path segment (file name), computes substrings before `.`
4. Checks UUID length (36 characters).
5. Creates two more substrings of the base name (0..13 and 15..35) and concatenates with replacementMode.
6. Replaces the last segment in the list.
8. Rebuilds the HttpUrl via HttpUrl.Builder, re-encodes the entire path, and calls .toString().

While `detectImageCodec` already established:

- A `/` exists.
- The file name's base name is strictly 36 characters long.
- Character at index 14 is 's'.

All the redundant URL parsing and path length re-checks are doing work that was already validated in `detectImageCodec`. 
New string indexing and character swapping is faster than full URL parsing and path re-encoding. (New version of `replaceFileNameMode` was suggested by AI previously)
All the checks that return `imageUrl` are probably also redundant, but I left them just in case.

Edit 2. Interceptor before #18611 had a similar functionality to adding `detectImageCodec`, but did it through image headers with `encodePageMeta` to `Page.url` (so  it worked, huh?). Adding `detectImageCodec` to the interceptor should ensure that interceptor skips anything that doesn't need decoding by checking the URL.
</details>

- [ ] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
