### PR TITLE
Slept Manga: Fix listing and chapter images

### DIFF
--- a/src/tr/sleptmanga/build.gradle.kts
+++ b/src/tr/sleptmanga/build.gradle.kts
@@ -6,12 +6,18 @@ plugins {
 
 keiyoushi {
     name = "Slept Manga"
-    versionCode = 1
+    versionCode = 2
     contentWarning = ContentWarning.SAFE
-    libVersion = "1.4"
+    libVersion = "1.6"
 
     source {
         lang = "tr"
         baseUrl = "https://sleptmanga.com.tr"
+    }
+
+    deeplink {
+        path("/manhwa/..*")
+        path("/manga/..*")
+        path("/manhua/..*")
     }
 }

--- a/src/tr/sleptmanga/src/eu/kanade/tachiyomi/extension/tr/sleptmanga/Dto.kt
+++ b/src/tr/sleptmanga/src/eu/kanade/tachiyomi/extension/tr/sleptmanga/Dto.kt
@@ -4,15 +4,8 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import keiyoushi.utils.tryParse
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.text.SimpleDateFormat
-import java.util.Locale
-import java.util.TimeZone
-
-private val chapterDateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ROOT).apply {
-    timeZone = TimeZone.getTimeZone("UTC")
-}
+import kotlin.time.Instant
 
 @Serializable
 class SeriesDto(
@@ -36,6 +29,7 @@ class SeriesDto(
         }
         genre = genres.joinToString()
         author = owner?.username
+        initialized = true
     }
 
     fun toSChapterList(encodedPath: String): List<SChapter> = chapters.map { it.toSChapter(encodedPath) }.sortedByDescending { it.chapter_number }
