### PR TITLE
Toonkor: Update URL and migrate to 1.6

### DIFF
--- a/src/ko/toonkor/build.gradle.kts
+++ b/src/ko/toonkor/build.gradle.kts
@@ -6,14 +6,14 @@ plugins {
 
 keiyoushi {
     name = "Toonkor"
-    versionCode = 9
+    versionCode = 10
     contentWarning = ContentWarning.MIXED
-    libVersion = "1.4"
+    libVersion = "1.6"
 
     source {
         lang = "ko"
         baseUrl {
-            custom("https://tkor151.com")
+            custom("https://tkor152.com")
         }
     }
 }

--- a/src/ko/toonkor/src/eu/kanade/tachiyomi/extension/ko/toonkor/Toonkor.kt
+++ b/src/ko/toonkor/src/eu/kanade/tachiyomi/extension/ko/toonkor/Toonkor.kt
@@ -1,31 +1,51 @@
 package eu.kanade.tachiyomi.extension.ko.toonkor
 
 import android.util.Base64
-import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import keiyoushi.annotation.Source
+import keiyoushi.network.get
+import keiyoushi.source.KeiSource
 import keiyoushi.utils.asJsoup
 import keiyoushi.utils.firstInstanceOrNull
-import keiyoushi.utils.tryParse
-import okhttp3.Request
+import keiyoushi.utils.tryParseDate
+import kotlinx.serialization.json.JsonElement
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Response
-import java.text.SimpleDateFormat
+import org.jsoup.nodes.Document
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 @Source
-abstract class Toonkor : HttpSource() {
+abstract class Toonkor : KeiSource() {
 
-    override val supportsLatest = true
+    override suspend fun getPopularManga(page: Int): MangasPage = parseMangaList(client.get("$baseUrl$WEBTOONS_PATH$ALL_STATUS_PATH$SORT_POPULAR"))
 
-    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl$WEBTOONS_PATH$ALL_STATUS_PATH$SORT_POPULAR", headers)
+    override suspend fun getLatestUpdates(page: Int): MangasPage = parseMangaList(client.get("$baseUrl$WEBTOONS_PATH$ALL_STATUS_PATH$SORT_LATEST"))
 
-    override fun popularMangaParse(response: Response): MangasPage {
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
+        val filterList = filters.ifEmpty { getFilterList() }
+
+        val type = filterList.firstInstanceOrNull<TypeFilter>()
+        val status = filterList.firstInstanceOrNull<StatusFilter>()
+        val sort = filterList.firstInstanceOrNull<SortFilter>()
+
+        val requestPath = when {
+            query.isNotEmpty() -> "/bbs/search.php?sfl=wr_subject%7C%7Cwr_content&stx=$query"
+            else -> "${type?.toUriPart() ?: ""}${status?.toUriPart() ?: ""}${sort?.toUriPart() ?: ""}"
+        }
+
+        return parseMangaList(client.get(baseUrl + requestPath))
+    }
+
+    private fun parseMangaList(response: Response): MangasPage {
         val document = response.asJsoup()
         val mangas = document.select("div.section-item-inner").map { element ->
             SManga.create().apply {
@@ -40,54 +60,40 @@ abstract class Toonkor : HttpSource() {
         return MangasPage(mangas, false)
     }
 
-    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl$WEBTOONS_PATH$ALL_STATUS_PATH$SORT_LATEST", headers)
-
-    override fun latestUpdatesParse(response: Response): MangasPage = popularMangaParse(response)
-
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        val filterList = filters.ifEmpty { getFilterList() }
-
-        val type = filterList.firstInstanceOrNull<TypeFilter>()
-        val status = filterList.firstInstanceOrNull<StatusFilter>()
-        val sort = filterList.firstInstanceOrNull<SortFilter>()
-
-        val requestPath = when {
-            query.isNotEmpty() -> "/bbs/search.php?sfl=wr_subject%7C%7Cwr_content&stx=$query"
-            else -> "${type?.toUriPart() ?: ""}${status?.toUriPart() ?: ""}${sort?.toUriPart() ?: ""}"
-        }
-
-        return GET(baseUrl + requestPath, headers)
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        val document = client.get(baseUrl + manga.url).asJsoup()
+        return SMangaUpdate(
+            manga = parseMangaDetails(document),
+            chapters = parseChapterList(document),
+        )
     }
 
-    override fun searchMangaParse(response: Response): MangasPage = popularMangaParse(response)
+    private fun parseMangaDetails(document: Document): SManga = SManga.create().apply {
+        with(document.select("table.bt_view1")) {
+            title = select("td.bt_title").text()
+            author = select("td.bt_label span.bt_data").text()
+            description = select("td.bt_over").text()
+            thumbnail_url = select("td.bt_thumb img").firstOrNull()?.attr("abs:src")
+        }
+    }
 
-    override fun mangaDetailsParse(response: Response): SManga {
-        val document = response.asJsoup()
-        return SManga.create().apply {
-            with(document.select("table.bt_view1")) {
-                title = select("td.bt_title").text()
-                author = select("td.bt_label span.bt_data").text()
-                description = select("td.bt_over").text()
-                thumbnail_url = select("td.bt_thumb img").firstOrNull()?.attr("abs:src")
+    private fun parseChapterList(document: Document): List<SChapter> = document.select("table.web_list tr:has(td.content__title)").map { element ->
+        SChapter.create().apply {
+            element.select("td.content__title").let {
+                url = it.attr("data-role")
+                name = it.text()
             }
+            date_upload = dateFormat.tryParseDate(element.select("td.episode__index").text(), KOREA_ZONE)
         }
     }
 
-    override fun chapterListParse(response: Response): List<SChapter> {
-        val document = response.asJsoup()
-        return document.select("table.web_list tr:has(td.content__title)").map { element ->
-            SChapter.create().apply {
-                element.select("td.content__title").let {
-                    url = it.attr("data-role")
-                    name = it.text()
-                }
-                date_upload = dateFormat.tryParse(element.select("td.episode__index").text())
-            }
-        }
-    }
-
-    override fun pageListParse(response: Response): List<Page> {
-        val document = response.asJsoup()
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        val document = client.get(baseUrl + chapter.url).asJsoup()
         val encoded = document.select("script:containsData(toon_img)").firstOrNull()?.data()
             ?.substringAfter("'")?.substringBefore("'") ?: return emptyList()
 
@@ -99,9 +105,21 @@ abstract class Toonkor : HttpSource() {
         }.toList()
     }
 
-    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+        if (url.host != baseUrl.toHttpUrl().host) return null
+        val path = url.encodedPath
+        if (path.isBlank() || path == "/" || path.startsWith("/bbs/")) return null
+        return try {
+            val document = client.get(url).asJsoup()
+            parseMangaDetails(document).apply {
+                this.url = path
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
 
-    override fun getFilterList(): FilterList = FilterList(
+    override fun getFilterList(data: JsonElement?): FilterList = FilterList(
         Filter.Header("Note: can't combine with text search!"),
         Filter.Separator(),
         TypeFilter(),
@@ -110,7 +128,8 @@ abstract class Toonkor : HttpSource() {
     )
 
     companion object {
-        private val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.ROOT)
+        private val KOREA_ZONE = ZoneId.of("Asia/Seoul")
+        private val dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ROOT)
         private val pageListRegex = Regex("""src="([^"]*)"""")
     }
 }


### PR DESCRIPTION
Closes #19024

### Changes

- Update base URL to `https://tkor152.com`
- Migrate to `KeiSource` (`libVersion = "1.6"`)

Tested with gradlew + device (Komikku)

### Checklist

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

---

🤖 This PR was opened by an AI agent under user direction to update Toonkor domain to tkor152.com and migrate to KeiSource 1.6 (#19024).
