### PR TITLE
Kuroi Manga: fix chapter names and manga listing

### DIFF
--- a/src/tr/kuroimanga/build.gradle.kts
+++ b/src/tr/kuroimanga/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "Kuroi Manga"
-    versionCode = 5
+    versionCode = 6
     contentWarning = ContentWarning.NSFW
     libVersion = "1.6"
     theme = "madara"

--- a/src/tr/kuroimanga/src/eu/kanade/tachiyomi/extension/tr/kuroimanga/KuroiManga.kt
+++ b/src/tr/kuroimanga/src/eu/kanade/tachiyomi/extension/tr/kuroimanga/KuroiManga.kt
@@ -1,6 +1,6 @@
 package eu.kanade.tachiyomi.extension.tr.kuroimanga
 
-import eu.kanade.tachiyomi.multisrc.madara.MadaraNoAjax
+import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.source.model.Page
 import keiyoushi.annotation.Source
 import org.jsoup.nodes.Document
@@ -8,9 +8,11 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 @Source
-abstract class KuroiManga : MadaraNoAjax() {
+abstract class KuroiManga : Madara() {
     override val chapterDateFormat = DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.forLanguageTag("tr"))
     override val chapterMode = ChapterMode.MangaAjax
+
+    override val chapterUrlSelector = "a:not(:has(img))"
 
     override fun parsePages(document: Document): List<Page> {
         val pageList = super.parsePages(document)


### PR DESCRIPTION
Regression from the 1.6 migration (#18075):

- Chapter names were empty. Each chapter row has a thumbnail anchor before the title anchor, so the default `a` selector picked the image link. The pre-migration `li > a` override was dropped; restore the same behaviour with `a:not(:has(img))` (same as LaviniaFansub).
- Browse stopped after 12 entries. `MadaraNoAjax` no longer recognises `nav.navigation-ajax` as a next-page marker, which is what the site uses. Switch to `Madara` (admin-ajax), which the site supports.

Tested on Suwayomi-Server with a before/after of the same title: on 1.6.59 chapter names are blank and popular ends at 12 entries; on 1.6.60 chapter names are "Bölüm N" with dates, and popular/latest paginate normally.

Closes #18768

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension (tested via Suwayomi-Server rather than Android Studio)
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

🤖 Opened by an AI agent (Claude Code), asked to fix #18768.
