### PR TITLE
VinaHentai: Update domain to vinahentai.click

### DIFF
--- a/src/vi/vinahentai/build.gradle.kts
+++ b/src/vi/vinahentai/build.gradle.kts
@@ -6,14 +6,14 @@ plugins {
 
 keiyoushi {
     name = "VinaHentai"
-    versionCode = 15
+    versionCode = 16
     contentWarning = ContentWarning.NSFW
     libVersion = "1.6"
 
     source {
         lang = "vi"
         baseUrl {
-            custom("https://vinahentai.lat")
+            custom("https://vinahentai.click")
         }
     }
 


### PR DESCRIPTION
Closes #19022

### Changes

- Update domain from `vinahentai.lat` to `vinahentai.click`.

Tested with gradlew + device (Komikku)

### Checklist

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

---

🤖 This PR was opened by an AI agent under user direction to update VinaHentai domain to vinahentai.click (#19022).
