### PR TITLE
MangaGG: Fix missing chapters, popular, and latest listings

### DIFF
--- a/src/en/mangagg/build.gradle.kts
+++ b/src/en/mangagg/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "MangaGG"
-    versionCode = 3
+    versionCode = 4
     contentWarning = ContentWarning.MIXED
     libVersion = "1.6"
     theme = "madara"

--- a/src/en/mangagg/src/eu/kanade/tachiyomi/extension/en/mangagg/MangaGG.kt
+++ b/src/en/mangagg/src/eu/kanade/tachiyomi/extension/en/mangagg/MangaGG.kt
@@ -2,15 +2,37 @@ package eu.kanade.tachiyomi.extension.en.mangagg
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.multisrc.madara.MadaraBase.ChapterMode
+import eu.kanade.tachiyomi.source.model.MangasPage
 import keiyoushi.annotation.Source
+import keiyoushi.network.get
+import keiyoushi.utils.asJsoup
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.jsoup.nodes.Element
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 @Source
 abstract class MangaGG : Madara() {
-    override val chapterMode = ChapterMode.MangaAjax
+    override val mangaSubString = "comic"
+    override val filterNonMangaItems = false
+    override val chapterMode = ChapterMode.MangaAjaxPaginated
     override val chapterDateFormat = DateTimeFormatter.ofPattern("MM/dd/yyyy", Locale.US)
+
+    override fun getHomeUrl() = "$baseUrl/$mangaSubString/?m_orderby=trending"
+
+    override suspend fun getPopularManga(page: Int): MangasPage = getMangaPage(page, "trending")
+
+    override suspend fun getLatestUpdates(page: Int): MangasPage = getMangaPage(page, "latest")
+
+    private suspend fun getMangaPage(page: Int, order: String): MangasPage {
+        val url = baseUrl.toHttpUrl().resolve("/$mangaSubString/")!!.newBuilder().apply {
+            if (page > 1) addPathSegments("page/$page/")
+            addQueryParameter("m_orderby", order)
+        }.build()
+        val document = client.get(url).asJsoup()
+        val mangas = parseArchive(document)
+        return MangasPage(mangas, document.selectFirst(".navigation-ajax, .load-ajax") != null && mangas.isNotEmpty())
+    }
 
     override fun imageFromElement(element: Element): String? {
         val url = element.attr("data-src").trim().ifEmpty {


### PR DESCRIPTION
Closes #19038

Fix missing chapters (> 24 chapters), popular, and latest listings for MangaGG.

Tested with gradlew + device (Mihon).

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

---

🤖 This PR was opened by an AI agent under user direction to fix missing chapters, popular, and latest listings for MangaGG (#19038).