@@ -58,15 +52,15 @@ class ChapterDto(
         name = chapterTitle?.takeIf { it.isNotBlank() && it != $$"$undefined" }
             ?: "Bölüm $numStr"
         chapter_number = number
-        date_upload = chapterDateFormat.tryParse(createdAt?.removePrefix($$"$D"))
+        date_upload = Instant.tryParse(createdAt?.removePrefix($$"$D"))
     }
 }
 
 @Serializable
 class ChapterDataDto(
-    @SerialName("images_url") private val imagesUrl: List<ImageDto>,
+    private val images: List<ImageDto>,
 ) {
-    fun toPageList(baseUrl: String): List<Page> = imagesUrl.mapIndexed { i, img ->
+    fun toPageList(baseUrl: String): List<Page> = images.mapIndexed { i, img ->
         val imgUrl = if (img.url.startsWith("http")) img.url else baseUrl + img.url
         Page(i, imageUrl = imgUrl)
     }
@@ -79,8 +73,8 @@ class ImageDto(
 
 @Serializable
 class PaginationDto(
-    private val currentPage: Int,
-    private val totalPages: Int,
+    val currentPage: Int,
+    val totalPages: Int,
 ) {
     val hasNextPage get() = currentPage < totalPages
 }

--- a/src/tr/sleptmanga/src/eu/kanade/tachiyomi/extension/tr/sleptmanga/SleptManga.kt
+++ b/src/tr/sleptmanga/src/eu/kanade/tachiyomi/extension/tr/sleptmanga/SleptManga.kt
@@ -1,65 +1,39 @@
 package eu.kanade.tachiyomi.extension.tr.sleptmanga
 
-import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import keiyoushi.annotation.Source
+import keiyoushi.network.get
+import keiyoushi.source.KeiSource
 import keiyoushi.utils.asJsoup
 import keiyoushi.utils.extractNextJs
 import keiyoushi.utils.firstInstanceOrNull
+import keiyoushi.utils.parseAs
+import kotlinx.serialization.json.JsonElement
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
-import okhttp3.Request
-import okhttp3.Response
+import org.jsoup.select.Elements
 
 @Source
-abstract class SleptManga : HttpSource() {
-
-    override val supportsLatest = true
-
-    override fun headersBuilder() = super.headersBuilder()
-        .add("Referer", "$baseUrl/")
+abstract class SleptManga : KeiSource() {
 
     // ============================== Popular ==============================
 
-    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/browse?sort=popular&page=$page", headers)
-
-    override fun popularMangaParse(response: Response): MangasPage {
-        val document = response.asJsoup()
-        val elements = document.select("a.group:has(article)")
-
-        val mangas = elements
-            .filterNot { it.absUrl("href").toHttpUrlOrNull()?.pathSegments?.firstOrNull() == "novel" }
-            .mapNotNull { element ->
-                SManga.create().apply {
-                    setUrlWithoutDomain(element.absUrl("href"))
-                    title = element.selectFirst("h3")?.text()?.takeIf { it.isNotEmpty() }
-                        ?: element.selectFirst("img")?.attr("alt")?.takeIf { it.isNotEmpty() }
-                        ?: return@mapNotNull null
-                    thumbnail_url = element.selectFirst("img")?.absUrl("src")
-                }
-            }
-
-        val hasNextPage = document.extractNextJs<PaginationDto>()?.hasNextPage
-            ?: (elements.size >= 20)
-
-        return MangasPage(mangas, hasNextPage)
-    }
+    override suspend fun getPopularManga(page: Int): MangasPage = getMangaList("$baseUrl/browse?sort=popular&page=$page")
 
     // ============================== Latest ===============================
 
-    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/browse?sort=latest&page=$page", headers)
-
-    override fun latestUpdatesParse(response: Response) = popularMangaParse(response)
+    override suspend fun getLatestUpdates(page: Int): MangasPage = getMangaList("$baseUrl/browse?sort=latest&page=$page")
 
     // ============================== Search ===============================
 
-    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+    override suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage {
         val url = baseUrl.toHttpUrl().newBuilder().apply {
             addPathSegment("browse")
             addQueryParameter("page", page.toString())
@@ -82,49 +56,117 @@ abstract class SleptManga : HttpSource() {
                 ?.forEach { addQueryParameter("genres", it.value) }
         }.build()
 
-        return GET(url, headers)
+        return getMangaList(url.toString())
     }
 
-    override fun searchMangaParse(response: Response) = popularMangaParse(response)
+    override suspend fun getMangaByUrl(url: HttpUrl): SManga? {
+        if (url.host != baseUrl.toHttpUrl().host) return null
+        val type = url.pathSegments.firstOrNull()
+        if (type != "manhwa" && type != "manga" && type != "manhua") return null
+        val slug = url.pathSegments.getOrNull(1)?.takeIf { it.isNotEmpty() } ?: return null
+        val manga = SManga.create().apply {
+            setUrlWithoutDomain("/$type/$slug")
+        }
+        return getMangaUpdate(manga, emptyList(), fetchDetails = true, fetchChapters = false).manga
+    }
 
-    // ============================== Details ==============================
+    // ============================== Details & Chapters ===================
 
-    override fun mangaDetailsParse(response: Response): SManga {
-        val series = response.extractNextJs<SeriesDto>()
+    override suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        val series = client.get(getMangaUrl(manga))
+            .extractNextJs<SeriesDto>()
             ?: throw Exception("Manga detayları bulunamadı")
 
-        return series.toSManga(baseUrl)
-    }
+        val encodedPath = manga.url.removeSuffix("/")
 
-    // ============================= Chapters ==============================
-
-    override fun chapterListParse(response: Response): List<SChapter> {
-        val series = response.extractNextJs<SeriesDto>()
-            ?: return emptyList()
-
-        val encodedPath = response.request.url.encodedPath.removeSuffix("/")
-
-        return series.toSChapterList(encodedPath)
+        return SMangaUpdate(
+            manga = if (fetchDetails) series.toSManga(baseUrl).apply { url = manga.url } else manga,
+            chapters = if (fetchChapters) series.toSChapterList(encodedPath) else chapters,
+        )
     }
 
     // =============================== Pages ===============================
 
-    override fun pageListParse(response: Response): List<Page> {
-        val data = response.extractNextJs<ChapterDataDto>()
-            ?: return emptyList()
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        val segments = chapter.url.toHttpUrlOrNull()?.pathSegments
+            ?: baseUrl.toHttpUrl().resolve(chapter.url.removePrefix("/"))?.pathSegments
+            ?: throw Exception("Geçersiz bölüm bağlantısı")
 
+        val slug = segments[segments.size - 2]
+        val chapterNumber = segments.last()
+        val url = "$baseUrl/api/chapters/$slug/$chapterNumber/images"
+
+        val apiHeaders = headers.newBuilder()
+            .add("X-API-Key", API_KEY)
+            .add("X-App-Version", APP_VERSION)
+            .build()
+
+        val response = client.get(url, apiHeaders)
+        val data = response.parseAs<ChapterDataDto>()
         return data.toPageList(baseUrl)
     }
 
-    override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
-
     // ============================== Filters ==============================
 
-    override fun getFilterList(): FilterList = FilterList(
+    override fun getFilterList(data: JsonElement?): FilterList = FilterList(
         SortFilter(),
         StatusFilter(),
         TypeFilter(),
         Filter.Separator(),
         GenreFilterGroup(getGenreList()),
     )
+
+    // ============================== Helpers ==============================
+
+    private suspend fun getMangaList(url: String): MangasPage {
+        val document = client.get(url).asJsoup()
+        val elements = document.select("div.group:has(h3 a)")
+        val mangas = parseMangaElements(elements)
+
+        val pagination = document.extractNextJs<PaginationDto>()
+        val hasNextPage = when {
+            pagination != null -> {
+                if (pagination.currentPage >= pagination.totalPages) {
+                    false
+                } else if (pagination.currentPage == pagination.totalPages - 1) {
+                    val nextUrl = url.toHttpUrl().newBuilder()
+                        .setQueryParameter("page", pagination.totalPages.toString())
+                        .build()
+                    val nextDoc = client.get(nextUrl).asJsoup()
+                    parseMangaElements(nextDoc.select("div.group:has(h3 a)")).isNotEmpty()
+                } else {
+                    true
+                }
+            }
+            else -> elements.size >= 24
+        }
+
+        return MangasPage(mangas, hasNextPage)
+    }
+
+    private fun parseMangaElements(elements: Elements): List<SManga> = elements
+        .filterNot { it.selectFirst("h3 a")?.absUrl("href")?.toHttpUrlOrNull()?.pathSegments?.firstOrNull() == "novel" }
+        .mapNotNull { element ->
+            val link = element.selectFirst("h3 a") ?: return@mapNotNull null
+            val href = link.absUrl("href").takeIf { it.isNotEmpty() } ?: return@mapNotNull null
+            val title = link.text().takeIf { it.isNotBlank() }
+                ?: element.selectFirst("img")?.attr("alt")?.takeIf { it.isNotBlank() }
+                ?: return@mapNotNull null
+
+            SManga.create().apply {
+                setUrlWithoutDomain(href)
+                this.title = title
+                thumbnail_url = element.selectFirst("img")?.absUrl("src")
+            }
+        }
+
+    companion object {
+        private const val API_KEY = "slept-flutter-xK9mP2wQ7vL4nJ8hB3cF6dR1"
+        private const val APP_VERSION = "1.0.5"
+    }
 }


### PR DESCRIPTION
Closes #19039

Migrate to KeiSource (libVersion = "1.6"), fix manga listing DOM selectors, and use mobile app API endpoint for chapter images.

Tested with gradlew + device (Mihon).

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [ ] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code)
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

---

🤖 This pull request was prepared and assisted by an AI agent under user supervision.
